### PR TITLE
fix: maxflow value when no path

### DIFF
--- a/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
+++ b/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
@@ -405,6 +405,42 @@ public class NetworkPathfinderTests
             {
                 Console.WriteLine($"\n{ConsoleColors.Yellow}NO PATH FOUND:{ConsoleColors.Reset} No valid path exists between source and sink with the given constraints.");
                 // This is now considered a valid case, not a failure
+              //  return;
+                // FLOW ZERO CONSISTENCY CHECK
+                Console.WriteLine($"\n{ConsoleColors.Magenta}FLOW ZERO CONSISTENCY CHECK:{ConsoleColors.Reset}");
+                bool flowZeroConsistencyPassed = true;
+
+                // Consistency check: if there are no transfers, maxFlow must be zero
+                if (result.Transfers.Count == 0 && result.MaxFlow != "0")
+                {
+                    Console.WriteLine($"{ConsoleColors.Red}INCONSISTENT STATE:{ConsoleColors.Reset} No transfers found but MaxFlow is not zero ({result.MaxFlow})");
+                    flowZeroConsistencyPassed = false;
+                }
+
+                // Consistency check: if maxFlow is zero, there should be no transfers
+                if (result.MaxFlow == "0" && result.Transfers.Count > 0)
+                {
+                    Console.WriteLine($"{ConsoleColors.Red}INCONSISTENT STATE:{ConsoleColors.Reset} MaxFlow is zero but {result.Transfers.Count} transfers were found");
+                    flowZeroConsistencyPassed = false;
+                }
+
+                Console.WriteLine($"Check: {(flowZeroConsistencyPassed ? ConsoleColors.Green + "PASSED" : ConsoleColors.Red + "FAILED")}{ConsoleColors.Reset}");
+                if (!flowZeroConsistencyPassed)
+                {
+                    validationPassed = false;
+                }
+
+                // Finally, assert if the entire validation succeeded.
+                if (validationPassed)
+                {
+                    Console.WriteLine($"\n{ConsoleColors.Green}Test completed successfully!{ConsoleColors.Reset}");
+                }
+                else
+                {
+                    Console.WriteLine($"\n{ConsoleColors.Red}Test failed due to one or more validation errors!{ConsoleColors.Reset}");
+                }
+
+                Assert.That(validationPassed, Is.True, "One or more validation checks failed.");
                 return;
             }
             
@@ -714,6 +750,7 @@ public class NetworkPathfinderTests
             {
                 Console.WriteLine($"\n{ConsoleColors.Red}Wrapped token validation skipped - graphs not loaded{ConsoleColors.Reset}");
             }
+
             
             // Finally, assert if the entire validation succeeded.
             if (validationPassed)

--- a/Circles.Pathfinder.Tests/pathfinder-test-cases.json
+++ b/Circles.Pathfinder.Tests/pathfinder-test-cases.json
@@ -109,5 +109,31 @@
         "fromTokens": [],
         "toTokens": ["0x4a9affa9249f36fd0629f342c182a4e94a13c2e0"],
         "withWrap": true
-      }
+    },
+    {
+        "name": "test-1",
+        "description": "Self-conversion with wrap",
+        "source": "0x3162085b7B2Ef572956F785A7Fec90a653A1e65d",
+        "sink": "0x3162085b7B2Ef572956F785A7Fec90a653A1e65d",
+        "targetFlow": "13038000000000000",
+        "fromTokens": ["0xc0d871bd13ebdf5c4ff059d8243fb38210608bd6",
+                "0x457ece12084cb7ab908623cbedd1843a6dc958d1",
+                "0x2cabc867a6c4a32846677e74b3f75df055e01f21",
+                "0x159e6881e6ec370b46f2fe9fe75cbdfd8f7877b4",
+                "0x5b10e15404c490892ebb6a2c7a22bb594c32e9e8",
+                "0xc4071f2324628634e619d02710abeec170b8ffa1",
+                "0x2ce85e0d3b5b875441ba84d4865ac99578688202",
+                "0xb88c41994d635b5a10cdc9621e4736b3a56b1e5b",
+                "0x3e8276616d598e237181978b1e83c592ed33004c",
+                "0xd9bad5c83d61c6613e51b8236b637bddeb48b6d7",
+                "0xf48554937f18885c7f15c432c596b5843648231d",
+                "0x57928fb15ffb7303b65edc326dc4dc38150008e1",
+                "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+                "0x009626daded5e90aecee30ad3ebf2b3e510fe256",
+                "0xf7bd3d83df90b4682725adf668791d4d1499207f",
+                "0x42cedde51198d1773590311e2a340dc06b24cb37",
+                "0x3a91df8d30899ed14946232c0a28468a69cb8de5"],
+        "toTokens": [],
+        "withWrap": true
+    }
   ]

