### PR TITLE
Feat/mint along a path

### DIFF
--- a/Circles.Pathfinder.Host/Settings.cs
+++ b/Circles.Pathfinder.Host/Settings.cs
@@ -16,4 +16,10 @@ public class Settings
     public readonly int MaxConcurrentRequests = Environment.GetEnvironmentVariable("MAX_CONCURRENT_REQUESTS") != null
         ? int.Parse(Environment.GetEnvironmentVariable("MAX_CONCURRENT_REQUESTS")!)
         : Environment.ProcessorCount * 2;
+
+    // Router address used for post-processing Avatar→Group transfers.
+    // The router node is tracked but not part of the capacity graph during pathfinding.
+    public readonly string RouterAddress =
+        Environment.GetEnvironmentVariable("ROUTER_ADDRESS")
+        ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f"; 
 }

--- a/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -30,7 +30,11 @@ public class NetworkStateUpdaterService : BackgroundService
     {
         var loadGraph = new LoadGraph(_settings.IndexReadonlyDbConnectionString);
         var graphFactory = new GraphFactory();
+        graphFactory.SetLoadGraph(loadGraph);
 
+        _pool.SetLoadGraph(loadGraph);
+        _pool.SetRouterAddress(_settings.RouterAddress);
+        
         long lastBlock = 0;
 
         while (!stoppingToken.IsCancellationRequested)
@@ -39,7 +43,7 @@ public class NetworkStateUpdaterService : BackgroundService
             lastBlock = await WaitForNextBlock(stoppingToken, lastBlock);
             _networkState.Replace(lastKnownBlockNumber: lastBlock);
 
-            _log.LogDebug("↳ got block {Block}", lastBlock);
+            _log.LogDebug("→ got block {Block}", lastBlock);
 
             var swTotal = Stopwatch.StartNew();
 
@@ -64,9 +68,12 @@ public class NetworkStateUpdaterService : BackgroundService
             await Task.WhenAll(trustTask, balanceTask);
             swTotal.Stop();
 
+            // Build full capacity graph with router address
             var cap = await CapacityGraphPool.BuildFullGraph(
                 _networkState.BalanceGraph,
-                _networkState.AccountTrusts
+                _networkState.AccountTrusts,
+                loadGraph,
+                _settings.RouterAddress
             );
             var snap = new CapacityGraphSnapshot(lastBlock, cap);
             _pool.UpdateSnapshot(snap);

--- a/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
+++ b/Circles.Pathfinder.Tests/NetworkPathfinderTests.cs
@@ -4,6 +4,8 @@ using System.Text.Json;
 using Circles.Pathfinder.DTOs;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Edges;
+using Circles.Pathfinder.Nodes;
 using Nethermind.Int256;
 using System.Text.Json.Serialization;
 using Circles.Index.Common;
@@ -38,6 +40,48 @@ public class PathfinderTestCase
 }
 
 /// <summary>
+/// NetworkSnapshot model matching the /snapshot endpoint response
+/// </summary>
+public class NetworkSnapshotResponse
+{
+    [JsonPropertyName("blockNumber")] 
+    public long BlockNumber { get; set; }
+    
+    [JsonPropertyName("addresses")] 
+    public List<string> Addresses { get; set; } = new();
+    
+    [JsonPropertyName("trust")] 
+    public Dictionary<int, HashSet<int>> Trust { get; set; } = new();
+    
+    [JsonPropertyName("balance")] 
+    public Dictionary<int, List<BalanceNodeJson>> Balance { get; set; } = new();
+}
+
+/// <summary>
+/// BalanceNode representation in JSON
+/// </summary>
+public class BalanceNodeJson
+{
+    [JsonPropertyName("address")] 
+    public int Address { get; set; }
+    
+    [JsonPropertyName("holder")] 
+    public int Holder { get; set; }
+    
+    [JsonPropertyName("token")] 
+    public int Token { get; set; }
+    
+    [JsonPropertyName("amount")] 
+    public long Amount { get; set; }
+    
+    [JsonPropertyName("isWrapped")] 
+    public bool IsWrapped { get; set; }
+    
+    [JsonPropertyName("isStatic")] 
+    public bool IsStatic { get; set; }
+}
+
+/// <summary>
 /// Tests for the pathfinder service using real network data via HTTP requests.
 /// These tests ensure the pathfinder respects flow conservation, token filters, and other integrity rules.
 /// </summary>
@@ -54,6 +98,10 @@ public class NetworkPathfinderTests
     private GraphFactory? _graphFactory;
     private bool _graphsLoaded = false;
 
