### PR TITLE
Add C++ loader prototype

### DIFF
--- a/Circles.Pathfinder.Cpp/CMakeLists.txt
+++ b/Circles.Pathfinder.Cpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.10)
+project(pathfinder_cpp)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(PostgreSQL REQUIRED)
+include_directories(${PostgreSQL_INCLUDE_DIRS})
+
+add_executable(pathfinder_cpp
+    src/main.cpp
+    src/AddressIdPool.cpp)
+
+target_link_libraries(pathfinder_cpp ${PostgreSQL_LIBRARIES})
+
+install(TARGETS pathfinder_cpp RUNTIME DESTINATION bin)

--- a/Circles.Pathfinder.Cpp/Queries/balanceQuery.sql
+++ b/Circles.Pathfinder.Cpp/Queries/balanceQuery.sql
@@ -1,0 +1,121 @@
+with static_token_transfers as (
+    select t."blockNumber"
+         , t."timestamp"
+         , t."transactionIndex"
+         , t."logIndex"
+         , t."transactionHash"
+         , t."tokenAddress"
+         , t."from"
+         , t."to"
+         , t."amount"
+    from "CrcV2_Erc20WrapperTransfer" t
+             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 1 and d."erc20Wrapper" = t."tokenAddress"
+    order by t."blockNumber", t."transactionIndex", t."logIndex"
+), static_from_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."from" as "account"
+         , -t1."amount" as diff
+    from static_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
+), static_to_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."to" as "account"
+         , t1."amount" as diff
+    from static_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
+), static_sum as (
+    select sum(diff) AS static_balance
+         , account
+         , "tokenAddress"
+         , max("timestamp") AS "timestamp"
+         , true as "isWrapped"
+         , 'static' as "circlesType"
+    from (
+             select *
+             from static_from_transfers
+             union all
+             select *
+             from static_to_transfers
+         ) as t
+    group by account
+           , "tokenAddress"
+),
+
+demurraged_wrapped_token_transfers as (
+    select t."blockNumber"
+         , t."timestamp"
+         , t."transactionIndex"
+         , t."logIndex"
+         , t."transactionHash"
+         , t."tokenAddress"
+         , t."from"
+         , t."to"
+         , t."amount"
+    from "CrcV2_Erc20WrapperTransfer" t
+             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 0 and d."erc20Wrapper" = t."tokenAddress"
+    order by t."blockNumber", t."transactionIndex", t."logIndex"
+), demurraged_wrapped_from_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."from" as "account"
+         , -t1."amount" as diff
+    from demurraged_wrapped_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
+), demurraged_wrapped_to_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."to" as "account"
+         , t1."amount" as diff
+    from demurraged_wrapped_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
+), demurraged_wrapped_sum as (
+    select floor(crc_demurrage(1675209600::bigint, max("timestamp"), sum(diff))) AS demurraged_balance
+         , account
+         , "tokenAddress"
+         , max("timestamp") AS "timestamp"
+         , true as "isWrapped"
+         , 'demurraged' as "circlesType"
+    from (
+             select *
+             from demurraged_wrapped_from_transfers
+             union all
+             select *
+             from demurraged_wrapped_to_transfers
+         ) as t
+    group by account
+           , "tokenAddress"
+),
+
+all_transfers as (
+    select "static_balance" as balance
+         , "account"
+         , "tokenAddress"
+         , "isWrapped"
+         , "circlesType"
+    from static_sum
+    union all
+    select "demurraged_balance" as balance
+         , "account"
+         , "tokenAddress"
+         , "isWrapped"
+         , "circlesType"
+    from demurraged_wrapped_sum
+    union all
+    select
+        "demurragedTotalBalance" as balance
+         ,"account"
+         ,"tokenAddress"
+         ,false AS "isWrapped"
+         ,'demurraged' AS "circlesType"
+    from "V_CrcV2_BalancesByAccountAndToken"
+)
+
+select balance::text
+     , account
+     , "tokenAddress"
+     , "isWrapped"
+     , "circlesType"
+from all_transfers
+where balance > 0;

