### PR TITLE
fix: finer grained indexes for offers

### DIFF
--- a/Circles.Index.CirclesV2.TokenOffers/DatabaseSchema.cs
+++ b/Circles.Index.CirclesV2.TokenOffers/DatabaseSchema.cs
@@ -44,7 +44,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("offerStart", ValueTypes.BigInt, true),
             new("offerEnd", ValueTypes.BigInt, true),
             new("orgName", ValueTypes.String, true),
-            new("acceptedCRC", ValueTypes.AddressArray, true)
+            new("acceptedCRC", ValueTypes.AddressArray, false)
         ]);
 
     public static readonly EventSchema ERC20TokenOfferCycleCreated = new(
@@ -105,9 +105,9 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
             new("nextOffer", ValueTypes.Address, true),
-            new("tokenPriceInCRC", ValueTypes.BigInt, true),
-            new("offerLimitInCRC", ValueTypes.BigInt, true),
-            new("acceptedCRC", ValueTypes.AddressArray, true)
+            new("tokenPriceInCRC", ValueTypes.BigInt, false),
+            new("offerLimitInCRC", ValueTypes.BigInt, false),
+            new("acceptedCRC", ValueTypes.AddressArray, false)
         ]);
 
     public static readonly EventSchema NextOfferTokensDeposited = new(
@@ -122,7 +122,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
             new("nextOffer", ValueTypes.Address, true),
-            new("amount", ValueTypes.BigInt, true)
+            new("amount", ValueTypes.BigInt, false)
         ]);
 
     public static readonly EventSchema OfferTrustSynced = new(
@@ -153,8 +153,8 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("emitter", ValueTypes.String, true),
             new("offer", ValueTypes.Address, true),
             new("account", ValueTypes.Address, true),
-            new("received", ValueTypes.BigInt, true),
-            new("spent", ValueTypes.BigInt, true)
+            new("received", ValueTypes.BigInt, false),
+            new("spent", ValueTypes.BigInt, false)
         ]);
 
     public static readonly EventSchema UnclaimedTokensWithdrawn = new(
@@ -169,7 +169,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
             new("offer", ValueTypes.Address, true),
-            new("amount", ValueTypes.BigInt, true)
+            new("amount", ValueTypes.BigInt, false)
         ]);
 
     // Offer events
@@ -185,8 +185,8 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
             new("account", ValueTypes.Address, true),
-            new("spent", ValueTypes.BigInt, true),
-            new("received", ValueTypes.BigInt, true)
+            new("spent", ValueTypes.BigInt, false),
+            new("received", ValueTypes.BigInt, false)
         ]);
 
     public static readonly EventSchema OfferTokensDeposited = new(
@@ -200,7 +200,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("logIndex", ValueTypes.Int, true, true),
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
-            new("amount", ValueTypes.BigInt, true)
+            new("amount", ValueTypes.BigInt, false)
         ]);
 
     // Provider events
@@ -217,7 +217,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("emitter", ValueTypes.String, true),
             new("offer", ValueTypes.Address, true),
             new("account", ValueTypes.Address, true),
-            new("weight", ValueTypes.BigInt, true)
+            new("weight", ValueTypes.BigInt, false)
         ]);
 
     public static readonly EventSchema WeightsFinalized = new(
@@ -232,8 +232,8 @@ public class DatabaseSchema : BaseDatabaseSchema
             new("transactionHash", ValueTypes.String, true),
             new("emitter", ValueTypes.String, true),
             new("offer", ValueTypes.Address, true),
-            new("accountsCount", ValueTypes.BigInt, true),
-            new("totalWeight", ValueTypes.BigInt, true)
+            new("accountsCount", ValueTypes.BigInt, false),
+            new("totalWeight", ValueTypes.BigInt, false)
         ]);
 
     public DatabaseSchema()