+    // Router and Groups - loaded dynamically from database
+    private readonly string _routerAddress;
+    private HashSet<string> _dynamicGroups = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    private Dictionary<string, HashSet<string>> _groupTrustedTokens = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
     // ANSI color escape sequences for console output
     private static class ConsoleColors
     {
@@ -71,17 +119,23 @@ public class NetworkPathfinderTests
         // Set the base URL for your Pathfinder service
         _pathfinderBaseUrl = Environment.GetEnvironmentVariable("PATHFINDER_URL") ?? "http://localhost:8545";
 
+        // Get router address from environment or use default
+        _routerAddress = Environment.GetEnvironmentVariable("ROUTER_ADDRESS") 
+                        ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
         _jsonOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
+
     }
 
     [OneTimeSetUp]
     public void OneTimeSetUp()
     {
         _httpClient = new HttpClient();
+        _httpClient.Timeout = TimeSpan.FromSeconds(30); // Set reasonable timeout
         Console.WriteLine(
             $"{ConsoleColors.Cyan}Connecting to Pathfinder service at: {_pathfinderBaseUrl}{ConsoleColors.Reset}");
 
@@ -101,6 +155,26 @@ public class NetworkPathfinderTests
     /// </summary>
     private void LoadGraphs()
     {
+        // First try to load from snapshot endpoint
+        try
+        {
+            Console.WriteLine($"{ConsoleColors.Cyan}Loading network graphs from pathfinder snapshot...{ConsoleColors.Reset}");
+            
+            var loadTask = LoadGraphsFromSnapshot();
+            loadTask.Wait(); // Wait synchronously since we're in a non-async method
+            
+            if (_graphsLoaded)
+            {
+                return; // Successfully loaded from snapshot
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(
+                $"{ConsoleColors.Yellow}Could not load from snapshot: {ex.Message}{ConsoleColors.Reset}");
+        }
+
+        // Fall back to original database loading method
         // Get connection string from environment variable
         string? connectionString = Environment.GetEnvironmentVariable("POSTGRES_READONLY_CONNECTION_STRING");
 
@@ -129,12 +203,36 @@ public class NetworkPathfinderTests
                 Console.WriteLine("Loading balance graph...");
                 _balanceGraph = _graphFactory.V2BalanceGraph(loadGraph);
 
+                // Load groups dynamically from database
+                Console.WriteLine("Loading groups...");
+                var groups = loadGraph.LoadGroups();
+                foreach (var groupAddress in groups)
+                {
+                    _dynamicGroups.Add(groupAddress.ToLowerInvariant());
+                }
+                Console.WriteLine($"Loaded {_dynamicGroups.Count} groups from database");
+
+                // Load group trust relationships
+                Console.WriteLine("Loading group trust relationships...");
+                var groupTrusts = loadGraph.LoadGroupTrusts();
+                foreach (var (groupAddress, trustedToken) in groupTrusts)
+                {
+                    var groupLower = groupAddress.ToLowerInvariant();
+                    if (!_groupTrustedTokens.TryGetValue(groupLower, out var trustedSet))
+                    {
+                        trustedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        _groupTrustedTokens[groupLower] = trustedSet;
+                    }
+                    trustedSet.Add(trustedToken.ToLowerInvariant());
+                }
+
                 if (_trustGraph != null && _balanceGraph != null)
                 {
                     Console.WriteLine(
                         $"{ConsoleColors.Green}Successfully loaded trust and balance graphs for validation{ConsoleColors.Reset}");
                     Console.WriteLine($"Trust graph: {_trustGraph.Edges.Count} trust relationships");
                     Console.WriteLine($"Balance graph: {_balanceGraph.BalanceNodes.Count} balances");
+                    Console.WriteLine($"Groups: {_dynamicGroups.Count} registered groups");
                     _graphsLoaded = true;
                 }
                 else
@@ -153,6 +251,171 @@ public class NetworkPathfinderTests
     }
 
     /// <summary>
+    /// Loads trust and balance graphs from the pathfinder's /snapshot endpoint
+    /// </summary>
+    private async Task LoadGraphsFromSnapshot()
+    {
+        try
+        {
+            // Get the current snapshot from the pathfinder
+            var response = await _httpClient!.GetAsync($"{_pathfinderBaseUrl}/snapshot");
+            
+            if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            {
+                Console.WriteLine($"{ConsoleColors.Yellow}Pathfinder graphs not ready yet. Falling back to database.{ConsoleColors.Reset}");
+                return;
+            }
+            
+            response.EnsureSuccessStatusCode();
+            var json = await response.Content.ReadAsStringAsync();
+            
+            // Deserialize the snapshot
+            var snapshot = JsonSerializer.Deserialize<NetworkSnapshotResponse>(json, _jsonOptions);
+            
+            if (snapshot == null)
+            {
+                Console.WriteLine($"{ConsoleColors.Red}Failed to deserialize snapshot response{ConsoleColors.Reset}");
+                return;
+            }
+            
+            Console.WriteLine($"Loaded snapshot at block {snapshot.BlockNumber}");
+            Console.WriteLine($"Trust relationships: {snapshot.Trust.Count} trusters");
+            Console.WriteLine($"Balance holders: {snapshot.Balance.Count}");
+            
+            // Build trust graph from snapshot
+            _trustGraph = new TrustGraph();
+            foreach (var (trusterId, trustees) in snapshot.Trust)
+            {
+                if (!_trustGraph.AvatarNodes.ContainsKey(trusterId))
+                {
+                    _trustGraph.AddAvatar(trusterId);
+                }
+                
+                foreach (var trusteeId in trustees)
+                {
+                    if (!_trustGraph.AvatarNodes.ContainsKey(trusteeId))
+                    {
+                        _trustGraph.AddAvatar(trusteeId);
+                    }
+                    _trustGraph.AddTrustEdge(trusterId, trusteeId);
+                }
+            }
+            
+            // Build balance graph from snapshot
+            _balanceGraph = new BalanceGraph();
+            foreach (var (holderId, balanceNodes) in snapshot.Balance)
+            {
+                if (!_balanceGraph.AvatarNodes.ContainsKey(holderId))
+                {
+                    _balanceGraph.AddAvatar(holderId);
+                }
+                
+                foreach (var node in balanceNodes)
+                {
+                    _balanceGraph.AddBalance(node.Holder, node.Token, node.Amount, node.IsWrapped, node.IsStatic);
+                }
+            }
+            
+            // Try to identify groups from snapshot using the router
+            int routerId = AddressIdPool.IdOf(_routerAddress.ToLowerInvariant());
+            
+            // Check if router exists in trust data and what it trusts (likely groups)
+            if (snapshot.Trust.TryGetValue(routerId, out var routerTrusts))
+            {
+                foreach (var trustedByRouter in routerTrusts)
+                {
+                    string address = AddressIdPool.StringOf(trustedByRouter);
+                    _dynamicGroups.Add(address);
+                }
+            }
+            
+            // Extract group trust relationships
+            foreach (var groupAddress in _dynamicGroups)
+            {
+                int groupId = AddressIdPool.IdOf(groupAddress);
+                
+                if (snapshot.Trust.TryGetValue(groupId, out var trustedTokens))
+                {
+                    var trustedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                    foreach (var tokenId in trustedTokens)
+                    {
+                        trustedSet.Add(AddressIdPool.StringOf(tokenId));
+                    }
+                    _groupTrustedTokens[groupAddress] = trustedSet;
+                }
+            }
+            
+            // Try to load additional groups from database if available
+            string? connectionString = Environment.GetEnvironmentVariable("POSTGRES_READONLY_CONNECTION_STRING");
+            if (!string.IsNullOrEmpty(connectionString))
+            {
+                try
+                {
+                    var loadGraph = new LoadGraph(connectionString);
+                    var groups = loadGraph.LoadGroups();
+                    foreach (var groupAddress in groups)
+                    {
+                        _dynamicGroups.Add(groupAddress.ToLowerInvariant());
+                    }
+                    
+                    // Load group trust relationships
+                    var groupTrusts = loadGraph.LoadGroupTrusts();
+                    foreach (var (groupAddress, trustedToken) in groupTrusts)
+                    {
+                        var groupLower = groupAddress.ToLowerInvariant();
+                        if (!_groupTrustedTokens.TryGetValue(groupLower, out var trustedSet))
+                        {
+                            trustedSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                            _groupTrustedTokens[groupLower] = trustedSet;
+                        }
+                        trustedSet.Add(trustedToken.ToLowerInvariant());
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"{ConsoleColors.Yellow}Could not load additional groups from database: {ex.Message}{ConsoleColors.Reset}");
+                }
+            }
+            
+            _graphsLoaded = true;
+            
+            Console.WriteLine($"{ConsoleColors.Green}Successfully loaded graphs from snapshot{ConsoleColors.Reset}");
+            Console.WriteLine($"Trust graph: {_trustGraph.Edges.Count} trust relationships");
+            Console.WriteLine($"Balance graph: {_balanceGraph.BalanceNodes.Count} balance nodes");
+            Console.WriteLine($"Groups: {_dynamicGroups.Count} groups identified");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"{ConsoleColors.Red}Failed to load snapshot: {ex.Message}{ConsoleColors.Reset}");
+            _graphsLoaded = false;
+        }
+    }
+
+    /// <summary>
+    /// Check if an address is the Router
+    /// </summary>
+    private bool IsRouter(string address)
+    {
+        return address.Equals(_routerAddress, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Check if an address is a known Group
+    /// </summary>
+    private bool IsGroup(string address)
+    {
+        return _dynamicGroups.Contains(address.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Check if an address is a special node (Router or Group)
+    /// </summary>
+    private bool IsSpecialNode(string address)
+    {
+        return IsRouter(address) || IsGroup(address);
+    }
+
+    /// <summary>
     /// Check if a receiving address trusts the token they are receiving
     /// </summary>
     private bool CheckTrustRelationship(string receiver, string token)
@@ -163,20 +426,81 @@ public class NetworkPathfinderTests
             return true; // Skip validation if graph not available
         }
 
+        // Skip trust checks for Router (it's just a pass-through)
+        if (IsRouter(receiver))
+        {
+            return true;
+        }
+
+        // For Groups receiving from Router, check if group trusts the token
+        if (IsGroup(receiver))
+        {
+            var receiverLower = receiver.ToLowerInvariant();
+            var tokenLower = token.ToLowerInvariant();
+            
+            if (_groupTrustedTokens.TryGetValue(receiverLower, out var trustedTokens))
+            {
+                return trustedTokens.Contains(tokenLower);
+            }
+            // If no trust info found, assume it's valid (was validated during edge creation)
+            return true;
+        }
+
         // Convert addresses to lowercase for comparison
         var receiverId = AddressIdPool.IdOf(receiver);
-        var tokenOd = AddressIdPool.IdOf(token);
+        var tokenId = AddressIdPool.IdOf(token);
 
         // Check if there's a trust edge from receiver to token
         foreach (var edge in _trustGraph.Edges)
         {
-            if (edge.From == receiverId && edge.To == tokenOd)
+            if (edge.From == receiverId && edge.To == tokenId)
             {
                 return true;
             }
         }
 
         return false;
+    }
+
+    /// <summary>
+    /// Identify complete minting paths through Router and Groups
+    /// </summary>
+    private List<List<string>> IdentifyMintingPaths(List<TransferPathStep> transfers)
+    {
+        var paths = new List<List<string>>();
+        
+        // Look for transfers that go through Router
+        var routerIncoming = transfers.Where(t => IsRouter(t.To)).ToList();
+        
+        foreach (var incoming in routerIncoming)
+        {
+            // Find the corresponding Router -> Group transfer
+            var routerToGroup = transfers.FirstOrDefault(t => 
+                IsRouter(t.From) && 
+                IsGroup(t.To) && 
+                t.TokenOwner.Equals(incoming.TokenOwner, StringComparison.OrdinalIgnoreCase));
+            
+            if (routerToGroup != null)
+            {
+                // Find the Group -> Avatar transfer (with group token)
+                var groupToAvatar = transfers.FirstOrDefault(t =>
+                    t.From.Equals(routerToGroup.To, StringComparison.OrdinalIgnoreCase) &&
+                    t.TokenOwner.Equals(t.From, StringComparison.OrdinalIgnoreCase)); // Group token
+                
+                if (groupToAvatar != null)
+                {
+                    paths.Add(new List<string> 
+                    { 
+                        incoming.From, 
+                        _routerAddress, 
+                        routerToGroup.To, 
+                        groupToAvatar.To 
+                    });
+                }
+            }
+        }
+        
+        return paths;
     }
 
     /// <summary>
@@ -364,18 +688,11 @@ public class NetworkPathfinderTests
             Console.WriteLine($"Max flow: {result.MaxFlow}");
             Console.WriteLine($"Transfers: {result.Transfers.Count}");
 
-            // foreach (var transfer in result.Transfers)
-            // {
-            //     Console.WriteLine($"  {ConsoleColors.Blue}{transfer.From} -> {transfer.To}{ConsoleColors.Reset} via {ConsoleColors.Cyan}{transfer.TokenOwner}{ConsoleColors.Reset} for {transfer.Value}");
-            // }
-
             // Check if there's no flow (zero max flow)
             if (result.MaxFlow == "0" || result.Transfers.Count == 0)
             {
                 Console.WriteLine(
                     $"\n{ConsoleColors.Yellow}NO PATH FOUND:{ConsoleColors.Reset} No valid path exists between source and sink with the given constraints.");
-                // This is now considered a valid case, not a failure
-                //  return;
                 // FLOW ZERO CONSISTENCY CHECK
                 Console.WriteLine($"\n{ConsoleColors.Magenta}FLOW ZERO CONSISTENCY CHECK:{ConsoleColors.Reset}");
                 bool flowZeroConsistencyPassed = true;
@@ -472,10 +789,6 @@ public class NetworkPathfinderTests
                 validationPassed = false;
             }
 
-            // Verify flow conservation
-            //  Assert.That(totalOutflowFromSource, Is.EqualTo(maxFlow), "Total outflow from source doesn't match the max flow");
-            //  Assert.That(totalInflowToSink, Is.EqualTo(maxFlow), "Total inflow to sink doesn't match the max flow");
-
             // Check intermediate nodes for flow conservation
             var intermediateNodes = transfers
                 .Select(t => t.From.ToLower())
@@ -489,21 +802,55 @@ public class NetworkPathfinderTests
 
             foreach (var node in intermediateNodes)
             {
-                var outflow = CalculateTotalFlow(transfers, t => t.From.ToLower() == node);
-                var inflow = CalculateTotalFlow(transfers, t => t.To.ToLower() == node);
-
-                bool nodeFlowValid = inflow == outflow;
-                if (!nodeFlowValid)
+                // Special handling for groups - they convert tokens
+                if (IsGroup(node))
                 {
-                    Console.WriteLine(
-                        $"{ConsoleColors.Red}Intermediate node {node} has unbalanced flow:{ConsoleColors.Reset} inflow={inflow}, outflow={outflow}");
-                    allIntermediateNodesValid = false;
+                    var groupInflow = CalculateTotalFlow(transfers, t => t.To.ToLower() == node);
+                    var groupOutflow = CalculateTotalFlow(transfers, t => t.From.ToLower() == node);
+                    
+                    // For groups, inflow and outflow should match (minting preserves value)
+                    bool groupFlowValid = groupInflow == groupOutflow;
+                    if (!groupFlowValid)
+                    {
+                        Console.WriteLine(
+                            $"{ConsoleColors.Red}Group {node} has unbalanced minting:{ConsoleColors.Reset} " +
+                            $"inflow={groupInflow}, outflow={groupOutflow}");
+                        allIntermediateNodesValid = false;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Group {node} minting: {groupInflow} -> {groupOutflow} {ConsoleColors.Green}VALID{ConsoleColors.Reset}");
+                    }
                 }
+                else if (IsRouter(node))
+                {
+                    // Router should have balanced flow
+                    var routerInflow = CalculateTotalFlow(transfers, t => t.To.ToLower() == node);
+                    var routerOutflow = CalculateTotalFlow(transfers, t => t.From.ToLower() == node);
+                    
+                    bool routerFlowValid = routerInflow == routerOutflow;
+                    if (!routerFlowValid)
+                    {
+                        Console.WriteLine(
+                            $"{ConsoleColors.Red}Router has unbalanced flow:{ConsoleColors.Reset} " +
+                            $"inflow={routerInflow}, outflow={routerOutflow}");
+                        allIntermediateNodesValid = false;
+                    }
+                }
+                else
+                {
+                    // Normal intermediate node validation
+                    var outflow = CalculateTotalFlow(transfers, t => t.From.ToLower() == node);
+                    var inflow = CalculateTotalFlow(transfers, t => t.To.ToLower() == node);
 
-                //  Console.WriteLine($"Node {ConsoleColors.Blue}{node}{ConsoleColors.Reset}: Inflow = {inflow}, Outflow = {outflow} - {(nodeFlowValid ? ConsoleColors.Green + "VALID" : ConsoleColors.Red + "INVALID")}{ConsoleColors.Reset}");
-
-                //  Assert.That(inflow, Is.EqualTo(outflow),
-                //      $"Intermediate node {node} has unbalanced flow: inflow={inflow}, outflow={outflow}");
+                    bool nodeFlowValid = inflow == outflow;
+                    if (!nodeFlowValid)
+                    {
+                        Console.WriteLine(
+                            $"{ConsoleColors.Red}Intermediate node {node} has unbalanced flow:{ConsoleColors.Reset} inflow={inflow}, outflow={outflow}");
+                        allIntermediateNodesValid = false;
+                    }
+                }
             }
 
             Console.WriteLine(
@@ -520,8 +867,6 @@ public class NetworkPathfinderTests
                 var tokensUsedFromSource = sourceTransfers.Select(t => t.TokenOwner.ToLower()).Distinct().ToList();
 
                 Console.WriteLine($"\n{ConsoleColors.Magenta}FROM TOKENS FILTER CHECK{ConsoleColors.Reset}");
-                // Console.WriteLine($"Specified tokens: {string.Join(", ", fromTokens.Select(t => t.ToLower()))}");
-                // Console.WriteLine($"Used tokens: {string.Join(", ", tokensUsedFromSource)}");
 
                 // Check if all used tokens were in the FromTokens list
                 var fromTokensLower = fromTokens.Select(t => t.ToLower()).ToHashSet();
@@ -533,7 +878,6 @@ public class NetworkPathfinderTests
                 {
                     validationPassed = false;
                 }
-                // Assert.That(allValidFromTokens, Is.True, "Transfers from source used tokens that weren't in the FromTokens list");
             }
 
             if (toTokens != null && toTokens.Length > 0)
@@ -542,8 +886,6 @@ public class NetworkPathfinderTests
                 var tokensUsedToSink = sinkTransfers.Select(t => t.TokenOwner.ToLower()).Distinct().ToList();
 
                 Console.WriteLine($"\n{ConsoleColors.Magenta}TO TOKENS FILTER CHECK{ConsoleColors.Reset}");
-                // Console.WriteLine($"Specified tokens: {string.Join(", ", toTokens.Select(t => t.ToLower()))}");
-                // Console.WriteLine($"Used tokens: {string.Join(", ", tokensUsedToSink)}");
 
                 // Check if all used tokens were in the ToTokens list
                 var toTokensLower = toTokens.Select(t => t.ToLower()).ToHashSet();
@@ -554,7 +896,94 @@ public class NetworkPathfinderTests
                 {
                     validationPassed = false;
                 }
-                // Assert.That(allValidToTokens, Is.True, "Transfers to sink used tokens that weren't in the ToTokens list");
+            }
+
+            // ROUTER AND GROUP VALIDATION
+            Console.WriteLine($"\n{ConsoleColors.Magenta}ROUTER AND GROUP VALIDATION:{ConsoleColors.Reset}");
+            bool routerGroupValidationPassed = true;
+
+            // Check for router and group nodes in the path
+            var routerTransfers = transfers.Where(t => IsRouter(t.From) || IsRouter(t.To)).ToList();
+            var groupTransfers = transfers.Where(t => IsGroup(t.From) || IsGroup(t.To)).ToList();
+
+            if (routerTransfers.Any() || groupTransfers.Any())
+            {
+                Console.WriteLine($"Found {routerTransfers.Count} router transfers and {groupTransfers.Count} group transfers");
+                
+                // Validate Router constraints
+                foreach (var transfer in routerTransfers)
+                {
+                    if (IsRouter(transfer.From))
+                    {
+                        // Router can only send to groups
+                        if (!IsGroup(transfer.To))
+                        {
+                            Console.WriteLine($"{ConsoleColors.Red}INVALID ROUTER TRANSFER:{ConsoleColors.Reset} " +
+                                            $"Router sending to non-group address {transfer.To}");
+                            routerGroupValidationPassed = false;
+                        }
+                    }
+                    
+                    if (IsRouter(transfer.To))
+                    {
+                        // Router can only receive from avatars (not groups or itself)
+                        if (IsSpecialNode(transfer.From))
+                        {
+                            Console.WriteLine($"{ConsoleColors.Red}INVALID ROUTER TRANSFER:{ConsoleColors.Reset} " +
+                                            $"Router receiving from special node {transfer.From}");
+                            routerGroupValidationPassed = false;
+                        }
+                    }
+                }
+                
+                // Validate Group constraints
+                foreach (var transfer in groupTransfers)
+                {
+                    if (IsGroup(transfer.From))
+                    {
+                        // Group sending - should be group token
+                        if (!transfer.TokenOwner.Equals(transfer.From, StringComparison.OrdinalIgnoreCase))
+                        {
+                            Console.WriteLine($"{ConsoleColors.Red}INVALID GROUP MINTING:{ConsoleColors.Reset} " +
+                                            $"Group {transfer.From} sending token {transfer.TokenOwner} instead of its own token");
+                            routerGroupValidationPassed = false;
+                        }
+                        
+                        // Group should not send to Router or other groups
+                        if (IsSpecialNode(transfer.To))
+                        {
+                            Console.WriteLine($"{ConsoleColors.Red}INVALID GROUP TRANSFER:{ConsoleColors.Reset} " +
+                                            $"Group {transfer.From} sending to special node {transfer.To}");
+                            routerGroupValidationPassed = false;
+                        }
+                    }
+                    
+                    if (IsGroup(transfer.To))
+                    {
+                        // Group can only receive from Router
+                        if (!IsRouter(transfer.From))
+                        {
+                            Console.WriteLine($"{ConsoleColors.Red}INVALID GROUP TRANSFER:{ConsoleColors.Reset} " +
+                                            $"Group {transfer.To} receiving from non-router {transfer.From}");
+                            routerGroupValidationPassed = false;
+                        }
+                    }
+                }
+                
+                // Check for proper minting flow pattern: Avatar -> Router -> Group -> Avatar
+                // This is a more complex check that looks for complete minting paths
+                var mintingPaths = IdentifyMintingPaths(transfers);
+                foreach (var path in mintingPaths)
+                {
+                    Console.WriteLine($"Minting path identified: {string.Join(" -> ", path)}");
+                }
+            }
+
+            Console.WriteLine(
+                $"Check: {(routerGroupValidationPassed ? ConsoleColors.Green + "PASSED" : ConsoleColors.Red + "FAILED")}{ConsoleColors.Reset}");
+            if (!routerGroupValidationPassed)
+            {
+                validationPassed = false;
             }
 
             // TRUST RELATIONSHIP VALIDATION
@@ -578,10 +1007,6 @@ public class NetworkPathfinderTests
                         Console.WriteLine(
                             $"{ConsoleColors.Red}INVALID TRUST:{ConsoleColors.Reset} {transfer.To} does not trust token {transfer.TokenOwner}");
                     }
-                    //    else
-                    //    {
-                    //        Console.WriteLine($"{ConsoleColors.Green}VALID TRUST:{ConsoleColors.Reset} {transfer.To} trusts token {transfer.TokenOwner}");
-                    //    }
                 }
 
                 Console.WriteLine(
@@ -590,7 +1015,6 @@ public class NetworkPathfinderTests
                 {
                     validationPassed = false;
                 }
-                // Assert.That(allTrustRelationshipsValid, Is.True, "Some receivers don't trust the tokens they're receiving");
             }
             else
             {
@@ -633,6 +1057,15 @@ public class NetworkPathfinderTests
                 foreach (var senderEntry in senderTokenOutflows)
                 {
                     string sender = senderEntry.Key;
+                    
+                    // Skip balance checks for Router and Groups (they don't need balances)
+                    if (IsRouter(sender) || IsGroup(sender))
+                    {
+                        Console.WriteLine(
+                            $"{ConsoleColors.Green}SPECIAL NODE:{ConsoleColors.Reset} {sender} is a special node (Router/Group), skipping balance check");
+                        continue;
+                    }
+                    
                     int senderId = AddressIdPool.IdOf(senderEntry.Key);
 
                     foreach (var tokenEntry in senderEntry.Value)
@@ -659,10 +1092,6 @@ public class NetworkPathfinderTests
                             Console.WriteLine(
                                 $"{ConsoleColors.Red}INSUFFICIENT BALANCE:{ConsoleColors.Reset} {sender} has {availableBalance} of token {token} but requires {requiredAmount}");
                         }
-                        //   else
-                        //   {
-                        //       Console.WriteLine($"{ConsoleColors.Green}SUFFICIENT BALANCE:{ConsoleColors.Reset} {sender} has {availableBalance} of token {token} for required {requiredAmount}");
-                        //   }
                     }
                 }
 