--- a/Circles.Pathfinder.Cpp/Queries/trustQuery.sql
+++ b/Circles.Pathfinder.Cpp/Queries/trustQuery.sql
@@ -1,0 +1,11 @@
+SELECT t1.truster, t1.trustee FROM "V_CrcV2_TrustRelations" t1
+LEFT JOIN "CrcV2_RegisterGroup" t2 on t2."group" = t1.truster
+WHERE t2."group"  IS NULL
+
+UNION ALL
+
+SELECT t1.truster, t2."erc20Wrapper" AS trustee FROM "V_CrcV2_TrustRelations" t1
+INNER JOIN "CrcV2_ERC20WrapperDeployed" t2
+ON t2.avatar = t1.trustee
+LEFT JOIN "CrcV2_RegisterGroup" t3 on t3."group" = t1.truster
+WHERE t3."group"  IS NULL

--- a/Circles.Pathfinder.Cpp/README.md
+++ b/Circles.Pathfinder.Cpp/README.md
@@ -1,0 +1,29 @@
+# Circles Pathfinder C++ Loader
+
+This small command line tool loads balance and trust data from PostgreSQL
+using the same queries as the .NET implementation. It prints the number of
+rows returned from each query.
+
+## Building
+
+```bash
+mkdir build && cd build
+cmake ..
+make
+```
+
+## Configuration
+
+The tool relies on environment variables:
+
+- `POSTGRES_READONLY_CONNECTION_STRING` – connection string to the database.
+- `PATHFINDER_QUERY_DIR` – optional path to the directory containing
+  `balanceQuery.sql` and `trustQuery.sql` (defaults to `Queries` inside the
+  project directory).
+
+## Running
+
+```bash
+POSTGRES_READONLY_CONNECTION_STRING="your conn string" ./pathfinder_cpp
+```
+

--- a/Circles.Pathfinder.Cpp/src/AddressIdPool.cpp
+++ b/Circles.Pathfinder.Cpp/src/AddressIdPool.cpp
@@ -1,0 +1,52 @@
+#include "AddressIdPool.hpp"
+#include <algorithm>
+
+std::unordered_map<std::string, int> AddressIdPool::map;
+std::unordered_map<std::string, int> AddressIdPool::balanceNodeMap;
+std::vector<std::string> AddressIdPool::reverse;
+int AddressIdPool::nextId = 0;
+std::mutex AddressIdPool::mutex;
+
+int AddressIdPool::IdOf(const std::string& address) {
+    std::string lower = address;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = map.find(lower);
+    if (it != map.end()) return it->second;
+    int id = nextId++;
+    map[lower] = id;
+    reverse.push_back(lower);
+    return id;
+}
+
+int AddressIdPool::BalanceNodeIdOf(const std::string& address) {
+    std::string lower = address;
+    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = map.find(lower);
+    if (it != map.end()) return it->second;
+    int id = nextId++;
+    map[lower] = id;
+    balanceNodeMap[lower] = id;
+    reverse.push_back(lower);
+    return id;
+}
+
+const std::string& AddressIdPool::StringOf(int id) {
+    return reverse[id];
+}
+
+bool AddressIdPool::IsBalanceNode(int id) {
+    std::lock_guard<std::mutex> lock(mutex);
+    return balanceNodeMap.count(reverse[id]) > 0;
+}
+
+std::vector<std::string> AddressIdPool::GetAvatarSnapshot() {
+    std::lock_guard<std::mutex> lock(mutex);
+    std::vector<std::string> result;
+    for (const auto& s : reverse) {
+        if (s.find('-') == std::string::npos) result.push_back(s);
+    }
+    return result;
+}
+

