### PR TITLE
fix: Enforce correct edge ordering for group minting in pathfinder

### DIFF
--- a/Circles.Pathfinder/README.md
+++ b/Circles.Pathfinder/README.md
@@ -108,3 +108,65 @@ public class FlowRequest
 ### Response Format
 - Remains unchanged
 - Virtual sink paths are automatically transformed to use actual sink address
+
+
+## 5. Group Minting Along a Path (Router Integration)
+
+### Overview
+
+The pathfinder supports minting group tokens as part of a transitive transfer path. This is implemented via a special `BaseGroupMintRouter` contract that acts as an intermediary between avatars and groups.
+
+### How Group Minting Works
+
+When a path includes group token acquisition, the flow is:
+
+1. **Avatar → Router**: Source sends collateral (personal CRC) to the router
+2. **Router → Group**: Router deposits collateral to the group's treasury
+3. **Group → Avatar**: Group mints group tokens to the recipient
+
+The router is necessary because `operateFlowMatrix` requires operator approval for transfers, and the router pre-approves all human CRCs.
+
+### Edge Ordering Constraint (Critical)
+
+**Contract Requirement**: The `operateFlowMatrix` smart contract processes edges sequentially. Groups can only transfer tokens they have received, so:
+
+> All collateral edges (Router → Group) MUST appear before the group's outbound mint edge (Group → Avatar)
+
+**Example of correct ordering**:
+
+```text
+1. Avatar1 → Router (Token A, 50 CRC)
+2. Avatar2 → Router (Token B, 30 CRC)
+3. Router → GroupX (Token A, 50 CRC)  ← collateral deposited
+4. Router → GroupX (Token B, 30 CRC)  ← collateral deposited
+5. GroupX → Sink (GroupX token, 80 CRC)  ← mint AFTER all collateral
+```
+
+**Example of incorrect ordering (causes ERC1155InsufficientBalance revert)**:
+
+```text
+1. Avatar1 → Router (Token A, 50 CRC)
+2. Router → GroupX (Token A, 50 CRC)
+3. GroupX → Sink (GroupX token, 80 CRC)  ← FAIL: only 50 CRC received!
+4. Avatar2 → Router (Token B, 30 CRC)   ← too late
+5. Router → GroupX (Token B, 30 CRC)
+```
+
+### Sorting and Validation
+
+The pathfinder enforces correct ordering via two methods in `V2Pathfinder.cs`:
+
+1. **`SortEdgesForMintDependencies()`**: Reorders edges after router insertion to ensure:
+   - All Avatar → Router edges come first
+   - For each group: all Router → Group edges before Group → Avatar edges
+   - Other edges last
+
+2. **`ValidateMintEdgeOrdering()`**: Runtime validation that throws `InvalidOperationException` if:
+   - A Router → Group edge appears after a Group → Avatar edge for the same group
+   - Cumulative outbound flow exceeds cumulative inbound flow at any point
+
+### Router Configuration
+
+The production router is: `0xdc287474114cc0551a81ddc2eb51783fbf34802f`
+
+Configure via environment variable: `V2_BASE_GROUP_ROUTER`

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -172,11 +172,23 @@ public class V2Pathfinder
         var processedEdges = InsertRouterInTransfers(aggregated.Edges, capacityGraph);
 
         /* --------------------------------------------------------------------
+         * 6b. Sort edges to ensure mint dependencies are satisfied.
+         *     All collateral edges (Router→Group) must precede the group's
+         *     outbound mint edge (Group→Avatar) for contract execution to succeed.
+         * ------------------------------------------------------------------ */
+        var sortedEdges = SortEdgesForMintDependencies(processedEdges, capacityGraph);
+
+        /* --------------------------------------------------------------------
+         * 6c. Validate the edge ordering - throw if mint dependencies violated
+         * ------------------------------------------------------------------ */
+        ValidateMintEdgeOrdering(sortedEdges, capacityGraph);
+
+        /* --------------------------------------------------------------------
          * 7. Build DTOs
          * ------------------------------------------------------------------ */
         var transfer = new List<TransferPathStep>();
 