@@ -672,7 +1101,6 @@ public class NetworkPathfinderTests
                 {
                     validationPassed = false;
                 }
-                // Assert.That(allBalancesValid, Is.True, "Some senders don't have sufficient balance for their transfers");
             }
             else
             {

--- a/Circles.Pathfinder.Tests/pathfinder-test-cases.json
+++ b/Circles.Pathfinder.Tests/pathfinder-test-cases.json
@@ -108,6 +108,18 @@
       "excludedToTokens": [],
       "withWrap": false
     },
+     {
+      "name": "SelfConversionWithToTokensFilter-Fail",
+      "description": "Self-conversion",
+      "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+      "sink": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+      "targetFlow": "100000000000000000000000000000",
+      "fromTokens": [],
+      "toTokens": ["0x7e09438a61ba64b2866b5fefb350146f93db7959"],
+      "excludedFromTokens": [],
+      "excludedToTokens": [],
+      "withWrap": false
+    },
     {
         "name": "SelfConversionWithToTokensFilter-2",
         "description": "Self-conversion",
@@ -207,5 +219,89 @@
       "excludedFromTokens": [],
       "excludedToTokens": [],
       "withWrap": false
-    }
+    },
+    {
+    "name": "RouterGroupMinting-Basic",
+    "description": "Test basic flow through Router and Group for minting",
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0x14c16ce62d26fd51582a646e2e30a3267b1e6d7e",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": ["0x86533d1aDA8Ffbe7b6F7244F9A1b707f7f3e239b"],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "RouterGroupMinting-SpecificFromToken",
+    "description": "Test Router->Group flow with specific source token",
+    "source": "0x14aaB8D72B68c79cbb7873D003585a7C3EF98633",
+    "sink": "0x76A42aEbb2c54d7E259b1C7e4Eb0Cadf5897a7de",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": [],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "GroupAsSource-ShouldFail",
+    "description": "Test that groups cannot be used as source (should return no path)",
+    "source": "0x86533d1aDA8Ffbe7b6F7244F9A1b707f7f3e239b",
+    "sink": "0x14c16ce62d26fd51582a646e2e30a3267b1e6d7e",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": [],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "GroupAsSink-ShouldFail",
+    "description": "Test that groups cannot be used as sink (should return no path)",
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0x86533d1aDA8Ffbe7b6F7244F9A1b707f7f3e239b",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": [],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "MultipleGroupTokens",
+    "description": "Test sink accepting multiple group tokens",
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0x14c16ce62d26fd51582a646e2e30a3267b1e6d7e",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": ["0x86533d1aDA8Ffbe7b6F7244F9A1b707f7f3e239b", "0x14c16ce62d26fd51582a646e2e30a3267b1e6d7e"],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "SelfConversionToGroupToken",
+    "description": "Convert own tokens to group tokens (source=sink)",
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": ["0x86533d1aDA8Ffbe7b6F7244F9A1b707f7f3e239b"],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  },
+  {
+    "name": "test",
+    "description": "Convert own tokens to group tokens (source=sink)",
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0xf7bd3d83df90b4682725adf668791d4d1499207f",
+    "targetFlow": "1000000000000000000",
+    "fromTokens": [],
+    "toTokens": ["0xbfce3136dbe261e4dbd757bb9a718bed8a9993d5"],
+    "excludedFromTokens": [],
+    "excludedToTokens": [],
+    "withWrap": false
+  }
   ]