--- a/Circles.Pathfinder.Cpp/src/AddressIdPool.hpp
+++ b/Circles.Pathfinder.Cpp/src/AddressIdPool.hpp
@@ -1,0 +1,25 @@
+#ifndef ADDRESS_ID_POOL_HPP
+#define ADDRESS_ID_POOL_HPP
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+
+class AddressIdPool {
+public:
+    static int IdOf(const std::string& address);
+    static int BalanceNodeIdOf(const std::string& address);
+    static const std::string& StringOf(int id);
+    static bool IsBalanceNode(int id);
+    static std::vector<std::string> GetAvatarSnapshot();
+
+private:
+    static std::unordered_map<std::string, int> map;
+    static std::unordered_map<std::string, int> balanceNodeMap;
+    static std::vector<std::string> reverse;
+    static int nextId;
+    static std::mutex mutex;
+};
+
+#endif

--- a/Circles.Pathfinder.Cpp/src/main.cpp
+++ b/Circles.Pathfinder.Cpp/src/main.cpp
@@ -1,0 +1,73 @@
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
+#include <libpq-fe.h>
+#include "AddressIdPool.hpp"
+
+std::string readFile(const std::string& path) {
+    std::ifstream in(path);
+    if (!in.is_open()) throw std::runtime_error("Unable to open " + path);
+    std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    return content;
+}
+
+int main() {
+    const char* connStr = std::getenv("POSTGRES_READONLY_CONNECTION_STRING");
+    if (!connStr) {
+        std::cerr << "POSTGRES_READONLY_CONNECTION_STRING not set" << std::endl;
+        return 1;
+    }
+
+    const char* queryDir = std::getenv("PATHFINDER_QUERY_DIR");
+    std::string dir = queryDir ? queryDir : std::string("Queries");
+    std::string balanceQuery = readFile(dir + "/balanceQuery.sql");
+    std::string trustQuery = readFile(dir + "/trustQuery.sql");
+
+    PGconn* conn = PQconnectdb(connStr);
+    if (PQstatus(conn) != CONNECTION_OK) {
+        std::cerr << "Connection failed: " << PQerrorMessage(conn);
+        PQfinish(conn);
+        return 1;
+    }
+
+    PGresult* res = PQexec(conn, balanceQuery.c_str());
+    if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+        std::cerr << "Balance query failed: " << PQerrorMessage(conn);
+        PQclear(res);
+        PQfinish(conn);
+        return 1;
+    }
+
+    int balanceRows = PQntuples(res);
+    for (int i = 0; i < balanceRows; ++i) {
+        std::string account = PQgetvalue(res, i, 1);
+        std::string token = PQgetvalue(res, i, 2);
+        AddressIdPool::IdOf(account);
+        AddressIdPool::IdOf(token);
+    }
+    PQclear(res);
+
+    res = PQexec(conn, trustQuery.c_str());
+    if (PQresultStatus(res) != PGRES_TUPLES_OK) {
+        std::cerr << "Trust query failed: " << PQerrorMessage(conn);
+        PQclear(res);
+        PQfinish(conn);
+        return 1;
+    }
+
+    int trustRows = PQntuples(res);
+    for (int i = 0; i < trustRows; ++i) {
+        std::string truster = PQgetvalue(res, i, 0);
+        std::string trustee = PQgetvalue(res, i, 1);
+        AddressIdPool::IdOf(truster);
+        AddressIdPool::IdOf(trustee);
+    }
+    PQclear(res);
+    PQfinish(conn);
+
+    std::cout << "Balances rows: " << balanceRows << std::endl;
+    std::cout << "Trust rows: " << trustRows << std::endl;
+
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- start C++ port in `Circles.Pathfinder.Cpp`
- implement `AddressIdPool` in C++
- add command line tool that loads data using libpq
- reuse existing SQL queries
- document build and configuration steps

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./pathfinder_cpp` *(fails: `POSTGRES_READONLY_CONNECTION_STRING not set`)*

------
https://chatgpt.com/codex/tasks/task_e_6849af86aa7c8329b2203c623b40b8b9