--- a/Circles.Pathfinder/Graphs/GraphExtensions.cs
+++ b/Circles.Pathfinder/Graphs/GraphExtensions.cs
@@ -69,7 +69,6 @@ public static class GraphExtensions
         for (int i = 0; i < maxFlowSolver.NumArcs(); ++i)
         {
             int tail = maxFlowSolver.Tail(i);
-            int head = maxFlowSolver.Head(i);
             long flow = maxFlowSolver.Flow(i);
             
             // Skip the superSource->source arc
@@ -88,17 +87,6 @@ public static class GraphExtensions
         if (!hasRealFlow)
         {
             Console.WriteLine("No actual flow paths found in the network. Returning max flow = 0.");
-            // Reset flows to zero since we're returning zero flow
-            foreach (var edge in graph.Edges)
-            {
-                edge.Flow = 0;
-                edge.CurrentCapacity = edge.InitialCapacity;
-                if (edge.ReverseEdge != null)
-                {
-                    edge.ReverseEdge.Flow = 0;
-                    edge.ReverseEdge.CurrentCapacity = 0;
-                }
-            }
             return 0;
         }
 

--- a/Circles.Pathfinder/Graphs/GraphExtensions.cs
+++ b/Circles.Pathfinder/Graphs/GraphExtensions.cs
@@ -64,6 +64,44 @@ public static class GraphExtensions
 
         long scaledFlowVal = maxFlowSolver.OptimalFlow();
 
+        // Check if any flow is actually going from source to other nodes or directly to sink
+        bool hasRealFlow = false;
+        for (int i = 0; i < maxFlowSolver.NumArcs(); ++i)
+        {
+            int tail = maxFlowSolver.Tail(i);
+            int head = maxFlowSolver.Head(i);
+            long flow = maxFlowSolver.Flow(i);
+            
+            // Skip the superSource->source arc
+            if (tail == superSourceIndex)
+                continue;
+                
+            // If any other arc has flow, then we have a real path
+            if (flow > 0)
+            {
+                hasRealFlow = true;
+                break;
+            }
+        }
+
+        // If there's no real flow in the network, return 0
+        if (!hasRealFlow)
+        {
+            Console.WriteLine("No actual flow paths found in the network. Returning max flow = 0.");
+            // Reset flows to zero since we're returning zero flow
+            foreach (var edge in graph.Edges)
+            {
+                edge.Flow = 0;
+                edge.CurrentCapacity = edge.InitialCapacity;
+                if (edge.ReverseEdge != null)
+                {
+                    edge.ReverseEdge.Flow = 0;
+                    edge.ReverseEdge.CurrentCapacity = 0;
+                }
+            }
+            return 0;
+        }
+
         // 9) Store each edge’s flow
         foreach (var edge in graph.Edges)
         {

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -162,9 +162,9 @@ public class V2Pathfinder : IPathfinder
         FlowLogger.LogTransferStepsFlow("[Circles.V2Pathfinder] transferSteps", source, sink, transferSteps);
 
         //  var totalValue = transferSteps.Sum(o => Convert.ToInt64(o.Value));
-      //  Console.WriteLine($"-----------------------------------");
-      //  Console.WriteLine($"Target flow: {targetFlow}");
-      //  Console.WriteLine($"Max flow: {maxFlow}");
+        Console.WriteLine($"-----------------------------------");
+        Console.WriteLine($"Target flow: {targetFlow}");
+        Console.WriteLine($"Max flow: {maxFlow}");
         //  Console.WriteLine($"Total value: {totalValue}");
 
         // Return


### PR DESCRIPTION
edge case for superSource that when no path was found (and only for source=sink) would return the maxFlow as the targetFlow.

Add a check after the computation of the maxflow to see if there is a edge with flow that is not the superSource to source one