### PR TITLE
added Double type, needed for some Views

### DIFF
--- a/Circles.Index.CirclesViews/DatabaseSchema.cs
+++ b/Circles.Index.CirclesViews/DatabaseSchema.cs
@@ -49,10 +49,11 @@ public class DatabaseSchema : IDatabaseSchema
         ("V_CrcV2", "Erc20BalancerVaultBalance_1d"),
 
         ("V_CrcV2", "GroupMintRedeem_1h"),
-        ("V_CrcV2", "GroupMintRedeem_1d")
+        ("V_CrcV2", "GroupMintRedeem_1d"),
+
+        ("V_CrcV2", "GroupWrapUnWrap_1h"),
+        ("V_CrcV2", "GroupWrapUnWrap_1d")
         
-        
- 
     };
     
     public ISchemaPropertyMap SchemaPropertyMap { get; } = new SchemaPropertyMap();

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
@@ -14,7 +14,7 @@ SELECT
     ,"id"
     ,"amountLocked"
     ,"demurragedAmountLocked"
-    ,"amountLocked" / (SUM("amountLocked") OVER (PARTITION BY "group")) AS "fractionLocked"
+    ,COALESCE("amountLocked" / NULLIF(SUM("amountLocked") OVER (PARTITION BY "group"),0),0) AS "fractionLocked"
 FROM (
     SELECT
         "group"

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
@@ -3,7 +3,7 @@
 -- id:ValueTypes.BigInt:true
 -- amountLocked:ValueTypes.BigInt:true
 -- demurragedAmountLocked:ValueTypes.BigInt:true
--- fractionLocked:ValueTypes.BigInt:true
+-- fractionLocked:ValueTypes.DoublePrecision:true
 
 
 create or replace view public."V_CrcV2_GroupCollateralByToken"

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupCollateralByToken.sql
@@ -3,7 +3,7 @@
 -- id:ValueTypes.BigInt:true
 -- amountLocked:ValueTypes.BigInt:true
 -- demurragedAmountLocked:ValueTypes.BigInt:true
--- fractionLocked:ValueTypes.DoublePrecision:true
+-- fractionLocked:ValueTypes.Double:true
 
 
 create or replace view public."V_CrcV2_GroupCollateralByToken"

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
@@ -3,7 +3,7 @@
 -- holder:ValueTypes.Address:true
 -- totalBalance:ValueTypes.BigInt:true
 -- demurragedTotalBalance:ValueTypes.BigInt:true
--- fractionOwnership:ValueTypes.DoublePrecision:true
+-- fractionOwnership:ValueTypes.Double:true
 
 create or replace view "V_CrcV2_GroupTokenHoldersBalance"
     ("group", "holder", "totalBalance", "demurragedTotalBalance", "fractionOwnership") as

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
@@ -12,7 +12,7 @@ SELECT
     t1."account" AS "holder",
     t1."totalBalance",
     t1."demurragedTotalBalance",
-    t1."demurragedTotalBalance" / (SUM(t1."demurragedTotalBalance") OVER (PARTITION BY t1."tokenAddress")) AS "fractionOwnership"
+    COALESCE(t1."demurragedTotalBalance" / NULLIF(SUM(t1."demurragedTotalBalance") OVER (PARTITION BY t1."tokenAddress"),0),0) AS "fractionOwnership"
 FROM 
     "V_CrcV2_BalancesByAccountAndToken" t1
 INNER JOIN

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupTokenHoldersBalance.sql
@@ -3,7 +3,7 @@
 -- holder:ValueTypes.Address:true
 -- totalBalance:ValueTypes.BigInt:true
 -- demurragedTotalBalance:ValueTypes.BigInt:true
--- fractionOwnership:ValueTypes.BigInt:true
+-- fractionOwnership:ValueTypes.DoublePrecision:true
 
 create or replace view "V_CrcV2_GroupTokenHoldersBalance"
     ("group", "holder", "totalBalance", "demurragedTotalBalance", "fractionOwnership") as

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
@@ -1,0 +1,35 @@
+-- COLUMNS:
+-- group:ValueTypes.Address:true
+-- timestamp:ValueTypes.BigInt:true
+-- tokenAddress:ValueTypes.Address:true
+-- currencyUnit:ValueTypes.Address:true
+-- wrapAmount:ValueTypes.BigInt:true
+-- unwrapAmount:ValueTypes.BigInt:true
+-- wrapSupply:ValueTypes.BigInt:true
+
+create or replace view "V_CrcV2_GroupWrapUnWrap_1d" ("group", "timestamp", "tokenAddress", "currencyUnit", "wrapAmount", "unwrapAmount", "wrapSupply") as
+
+WITH
+
+group_wrap_unwrap AS (
+  SELECT 
+    "group",
+    date_trunc('day', "timestamp") AS "timestamp",
+    "tokenAddress",
+    "currencyUnit",
+    SUM("wrapAmount") As "wrapAmount",
+    SUM("unwrapAmount") As "unwrapAmount",
+    ARRAY_AGG("wrapSupply" ORDER BY "timestamp" DESC) AS supplies
+  FROM "V_CrcV2_GroupWrapUnWrap_1h"
+  GROUP BY 1, 2, 3, 4
+)
+
+SELECT 
+  "group"
+  ,"timestamp"
+  ,"tokenAddress"
+  ,"currencyUnit"
+  ,"wrapAmount"
+  ,"unwrapAmount"
+  ,supplies[1] AS  "supply" 
+FROM group_wrap_unwrap;

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
@@ -2,12 +2,12 @@
 -- group:ValueTypes.Address:true
 -- timestamp:ValueTypes.BigInt:true
 -- tokenAddress:ValueTypes.Address:true
--- currencyUnit:ValueTypes.Address:true
+-- tokenType:ValueTypes.Address:true
 -- wrapAmount:ValueTypes.BigInt:true
 -- unwrapAmount:ValueTypes.BigInt:true
 -- wrapSupply:ValueTypes.BigInt:true
 
-create or replace view "V_CrcV2_GroupWrapUnWrap_1d" ("group", "timestamp", "tokenAddress", "currencyUnit", "wrapAmount", "unwrapAmount", "wrapSupply") as
+create or replace view "V_CrcV2_GroupWrapUnWrap_1d" ("group", "timestamp", "tokenAddress", "tokenType", "wrapAmount", "unwrapAmount", "wrapSupply") as
 
 WITH
 
@@ -16,7 +16,7 @@ group_wrap_unwrap AS (
     "group",
     date_trunc('day', "timestamp") AS "timestamp",
     "tokenAddress",
-    "currencyUnit",
+    "tokenType",
     SUM("wrapAmount") As "wrapAmount",
     SUM("unwrapAmount") As "unwrapAmount",
     ARRAY_AGG("wrapSupply" ORDER BY "timestamp" DESC) AS supplies
@@ -28,7 +28,7 @@ SELECT
   "group"
   ,"timestamp"
   ,"tokenAddress"
-  ,"currencyUnit"
+  ,"tokenType"
   ,"wrapAmount"
   ,"unwrapAmount"
   ,supplies[1] AS  "supply" 

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1h.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1h.sql
@@ -2,12 +2,12 @@
 -- group:ValueTypes.Address:true
 -- timestamp:ValueTypes.BigInt:true
 -- tokenAddress:ValueTypes.Address:true
--- currencyUnit:ValueTypes.Address:true
+-- tokenType:ValueTypes.Address:true
 -- wrapAmount:ValueTypes.BigInt:true
 -- unwrapAmount:ValueTypes.BigInt:true
 -- wrapSupply:ValueTypes.BigInt:true
 
-create or replace view "V_CrcV2_GroupWrapUnWrap_1h" ("group", "timestamp", "tokenAddress", "currencyUnit", "wrapAmount", "unwrapAmount", "wrapSupply") as
+create or replace view "V_CrcV2_GroupWrapUnWrap_1h" ("group", "timestamp", "tokenAddress", "tokenType", "wrapAmount", "unwrapAmount", "wrapSupply") as
 
 WITH
 
@@ -19,7 +19,7 @@ group_wrap_tokens AS (
 		,CASE
 			WHEN t2."circlesType"=0 THEN 'Demurrage'
 			ELSE 'Inflation'
-		END AS "currencyUnit"
+		END AS "tokenType"
 		,SUM(
 			CASE
 				WHEN t1."from"='0x0000000000000000000000000000000000000000' THEN t1.amount
@@ -47,7 +47,7 @@ min_per_group AS (
     SELECT
         "group",
 		"tokenAddress",
-		"currencyUnit",
+		"tokenType",
         MIN("timestamp") AS min_timestamp
     FROM 
         group_wrap_tokens
@@ -59,7 +59,7 @@ calendar AS (
     SELECT
         g."group",
 		g."tokenAddress",
-		g."currencyUnit",
+		g."tokenType",
         generate_series(
             g.min_timestamp,
             date_trunc('hour', CURRENT_TIMESTAMP),
@@ -72,7 +72,7 @@ SELECT
 	t1."group"
 	,t1."timestamp"
 	,t1."tokenAddress"
-	,t1."currencyUnit"
+	,t1."tokenType"
 	,COALESCE(t2."wrapAmount", 0) AS "wrapAmount"
 	,COALESCE(t2."unwrapAmount", 0) AS "unwrapAmount"
 	,SUM(COALESCE(t2."wrapAmount", 0) + COALESCE(t2."unwrapAmount", 0)) OVER (PARTITION BY t1."group", t1."tokenAddress" ORDER BY t1."timestamp") AS "wrapSupply"

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1h.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1h.sql
@@ -1,0 +1,85 @@
+-- COLUMNS:
+-- group:ValueTypes.Address:true
+-- timestamp:ValueTypes.BigInt:true
+-- tokenAddress:ValueTypes.Address:true
+-- currencyUnit:ValueTypes.Address:true
+-- wrapAmount:ValueTypes.BigInt:true
+-- unwrapAmount:ValueTypes.BigInt:true
+-- wrapSupply:ValueTypes.BigInt:true
+
+create or replace view "V_CrcV2_GroupWrapUnWrap_1h" ("group", "timestamp", "tokenAddress", "currencyUnit", "wrapAmount", "unwrapAmount", "wrapSupply") as
+
+WITH
+
+group_wrap_tokens AS (
+	SELECT
+		date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+		,t2."avatar" AS "group"
+		,t1."tokenAddress"
+		,CASE
+			WHEN t2."circlesType"=0 THEN 'Demurrage'
+			ELSE 'Inflation'
+		END AS "currencyUnit"
+		,SUM(
+			CASE
+				WHEN t1."from"='0x0000000000000000000000000000000000000000' THEN t1.amount
+				ELSE 0 
+			END 
+		) AS "wrapAmount"
+		,SUM(
+			CASE
+				WHEN t1."to"='0x0000000000000000000000000000000000000000' THEN -t1.amount
+				ELSE 0
+			END
+		) AS "unwrapAmount"
+	FROM public."CrcV2_Erc20WrapperTransfer" t1
+	INNER JOIN
+		"CrcV2_ERC20WrapperDeployed" t2
+		ON t2."erc20Wrapper" = t1."tokenAddress"
+	INNER JOIN
+		"V_CrcV2_Avatars" t3
+		ON t3."avatar" = t2."avatar"
+		AND t3."type" = 'CrcV2_RegisterGroup'
+	GROUP BY 1, 2, 3, 4
+),
+
+min_per_group AS (
+    SELECT
+        "group",
+		"tokenAddress",
+		"currencyUnit",
+        MIN("timestamp") AS min_timestamp
+    FROM 
+        group_wrap_tokens
+    GROUP BY 1, 2, 3
+),
+
+
+calendar AS (
+    SELECT
+        g."group",
+		g."tokenAddress",
+		g."currencyUnit",
+        generate_series(
+            g.min_timestamp,
+            date_trunc('hour', CURRENT_TIMESTAMP),
+            interval '1 hour'
+        ) AS "timestamp"
+    FROM min_per_group g
+)
+
+SELECT 
+	t1."group"
+	,t1."timestamp"
+	,t1."tokenAddress"
+	,t1."currencyUnit"
+	,COALESCE(t2."wrapAmount", 0) AS "wrapAmount"
+	,COALESCE(t2."unwrapAmount", 0) AS "unwrapAmount"
+	,SUM(COALESCE(t2."wrapAmount", 0) + COALESCE(t2."unwrapAmount", 0)) OVER (PARTITION BY t1."group", t1."tokenAddress" ORDER BY t1."timestamp") AS "wrapSupply"
+FROM 
+	calendar t1
+LEFT JOIN
+	group_wrap_tokens t2
+    ON t2."timestamp" = t1."timestamp"
+	AND t2."group" = t1."group"
+	AND t2."tokenAddress" = t1."tokenAddress"

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
@@ -54,8 +54,18 @@ AS
     member_counts AS (
         SELECT bgc."group", count(*) as "memberCount"
         FROM "CrcV2_RegisterGroup" bgc
-            JOIN "V_CrcV2_TrustRelations" tr on tr.truster = bgc."group"
+                 JOIN "V_CrcV2_TrustRelations" tr on tr.truster = bgc."group"
         GROUP BY bgc."group"
+    ),
+    erc20_demurraged AS (
+        SELECT ed.avatar, ed."erc20Wrapper" as "erc20WrapperDemurraged"
+        FROM "CrcV2_RegisterGroup" bgc
+                 JOIN "CrcV2_ERC20WrapperDeployed" ed on ed."circlesType" = 0 and ed.avatar = bgc."group"
+    ),
+    erc20_static AS (
+        SELECT ed.avatar, ed."erc20Wrapper" as "erc20WrapperStatic"
+        FROM "CrcV2_RegisterGroup" bgc
+                 JOIN "CrcV2_ERC20WrapperDeployed" ed on ed."circlesType" = 1 and ed.avatar = bgc."group"
     )
     SELECT
         c."blockNumber",
@@ -79,12 +89,16 @@ AS
         COALESCE(m."memberCount", 0)        AS "memberCount",
         c.name,
         c.symbol,
-        ci."metadataDigest" as "cidV0Digest"
+        ci."metadataDigest" as "cidV0Digest",
+        ed."erc20WrapperDemurraged",
+        es."erc20WrapperStatic"
     FROM       "CrcV2_RegisterGroup" c
-    LEFT JOIN  latest_owner             o ON o.emitter  = c."group"
-    LEFT JOIN  latest_service           s ON s.emitter  = c."group"
-    LEFT JOIN  latest_fee               f ON f.emitter  = c."group"
-    LEFT JOIN  member_counts            m ON m."group"  = c."group"
-    LEFT JOIN  latest_cid               ci ON ci.avatar = c."group"
-    LEFT JOIN  "CrcV2_CMGroupCreated"   cm ON cm.proxy  = c."group"
+    LEFT JOIN  latest_owner             o ON o.emitter   = c."group"
+    LEFT JOIN  latest_service           s ON s.emitter   = c."group"
+    LEFT JOIN  latest_fee               f ON f.emitter   = c."group"
+    LEFT JOIN  member_counts            m ON m."group"   = c."group"
+    LEFT JOIN  latest_cid               ci ON ci.avatar  = c."group"
+    LEFT JOIN  erc20_demurraged         ed ON ed.avatar  = c."group"
+    LEFT JOIN  erc20_static             es ON es.avatar  = c."group"
+    LEFT JOIN  "CrcV2_CMGroupCreated"   cm ON cm.proxy   = c."group"
     LEFT JOIN  "CrcV2_BaseGroupCreated" bg ON bg."group" = c."group";

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
@@ -16,7 +16,8 @@
 -- name:ValueTypes.String:true
 -- symbol:ValueTypes.String:true
 -- cidV0Digest:ValueTypes.Bytes:true
-
+-- erc20WrapperDemurraged:ValueTypes.Address:true
+-- erc20WrapperStatic:ValueTypes.Address:true
 CREATE OR REPLACE VIEW "V_CrcV2_Groups"
 AS
     WITH latest_owner AS (

--- a/Circles.Index.Common/ValueTypes.cs
+++ b/Circles.Index.Common/ValueTypes.cs
@@ -9,5 +9,6 @@ public enum ValueTypes
     String = 4,
     Bytes = 5,
     AddressArray = 6,
-    Json = 7
+    Json = 7,
+    Double = 8
 }

--- a/Circles.Index.Postgres/PostgresDb.cs
+++ b/Circles.Index.Postgres/PostgresDb.cs
@@ -47,25 +47,35 @@ public class ReadonlyPostgresDb(string connectionString, IDatabaseSchema schema)
                     continue;
                 }
 
-                // Special handling for numeric values
                 if (resultSchema[i].NpgsqlDbType == NpgsqlDbType.Numeric)
                 {
-                    // First try BigInteger 
-                    try 
+                    int precision = resultSchema[i].NumericPrecision ?? 0;
+                    int scale = resultSchema[i].NumericScale ?? 0;
+
+                    bool hasNoScale = scale == 0;
+                    bool fitsInDecimal = precision <= 28;
+                    bool fitsIn256BitInteger = precision <= 78; // 256-bit max ≈ 7.9e76 (78 digits)
+
+                    if (hasNoScale)
                     {
-                        row[i] = reader.GetFieldValue<BigInteger>(i);
+                        if (fitsIn256BitInteger)
+                        {
+                            row[i] = reader.GetFieldValue<BigInteger>(i);
+                        }
+                        else
+                        {
+                            row[i] = reader.GetValue(i).ToString();
+                        }
                     }
-                    catch (InvalidCastException) 
+                    else
                     {
-                        // If BigInteger fails (likely due to fractional parts), try decimal
-                        try 
+                        if (fitsInDecimal)
                         {
                             row[i] = reader.GetFieldValue<decimal>(i);
                         }
-                        catch (Exception)
+                        else
                         {
-                            // Last resort: get as string to preserve the value
-                            row[i] = reader.GetValue(i).ToString();
+                            row[i] = reader.GetFieldValue<double>(i);
                         }
                     }
                 }

--- a/Circles.Index.Postgres/PostgresDb.cs
+++ b/Circles.Index.Postgres/PostgresDb.cs
@@ -41,33 +41,37 @@ public class ReadonlyPostgresDb(string connectionString, IDatabaseSchema schema)
             var row = new object?[reader.FieldCount];
             for (int i = 0; i < reader.FieldCount; i++)
             {
+                if (reader.IsDBNull(i))
+                {
+                    row[i] = null;
+                    continue;
+                }
+
+                // Special handling for numeric values
                 if (resultSchema[i].NpgsqlDbType == NpgsqlDbType.Numeric)
                 {
-                    // Check if this is a Double-type column (which can have fractional parts)
-                    var columnName = reader.GetName(i);
-                    var column = schema.Tables.Values
-                        .SelectMany(t => t.Columns)
-                        .FirstOrDefault(c => c.Column.Equals(columnName, StringComparison.OrdinalIgnoreCase));
-                    
-                    if (column != null && column.Type == ValueTypes.Double)
+                    // First try BigInteger 
+                    try 
                     {
-                        // Read as double for columns with ValueTypes.Double
-                        row[i] = reader.GetFieldValue<double?>(i);
+                        row[i] = reader.GetFieldValue<BigInteger>(i);
                     }
-                    else
+                    catch (InvalidCastException) 
                     {
-                        // Otherwise read as BigInteger as before
-                        row[i] = reader.GetFieldValue<BigInteger?>(i);
+                        // If BigInteger fails (likely due to fractional parts), try decimal
+                        try 
+                        {
+                            row[i] = reader.GetFieldValue<decimal>(i);
+                        }
+                        catch (Exception)
+                        {
+                            // Last resort: get as string to preserve the value
+                            row[i] = reader.GetValue(i).ToString();
+                        }
                     }
                 }
                 else
                 {
                     row[i] = reader.GetValue(i);
-                }
-
-                if (row[i] is DBNull)
-                {
-                    row[i] = null;
                 }
             }
 

--- a/Circles.Index.Postgres/PostgresDb.cs
+++ b/Circles.Index.Postgres/PostgresDb.cs
@@ -43,7 +43,22 @@ public class ReadonlyPostgresDb(string connectionString, IDatabaseSchema schema)
             {
                 if (resultSchema[i].NpgsqlDbType == NpgsqlDbType.Numeric)
                 {
-                    row[i] = reader.GetFieldValue<BigInteger?>(i);
+                    // Check if this is a Double-type column (which can have fractional parts)
+                    var columnName = reader.GetName(i);
+                    var column = schema.Tables.Values
+                        .SelectMany(t => t.Columns)
+                        .FirstOrDefault(c => c.Column.Equals(columnName, StringComparison.OrdinalIgnoreCase));
+                    
+                    if (column != null && column.Type == ValueTypes.Double)
+                    {
+                        // Read as double for columns with ValueTypes.Double
+                        row[i] = reader.GetFieldValue<double?>(i);
+                    }
+                    else
+                    {
+                        // Otherwise read as BigInteger as before
+                        row[i] = reader.GetFieldValue<BigInteger?>(i);
+                    }
                 }
                 else
                 {

--- a/Circles.Index.Postgres/PostgresDb.cs
+++ b/Circles.Index.Postgres/PostgresDb.cs
@@ -253,6 +253,7 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
             ValueTypes.Bytes => "BYTEA",
             ValueTypes.AddressArray => "TEXT[]",
             ValueTypes.Json => "JSON",
+            ValueTypes.Double => "DOUBLE PRECISION",
             _ => throw new ArgumentException("Unsupported type")
         };
     }
@@ -269,6 +270,7 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
             ValueTypes.Bytes => NpgsqlDbType.Bytea,
             ValueTypes.AddressArray => NpgsqlDbType.Array | NpgsqlDbType.Text,
             ValueTypes.Json => NpgsqlDbType.Json,
+            ValueTypes.Double => NpgsqlDbType.Double,
             _ => throw new ArgumentException("Unsupported type")
         };
     }

--- a/Circles.Pathfinder.Host/Program.cs
+++ b/Circles.Pathfinder.Host/Program.cs
@@ -73,7 +73,7 @@ var sem = new SemaphoreSlim(settings.MaxConcurrentRequests,
 builder.Services.AddSingleton(sem);
 
 builder.Services.AddSingleton<NetworkState>();
-builder.Services.AddSingleton(new CapacityGraphPool(settings.IndexReadonlyDbConnectionString));
+builder.Services.AddSingleton(new CapacityGraphPool());
 builder.Services.AddHostedService<NetworkStateUpdaterService>();
 builder.Services.AddHostedService<LogStatsService>();
 

--- a/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -87,12 +87,11 @@ public class NetworkStateUpdaterService : BackgroundService
             await Task.WhenAll(trustTask, balanceTask);
             swTotal.Stop();
 
-            // var baseGraph = await FlowGraphPool.CreateFlowGraph(_settings.IndexReadonlyDbConnectionString, new FlowRequest());
-            // var snapshot = new FlowGraphSnapshot(lastBlock, baseGraph);
-            // _pool.UpdateSnapshot(snapshot);
-            
-            var cap       = await CapacityGraphPool.BuildFullGraph(_settings.IndexReadonlyDbConnectionString);
-            var snap      = new CapacityGraphSnapshot(lastBlock, cap);
+            var cap = await CapacityGraphPool.BuildFullGraph(
+                _networkState.BalanceGraph,
+                _networkState.AccountTrusts
+            );
+            var snap = new CapacityGraphSnapshot(lastBlock, cap);
             _pool.UpdateSnapshot(snap);
 
             upd?.SetTag("trust_ms", swTrustGraph.ElapsedMilliseconds);

--- a/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -64,20 +64,12 @@ public sealed class CapacityGraphPool
     /* One-off builder used by the background service                     */
     /* ------------------------------------------------------------------ */
 
-    public static async Task<CapacityGraph> BuildFullGraph(string cs)
+    public static async Task<CapacityGraph> BuildFullGraph(
+        BalanceGraph balanceGraph,
+        IReadOnlyDictionary<int, HashSet<int>> accountTrusts)
     {
-        var load = new LoadGraph(cs);
         var gf = new GraphFactory();
-
-        var balTask = Task.Run(() => gf.V2BalanceGraph(load));
-        var trustTask = Task.Run(() =>
-        {
-            var g = gf.V2TrustGraph(load);
-            return GraphFactory.BuildTrustLookup(g);
-        });
-
-        await Task.WhenAll(balTask, trustTask);
-        return gf.CreateCapacityGraph(balTask.Result, trustTask.Result, new FlowRequest());
+        return gf.CreateCapacityGraph(balanceGraph, accountTrusts, new FlowRequest());
     }
 
     public static bool RequestNeedsFiltering(FlowRequest r)

--- a/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -1,7 +1,4 @@
-// Circles.Pathfinder/Graphs/CapacityGraphPool.cs
-
 using System.Collections.Concurrent;
-using Circles.Pathfinder.Data;
 using Circles.Pathfinder.DTOs;
 
 namespace Circles.Pathfinder.Graphs;
@@ -10,10 +7,7 @@ public sealed class CapacityGraphPool
 {
     private readonly ConcurrentDictionary<CapacityGraphSnapshot, int> _ref = new();
     private volatile CapacityGraphSnapshot? _current;
-    private readonly string _cs;
     private readonly GraphFactory _gf = new();
-
-    public CapacityGraphPool(string connectionString) => _cs = connectionString;
 
     /* ------------------------------------------------------------------ */
     /* Snapshot                                                           */
@@ -40,7 +34,7 @@ public sealed class CapacityGraphPool
         if (_current == null)
             throw new InvalidOperationException("No capacity graph available yet.");
 
-        if (CapacityGraphPool.RequestNeedsFiltering(r))
+        if (RequestNeedsFiltering(r))
         {
             // build ad-hoc filtered graph
             var g = _gf.CreateCapacityGraph(balances, trust, r);

--- a/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -185,16 +185,6 @@ public class GraphFactory
         return capacityGraph;
     }
 
-    /// <summary>
-    /// Creates a flow graph from a capacity graph.
-    /// </summary>
-    public FlowGraph CreateFlowGraph(CapacityGraph capacityGraph)
-    {
-        var flowGraph = new FlowGraph(capacityGraph.Nodes.Count + 1, capacityGraph.Edges.Count * 2 + 1);
-        flowGraph.AddCapacity(capacityGraph);
-        return flowGraph;
-    }
-
     #region Helper Methods
 
     private void AddAllAvatarNodes(


### PR DESCRIPTION
New View tables like `V_CrcV2_GroupTokenHoldersBalance` and `V_CrcV2_GroupCollateralBalanceByToken`have columns that compute fractions and should be Real/Double values.

Added `ValueTypes.Double` that is postgres `DOUBLE PRECISION`