### PR TITLE
Add graph proximity ranking endpoint

### DIFF
--- a/Circles.Pathfinder.Host/Program.cs
+++ b/Circles.Pathfinder.Host/Program.cs
@@ -346,6 +346,56 @@ app.MapPost("/findPath", async (
     }
 });
 
+// POST  /rankByGraphProximity -----------------------------------------------
+app.MapPost("/rankByGraphProximity", async (
+    [FromBody] ProximityRequest request,
+    NetworkState state,
+    SemaphoreSlim sem,
+    CapacityGraphPool pool,
+    ILogger<Program> log) =>
+{
+    if (request.Reference is null || request.Addresses is null)
+        return Results.BadRequest("reference and addresses are required.");
+    if (request.Addresses.Count > 100)
+        return Results.BadRequest("maximum 100 addresses allowed.");
+
+    if (!sem.Wait(0))
+    {
+        FindPathMetrics.RejectedRequestsCounter.Inc();
+        log.LogWarning("Concurrency limit hit — request rejected");
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+    }
+
+    FindPathMetrics.InFlightRequestsGauge.Inc();
+    try
+    {
+        var balanceGraph = state.BalanceGraph;
+        if (balanceGraph is null)
+        {
+            log.LogWarning("Graphs not ready");
+            return Results.BadRequest("Graphs are not loaded yet.");
+        }
+
+        using var h = await pool.Rent(new FlowRequest(), balanceGraph, state.AccountTrusts);
+        var pf = new V2Pathfinder();
+        var ranks = pf.RankByGraphProximity(
+            h.Graph,
+            request.Reference.ToLowerInvariant(),
+            request.Addresses.Select(a => a.ToLowerInvariant()));
+        return Results.Ok(ranks);
+    }
+    catch (Exception ex) when (ex is not OutOfMemoryException)
+    {
+        log.LogWarning(ex, "rankByGraphProximity threw non-fatal exception");
+        return Results.StatusCode(StatusCodes.Status500InternalServerError);
+    }
+    finally
+    {
+        sem.Release();
+        FindPathMetrics.InFlightRequestsGauge.Dec();
+    }
+});
+
 app.MapGet("/snapshot", async (NetworkState state) =>
 {
     var graphsReady = state.BalanceGraph is not null &&

--- a/Circles.Pathfinder/DTOs/ProximityRank.cs
+++ b/Circles.Pathfinder/DTOs/ProximityRank.cs
@@ -1,0 +1,3 @@
+namespace Circles.Pathfinder.DTOs;
+
+public record ProximityRank(string Address, int Distance);

--- a/Circles.Pathfinder/DTOs/ProximityRequest.cs
+++ b/Circles.Pathfinder/DTOs/ProximityRequest.cs
@@ -1,0 +1,7 @@
+namespace Circles.Pathfinder.DTOs;
+
+public class ProximityRequest
+{
+    public string? Reference { get; set; }
+    public List<string>? Addresses { get; set; }
+}

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -295,4 +295,69 @@ public class V2Pathfinder
     }
 
     private bool IsBalanceNode(int addr) => AddressIdPool.IsBalanceNode(addr);
+
+    /* --------------------------------------------------------------------
+     * Rank a set of addresses by their graph distance to a reference.
+     * The distance calculation can be swapped by providing a custom metric
+     * implementation.
+     * ------------------------------------------------------------------ */
+    public delegate Dictionary<int, int> ProximityMetric(CapacityGraph g, int referenceId);
+
+    public List<ProximityRank> RankByGraphProximity(
+        CapacityGraph graph,
+        string referenceAddress,
+        IEnumerable<string> addresses,
+        ProximityMetric? metric = null)
+    {
+        if (graph == null) throw new ArgumentNullException(nameof(graph));
+        if (referenceAddress == null) throw new ArgumentNullException(nameof(referenceAddress));
+
+        var unique = addresses.Distinct(StringComparer.OrdinalIgnoreCase).ToList();
+        int referenceId = AddressIdPool.IdOf(referenceAddress);
+
+        var distances = (metric ?? DefaultBfsMetric)(graph, referenceId);
+
+        var ranked = new List<ProximityRank>(unique.Count);
+        foreach (var addr in unique)
+        {
+            int id = AddressIdPool.IdOf(addr);
+            distances.TryGetValue(id, out int dist);
+            ranked.Add(new ProximityRank(addr, dist));
+        }
+
+        return ranked.OrderBy(r => r.Distance).ToList();
+    }
+
+    private static Dictionary<int, int> DefaultBfsMetric(CapacityGraph g, int start)
+    {
+        var result = new Dictionary<int, int> { [start] = 0 };
+        var q = new Queue<int>();
+        q.Enqueue(start);
+
+        var adj = new Dictionary<int, List<int>>();
+        foreach (var e in g.Edges)
+        {
+            if (e.InitialCapacity <= 0) continue;
+            if (!adj.TryGetValue(e.From, out var list))
+            {
+                list = new List<int>();
+                adj[e.From] = list;
+            }
+            list.Add(e.To);
+        }
+
+        while (q.Count > 0)
+        {
+            int cur = q.Dequeue();
+            if (!adj.TryGetValue(cur, out var neigh)) continue;
+            foreach (var n in neigh)
+            {
+                if (result.ContainsKey(n)) continue;
+                result[n] = result[cur] + 1;
+                q.Enqueue(n);
+            }
+        }
+
+        return result;
+    }
 }


### PR DESCRIPTION
## Summary
- implement RankByGraphProximity in `V2Pathfinder`
- add DTOs for proximity ranking request & response
- expose `/rankByGraphProximity` POST endpoint in the host

## Testing
- `dotnet test Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ad18238ec8329bd4f341f78e4df7b