### PR DESCRIPTION
Delete the following indexes before restarting:
```
drop index "idx_CrcV2_TokenOffers_ERC20TokenOfferCreated_acceptedCRC";
drop index "idx_CrcV2_TokenOffers_NextOfferCreated_tokenPriceInCRC";
drop index "idx_CrcV2_TokenOffers_NextOfferCreated_offerLimitInCRC";
drop index "idx_CrcV2_TokenOffers_NextOfferCreated_acceptedCRC";
drop index "idx_CrcV2_TokenOffers_NextOfferTokensDeposited_amount";
drop index "idx_CrcV2_TokenOffers_OfferClaimedFromCycle_received";
drop index "idx_CrcV2_TokenOffers_OfferClaimedFromCycle_spent";
drop index "idx_CrcV2_TokenOffers_UnclaimedTokensWithdrawn_amount";
drop index "idx_CrcV2_TokenOffers_OfferTokensDeposited_amount";
drop index "idx_CrcV2_TokenOffers_OfferClaimed_spent";
drop index "idx_CrcV2_TokenOffers_OfferClaimed_received";
drop index "idx_CrcV2_TokenOffers_AccountWeightSet_weight";
drop index "idx_CrcV2_TokenOffers_WeightsFinalized_accountsCount";
drop index "idx_CrcV2_TokenOffers_WeightsFinalized_totalWeight";
```

Also roll back the index to block 42183680 (before the event that broke the indexer was emitted):

```
DELETE FROM "System_Block" WHERE "blockNumber" >= 42183681;
DELETE FROM "System_EventTableHead" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_Signup" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_OrganizationSignup" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_Trust" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_HubTransfer" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_Transfer" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_TransferSummary" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_PersonalMint" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_RegisterGroup" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_RegisterHuman" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_RegisterOrganization" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_Stopped" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_Trust" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_DiscountCost" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TransferSingle" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_ApprovalForAll" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TransferBatch" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_ERC20WrapperDeployed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_Erc20WrapperTransfer" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_DepositInflationary" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_WithdrawInflationary" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_DepositDemurraged" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_WithdrawDemurraged" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_StreamCompleted" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_GroupMint" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_FlowEdgesScopeSingleStarted" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_FlowEdgesScopeLastEnded" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TransferSummary" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_RegisterShortName" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CidV0" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CreateVault" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CollateralLockedSingle" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CollateralLockedBatch" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_GroupRedeem" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_GroupRedeemCollateralReturn" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_GroupRedeemCollateralBurn" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CMGroupCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_BaseGroupCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_BaseGroupOwnerUpdated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_BaseGroupServiceUpdated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_BaseGroupFeeCollectionUpdated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CirclesBackingDeployed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_LBPDeployed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CirclesBackingInitiated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_CirclesBackingCompleted" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_Released" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_AccountWeightProviderCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_ERC20TokenOfferCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_ERC20TokenOfferCycleCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_CycleConfiguration" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_NextOfferCreated" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_NextOfferTokensDeposited" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_OfferTrustSynced" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_OfferClaimedFromCycle" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_UnclaimedTokensWithdrawn" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_OfferClaimed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_OfferTokensDeposited" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_AccountWeightSet" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_TokenOffers_WeightsFinalized" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_AffiliateGroupChanged" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_NotificationFailed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_NotificationSuccessful" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_InvitationEscrow_InvitationEscrowed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_InvitationEscrow_InvitationRedeemed" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_InvitationEscrow_InvitationRefunded" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_InvitationEscrow_InvitationRevoked" WHERE "blockNumber" >= 42183681;
DELETE FROM "Safe_ProxyCreation" WHERE "blockNumber" >= 42183681;
DELETE FROM "Safe_SafeSetup" WHERE "blockNumber" >= 42183681;
DELETE FROM "Safe_AddedOwner" WHERE "blockNumber" >= 42183681;
DELETE FROM "Safe_RemovedOwner" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV1_UpdateMetadataDigest" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_UpdateMetadataDigest" WHERE "blockNumber" >= 42183681;
DELETE FROM "CrcV2_OIC_OpenMiddlewareTransfer" WHERE "blockNumber" >= 42183681;
```