### PR TITLE
Fixes _indexerContext.NethermindApi.RpcModuleProvider is not set & relation "CrcV2_AffiliateGroupChanged" does not exist at character 501

### DIFF
--- a/Circles.Index.Postgres/PostgresDb.cs
+++ b/Circles.Index.Postgres/PostgresDb.cs
@@ -111,30 +111,34 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
         using var transaction = connection.BeginTransaction();
         try
         {
-            StringBuilder ddlSql = new StringBuilder();
-            foreach (var table in Schema.Tables)
+            // --- PHASE 1: Create all TABLES and their INDEXES ---
+            StringBuilder tableAndIndexDdlSql = new StringBuilder();
+            foreach (var table in Schema.Tables.Values) // Iterate through all EventSchemas
             {
-                var ddl = GetDdl(table.Value);
-                ddlSql.AppendLine(ddl);
+                // Pass 'false' to GetDdl to indicate we are in the table creation phase
+                tableAndIndexDdlSql.AppendLine(GetDdl(table, false));
             }
+            ExecuteNonQuery(connection, tableAndIndexDdlSql.ToString());
 
-            ExecuteNonQuery(connection, ddlSql.ToString());
 
-            StringBuilder indexesSql = new StringBuilder();
-            foreach (var index in Schema.Indexes)
+            // --- PHASE 2: Create all VIEWS ---
+            StringBuilder viewDdlSql = new StringBuilder();
+            foreach (var view in Schema.Tables.Values) // Iterate again, this time for views
             {
-                var ddl = index.Value;
-                indexesSql.AppendLine(ddl);
+                // Pass 'true' to GetDdl to indicate we are in the view creation phase
+                viewDdlSql.AppendLine(GetDdl(view, true));
             }
+            // Execute views DDL. Use IF EXISTS and IF NOT EXISTS where appropriate in the SQL.
+            ExecuteNonQuery(connection, viewDdlSql.ToString());
 
-            ExecuteNonQuery(connection, indexesSql.ToString());
 
+            // --- PHASE 3: Add PRIMARY KEYS ---
             StringBuilder primaryKeyDdl = new StringBuilder();
             foreach (var table in Schema.Tables)
             {
                 if (table.Key.Namespace.StartsWith("V_"))
                 {
-                    // Skip views
+                    // Skip views for primary keys
                     continue;
                 }
 
@@ -153,10 +157,10 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
                         $"ALTER TABLE \"{table.Value.Namespace}_{table.Value.Table}\" ADD PRIMARY KEY (\"blockNumber\");");
                 }
                 else if (table.Value is
-                         {
-                             Namespace: Common.DatabaseSchema.SystemNamespace,
-                             Table: Common.DatabaseSchema.EventTableHeadTable
-                         })
+                {
+                    Namespace: Common.DatabaseSchema.SystemNamespace,
+                    Table: Common.DatabaseSchema.EventTableHeadTable
+                })
                 {
                     primaryKeyDdl.AppendLine(
                         $"ALTER TABLE \"{table.Value.Namespace}_{table.Value.Table}\" ADD PRIMARY KEY (\"tableName\");");
@@ -217,12 +221,14 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
         await writer.CompleteAsync();
     }
 