--- a/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -14,8 +14,12 @@
     <ItemGroup>
         <None Remove="Data\Queries\balanceQuery.sql" />
         <None Remove="Data\Queries\trustQuery.sql" />
+        <None Remove="Data\Queries\groupQuery.sql" />
+        <None Remove="Data\Queries\groupTrustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\balanceQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\groupQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\groupTrustQuery.sql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/Circles.Pathfinder/Data/LoadGraph.cs
@@ -13,6 +13,9 @@ namespace Circles.Pathfinder.Data
             LoadV2Balances();
 
         IEnumerable<(string Truster, string Trustee, int Limit)> LoadV2Trust();
+
+        IEnumerable<string> LoadGroups();
+        IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts();
     }
 
     public class LoadGraph : ILoadGraph
@@ -105,6 +108,43 @@ namespace Circles.Pathfinder.Data
                 var trustee = reader.GetString(1);
 
                 yield return (truster, trustee, 100); // Assuming a default trust limit of 100 in V2
+            }
+        }
+
+        // Load groups
+        public IEnumerable<string> LoadGroups()
+        {
+            var groupQuery = LoadQueryFromResource("groupQuery.sql");
+
+            using var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+
+            using var command = new NpgsqlCommand(groupQuery, connection);
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                var groupAddress = reader.GetString(0);
+                yield return groupAddress;
+            }
+        }
+
+        // Load group trust relationships
+        public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
+        {
+            var groupTrustQuery = LoadQueryFromResource("groupTrustQuery.sql");
+
+            using var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+
+            using var command = new NpgsqlCommand(groupTrustQuery, connection);
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                var groupAddress = reader.GetString(0);
+                var trustedToken = reader.GetString(1);
+                yield return (groupAddress, trustedToken);
             }
         }
     }

--- a/Circles.Pathfinder/Data/Queries/groupQuery.sql
+++ b/Circles.Pathfinder/Data/Queries/groupQuery.sql
@@ -1,0 +1,4 @@
+SELECT  
+    "group" as group_address
+FROM "CrcV2_RegisterGroup" 
+WHERE "mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842');

--- a/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,0 +1,6 @@
+SELECT 
+    t.truster as group_address,
+    t.trustee as trusted_token
+FROM "V_CrcV2_TrustRelations" t
+INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
+WHERE g."mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842');

--- a/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -11,6 +11,13 @@ public class CapacityGraph : IGraph<CapacityEdge>
     public List<CapacityEdge> Edges { get; } = new();
 
     public int? VirtualSinkAddress { get; set; }
+
+    // Track special avatar types
+    public HashSet<int> GroupNodes { get; } = new HashSet<int>();
+    public int? RouterNode { get; set; }
+    
+    // Track which tokens each group trusts
+    public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();
     
     public void AddTokenNode(int tokenId, int? poolNodeId = null)
     {
@@ -33,6 +40,26 @@ public class CapacityGraph : IGraph<CapacityEdge>
             Nodes.Add(avatarAddress, AvatarNodes[avatarAddress]);
         }
     }
+
+    // Add a group
+    public void AddGroup(int groupAddress)
+    {
+        AddAvatar(groupAddress); 
+        GroupNodes.Add(groupAddress);
+    }
+
+    // Track the router node ID for post-processing.
+    // Note: Router is added as an avatar node but has no edges in the capacity graph during construction.
+    // It's only used during path post-processing to insert router steps between Avatar→Group transfers.
+    public void SetRouter(int routerAddress)
+    {
+        AddAvatar(routerAddress);
+        RouterNode = routerAddress;
+    }
+
+    // Helper methods
+    public bool IsGroup(int nodeAddress) => GroupNodes.Contains(nodeAddress);
+    public bool IsRouter(int nodeAddress) => RouterNode.HasValue && RouterNode.Value == nodeAddress;
 
     public void AddCapacityEdge(int from, int to, int token, long capacity)
     {

--- a/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using Circles.Pathfinder.Data; 
 using Circles.Pathfinder.DTOs;
 
 namespace Circles.Pathfinder.Graphs;
@@ -8,6 +9,16 @@ public sealed class CapacityGraphPool
     private readonly ConcurrentDictionary<CapacityGraphSnapshot, int> _ref = new();
     private volatile CapacityGraphSnapshot? _current;
     private readonly GraphFactory _gf = new();
+
+    public void SetLoadGraph(LoadGraph loadGraph)
+    {
+        _gf.SetLoadGraph(loadGraph);
+    }
+
+    public void SetRouterAddress(string routerAddress)
+    {
+        _gf.SetRouterAddress(routerAddress);
+    }
 
     /* ------------------------------------------------------------------ */
     /* Snapshot                                                           */
@@ -60,9 +71,19 @@ public sealed class CapacityGraphPool
 
     public static Task<CapacityGraph> BuildFullGraph(
         BalanceGraph balanceGraph,
-        IReadOnlyDictionary<int, HashSet<int>> accountTrusts)
+        IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
+        LoadGraph? loadGraph = null,
+        string? routerAddress = null)
     {
         var gf = new GraphFactory();
+        if (loadGraph != null)
+        {
+            gf.SetLoadGraph(loadGraph);
+        }
+        if (routerAddress != null)
+        {
+            gf.SetRouterAddress(routerAddress);
+        }
         return Task.FromResult(gf.CreateCapacityGraph(balanceGraph, accountTrusts, new FlowRequest()));
     }
 