-        foreach (var e in processedEdges)
+        foreach (var e in sortedEdges)
         {
             if (e.Flow <= 0)
             {
@@ -586,5 +598,171 @@ public class V2Pathfinder
         }
 
         return triples;
+    }
+
+    /* ------------------------------------------------------------------------
+     * Sort edges to ensure mint dependencies are satisfied.
+     *
+     * Contract constraint: Groups need to receive ALL collateral BEFORE they
+     * can transfer group tokens. The operateFlowMatrix processes edges
+     * sequentially, so we must order them correctly.
+     *
+     * Ordering rules:
+     * 1. All Avatar → Router edges (collateral handoff to router)
+     * 2. For each group: All Router → Group edges (collateral deposit)
+     * 3. For each group: All Group → Avatar edges (group token minting)
+     * 4. All other edges (standard avatar-to-avatar transfers)
+     *
+     * This ensures that when a group's outbound edge is processed, it has
+     * already received all the collateral it needs.
+     * --------------------------------------------------------------------- */
+    private List<FlowEdge> SortEdgesForMintDependencies(List<FlowEdge> edges, CapacityGraph capacityGraph)
+    {
+        if (capacityGraph.RouterNode == null || capacityGraph.GroupNodes.Count == 0)
+        {
+            // No router or no groups - nothing to sort
+            return edges;
+        }
+
+        // Categorize edges into buckets
+        var avatarToRouter = new List<FlowEdge>();
+        var groupEdges = new Dictionary<int, (List<FlowEdge> Inbound, List<FlowEdge> Outbound)>();
+        var otherEdges = new List<FlowEdge>();
+
+        foreach (var edge in edges)
+        {
+            bool fromIsRouter = capacityGraph.IsRouter(edge.From);
+            bool toIsRouter = capacityGraph.IsRouter(edge.To);
+            bool fromIsGroup = capacityGraph.IsGroup(edge.From);
+            bool toIsGroup = capacityGraph.IsGroup(edge.To);
+
+            if (!fromIsRouter && !fromIsGroup && toIsRouter)
+            {
+                // Avatar → Router (collateral sent to router)
+                avatarToRouter.Add(edge);
+            }
+            else if (fromIsRouter && toIsGroup)
+            {
+                // Router → Group (collateral deposited to group)
+                int groupId = edge.To;
+                if (!groupEdges.TryGetValue(groupId, out var lists))
+                {
+                    lists = (new List<FlowEdge>(), new List<FlowEdge>());
+                    groupEdges[groupId] = lists;
+                }
+                lists.Inbound.Add(edge);
+            }
+            else if (fromIsGroup && !toIsGroup && !toIsRouter)
+            {
+                // Group → Avatar (group token minting)
+                int groupId = edge.From;
+                if (!groupEdges.TryGetValue(groupId, out var lists))
+                {
+                    lists = (new List<FlowEdge>(), new List<FlowEdge>());
+                    groupEdges[groupId] = lists;
+                }
+                lists.Outbound.Add(edge);
+            }
+            else
+            {
+                // All other edges (including direct Avatar → Avatar transfers)
+                otherEdges.Add(edge);
+            }
+        }
+
+        // Build result in dependency order
+        var result = new List<FlowEdge>(edges.Count);
+
+        // 1. All Avatar → Router edges first
+        result.AddRange(avatarToRouter);
+
+        // 2. For each group: all inbound (Router → Group) before outbound (Group → Avatar)
+        foreach (var (groupId, (inbound, outbound)) in groupEdges)
+        {
+            result.AddRange(inbound);
+            result.AddRange(outbound);
+        }
+
+        // 3. Other edges last
+        result.AddRange(otherEdges);
+
+        return result;
+    }
+
+    /* ------------------------------------------------------------------------
+     * Validate that edge ordering satisfies mint dependency constraints.
+     * Throws InvalidOperationException if ordering is violated.
+     *
+     * Invariants checked:
+     * 1. For each group G, all Router → G edges must appear BEFORE any G → Avatar edge
+     * 2. When a Group → Avatar edge is seen, the cumulative inbound flow must be
+     *    >= the cumulative outbound flow required so far
+     *
+     * This validation ensures the contract won't revert with ERC1155InsufficientBalance.
+     * --------------------------------------------------------------------- */
+    private void ValidateMintEdgeOrdering(List<FlowEdge> edges, CapacityGraph capacityGraph)
+    {
+        if (capacityGraph.RouterNode == null || capacityGraph.GroupNodes.Count == 0)
+        {
+            // No router or no groups - nothing to validate
+            return;
+        }
+
+        // Track which groups have had their outbound edge seen
+        var groupsWithOutboundSeen = new HashSet<int>();
+
+        // Track cumulative inbound flow per group
+        var groupInboundFlow = new Dictionary<int, long>();
+
+        // Track cumulative outbound flow per group
+        var groupOutboundFlow = new Dictionary<int, long>();
+
+        for (int i = 0; i < edges.Count; i++)
+        {
+            var edge = edges[i];
+            bool fromIsRouter = capacityGraph.IsRouter(edge.From);
+            bool fromIsGroup = capacityGraph.IsGroup(edge.From);
+            bool toIsGroup = capacityGraph.IsGroup(edge.To);
+
+            if (fromIsRouter && toIsGroup)
+            {
+                // Router → Group (inbound to group)
+                int groupId = edge.To;
+
+                // Violation: We've already seen an outbound from this group
+                // but we're now seeing more inbound - ordering is wrong
+                if (groupsWithOutboundSeen.Contains(groupId))
+                {
+                    string groupAddr = AddressIdPool.StringOf(groupId);
+                    throw new InvalidOperationException(
+                        $"Edge ordering violation: Router → Group edge for group {groupAddr} " +
+                        $"appears after Group → Avatar edge at index {i}. " +
+                        "All collateral must be deposited before minting.");
+                }
+
+                groupInboundFlow.TryGetValue(groupId, out long current);
+                groupInboundFlow[groupId] = current + edge.Flow;
+            }
+            else if (fromIsGroup && !capacityGraph.IsRouter(edge.To) && !capacityGraph.IsGroup(edge.To))
+            {
+                // Group → Avatar (outbound from group - minting)
+                int groupId = edge.From;
+                groupsWithOutboundSeen.Add(groupId);
+
+                groupOutboundFlow.TryGetValue(groupId, out long currentOutbound);
+                groupOutboundFlow[groupId] = currentOutbound + edge.Flow;
+
+                // Check flow conservation: cumulative inbound >= cumulative outbound so far
+                groupInboundFlow.TryGetValue(groupId, out long inbound);
+                if (inbound < groupOutboundFlow[groupId])
+                {
+                    string groupAddr = AddressIdPool.StringOf(groupId);
+                    throw new InvalidOperationException(
+                        $"Flow violation: Group {groupAddr} has insufficient collateral at edge index {i}. " +
+                        $"Cumulative inbound: {inbound}, cumulative outbound required: {groupOutboundFlow[groupId]}. " +
+                        "Ensure all Router → Group edges precede Group → Avatar edges.");
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes a critical bug where `operateFlowMatrix` reverts with `ERC1155InsufficientBalance` when group minting edges are processed out of order
- Adds `SortEdgesForMintDependencies()` to reorder edges ensuring collateral deposits (Router→Group) precede minting (Group→Avatar)
- Adds `ValidateMintEdgeOrdering()` for runtime validation of edge ordering constraints

## Problem

The `operateFlowMatrix` contract processes edges sequentially. When minting group tokens, the group must have received ALL collateral before it can transfer tokens. Without proper ordering:

```
❌ Bad: Router→GroupX, GroupX→Sink (50), Avatar2→Router, Router→GroupX  
   → Group only has 50 CRC when trying to mint 80 → REVERT
   
✅ Good: Avatar1→Router, Avatar2→Router, Router→GroupX (all), GroupX→Sink
   → Group has 80 CRC collateral before minting
```

## Test plan

- [x] Cherry-picked from tested branch with passing regression tests
- [ ] Run pathfinder tests: `./scripts/test.sh pathfinder`
- [ ] Verify group minting scenarios work in staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive documentation for group token minting via router integration, detailing the minting flow and configuration.

* **Improvements**
  * Enhanced pathfinding logic with improved dependency handling for group token minting operations.
  * Added validation to ensure correct operation sequencing and prevent errors during minting workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->