-    private string GetDdl(EventSchema @event)
+    private string GetDdl(EventSchema @event, bool isViewPhase)
     {
         StringBuilder ddlSql = new StringBuilder();
 
-        if (!@event.Namespace.StartsWith("V_"))
+        if (!@event.Namespace.StartsWith("V_")) // This is a TABLE
         {
+            if (isViewPhase) return ""; // Skip tables if we are in the view phase
+
             ddlSql.AppendLine($"CREATE TABLE IF NOT EXISTS \"{@event.Namespace}_{@event.Table}\" (");
 
             List<string> columnDefinitions = new List<string>();
@@ -240,30 +246,27 @@ public class PostgresDb(string connectionString, IDatabaseSchema schema)
             ddlSql.AppendLine(");");
             ddlSql.AppendLine();
 
-            // Generate index creation statements
-            var indexedColumns = @event.Columns
-                .Where(column => column.IsIndexed);
+            // Generate index creation statements (usually after tables, before views)
+            var indexedColumns = @event.Columns.Where(column => column.IsIndexed);
 
             foreach (var column in indexedColumns)
             {
-                if (@event.Namespace.StartsWith("V_"))
-                {
-                    // Dirty way to skip indexes and primary keys for views
-                    continue;
-                }
-
                 string indexName = $"idx_{@event.Namespace}_{@event.Table}_{column.Column}";
                 ddlSql.AppendLine(
                     $"CREATE INDEX IF NOT EXISTS \"{indexName}\" ON \"{@event.Namespace}_{@event.Table}\" (\"{column.Column}\");");
             }
         }
-
-        // If the event schema has a SqlMigrationItem, execute it
-        if (@event.SqlMigrationItem != null)
+        else // This is a VIEW (Namespace starts with V_)
         {
-            ddlSql.AppendLine();
-            ddlSql.AppendLine(@event.SqlMigrationItem.Sql);
-            ddlSql.AppendLine(";"); // An additional semicolon doesn't hurt
+            if (!isViewPhase) return ""; // Skip views if we are in the table phase
+
+            // If the event schema has a SqlMigrationItem, it's likely the view definition
+            if (@event.SqlMigrationItem != null)
+            {
+                ddlSql.AppendLine();
+                ddlSql.AppendLine(@event.SqlMigrationItem.Sql); // This should be CREATE OR REPLACE VIEW
+                ddlSql.AppendLine(";");
+            }
         }
 
         return ddlSql.ToString();

--- a/Circles.Index/Plugin.cs
+++ b/Circles.Index/Plugin.cs
@@ -29,9 +29,12 @@ public class Plugin : INethermindPlugin
     private int _newItemsArrived;
     private long _latestHeadToIndex = -1;
     private Task? _ipfsDownloader;
+    private INethermindApi _nethermindApi = null!;
 
-    public async Task Init(INethermindApi nethermindApi)
+    public Task Init(INethermindApi nethermindApi)
     {
+        _nethermindApi = nethermindApi;
+
         ILogger baseLogger = nethermindApi.LogManager.GetClassLogger();
         InterfaceLogger pluginLogger = new LoggerWithPrefix($"{Name}: ", baseLogger);
 
@@ -120,7 +123,6 @@ public class Plugin : INethermindPlugin
         {
             logParsers.Add(new CirclesV2.AffiliateGroupRegistry.LogParser(settings.AffiliateGroupRegistry));
         }
-        
 
         _indexerContext = new Context(
             nethermindApi,
@@ -140,6 +142,8 @@ public class Plugin : INethermindPlugin
         // Run the downloader
         _ipfsDownloader = Task.Run(async () => await RunIpfsDownloader(settings),
             _cancellationTokenSource.Token);
+
+        return Task.CompletedTask;
     }
 
     private async Task RunIpfsDownloader(Settings settings)
@@ -320,23 +324,26 @@ public class Plugin : INethermindPlugin
 
     public Task InitRpcModules()
     {
-        if (_indexerContext?.NethermindApi.RpcModuleProvider == null)
+        if (_indexerContext == null)
         {
-            throw new Exception("_indexerContext.NethermindApi.RpcModuleProvider is not set");
+            throw new InvalidOperationException("InitRpcModules: _indexerContext is not set");
         }
-
-        var (getFromAPi, _) = _indexerContext.NethermindApi.ForRpc;
+        if (_nethermindApi.RpcModuleProvider == null)
+        {
+            _indexerContext.Logger.Error("RpcModuleProvider is NULL");
+            throw new InvalidOperationException("RpcModuleProvider is null in InitRpcModules. Nethermind API might not be fully ready for plugin registration.");
+        }
+        if (_nethermindApi.SubscriptionFactory == null)
+        {
+            _indexerContext.Logger.Error("SubscriptionFactory is NULL");
+            throw new InvalidOperationException("SubscriptionFactory is null in InitRpcModules. Nethermind API might not be fully ready for plugin registration.");
+        }
 
         CirclesRpcModule circlesRpcModule = new(_indexerContext);
-        getFromAPi.RpcModuleProvider?.Register(
+        _nethermindApi.RpcModuleProvider.Register(
             new SingletonModulePool<ICirclesRpcModule>(circlesRpcModule));
 
-        if (getFromAPi.SubscriptionFactory == null)
-        {
-            throw new Exception("getFromAPi.SubscriptionFactory is not set");
-        }
-
-        getFromAPi.SubscriptionFactory.RegisterSubscriptionType<CirclesSubscriptionParams>(
+        _nethermindApi.SubscriptionFactory.RegisterSubscriptionType<CirclesSubscriptionParams>(
             "circles",
             (client, param) => new CirclesSubscription(client, _indexerContext, param));
 
@@ -345,7 +352,7 @@ public class Plugin : INethermindPlugin
         // TODO: Any event we can subscribe to that indicates that rpc is ready?
         _ = Task.Delay(10_000, _cancellationTokenSource.Token).ContinueWith(async _ =>
         {
-            await _indexerMachine.TransitionTo(StateMachine.State.Initial);
+            await _indexerMachine!.TransitionTo(StateMachine.State.Initial);
 
             _indexerContext.NethermindApi.BlockTree!.NewHeadBlock += (_, args) =>
             {

--- a/docker-compose.chiado.yml
+++ b/docker-compose.chiado.yml
@@ -1,5 +1,6 @@
 services:
   nethermind-chiado:
+    container_name: nethermind-chiado
     build:
       context: .
       dockerfile: x64.Dockerfile
@@ -41,6 +42,7 @@ services:
       - POSTGRES_CONNECTION_STRING=Server=postgres-chiado;Port=5432;Database=postgres;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
 
   postgres-chiado:
+    container_name: postgres-chiado
     image: postgres:16
     command: -c 'max_connections=100'
     restart: unless-stopped

--- a/docker-compose.gnosis.yml
+++ b/docker-compose.gnosis.yml
@@ -1,8 +1,9 @@
 services:
   nethermind-gnosis:
+    container_name: nethermind-gnosis
     build:
       context: .
-      dockerfile: x64.Dockerfile
+      dockerfile: arm64.Dockerfile
     restart: unless-stopped
     depends_on:
       - postgres-gnosis
@@ -60,6 +61,7 @@ services:
       - IPFS_MAX_PARALLELISM=192
   
   pathfinder:
+    container_name: pathfinder
     build:
       context: .
       dockerfile: pathfinder-host.Dockerfile
@@ -75,6 +77,7 @@ services:
       - POSTGRES_READONLY_CONNECTION_STRING=Server=postgres-gnosis;Port=5432;Database=postgres;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};
 
   postgres-gnosis:
+    container_name: postgres-gnosis
     image: postgres:17
     command: -c 'max_connections=100'
     restart: unless-stopped

--- a/docker-compose.gnosis.yml
+++ b/docker-compose.gnosis.yml
@@ -3,7 +3,7 @@ services:
     container_name: nethermind-gnosis
     build:
       context: .
-      dockerfile: arm64.Dockerfile
+      dockerfile: x64.Dockerfile
     restart: unless-stopped
     depends_on:
       - postgres-gnosis

--- a/docker-compose.spaceneth.yml
+++ b/docker-compose.spaceneth.yml
@@ -1,5 +1,6 @@
 services:
   circles-spaceneth:
+    container_name: circles-spaceneth
     depends_on:
       - db2
     restart: unless-stopped


### PR DESCRIPTION
I've encountered several error before I could spin up all containers successfully.

The logs attached:

1) Nethermind crashes, as the _indexerContext.NethermindApi.RpcModuleProvider is not yet ready:

```shell
nethermind-gnosis-1  | 27 Jul 13:45:23 | Step StepWrapper              failed after 9,420ms System.Exception: _indexerContext.NethermindApi.RpcModuleProvider is not set
nethermind-gnosis-1  |    at Circles.Index.Plugin.InitRpcModules()
nethermind-gnosis-1  |    at Nethermind.Init.Steps.RegisterPluginRpcModules.Execute(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/RegisterPluginRpcModules.cs:line 27
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.StepWrapper.StartExecute(IEnumerable`1 dependentSteps, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 167
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.ExecuteStep(StepWrapper stepWrapper, StepInfo stepInfo, Dictionary`2 stepBaseTypeMap, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 103
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.ReviewFailedAndThrow(Task task) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 150
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.InitializeAll(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 48
nethermind-gnosis-1  |    at Nethermind.Runner.Ethereum.EthereumRunner.Start(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs:line 30
nethermind-gnosis-1  |    at Program.<>c__DisplayClass0_0.<<<Main>$>g__RunAsync|2>d.MoveNext() in /src/Nethermind/Nethermind.Runner/Program.cs:line 208
nethermind-gnosis-1  | 27 Jul 13:45:23 | A critical error has occurred System.Exception: _indexerContext.NethermindApi.RpcModuleProvider is not set
nethermind-gnosis-1  |    at Circles.Index.Plugin.InitRpcModules()
nethermind-gnosis-1  |    at Nethermind.Init.Steps.RegisterPluginRpcModules.Execute(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/RegisterPluginRpcModules.cs:line 27
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.StepWrapper.StartExecute(IEnumerable`1 dependentSteps, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 167
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.ExecuteStep(StepWrapper stepWrapper, StepInfo stepInfo, Dictionary`2 stepBaseTypeMap, CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 103
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.ReviewFailedAndThrow(Task task) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 150
nethermind-gnosis-1  |    at Nethermind.Init.Steps.EthereumStepsManager.InitializeAll(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Init/Steps/EthereumStepsManager.cs:line 48
nethermind-gnosis-1  |    at Nethermind.Runner.Ethereum.EthereumRunner.Start(CancellationToken cancellationToken) in /src/Nethermind/Nethermind.Runner/Ethereum/EthereumRunner.cs:line 30
nethermind-gnosis-1  |    at Program.<>c__DisplayClass0_0.<<<Main>$>g__RunAsync|2>d.MoveNext() in /src/Nethermind/Nethermind.Runner/Program.cs:line 208
```

2) Postgres doesn't execute all sql as there are entities not yet defined:

```shell
postgres-gnosis-1    | 2025-07-27 15:13:57.175 UTC [69] ERROR:  relation "CrcV2_AffiliateGroupChanged" does not exist at character 501
postgres-gnosis-1    | 2025-07-27 15:13:57.175 UTC [69] STATEMENT:  create or replace view "V_CrcV2_AffiliateMembersCount_1h" ("group", "timestamp", "value") as
postgres-gnosis-1    | 
postgres-gnosis-1    |  WITH
postgres-gnosis-1    | 
postgres-gnosis-1    |  affiliate_groups_sparse AS (
postgres-gnosis-1    |      SELECT
postgres-gnosis-1    |          "timestamp"
postgres-gnosis-1    |          ,affiliate_group AS "group"
postgres-gnosis-1    |          ,SUM(cnt) AS members_change
postgres-gnosis-1    |      FROM (
postgres-gnosis-1    |          SELECT
postgres-gnosis-1    |              "timestamp"
postgres-gnosis-1    |              ,affiliate_group
postgres-gnosis-1    |              ,SUM(cnt) AS cnt
postgres-gnosis-1    |          FROM (
postgres-gnosis-1    |              SELECT 
postgres-gnosis-1    |                  "timestamp"
postgres-gnosis-1    |                  ,"newGroup" AS affiliate_group
postgres-gnosis-1    |                  ,COUNT(*) AS cnt
postgres-gnosis-1    |              FROM "CrcV2_AffiliateGroupChanged"
postgres-gnosis-1    |              GROUP BY 1, 2
postgres-gnosis-1    |          
postgres-gnosis-1    |              UNION ALL
postgres-gnosis-1    |          
postgres-gnosis-1    |              SELECT 
postgres-gnosis-1    |                  "timestamp"
postgres-gnosis-1    |                  ,"oldGroup" AS affiliate_group
postgres-gnosis-1    |                  ,-COUNT(*) AS cnt
postgres-gnosis-1    |              FROM "CrcV2_AffiliateGroupChanged"
postgres-gnosis-1    |              WHERE "oldGroup" != '0x0000000000000000000000000000000000000000'
postgres-gnosis-1    |              GROUP BY 1, 2
postgres-gnosis-1    |          )
postgres-gnosis-1    |          GROUP BY 1, 2
postgres-gnosis-1    |      ) 
postgres-gnosis-1    |          GROUP BY 1, 2
postgres-gnosis-1    |  ),
postgres-gnosis-1    | 
postgres-gnosis-1    |  affiliate_groups_hourly_sparse AS (
postgres-gnosis-1    |      SELECT 
postgres-gnosis-1    |          date_trunc('hour',TO_TIMESTAMP("timestamp")) AS "timestamp"
postgres-gnosis-1    |          ,"group"
postgres-gnosis-1    |          ,SUM(members_change) AS members_change
postgres-gnosis-1    |      FROM 
postgres-gnosis-1    |          affiliate_groups_sparse
postgres-gnosis-1    |          GROUP BY 1, 2
postgres-gnosis-1    |  ),
postgres-gnosis-1    | 
postgres-gnosis-1    |  min_max_per_group AS (
postgres-gnosis-1    |      SELECT
postgres-gnosis-1    |          "group",
postgres-gnosis-1    |          MIN("timestamp") AS min_timestamp
postgres-gnosis-1    |      FROM 
postgres-gnosis-1    |          affiliate_groups_hourly_sparse
postgres-gnosis-1    |      GROUP BY 1
postgres-gnosis-1    |  ),
postgres-gnosis-1    | 
postgres-gnosis-1    |  calendar AS (
postgres-gnosis-1    |      SELECT
postgres-gnosis-1    |          g."group",
postgres-gnosis-1    |          generate_series(
postgres-gnosis-1    |              g.min_timestamp,
postgres-gnosis-1    |              date_trunc('hour', CURRENT_TIMESTAMP),
postgres-gnosis-1    |              interval '1 hour'
postgres-gnosis-1    |          ) AS "timestamp"
postgres-gnosis-1    |      FROM min_max_per_group g
postgres-gnosis-1    |  )
postgres-gnosis-1    | 
postgres-gnosis-1    | 
postgres-gnosis-1    | 
postgres-gnosis-1    |  SELECT 
postgres-gnosis-1    |          t1."group",
postgres-gnosis-1    |          t1."timestamp",
postgres-gnosis-1    |          SUM(COALESCE(t2.members_change, 0))  OVER (PARTITION BY t1."group" ORDER BY t1."timestamp") AS value
postgres-gnosis-1    |  FROM 
postgres-gnosis-1    |          calendar t1
postgres-gnosis-1    |  LEFT JOIN 
postgres-gnosis-1    |          affiliate_groups_hourly_sparse t2
postgres-gnosis-1    |          ON t1."group" = t2."group" AND t1."timestamp" = t2."timestamp" 
```

Also, for consistency I've add container_name to all docker services. 

I could also separate the PR into several if preferred.

Hope it helps!