--- a/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -8,6 +8,18 @@ namespace Circles.Pathfinder.Graphs;
 public class GraphFactory
 {
     private const string VIRTUAL_SINK_SUFFIX = "_virtual_sink";
+    private LoadGraph? _loadGraph; 
+    private string _routerAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f"; // Default fallback
+
+    public void SetLoadGraph(LoadGraph loadGraph)
+    {
+        _loadGraph = loadGraph;
+    }
+
+    public void SetRouterAddress(string routerAddress)
+    {
+        _routerAddress = routerAddress;
+    }
 
     public static Dictionary<int, HashSet<int>> BuildTrustLookup(TrustGraph graph)
     {
@@ -91,9 +103,10 @@ public class GraphFactory
     /// Also sets up a "virtual sink" if source == sink and toTokens are specified.
     /// </summary>
     /// <param name="balanceGraph">The balance graph to use.</param>
-    /// <param name="trustGraph">The trust graph to use.</param>
+    /// <param name="trustLookup">The trust graph to use.</param>
     /// <param name="request">Flow request parameters.</param>
     /// <returns>A capacity graph created from the balance and trust graphs.</returns>
+    
     public CapacityGraph CreateCapacityGraph(
         BalanceGraph balanceGraph,
         IReadOnlyDictionary<int, HashSet<int>> trustLookup,
@@ -126,38 +139,66 @@ public class GraphFactory
             }
         }
 
+        // STEP 1d: Load groups and track router node for post-processing
+        // Only load if we have a LoadGraph instance available
+        if (_loadGraph != null)
+        {
+            LoadGroupsAndTrackRouter(capacityGraph, _loadGraph, _routerAddress);
+        }
+
         var mergedTrust = simulatedTrust.Count == 0 ? trustLookup : MergeTrust(trustLookup, simulatedTrust);
 
         int? virtualSinkAddress = null;
         HashSet<int> virtualSinkTrustedTokens = new HashSet<int>();
 
-        var sourceEqualsSink = r.Source?.Trim().ToLowerInvariant() == r.Sink?.Trim().ToLowerInvariant();
+        var sourceEqualsSink = r?.Source?.Trim().ToLowerInvariant() == r?.Sink?.Trim().ToLowerInvariant();
 
         // Setup key filters
-        var toTokensFilter = r.ToTokens?
-                                 .Select(AddressIdPool.IdOf)
-                                 .ToHashSet()
-                             ?? new HashSet<int>();
+        var toTokensFilter = r?.ToTokens?
+                                .Select(AddressIdPool.IdOf)
+                                .ToHashSet()
+                            ?? new HashSet<int>();
 
-        var fromTokensFilter = r.FromTokens?
-                                   .Select(AddressIdPool.IdOf)
-                                   .ToHashSet()
-                               ?? new HashSet<int>();
+        var fromTokensFilter = r?.FromTokens?
+                                .Select(AddressIdPool.IdOf)
+                                .ToHashSet()
+                            ?? new HashSet<int>();
 
-        var excludedFromTokensFilter = r.ExcludedFromTokens?
-                                           .Select(AddressIdPool.IdOf)
-                                           .ToHashSet()
-                                       ?? new HashSet<int>();
+        var excludedFromTokensFilter = r?.ExcludedFromTokens?
+                                        .Select(AddressIdPool.IdOf)
+                                        .ToHashSet()
+                                    ?? new HashSet<int>();
 
-        var excludedToTokensFilter = r.ExcludedToTokens?
-                                         .Select(AddressIdPool.IdOf)
-                                         .ToHashSet()
-                                     ?? new HashSet<int>();
+        var excludedToTokensFilter = r?.ExcludedToTokens?
+                                        .Select(AddressIdPool.IdOf)
+                                        .ToHashSet()
+                                    ?? new HashSet<int>();
 
-        // STEP 2: Create a virtual sink if needed
-        int? sourceId = !string.IsNullOrWhiteSpace(r.Source) ? AddressIdPool.IdOf(r.Source) : null;
-        int? sinkId = !string.IsNullOrWhiteSpace(r.Sink) ? AddressIdPool.IdOf(r.Sink) : null;
+        // STEP 2: Validate source and sink are not groups or router
+        int? sourceId = !string.IsNullOrWhiteSpace(r?.Source) ? AddressIdPool.IdOf(r.Source) : null;
+        int? sinkId = !string.IsNullOrWhiteSpace(r?.Sink) ? AddressIdPool.IdOf(r.Sink) : null;
 
+        if (sourceId != null && capacityGraph.IsGroup(sourceId.Value))
+        {
+            throw new ArgumentException($"Groups cannot be source. '{r!.Source}' is a group.");
+        }
+
+        if (sinkId != null && capacityGraph.IsGroup(sinkId.Value))
+        {
+            throw new ArgumentException($"Groups cannot be sink. '{r!.Sink}' is a group.");
+        }
+
+        if (sourceId != null && capacityGraph.IsRouter(sourceId.Value))
+        {
+            throw new ArgumentException($"Router cannot be source. '{r!.Source}' is the router.");
+        }
+
+        if (sinkId != null && capacityGraph.IsRouter(sinkId.Value))
+        {
+            throw new ArgumentException($"Router cannot be sink. '{r!.Sink}' is the router.");
+        }
+
+        // STEP 2b: Create a virtual sink if needed
         if (sourceId != null && sourceEqualsSink && toTokensFilter.Count > 0)
         {
             var wrappedTokensInSim = simulated
@@ -170,7 +211,8 @@ public class GraphFactory
                 sourceId.Value,
                 toTokensFilter,
                 balanceGraph,
-                wrappedTokensInSim);
+                wrappedTokensInSim,
+                mergedTrust);
         }
 
         // STEP 3: Add pooled H→TokenPool edges from snapshot balances (applying filters)
@@ -202,10 +244,20 @@ public class GraphFactory
         }
 
         // STEP 6/7/8: Add trust-based out-edges from TokenPool→avatars (+ virtual sink in swap mode)
+        // Groups can now receive tokens directly
         AddTokenPoolOutEdges(
             capacityGraph,
             mergedTrust,
             virtualSinkAddress,
+            virtualSinkTrustedTokens,  
+            sinkId,
+            toTokensFilter,
+            excludedToTokensFilter);
+
+        // STEP 8: Add Group minting edges (Group → Avatar with group token)
+        AddGroupMintingEdges(
+            capacityGraph,
+            mergedTrust,
             sinkId,
             toTokensFilter,
             excludedToTokensFilter);
@@ -224,7 +276,6 @@ public class GraphFactory
 
         return capacityGraph;
     }
-
 
     #region Helper Methods
 
@@ -357,6 +408,46 @@ public class GraphFactory
         return list;
     }
 
