### PR TITLE
optimize daily resolution queries

### DIFF
--- a/Circles.Index.CirclesViews/queries/V_CrcV2_Erc20BalancerVaultBalance_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_Erc20BalancerVaultBalance_1d.sql
@@ -8,17 +8,66 @@ create or replace view public."V_CrcV2_Erc20BalancerVaultBalance_1d"
     ("timestamp", "tokenAddress", "value") as
 WITH
 
-vault_balance AS (
-  SELECT 
-    date_trunc('day', "timestamp") AS "timestamp",
-	"tokenAddress",
-    ARRAY_AGG(value ORDER BY "timestamp" DESC) AS values
-  FROM "V_CrcV2_Erc20BalancerVaultBalance_1h"
-  GROUP BY 1, 2
+balancer_vault_diffs AS (
+	SELECT
+		date_trunc('day',TO_TIMESTAMP("timestamp"))  AS "timestamp"
+		,"tokenAddress"
+		,SUM("vaultBalanceDiff") AS "vaultBalanceDiff"
+	FROM (
+		SELECT 
+			"timestamp"
+			,"tokenAddress"
+			,amount AS "vaultBalanceDiff"
+		FROM "CrcV2_Erc20WrapperTransfer"
+		WHERE 
+			"to" = LOWER('0xBA12222222228d8Ba445958a75a0704d566BF2C8')
+		UNION ALL
+		SELECT 
+			"timestamp"
+			,"tokenAddress"
+			,-amount AS "vaultBalanceDiff"
+		FROM "CrcV2_Erc20WrapperTransfer"
+		WHERE 
+			"from" = LOWER('0xBA12222222228d8Ba445958a75a0704d566BF2C8')
+	)
+	GROUP BY 1, 2
+),
+
+min_timestamp_tokenAddress AS (
+    SELECT
+        "tokenAddress",
+        MIN("timestamp") AS min_timestamp
+    FROM 
+        balancer_vault_diffs
+    GROUP BY 1
+),
+
+calendar AS (
+    SELECT
+        g."tokenAddress",
+        generate_series(
+            g.min_timestamp,
+            date_trunc('day', CURRENT_TIMESTAMP),
+            interval '1 day'
+        ) AS "timestamp"
+    FROM min_timestamp_tokenAddress g
+),
+
+balancer_vault_diffs_dense AS (
+    SELECT 
+	    t1."tokenAddress",
+	    t1."timestamp" ,
+	    COALESCE(t2."vaultBalanceDiff", 0) AS "vaultBalanceDiff"
+	FROM 
+	    calendar t1
+	LEFT JOIN 
+		balancer_vault_diffs t2
+	    ON t1."tokenAddress" = t2."tokenAddress" AND t1."timestamp" = t2."timestamp"
 )
 
-SELECT 
-  "timestamp",
-  "tokenAddress",
-  values[1] AS value 
-FROM vault_balance;
+SELECT
+	"timestamp"
+	,"tokenAddress"
+	,SUM("vaultBalanceDiff") OVER (PARTITION BY "tokenAddress" ORDER BY "timestamp") AS value
+FROM
+	balancer_vault_diffs_dense

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupMembersCount_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupMembersCount_1d.sql
@@ -4,19 +4,100 @@
 -- value:ValueTypes.Int:true
 
 create or replace view "V_CrcV2_GroupMembersCount_1d" ("group", "timestamp", "value") as
-WITH
 
-members_1d AS (
-  SELECT 
-    "group",
-    date_trunc('day', "timestamp") AS "timestamp",
-    ARRAY_AGG(value ORDER BY "timestamp" DESC) AS values
-  FROM "V_CrcV2_GroupMembersCount_1h"
-  GROUP BY 1, 2
+WITH 
+
+---- GroupMembersChange
+groups_trusts AS (
+	SELECT
+		t1."timestamp",
+		t1."logIndex",
+		t1.truster,
+		t1.trustee,
+		t1."expiryTime",
+		LEAD(t1."timestamp") OVER (PARTITION BY t1.truster, t1.trustee ORDER BY t1."timestamp", t1."logIndex") AS next_ts
+	FROM 
+		"CrcV2_Trust" t1
+	INNER JOIN 
+		"V_CrcV2_Groups" t2 
+		ON t2.group = t1.truster 
+),
+
+trust_intervals AS (
+	SELECT 
+		truster AS "group",
+		"timestamp" AS start_ts,
+		CASE 
+			WHEN "expiryTime" < 10000000000 THEN "expiryTime"
+			WHEN next_ts IS NOT NULL THEN next_ts
+			ELSE NULL -- Still valid
+		END AS end_ts
+	FROM groups_trusts
+),
+
+group_membership_changes AS (
+	SELECT 
+		start_ts AS "timestamp",
+		"group",
+		1 AS cnt
+	FROM trust_intervals
+
+	UNION ALL
+
+	SELECT 
+		end_ts AS "timestamp",
+		"group",
+		-1 AS cnt
+	FROM trust_intervals
+	WHERE end_ts IS NOT NULL
+),
+
+-- V_CrcV2_GroupMembersCount_1h
+members_hourly_sparse AS (
+    SELECT 
+        date_trunc('day',TO_TIMESTAMP("timestamp")) AS "timestamp"
+        ,"group"
+        ,SUM(cnt) AS cnt
+    FROM 
+        group_membership_changes
+	GROUP BY 1, 2
+),
+
+min_max_per_group AS (
+    SELECT
+        "group",
+        MIN("timestamp") AS min_timestamp
+    FROM 
+        members_hourly_sparse
+    GROUP BY 1
+),
+
+calendar AS (
+    SELECT
+        g."group",
+        generate_series(
+            g.min_timestamp,
+            date_trunc('day', CURRENT_TIMESTAMP),
+            interval '1 day'
+        ) AS "timestamp"
+    FROM min_max_per_group g
+),
+
+members_change AS (
+    SELECT 
+	    t1."group",
+	    t1."timestamp" ,
+	    COALESCE(t2.cnt, 0) AS cnt
+	FROM 
+	    calendar t1
+	LEFT JOIN 
+		members_hourly_sparse t2
+	    ON t1."group" = t2."group" AND t1."timestamp" = t2."timestamp"
 )
 
+
 SELECT 
-  "group",
-  "timestamp",
-  values[1] AS value 
-FROM members_1d;
+    "group",
+    "timestamp",
+    SUM(cnt) OVER (PARTITION BY "group" ORDER BY "timestamp") AS value
+FROM members_change;

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupMintRedeem_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupMintRedeem_1d.sql
@@ -11,26 +11,116 @@
 create or replace view "V_CrcV2_GroupMintRedeem_1d" ("group", "timestamp", "minted", "burned", "supply", "demurragedMinted", "demurragedBurned", "demurragedSupply") as
 
 
-WITH
+WITH 
+	mint AS (
+    SELECT 
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   INNER JOIN
+		   		"V_Crc_Avatars" t2
+				 ON t2.avatar = t1."tokenAddress"
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		   GROUP BY 1, 2, 4
+        UNION ALL
+         SELECT 
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   INNER JOIN
+		   		"V_Crc_Avatars" t2
+				 ON t2.avatar = t1."tokenAddress"
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		   GROUP BY 1, 2, 4
+        ), 
 
-group_mints_redeems AS (
-  SELECT 
-    "group",
-    date_trunc('day', "timestamp") AS "timestamp",
-    SUM("minted") As "minted",
-    SUM("burned") As "burned",
-    ARRAY_AGG("supply" ORDER BY "timestamp" DESC) AS supplies
-  FROM "V_CrcV2_GroupMintRedeem_1h"
-  GROUP BY 1, 2
+	burn AS (
+         SELECT 
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   INNER JOIN
+		   		"V_Crc_Avatars" t2
+				 ON t2.avatar = t1."tokenAddress"
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		   GROUP BY 1, 2, 3
+        UNION ALL
+         SELECT 
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   INNER JOIN
+		   		"V_Crc_Avatars" t2
+				 ON t2.avatar = t1."tokenAddress"
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		   GROUP BY 1, 2, 3
+        ),
+
+group_actions AS (
+	SELECT
+		"timestamp"
+		,"group"
+		,SUM("minted") AS "minted"
+		,SUM("burned") AS "burned"
+	FROM (
+		SELECT * FROM mint
+		UNION ALL
+		SELECT * FROM burn
+	)
+	GROUP BY 1, 2
+	
+),
+
+min_max_per_group AS (
+    SELECT
+        "group",
+        MIN("timestamp") AS min_timestamp
+    FROM 
+        group_actions
+    GROUP BY 1
+),
+
+
+calendar AS (
+    SELECT
+        g."group",
+        generate_series(
+            g.min_timestamp,
+            date_trunc('day', CURRENT_TIMESTAMP),
+            interval '1 day'
+        ) AS "timestamp"
+    FROM min_max_per_group g
 )
 
-SELECT 
-  "group"
-  ,"timestamp"
-  ,"minted"
-  ,"burned"
-  ,supplies[1] AS  "supply" 
-  ,floor(crc_demurrage(1675209600::bigint, CAST(EXTRACT(EPOCH FROM "timestamp") AS BIGINT), "minted")) AS "demurragedMinted"
+
+SELECT
+	"group"
+	,"timestamp"
+	,"minted"
+	,"burned"
+	,"supply"
+	,floor(crc_demurrage(1675209600::bigint, CAST(EXTRACT(EPOCH FROM "timestamp") AS BIGINT), "minted")) AS "demurragedMinted"
 	,floor(crc_demurrage(1675209600::bigint, CAST(EXTRACT(EPOCH FROM "timestamp") AS BIGINT), "burned")) AS "demurragedBurned"
-	,floor(crc_demurrage(1675209600::bigint, CAST(EXTRACT(EPOCH FROM "timestamp") AS BIGINT), supplies[1])) AS "demurragedSupply"
-FROM group_mints_redeems;
+	,floor(crc_demurrage(1675209600::bigint, CAST(EXTRACT(EPOCH FROM "timestamp") AS BIGINT), "supply")) AS "demurragedSupply"
+FROM (
+    SELECT 
+        t1."group"
+        ,t1."timestamp"
+        ,COALESCE(t2."minted", 0) AS "minted"
+        ,COALESCE(t2."burned", 0) AS "burned"
+        ,SUM(COALESCE(t2."minted", 0) + COALESCE(t2."burned", 0)) OVER (PARTITION BY t1."group" ORDER BY t1."timestamp") AS "supply"
+    FROM 
+        calendar t1
+    LEFT JOIN
+        group_actions t2
+        ON t2."group" = t1."group"
+        AND t2."timestamp" = t1."timestamp"
+)

--- a/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
+++ b/Circles.Index.CirclesViews/queries/V_CrcV2_GroupWrapUnWrap_1d.sql
@@ -11,25 +11,75 @@ create or replace view "V_CrcV2_GroupWrapUnWrap_1d" ("group", "timestamp", "toke
 
 WITH
 
-group_wrap_unwrap AS (
-  SELECT 
-    "group",
-    date_trunc('day', "timestamp") AS "timestamp",
-    "tokenAddress",
-    "tokenType",
-    SUM("wrapAmount") As "wrapAmount",
-    SUM("unwrapAmount") As "unwrapAmount",
-    ARRAY_AGG("wrapSupply" ORDER BY "timestamp" DESC) AS supplies
-  FROM "V_CrcV2_GroupWrapUnWrap_1h"
-  GROUP BY 1, 2, 3, 4
+group_wrap_tokens AS (
+	SELECT
+		date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+		,t2."avatar" AS "group"
+		,t1."tokenAddress"
+		,CASE
+			WHEN t2."circlesType"=0 THEN 'Demurrage'
+			ELSE 'Inflation'
+		END AS "tokenType"
+		,SUM(
+			CASE
+				WHEN t1."from"='0x0000000000000000000000000000000000000000' THEN t1.amount
+				ELSE 0 
+			END 
+		) AS "wrapAmount"
+		,SUM(
+			CASE
+				WHEN t1."to"='0x0000000000000000000000000000000000000000' THEN -t1.amount
+				ELSE 0
+			END
+		) AS "unwrapAmount"
+	FROM public."CrcV2_Erc20WrapperTransfer" t1
+	INNER JOIN
+		"CrcV2_ERC20WrapperDeployed" t2
+		ON t2."erc20Wrapper" = t1."tokenAddress"
+	INNER JOIN
+		"V_CrcV2_Avatars" t3
+		ON t3."avatar" = t2."avatar"
+		AND t3."type" = 'CrcV2_RegisterGroup'
+	GROUP BY 1, 2, 3, 4
+),
+
+min_per_group AS (
+    SELECT
+        "group",
+        "tokenAddress",
+        "tokenType",
+        MIN("timestamp") AS min_timestamp
+    FROM 
+        group_wrap_tokens
+    GROUP BY 1, 2, 3
+),
+
+
+calendar AS (
+    SELECT
+        g."group",
+		g."tokenAddress",
+		g."tokenType",
+        generate_series(
+            g.min_timestamp,
+            date_trunc('day', CURRENT_TIMESTAMP),
+            interval '1 day'
+        ) AS "timestamp"
+    FROM min_per_group g
 )
 
 SELECT 
-  "group"
-  ,"timestamp"
-  ,"tokenAddress"
-  ,"tokenType"
-  ,"wrapAmount"
-  ,"unwrapAmount"
-  ,supplies[1] AS  "supply" 
-FROM group_wrap_unwrap;
+	t1."group"
+	,t1."timestamp"
+	,t1."tokenAddress"
+	,t1."tokenType"
+	,COALESCE(t2."wrapAmount", 0) AS "wrapAmount"
+	,COALESCE(t2."unwrapAmount", 0) AS "unwrapAmount"
+	,SUM(COALESCE(t2."wrapAmount", 0) + COALESCE(t2."unwrapAmount", 0)) OVER (PARTITION BY t1."group", t1."tokenAddress" ORDER BY t1."timestamp") AS "wrapSupply"
+FROM 
+	calendar t1
+LEFT JOIN
+	group_wrap_tokens t2
+    ON t2."timestamp" = t1."timestamp"
+	AND t2."group" = t1."group"
+	AND t2."tokenAddress" = t1."tokenAddress"


### PR DESCRIPTION
Quick fix for optimizing 1d resolution queries.
Copy same logic as 1h, replace the `hour` to `day` resolution. 
Allows filters to work more efficiently. 