### PR TITLE
remove wrong check

### DIFF
--- a/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
+++ b/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
@@ -721,15 +721,6 @@ public class NetworkPathfinderTests
                                     $"{ConsoleColors.Red}INVALID WRAPPED TOKEN USAGE:{ConsoleColors.Reset} " +
                                     $"Non-source account {transfer.From} is using wrapped token {transfer.TokenOwner}");
                             }
-
-                            // Wrapped tokens cannot go to sink
-                            if (transfer.To.Equals(sink, StringComparison.OrdinalIgnoreCase))
-                            {
-                                wrappedTokenCheckPassed = false;
-                                Console.WriteLine(
-                                    $"{ConsoleColors.Red}INVALID WRAPPED TOKEN USAGE:{ConsoleColors.Reset} " +
-                                    $"Wrapped token {transfer.TokenOwner} is being sent to sink {transfer.To}");
-                            }
                         }
                     }
                 }


### PR DESCRIPTION
To check wrap tokens  in test it is enough to check if only the source sends them.
Sink can receive if is source sending, remove the sink logic check