+    // Load groups and router
+    private void LoadGroupsAndTrackRouter(CapacityGraph capacityGraph, LoadGraph loadGraph, string routerAddress)
+    {
+        try
+        {
+            // Track router node ID for post-processing (inserting router between Avatar->Group transfers)
+            // Note: Router node is added to graph but has no edges during graph construction
+            int routerId = AddressIdPool.IdOf(routerAddress.ToLowerInvariant());
+            capacityGraph.SetRouter(routerId);
+
+            // Load groups
+            var groups = loadGraph.LoadGroups().ToList();
+            foreach (var groupAddress in groups)
+            {
+                int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
+                capacityGraph.AddGroup(groupId);
+            }
+
+            // Load group trust relationships
+            var groupTrusts = loadGraph.LoadGroupTrusts().ToList();
+            foreach (var (groupAddress, trustedToken) in groupTrusts)
+            {
+                int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
+                int tokenId = AddressIdPool.IdOf(trustedToken.ToLowerInvariant());
+
+                if (!capacityGraph.GroupTrustedTokens.TryGetValue(groupId, out var trustedSet))
+                {
+                    trustedSet = new HashSet<int>();
+                    capacityGraph.GroupTrustedTokens[groupId] = trustedSet;
+                }
+                trustedSet.Add(tokenId);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Log but don't fail if groups/router can't be loaded
+            Console.WriteLine($"Warning: Could not load groups and router tracking: {ex.Message}");
+        }
+    }
+
     private void AddHolderToTokenEdges_Pooled(
         CapacityGraph g,
         BalanceGraph snapshot,
@@ -370,6 +461,10 @@ public class GraphFactory
 
         foreach (var bn in snapshot.BalanceNodes.Values)
         {
+            // Skip if holder is Router or Group (they don't use token pools)
+            if (g.IsRouter(bn.Holder) || g.IsGroup(bn.Holder))
+                continue;
+
             bool isSource = sourceId.HasValue && bn.Holder == sourceId.Value;
 
             // keep all your existing filters verbatim:
@@ -401,6 +496,10 @@ public class GraphFactory
 
         foreach (var sb in simulated)
         {
+            // Skip if holder is Router or Group
+            if (g.IsRouter(sb.HolderId) || g.IsGroup(sb.HolderId))
+                continue;
+
             bool isSource = sourceId.HasValue && sb.HolderId == sourceId.Value;
 
             if (sourceEqualsSink && isSource && toTokensFilter.Count > 0 &&
@@ -419,18 +518,27 @@ public class GraphFactory
         }
     }
 
+    // Modified version of AddTokenPoolOutEdges that allows Groups to receive tokens directly
     private void AddTokenPoolOutEdges(
         CapacityGraph g,
         IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
         int? virtualSink,
+        HashSet<int> virtualSinkTrustedTokens,
         int? sinkId,
         HashSet<int> toTokensFilter,
         HashSet<int> excludedToTokensFilter)
     {
-        // Build token -> list of avatars who trust that token (same as before)
+        // Build token -> list of avatars who trust that token
         var tokenToAvatars = new Dictionary<int, List<int>>();
+        
         foreach (var (truster, trustedTokens) in accountTrusts)
         {
+            // Skip Router - it doesn't directly receive from pools
+            if (g.IsRouter(truster))
+                continue;
+            
+            // Groups CAN be trusters now - they receive tokens directly
+
             foreach (var t in trustedTokens)
             {
                 bool isSink = sinkId.HasValue && truster == sinkId.Value;
@@ -443,16 +551,28 @@ public class GraphFactory
             }
         }
 
+        // Groups can receive tokens they trust directly from token pools
+        foreach (var groupId in g.GroupNodes)
+        {
+            if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
+            {
+                foreach (var token in trustedTokens)
+                {
+                    if (!tokenToAvatars.TryGetValue(token, out var list))
+                        tokenToAvatars[token] = list = new List<int>();
+                    if (!list.Contains(groupId))
+                        list.Add(groupId);
+                }
+            }
+        }
+
         foreach (var (token, acceptors) in tokenToAvatars)
         {
             int pool = AddressIdPool.TokenPoolIdOf(token);
             if (!g.Nodes.ContainsKey(pool)) continue; // no supply -> no out-edges
 
-            // Capacity tip: bound each out-edge by the total token supply to help the solver.
             foreach (var a in acceptors)
             {
-                // we deliberately keep 'self' edges (pool->holder) out; holders already contribute via H->pool
-                // but there is no concept of "holder" on pool edges; skip avatar==source in certain swap cases below
                 g.AddCapacityEdge(pool, a, token, long.MaxValue);
             }
         }
@@ -460,11 +580,52 @@ public class GraphFactory
         // Virtual sink edges (swap mode): TokenPool(token) -> virtualSink
         if (virtualSink is int vs)
         {
-            foreach (var t in toTokensFilter)
+            foreach (var t in virtualSinkTrustedTokens) 
             {
                 int pool = AddressIdPool.TokenPoolIdOf(t);
                 if (!g.Nodes.ContainsKey(pool)) continue;
                 g.AddCapacityEdge(pool, vs, t, long.MaxValue);
+            }
+        }
+    }
+
+    // Add Group → Avatar edges for group token minting
+    private void AddGroupMintingEdges(
+        CapacityGraph g,
+        IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
+        int? sinkId,
+        HashSet<int> toTokensFilter,
+        HashSet<int> excludedToTokensFilter)
+    {
+        foreach (var groupId in g.GroupNodes)
+        {
+            // Each group mints its own token (the group address IS the token address)
+            int groupToken = groupId;
+
+            // Find avatars that trust this group's token
+            var trustingAvatars = new List<int>();
+            foreach (var (truster, trustedTokens) in accountTrusts)
+            {
+                // Skip other groups and router
+                if (g.IsGroup(truster) || g.IsRouter(truster))
+                    continue;
+
+                if (trustedTokens.Contains(groupToken))
+                {
+                    bool isSink = sinkId.HasValue && truster == sinkId.Value;
+                    if (isSink && toTokensFilter.Count > 0 && !toTokensFilter.Contains(groupToken)) 
+                        continue;
+                    if (isSink && excludedToTokensFilter.Count > 0 && excludedToTokensFilter.Contains(groupToken)) 
+                        continue;
+
+                    trustingAvatars.Add(truster);
+                }
+            }
+
+            // Add Group → Avatar edges for group token
+            foreach (var avatar in trustingAvatars)
+            {
+                g.AddCapacityEdge(groupId, avatar, groupToken, long.MaxValue);
             }
         }
     }
@@ -516,7 +677,8 @@ public class GraphFactory
         int sourceAddress,
         HashSet<int> toTokensFilter,
         BalanceGraph balanceGraph,
-        HashSet<int> wrappedTokensInSim)
+        HashSet<int> wrappedTokensInSim,
+        IReadOnlyDictionary<int, HashSet<int>> mergedTrust)  
     {
         var virtualSinkAddress = sourceAddress + VIRTUAL_SINK_SUFFIX;
         var virtualSinkAddressId = AddressIdPool.IdOf(virtualSinkAddress);
@@ -531,22 +693,34 @@ public class GraphFactory
             if (bn.IsWrapped) snapshotWrappedTokens.Add(bn.Token);
         }
 
-        // Collect tokens trusted by virtual sink (excluding wrapped tokens)
+        // Get tokens that the source actually trusts
+        HashSet<int> sourceTrustedTokens = new HashSet<int>();
+        if (mergedTrust.TryGetValue(sourceAddress, out var trustedBySource))
+        {
+            sourceTrustedTokens = trustedBySource;
+        }
+
+        // Collect tokens trusted by virtual sink (must be in toTokensFilter AND trusted by source)
         var virtualSinkTrustedTokens = new HashSet<int>();
         foreach (var token in toTokensFilter)
         {
+            // Check if source actually trusts this token
+            if (!sourceTrustedTokens.Contains(token))
+            {
+                // Source doesn't trust this token, so virtual sink can't receive it
+                continue;
+            }
+
             bool tokenWrappedInSnapshot = snapshotWrappedTokens.Contains(token);
             bool tokenWrappedInSim = wrappedTokensInSim.Contains(token);
 
             bool shouldSkip = tokenWrappedInSnapshot || tokenWrappedInSim;
             if (shouldSkip)
             {
-                // // Console.WriteLine($"Skipping wrapped token {token} for virtual sink trust");
                 continue;
             }
 
             virtualSinkTrustedTokens.Add(token);
-            // // Console.WriteLine($"Virtual sink trusts token: {token}");
         }
 
         return (virtualSinkAddressId, virtualSinkTrustedTokens);

--- a/Circles.Pathfinder/PATHFINDER.md
+++ b/Circles.Pathfinder/PATHFINDER.md
@@ -1,0 +1,237 @@
+# Circles Pathfinder: Node Types & Graph Construction
+
+## Node Types in Detail
+
+### 1. Avatar Node
+**When Created**: During graph initialization from trust/balance data  
+**Used In**: Graph construction & pathfinding  
+**Properties**:
+- Represents a user account address
+- Can hold token balances
+- Can establish trust relationships
+- Can be source/sink (except Router & Groups)
+
+### 2. TokenPool Node  
+**When Created**: Dynamically during graph construction  
+**Used In**: Graph construction & pathfinding (removed in post-processing)  
+**Properties**:
+- Virtual node (not in database)
+- One per unique token in the system
+- ID format: `tpool-{tokenId}`
+- Aggregates all holders of a specific token
+- Acts as distribution hub
+
+### 3. Group Node
+**When Created**: Loaded from database during graph initialization  
+**Used In**: Graph construction & pathfinding  
+**Properties**:
+- Special avatar that mints tokens
+- Group address = Group token address
+- Cannot be source or sink
+- Stored in `CrcV2_RegisterGroup` table
+- Can trust other tokens (receive them)
+- Can mint unlimited own tokens
+
+### 4. Router Node
+**When Created**: Tracked during graph init, used in post-processing only  
+**Used In**: NOT in capacity graph, only in final output  
+**Properties**:
+- Address: `0xdc287474114cc0551a81ddc2eb51783fbf34802f`
+- No edges during graph construction
+- Inserted between Avatar→Group transfers after pathfinding
+- Preserves token identity (no transformation)
+
+### 5. Virtual Sink Node
+**When Created**: Only when `source == sink && toTokens.length > 0`  
+**Used In**: Graph construction & pathfinding (replaced in output)  
+**Properties**:
+- ID format: `{sourceId}_virtual_sink`
+- Enables token-to-token conversion
+- Trusts only tokens in `toTokens` that source also trusts
+- Replaced with real sink address in final output
+
+## Graph Construction Flow
+
+```mermaid
+graph TD
+    subgraph "Phase 1: Initialize Nodes"
+        LoadAvatars[Load all Avatars from trust/balance data]
+        LoadGroups[Load Groups from CrcV2_RegisterGroup]
+        TrackRouter[Track Router address]
+        CheckVirtual{source == sink?}
+        CreateVirtual[Create Virtual Sink]
+        
+        LoadAvatars --> LoadGroups
+        LoadGroups --> TrackRouter
+        TrackRouter --> CheckVirtual
+        CheckVirtual -->|Yes + toTokens| CreateVirtual
+        CheckVirtual -->|No| Phase2
+        CreateVirtual --> Phase2[Continue to Phase 2]
+    end
+```
+
+## Edge Construction in Detail
+
+### Phase 1: Avatar → TokenPool Edges
+
+```mermaid
+graph LR
+    subgraph "Balance Edges"
+        A1[Avatar1<br/>Balance: 100 T1<br/>50 T2] 
+        A2[Avatar2<br/>Balance: 75 T1]
+        TP1[TokenPool T1<br/>Created on-demand]
+        TP2[TokenPool T2<br/>Created on-demand]
+        
+        A1 -->|"100 T1"| TP1
+        A1 -->|"50 T2"| TP2
+        A2 -->|"75 T1"| TP1
+    end
+```
+
+**Node Creation**:
+```csharp
+foreach (balance in balances) {
+    // Skip Router and Groups - they don't use pools
+    if (IsRouter(balance.Holder) || IsGroup(balance.Holder)) continue;
+    
+    // Create TokenPool node if doesn't exist
+    int poolId = AddressIdPool.TokenPoolIdOf(balance.Token);
+    graph.AddTokenNode(balance.Token, poolId);
+    
+    // Add edge with balance as capacity
+    graph.AddCapacityEdge(
+        from: balance.Holder,
+        to: poolId,
+        token: balance.Token,
+        capacity: balance.Amount
+    );
+}
+```
+
+### Phase 2: TokenPool → Avatar/Group Edges
+
+```mermaid
+graph LR
+    subgraph "Trust-Based Distribution"
+        TP1[TokenPool T1]
+        TP2[TokenPool T2]
+        A1[Avatar1<br/>trusts: T1,T2]
+        A2[Avatar2<br/>trusts: T1]
+        G1[Group1<br/>trusts: T1,T2]
+        R[Router<br/>NO EDGES]
+        
+        TP1 -->|"∞"| A1
+        TP1 -->|"∞"| A2
+        TP1 -->|"∞"| G1
+        TP2 -->|"∞"| A1
+        TP2 -->|"∞"| G1
+        TP1 -.->|"NO!"| R
+    end
+```
+
+**Key Points**:
+- Router NEVER receives from TokenPools
+- Groups CAN receive from TokenPools (for tokens they trust)
+- Capacity always ∞ (unlimited)
+
+### Phase 3: Group → Avatar Minting Edges
+
+```mermaid
+graph LR
+    subgraph "Minting Edges"
+        G1[Group1<br/>Token: G1]
+        G2[Group2<br/>Token: G2]
+        A1[Avatar1<br/>trusts: G1]
+        A2[Avatar2<br/>trusts: G1,G2]
+        A3[Avatar3<br/>trusts: G2]
+        R[Router<br/>NO EDGES]
+        G3[Group3<br/>NO EDGES]
+        
+        G1 -->|"∞ G1 token"| A1
+        G1 -->|"∞ G1 token"| A2
+        G2 -->|"∞ G2 token"| A2
+        G2 -->|"∞ G2 token"| A3
+        G1 -.->|"NO!"| R
+        G1 -.->|"NO!"| G3
+    end
+```
+
+**Implementation**:
+```csharp
+foreach (group in groups) {
+    int groupToken = group; // Group IS its token
+    
+    foreach (avatar in avatars) {
+        // Skip Router and other Groups
+        if (IsRouter(avatar) || IsGroup(avatar)) continue;
+        
+        if (trustsToken(avatar, groupToken)) {
+            graph.AddCapacityEdge(
+                from: group,
+                to: avatar,
+                token: groupToken,
+                capacity: long.MaxValue
+            );
+        }
+    }
+}
+```
+
+## Complete Flow Example
+
+```mermaid
+graph TD
+    subgraph sub1["1. Graph Construction"]
+        direction LR
+        A[Avatar A<br/>Has: 100 AT]
+        TPat[TokenPool AT]
+        G[Group G<br/>Trusts: AT<br/>Mints: GT]
+        B[Avatar B<br/>Trusts: GT]
+        
+        A -->|"100 AT"| TPat
+        TPat -->|"∞ AT"| G
+        G -->|"∞ GT"| B
+    end
+    
+    subgraph sub2["2. Path Found by MaxFlow"]
+        direction LR
+        A2[A] -->|"50 AT"| TP2[Pool AT]
+        TP2 -->|"50 AT"| G2[G]
+        G2 -->|"50 GT"| B2[B]
+    end
+    
+    subgraph sub3["3. After Collapse"]
+        direction LR
+        A3[A] -->|"50 AT"| G3[G]
+        G3 -->|"50 GT"| B3[B]
+    end
+    
+    subgraph sub4["4. After Router Insertion"]
+        direction LR
+        A4[A] -->|"50 AT"| R[Router]
+        R -->|"50 AT"| G4[G]
+        G4 -->|"50 GT"| B4[B]
+    end
+    
+    sub1 ~~~ sub2
+    sub2 ~~~ sub3
+    sub3 ~~~ sub4
+```
+
+## Node Presence by Phase
+
+| Node Type | Graph Construction | MaxFlow | Path Collapse | Post-Process | Final Output |
+|-----------|-------------------|---------|---------------|--------------|--------------|
+| Avatar | ✓ | ✓ | ✓ | ✓ | ✓ |
+| TokenPool | ✓ | ✓ | Removed | - | - |
+| Group | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Router | Tracked only | - | - | Inserted | ✓ |
+| Virtual Sink | ✓ (conditional) | ✓ | ✓ | Replaced | - |
+
+## Critical Implementation Rules
+
+1. **TokenPool Creation**: Created on-demand when first balance references the token
+2. **Router Isolation**: Router node exists but has ZERO edges during graph construction
+3. **Group Direct Access**: Groups receive directly from TokenPools (no Router needed here)
+4. **Minting Restriction**: Groups only send their own token, only to Avatars
+5. **Post-Process Router**: Router inserted ONLY between Avatar→Group, preserving token identity

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -25,13 +25,13 @@ public class V2Pathfinder
         bool sourceMissing = !capacityGraph.AvatarNodes.ContainsKey(sourceId);
         if (sourceMissing)
         {
-            throw new ArgumentException($"Source '{flowRequest.Source}' isn’t in the graph snapshot.");
+            throw new ArgumentException($"Source '{flowRequest.Source}' isn't in the graph snapshot.");
         }
 
         bool sinkMissing = !capacityGraph.AvatarNodes.ContainsKey(effSink);
         if (sinkMissing)
         {
-            throw new ArgumentException($"Sink '{flowRequest.Sink}' isn’t in the graph snapshot.");
+            throw new ArgumentException($"Sink '{flowRequest.Sink}' isn't in the graph snapshot.");
         }
 
         /* --------------------------------------------------------------------
@@ -80,9 +80,9 @@ public class V2Pathfinder
         bool srcMissing = !capacityGraph.AvatarNodes.ContainsKey(sourceId);
         bool dstMissing = !capacityGraph.AvatarNodes.ContainsKey(effSink);
         if (srcMissing)
-            throw new ArgumentException($"Source '{request.Source}' isn’t in the graph snapshot.");
+            throw new ArgumentException($"Source '{request.Source}' isn't in the graph snapshot.");
         if (dstMissing)
-            throw new ArgumentException($"Sink '{request.Sink}' isn’t in the graph snapshot.");
+            throw new ArgumentException($"Sink '{request.Sink}' isn't in the graph snapshot.");
 
         /* --------------------------------------------------------------------
          * 2. Run max-flow and peel paths
@@ -100,17 +100,17 @@ public class V2Pathfinder
         if (hasStepCap)
         {
             int stepCap = request.MaxTransfers!.Value;
-            int currentSteps = CountCollapsedTransferSteps(simplePaths);
+            int currentSteps = CountCollapsedTransferSteps(simplePaths, capacityGraph);
 
             bool needsPrune = currentSteps > stepCap;
             if (needsPrune)
             {
-                simplePaths = PrunePathsByStepLimit(simplePaths, stepCap);
+                simplePaths = PrunePathsByStepLimit(simplePaths, stepCap, capacityGraph);
             }
         }
 
         /* --------------------------------------------------------------------
-         * 3. Convert SimpleEdge ➜ FlowEdge
+         * 3. Convert SimpleEdge → FlowEdge
          * ------------------------------------------------------------------ */
         var flowPaths = new List<List<FlowEdge>>(simplePaths.Count);
 
@@ -163,15 +163,20 @@ public class V2Pathfinder
         /* --------------------------------------------------------------------
          * 5. Collapse balance nodes + aggregate identical edges
          * ------------------------------------------------------------------ */
-        var collapsed = CollapseBalanceNodes(flowPaths);
-        var aggregated = collapsed.AggregateIdenticalEdges(); // legacy helper
+        var collapsed = CollapseBalanceNodes(flowPaths, capacityGraph);
+        var aggregated = collapsed.AggregateIdenticalEdges();
 
         /* --------------------------------------------------------------------
-         * 6. Build DTOs
+         * 6. Post-process to insert Router between Avatar → Group transfers
+         * ------------------------------------------------------------------ */
+        var processedEdges = InsertRouterInTransfers(aggregated.Edges, capacityGraph);
+
+        /* --------------------------------------------------------------------
+         * 7. Build DTOs
          * ------------------------------------------------------------------ */
         var transfer = new List<TransferPathStep>();
 
-        foreach (var e in aggregated.Edges)
+        foreach (var e in processedEdges)
         {
             if (e.Flow <= 0)
             {
@@ -203,10 +208,58 @@ public class V2Pathfinder
             transfer);
     }
 
-/* ------------------------------------------------------------------------
- * Collapse balance nodes in a set of paths.
- * --------------------------------------------------------------------- */
-    private FlowGraph CollapseBalanceNodes(List<List<FlowEdge>> pathsWithFlow)
+    /* ------------------------------------------------------------------------
+     * Post-process: Insert Router node between Avatar → Group transfers.
+     * The router itself is not part of the capacity graph during pathfinding,
+     * but the contract requires all Avatar→Group transfers to route through it.
+     * This method splits any Avatar→Group edge into Avatar→Router→Group.
+     * Group→Avatar minting transfers are left as-is (direct edge).
+     * --------------------------------------------------------------------- */
+    private List<FlowEdge> InsertRouterInTransfers(List<FlowEdge> transfers, CapacityGraph capacityGraph)
+    {
+        if (capacityGraph.RouterNode == null)
+            return transfers;
+
+        var result = new List<FlowEdge>();
+        int routerId = capacityGraph.RouterNode.Value;
+
+        foreach (var transfer in transfers)
+        {
+            // If this is Avatar → Group transfer, insert Router in between
+            // (Group → Avatar minting transfers are left as-is)
+            if (!capacityGraph.IsGroup(transfer.From) && 
+                !capacityGraph.IsRouter(transfer.From) &&
+                capacityGraph.IsGroup(transfer.To))
+            {
+                // Split into Avatar → Router → Group
+                // Avatar → Router (same token)
+                result.Add(new FlowEdge(transfer.From, routerId, transfer.Token, transfer.InitialCapacity)
+                {
+                    Flow = transfer.Flow,
+                    CurrentCapacity = transfer.CurrentCapacity
+                });
+                
+                // Router → Group (same token)
+                result.Add(new FlowEdge(routerId, transfer.To, transfer.Token, transfer.InitialCapacity)
+                {
+                    Flow = transfer.Flow,
+                    CurrentCapacity = transfer.CurrentCapacity
+                });
+            }
+            else
+            {
+                // Keep as-is (includes Group → Avatar minting transfers)
+                result.Add(transfer);
+            }
+        }
+
+        return result;
+    }
+
+    /* ------------------------------------------------------------------------
+     * Collapse balance nodes and token pools in a set of paths.
+     * --------------------------------------------------------------------- */
+    private FlowGraph CollapseBalanceNodes(List<List<FlowEdge>> pathsWithFlow, CapacityGraph capacityGraph)
     {
         var collapsed = new FlowGraph();
 
@@ -217,10 +270,10 @@ public class V2Pathfinder
         {
             foreach (var edge in path)
             {
-                if (!IsBalanceNode(edge.From))
+                if (!IsPoolNode(edge.From))
                     avatarSet.Add(edge.From);
 
-                if (!IsBalanceNode(edge.To))
+                if (!IsPoolNode(edge.To))
                     avatarSet.Add(edge.To);
             }
         }
@@ -230,44 +283,12 @@ public class V2Pathfinder
             collapsed.AddAvatar(a);
         }
 
-        /* ---------------- aggregate avatar-to-avatar flows ----------------- */
+        /* ---------------- aggregate flows ----------------- */
         var agg = new Dictionary<(int From, int To, int Token), long>();
 
         foreach (var path in pathsWithFlow)
         {
-            for (int i = 0; i < path.Count; i++)
-            {
-                var e = path[i];
-
-                bool eToIsPool = IsBalanceNode(e.To);
-                bool hasNext = (i + 1) < path.Count;
-                bool nextContinuesFromPool = hasNext && path[i + 1].From == e.To;
-                bool isChain = eToIsPool && nextContinuesFromPool;
-
-                if (isChain)
-                {
-                    // Fold Avatar → TokenPool(token) → Avatar
-                    var next = path[i + 1];
-
-                    int fromAvatar = e.From; // Avatar
-                    int toAvatar = next.To; // Avatar
-                    int token = e.Token;
-
-                    long flow = Math.Min(e.Flow, next.Flow);
-                    var key = (fromAvatar, toAvatar, token);
-
-                    if (agg.TryGetValue(key, out long existing))
-                    {
-                        agg[key] = existing + flow;
-                    }
-                    else
-                    {
-                        agg[key] = flow;
-                    }
-
-                    i += 1; // consume the next edge too
-                }
-            }
+            CollapseSinglePath(path, capacityGraph, agg);
         }
 
         /* ---------------- materialise collapsed edges ---------------------- */
@@ -291,17 +312,89 @@ public class V2Pathfinder
         return collapsed;
     }
 
