### PR TITLE
Improve reorg cache logging

### DIFF
--- a/Circles.Index.Common.Tests/RollbackCache.cs
+++ b/Circles.Index.Common.Tests/RollbackCache.cs
@@ -92,9 +92,14 @@ public sealed class RollbackCacheTests
 
         Assert.That(cache.LastBlockNo, Is.EqualTo(6));
 
-        cache.DeleteAllGreaterOrEqualBlock(5);
+        var stats = cache.DeleteAllGreaterOrEqualBlock(5);
 
-        Assert.That(cache.LastBlockNo, Is.EqualTo(long.MinValue));
+        Assert.Multiple(() =>
+        {
+            Assert.That(stats.Removed, Is.EqualTo(2));
+            Assert.That(stats.Restored, Is.EqualTo(0));
+            Assert.That(cache.LastBlockNo, Is.EqualTo(long.MinValue));
+        });
     }
 
     /* ----------------------------------------------------------------- */
@@ -110,10 +115,12 @@ public sealed class RollbackCacheTests
         cache.Add(2, "k", 2);
         cache.Add(2, "m", 5);
 
-        cache.DeleteAllGreaterOrEqualBlock(2);
+        var stats = cache.DeleteAllGreaterOrEqualBlock(2);
 
         Assert.Multiple(() =>
         {
+            Assert.That(stats.Removed, Is.EqualTo(1));
+            Assert.That(stats.Restored, Is.EqualTo(1));
             Assert.That(cache.Get("k"), Is.EqualTo(1));
             Assert.That(cache.ContainsKey("m"), Is.False);
             Assert.That(cache.LastBlockNo, Is.EqualTo(1));

--- a/Circles.Index.Common/RollbackCache.cs
+++ b/Circles.Index.Common/RollbackCache.cs
@@ -5,11 +5,23 @@ public interface IRollbackCache
     /// <summary>The number of blocks that can be rolled back.</summary>
     int RollbackCapacity { get; }
 
-    void DeleteAllGreaterOrEqualBlock(long toBlockNo);
+    RollbackStats DeleteAllGreaterOrEqualBlock(long toBlockNo);
 
     int Count { get; }
 
     string Name { get; }
+}
+
+public readonly struct RollbackStats
+{
+    public int Removed { get; }
+    public int Restored { get; }
+
+    public RollbackStats(int removed, int restored)
+    {
+        Removed = removed;
+        Restored = restored;
+    }
 }
 
 /// <summary>
@@ -154,22 +166,24 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     /// is a no-op.  
     /// If the target precedes the retained history window an exception is thrown.
     /// </summary>
-    public void DeleteAllGreaterOrEqualBlock(long toBlockNo)
+    public RollbackStats DeleteAllGreaterOrEqualBlock(long toBlockNo)
     {
         _lock.EnterWriteLock();
         try
         {
             // Nothing stored yet or already behind the requested head.
             if (_lastBlockNo == long.MinValue || _lastBlockNo < toBlockNo)
-                return;
+                return new RollbackStats(0, 0);
 
             if (_blockOrder.Count == 0)
-                return;
+                return new RollbackStats(0, 0);
 
             if (toBlockNo < _blockOrder.First!.Value)
                 throw new InvalidOperationException("Cannot roll back beyond stored history.");
 
             // Roll back blocks one by one while _lastBlockNo >= toBlockNo
+            var removed = 0;
+            var restored = 0;
             while (_lastBlockNo >= toBlockNo)
             {
                 var diff = _blockDiffs[_lastBlockNo];
@@ -177,15 +191,23 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
                 foreach (var (key, change) in diff)
                 {
                     if (change.HadPrevious)
+                    {
                         _current[key] = change.PreviousValue;
+                        restored++;
+                    }
                     else
+                    {
                         _current.Remove(key);
+                        removed++;
+                    }
                 }
 
                 _blockDiffs.Remove(_lastBlockNo);
                 _blockOrder.RemoveLast();
                 _lastBlockNo = _blockOrder.Count > 0 ? _blockOrder.Last!.Value : long.MinValue;
             }
+
+            return new RollbackStats(removed, restored);
         }
         finally
         {

--- a/Circles.Index/StateMachine.cs
+++ b/Circles.Index/StateMachine.cs
@@ -88,10 +88,13 @@ public class StateMachine(
                             var allCaches = context.LogParsers.SelectMany(o => o.Caches).ToArray();
                             foreach (var cache in allCaches)
                             {
-                                var countBeforeDelete = cache.Count;
-                                cache.DeleteAllGreaterOrEqualBlock(enterState.Arg);
+                                var countBefore = cache.Count;
+                                var stats = cache.DeleteAllGreaterOrEqualBlock(enterState.Arg);
+                                var removed = stats.Removed;
+                                var restored = stats.Restored;
+                                var deleted = countBefore - cache.Count;
                                 context.Logger.Info(
-                                    $"Deleted {countBeforeDelete - cache.Count} items from the '{cache.Name}' cache.");
+                                    $"Cache '{cache.Name}' maintenance: removed {removed}, restored {restored}, count delta {deleted}.");
                             }
 
                             await TransitionTo(State.WaitForNewBlock);


### PR DESCRIPTION
## Summary
- extend `IRollbackCache.DeleteAllGreaterOrEqualBlock` to return rollback stats
- capture how many items were removed vs restored during cache rollback
- log these metrics from the state machine
- update unit tests for the new return type

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840cf4a08548329a0fd40ac5d2add7b