+    private void CollapseSinglePath(
+        List<FlowEdge> path,
+        CapacityGraph capacityGraph,
+        Dictionary<(int From, int To, int Token), long> agg)
+    {
+        int i = 0;
+        while (i < path.Count)
+        {
+            var e = path[i];
+
+            // Case 1: Standard TokenPool collapse (Avatar → TokenPool → Avatar/Group)
+            if (IsPoolNode(e.To))
+            {
+                bool hasNext = (i + 1) < path.Count;
+                if (hasNext && path[i + 1].From == e.To)
+                {
+                    var next = path[i + 1];
+                    
+                    // Collapse Avatar → TokenPool → (Avatar/Group)
+                    // Result: Avatar → (Avatar/Group)
+                    AddToAggregation(agg, e.From, next.To, e.Token, Math.Min(e.Flow, next.Flow));
+                    i += 2;
+                    continue;
+                }
+            }
+
+            // Case 2: Group → Avatar (group token minting, keep as-is)
+            if (capacityGraph.IsGroup(e.From))
+            {
+                // Keep Group → Avatar edge with group token
+                AddToAggregation(agg, e.From, e.To, e.Token, e.Flow);
+                i += 1;
+                continue;
+            }
+
+            // Case 3: Any other direct edge (keep as-is)
+            if (!IsPoolNode(e.To))
+            {
+                AddToAggregation(agg, e.From, e.To, e.Token, e.Flow);
+                i += 1;
+                continue;
+            }
+
+            // Shouldn't reach here in normal operation, but handle gracefully
+            i += 1;
+        }
+    }
+
+    private void AddToAggregation(
+        Dictionary<(int From, int To, int Token), long> agg,
+        int from,
+        int to,
+        int token,
+        long flow)
+    {
+        var key = (from, to, token);
+        if (agg.TryGetValue(key, out long existing))
+        {
+            agg[key] = existing + flow;
+        }
+        else
+        {
+            agg[key] = flow;
+        }
+    }
+
     private bool IsBalanceNode(int addr) => AddressIdPool.IsBalanceNode(addr);
+    
+    private bool IsPoolNode(int addr)
+    {
+        if (!AddressIdPool.IsBalanceNode(addr)) return false;
+        var str = AddressIdPool.StringOf(addr);
+        return str.StartsWith("tpool-");
+    }
 
     // Count how many (From,To,Token) transfer steps remain after collapsing
-    // all paths (Avatar→TokenPool→Avatar folds to Avatar→Avatar per token).
-    private static int CountCollapsedTransferSteps(IReadOnlyList<List<SimpleEdge>> paths)
+    private static int CountCollapsedTransferSteps(IReadOnlyList<List<SimpleEdge>> paths, CapacityGraph capacityGraph)
     {
         var unique = new HashSet<(int From, int To, int Token)>();
 
         for (int i = 0; i < paths.Count; i++)
         {
-            var triples = CollapsePathToTransfers(paths[i]);
+            var triples = CollapsePathToTransfers(paths[i], capacityGraph);
             for (int j = 0; j < triples.Count; j++)
             {
                 unique.Add(triples[j]);
@@ -312,11 +405,10 @@ public class V2Pathfinder
     }
 
     // Greedy pruning: pick paths that give the highest flow per *marginal* step
-    // (steps that aren't already "paid for" by previously picked paths), until
-    // we reach the step budget.
     private static List<List<SimpleEdge>> PrunePathsByStepLimit(
         IReadOnlyList<List<SimpleEdge>> original,
-        int stepCap)
+        int stepCap,
+        CapacityGraph capacityGraph)
     {
         // Precompute collapsed triples for each path + path flow.
         var metas = new List<(int Index, long Flow, HashSet<(int F, int T, int K)> Triples)>(original.Count);
@@ -326,11 +418,10 @@ public class V2Pathfinder
             long flow = 0;
             if (path.Count > 0)
             {
-                // Each edge in the peeled path has the same min-bottleneck flow.
                 flow = path[0].Flow;
             }
 
-            var triples = new HashSet<(int F, int T, int K)>(CollapsePathToTransfers(path)
+            var triples = new HashSet<(int F, int T, int K)>(CollapsePathToTransfers(path, capacityGraph)
                 .Select(t => (t.From, t.To, t.Token)));
 
             metas.Add((i, flow, triples));
@@ -460,33 +551,36 @@ public class V2Pathfinder
     }
 
     // Collapse ONE peeled path into transfer triples (FromAvatar, ToAvatar, Token).
-    // Mirrors the logic in CollapseBalanceNodes, but works on SimpleEdge.
-    private static List<(int From, int To, int Token)> CollapsePathToTransfers(List<SimpleEdge> path)
+    private static List<(int From, int To, int Token)> CollapsePathToTransfers(
+        List<SimpleEdge> path, 
+        CapacityGraph capacityGraph)
     {
-        // Returns triples (AvatarFrom, AvatarTo, Token) for a single peeled path.
-        // With pooled graphs, paths alternate Avatar→TokenPool→Avatar; we fold those pairs.
-        var triples = new List<(int From, int To, int Token)>(Math.Max(1, path.Count / 2));
+        var triples = new List<(int From, int To, int Token)>(Math.Max(1, path.Count));
 
         int i = 0;
         while (i < path.Count)
         {
             var e = path[i];
 
-            bool eToIsPool = AddressIdPool.IsBalanceNode(e.To);
-            bool hasNext = (i + 1) < path.Count;
-            bool nextContinuesFromPool = hasNext && path[i + 1].From == e.To;
-            bool isChain = eToIsPool && nextContinuesFromPool;
-
-            if (isChain)
+            // Check if this is a pool node
+            bool eToIsPool = AddressIdPool.IsBalanceNode(e.To) && 
+                            AddressIdPool.StringOf(e.To).StartsWith("tpool-");
+            
+            // Standard pool collapse: Avatar → TokenPool → Next
+            if (eToIsPool)
             {
-                // Fold Avatar → TokenPool(token) → Avatar
-                var next = path[i + 1];
-                triples.Add((e.From, next.To, e.Token));
-                i += 2;
-                continue;
+                bool hasNext = (i + 1) < path.Count;
+                if (hasNext && path[i + 1].From == e.To)
+                {
+                    var next = path[i + 1];
+                    // Collapse to Avatar → Next
+                    triples.Add((e.From, next.To, e.Token));
+                    i += 2;
+                    continue;
+                }
             }
 
-            // Fallback: treat as direct Avatar→Avatar hop (rare / not expected here)
+            // Direct edges (including Group → Avatar minting)
             triples.Add((e.From, e.To, e.Token));
             i += 1;
         }


### PR DESCRIPTION
Additions:
- Fix virtual sink, can only get tokens in toTokens that original avatar trusts
- Introduce group nodes that can only send group tokens and are connected with tokens nodes with incoming edges
- Router logic is only added after the path found. It will replace the edge 
`Avatar --> sends token A ---> Group` with `Avatar --> sends token A --> Router --> sends token A ---> Group`
this way router always pushed the same token forward. Minted tokens are hold by the group when the collateral is transfered to the group.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Support for Router and Group nodes in pathfinding, including group token minting and Router insertion in transfers.
  - Configurable Router address via environment variable with a sensible default.
- Bug Fixes
  - Improved path collapsing and step counting to accurately handle pools, groups, and router-aware transfers.
- Tests
  - Added extensive scenarios covering Router/Group interactions, minting flows, and failure cases; improved snapshot-based graph loading and timeouts.
- Documentation
  - New guide explaining node types and graph construction phases, with examples and diagrams.
- Chores
  - Embedded SQL resources for group and trust data loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->