### PR TITLE
feat: Add quantized mode for invitation module integration

### DIFF
--- a/Circles.Pathfinder.Host/Program.cs
+++ b/Circles.Pathfinder.Host/Program.cs
@@ -203,6 +203,7 @@ app.MapGet("/findPath", async (
     bool? withWrap,
     string? simulatedBalances,
     int? maxTransfers,
+    bool? quantizedMode,
     NetworkState state,
     SemaphoreSlim sem,
     CapacityGraphPool pool,
@@ -270,7 +271,8 @@ app.MapGet("/findPath", async (
             ExcludedToTokens = excludedToTokens?.ToList(),
             WithWrap = withWrap,
             SimulatedBalances = sim,
-            MaxTransfers = maxTransfers
+            MaxTransfers = maxTransfers,
+            QuantizedMode = quantizedMode
         };
 
         using var h = await pool.Rent(request, balanceGraph, trustGraph);

--- a/Circles.Pathfinder.Tests/QuantizedModeTests.cs
+++ b/Circles.Pathfinder.Tests/QuantizedModeTests.cs
@@ -6,13 +6,14 @@ namespace Circles.Pathfinder.Tests;
 /// <summary>
 /// Unit tests for the quantized mode feature in PathUtils.QuantizeSinkBoundFlows.
 /// Quantized mode ensures all sink-bound transfers are exact multiples of 96 CRC
-/// (96 × 10^12 in 6-decimal precision) for the invitation module.
+/// (96 × 10^6 in 6-decimal precision) for the invitation module.
 /// </summary>
 [TestFixture]
 public class QuantizedModeTests
 {
     // 96 CRC in 6-decimal precision (pathfinder internal format)
-    private const long Quanta96CRC = 96_000_000_000_000L;
+    // Internal balances: 1 CRC = 10^6 units
+    private const long Quanta96CRC = 96_000_000L;
 
     // Test node IDs
     private const int Source = 1;
@@ -51,7 +52,7 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_NonMultiple_RoundsDown()
     {
         // Path with 100 CRC should round down to 96 CRC
-        long flow100CRC = 100_000_000_000_000L;
+        long flow100CRC = 100_000_000L;
         var path = CreatePath(Source, Sink, Token1, flow100CRC);
         var paths = new List<List<SimpleEdge>> { path };
 
@@ -65,7 +66,7 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_LessThanQuanta_ExcludesPath()
     {
         // Path with 50 CRC (less than 96) should be excluded entirely
-        long flow50CRC = 50_000_000_000_000L;
+        long flow50CRC = 50_000_000L;
         var path = CreatePath(Source, Sink, Token1, flow50CRC);
         var paths = new List<List<SimpleEdge>> { path };
 
@@ -78,9 +79,9 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_MultiplePaths_EachQuantized()
     {
         // Multiple paths: 100, 200, 50 CRC → returns paths with 96, 192 (50 excluded)
-        long flow100CRC = 100_000_000_000_000L;
-        long flow200CRC = 200_000_000_000_000L;
-        long flow50CRC = 50_000_000_000_000L;
+        long flow100CRC = 100_000_000L;
+        long flow200CRC = 200_000_000L;
+        long flow50CRC = 50_000_000L;
 
         var path1 = CreatePath(Source, Sink, Token1, flow100CRC);
         var path2 = CreatePath(Source, Sink, Token2, flow200CRC);
@@ -88,19 +89,19 @@ public class QuantizedModeTests
         var paths = new List<List<SimpleEdge>> { path1, path2, path3 };
 
         // Set targetFlow high enough to include all valid paths
-        long targetFlow = 1000_000_000_000_000L;
+        long targetFlow = 1000_000_000L;
         var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, targetFlow);
 
         Assert.That(result, Has.Count.EqualTo(2));
         Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
-        Assert.That(result[1][0].Flow, Is.EqualTo(192_000_000_000_000L)); // 2 × 96 CRC
+        Assert.That(result[1][0].Flow, Is.EqualTo(192_000_000L)); // 2 × 96 CRC
     }
 
     [Test]
     public void QuantizeSinkBoundFlows_TargetFlowLimitsResults()
     {
         // With targetFlow = 96 CRC, only 1 invite should be returned
-        long flow200CRC = 200_000_000_000_000L;
+        long flow200CRC = 200_000_000L;
         var path = CreatePath(Source, Sink, Token1, flow200CRC);
         var paths = new List<List<SimpleEdge>> { path };
 
@@ -114,7 +115,7 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_TargetFlow192_ReturnsTwoInvites()
     {
         // With targetFlow = 192 CRC, up to 2 invites should be returned
-        long flow300CRC = 300_000_000_000_000L;
+        long flow300CRC = 300_000_000L;
         var path = CreatePath(Source, Sink, Token1, flow300CRC);
         var paths = new List<List<SimpleEdge>> { path };
 
@@ -130,7 +131,7 @@ public class QuantizedModeTests
     {
         // Multi-hop path: Source → Intermediate → Sink
         // All edges in the path should have the same quantized flow
-        long flow150CRC = 150_000_000_000_000L;
+        long flow150CRC = 150_000_000L;
 
         var edge1 = new SimpleEdge(Source, Intermediate, Token1, long.MaxValue) { Flow = flow150CRC };
         var edge2 = new SimpleEdge(Intermediate, Sink, Token1, long.MaxValue) { Flow = flow150CRC };
@@ -184,9 +185,9 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_MaxTargetFlow_ReturnsAllPossible()
     {
         // Simulate discovery mode with max uint256-like targetFlow
-        long flow100CRC = 100_000_000_000_000L;
-        long flow200CRC = 200_000_000_000_000L;
-        long flow300CRC = 300_000_000_000_000L;
+        long flow100CRC = 100_000_000L;
+        long flow200CRC = 200_000_000L;
+        long flow300CRC = 300_000_000L;
 
         var path1 = CreatePath(Source, Sink, Token1, flow100CRC);
         var path2 = CreatePath(Source, Sink, Token2, flow200CRC);
@@ -217,7 +218,7 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_PartiallyMeetsTarget()
     {
         // Request 3 invites but only 2 possible
-        long flow200CRC = 200_000_000_000_000L;
+        long flow200CRC = 200_000_000L;
         var path = CreatePath(Source, Sink, Token1, flow200CRC);
         var paths = new List<List<SimpleEdge>> { path };
 
@@ -232,7 +233,7 @@ public class QuantizedModeTests
     public void QuantizeSinkBoundFlows_StopsAtTargetAcrossMultiplePaths()
     {
         // Two paths each with 192 CRC capacity, but only request 288 CRC (3 invites)
-        long flow192CRC = 192_000_000_000_000L;
+        long flow192CRC = 192_000_000L;
         var path1 = CreatePath(Source, Sink, Token1, flow192CRC);
         var path2 = CreatePath(Source, Sink, Token2, flow192CRC);
         var paths = new List<List<SimpleEdge>> { path1, path2 };

--- a/Circles.Pathfinder.Tests/QuantizedModeTests.cs
+++ b/Circles.Pathfinder.Tests/QuantizedModeTests.cs
@@ -1,0 +1,257 @@
+using Circles.Pathfinder;
+using Circles.Pathfinder.Edges;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Unit tests for the quantized mode feature in PathUtils.QuantizeSinkBoundFlows.
+/// Quantized mode ensures all sink-bound transfers are exact multiples of 96 CRC
+/// (96 × 10^12 in 6-decimal precision) for the invitation module.
+/// </summary>
+[TestFixture]
+public class QuantizedModeTests
+{
+    // 96 CRC in 6-decimal precision (pathfinder internal format)
+    private const long Quanta96CRC = 96_000_000_000_000L;
+
+    // Test node IDs
+    private const int Source = 1;
+    private const int Intermediate = 2;
+    private const int Sink = 3;
+    private const int Token1 = 100;
+    private const int Token2 = 101;
+
+    [Test]
+    public void QuantizeSinkBoundFlows_ExactMultiple_ReturnsUnchanged()
+    {
+        // Path with exactly 96 CRC flow should remain unchanged
+        var path = CreatePath(Source, Sink, Token1, Quanta96CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, Quanta96CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_DoubleQuanta_ReturnsTwoQuanta()
+    {
+        // Path with exactly 192 CRC (2 × 96) should remain unchanged
+        var path = CreatePath(Source, Sink, Token1, 2 * Quanta96CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, 2 * Quanta96CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(2 * Quanta96CRC));
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_NonMultiple_RoundsDown()
+    {
+        // Path with 100 CRC should round down to 96 CRC
+        long flow100CRC = 100_000_000_000_000L;
+        var path = CreatePath(Source, Sink, Token1, flow100CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, flow100CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_LessThanQuanta_ExcludesPath()
+    {
+        // Path with 50 CRC (less than 96) should be excluded entirely
+        long flow50CRC = 50_000_000_000_000L;
+        var path = CreatePath(Source, Sink, Token1, flow50CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, flow50CRC);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_MultiplePaths_EachQuantized()
+    {
+        // Multiple paths: 100, 200, 50 CRC → returns paths with 96, 192 (50 excluded)
+        long flow100CRC = 100_000_000_000_000L;
+        long flow200CRC = 200_000_000_000_000L;
+        long flow50CRC = 50_000_000_000_000L;
+
+        var path1 = CreatePath(Source, Sink, Token1, flow100CRC);
+        var path2 = CreatePath(Source, Sink, Token2, flow200CRC);
+        var path3 = CreatePath(Source, Sink, Token1, flow50CRC);
+        var paths = new List<List<SimpleEdge>> { path1, path2, path3 };
+
+        // Set targetFlow high enough to include all valid paths
+        long targetFlow = 1000_000_000_000_000L;
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, targetFlow);
+
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
+        Assert.That(result[1][0].Flow, Is.EqualTo(192_000_000_000_000L)); // 2 × 96 CRC
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_TargetFlowLimitsResults()
+    {
+        // With targetFlow = 96 CRC, only 1 invite should be returned
+        long flow200CRC = 200_000_000_000_000L;
+        var path = CreatePath(Source, Sink, Token1, flow200CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, Quanta96CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC)); // Only 1 quanta despite 2 available
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_TargetFlow192_ReturnsTwoInvites()
+    {
+        // With targetFlow = 192 CRC, up to 2 invites should be returned
+        long flow300CRC = 300_000_000_000_000L;
+        var path = CreatePath(Source, Sink, Token1, flow300CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        long targetFlow = 2 * Quanta96CRC; // 192 CRC
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, targetFlow);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(2 * Quanta96CRC)); // 2 quanta
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_MultiHopPath_AllEdgesQuantized()
+    {
+        // Multi-hop path: Source → Intermediate → Sink
+        // All edges in the path should have the same quantized flow
+        long flow150CRC = 150_000_000_000_000L;
+
+        var edge1 = new SimpleEdge(Source, Intermediate, Token1, long.MaxValue) { Flow = flow150CRC };
+        var edge2 = new SimpleEdge(Intermediate, Sink, Token1, long.MaxValue) { Flow = flow150CRC };
+        var path = new List<SimpleEdge> { edge1, edge2 };
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, flow150CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0], Has.Count.EqualTo(2));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
+        Assert.That(result[0][1].Flow, Is.EqualTo(Quanta96CRC));
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_PathNotEndingAtSink_Excluded()
+    {
+        // A path that doesn't end at the sink should be excluded
+        var path = CreatePath(Source, Intermediate, Token1, Quanta96CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, Quanta96CRC);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_EmptyPaths_ReturnsEmpty()
+    {
+        var paths = new List<List<SimpleEdge>>();
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, Quanta96CRC);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_EmptyPathInList_Skipped()
+    {
+        var emptyPath = new List<SimpleEdge>();
+        var validPath = CreatePath(Source, Sink, Token1, Quanta96CRC);
+        var paths = new List<List<SimpleEdge>> { emptyPath, validPath };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, Quanta96CRC);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(Quanta96CRC));
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_MaxTargetFlow_ReturnsAllPossible()
+    {
+        // Simulate discovery mode with max uint256-like targetFlow
+        long flow100CRC = 100_000_000_000_000L;
+        long flow200CRC = 200_000_000_000_000L;
+        long flow300CRC = 300_000_000_000_000L;
+
+        var path1 = CreatePath(Source, Sink, Token1, flow100CRC);
+        var path2 = CreatePath(Source, Sink, Token2, flow200CRC);
+        var path3 = CreatePath(Source, Sink, Token1, flow300CRC);
+        var paths = new List<List<SimpleEdge>> { path1, path2, path3 };
+
+        // Use max long as targetFlow (simulating max uint256)
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, long.MaxValue);
+
+        Assert.That(result, Has.Count.EqualTo(3));
+        // Total quanta: 1 + 2 + 3 = 6 invites possible
+        long totalFlow = result.Sum(p => p[0].Flow);
+        Assert.That(totalFlow, Is.EqualTo(6 * Quanta96CRC)); // 576 CRC total
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_ZeroTargetFlow_ReturnsEmpty()
+    {
+        var path = CreatePath(Source, Sink, Token1, Quanta96CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, 0);
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_PartiallyMeetsTarget()
+    {
+        // Request 3 invites but only 2 possible
+        long flow200CRC = 200_000_000_000_000L;
+        var path = CreatePath(Source, Sink, Token1, flow200CRC);
+        var paths = new List<List<SimpleEdge>> { path };
+
+        long targetFlow = 3 * Quanta96CRC; // Want 3 invites
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, targetFlow);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(2 * Quanta96CRC)); // Only 2 possible
+    }
+
+    [Test]
+    public void QuantizeSinkBoundFlows_StopsAtTargetAcrossMultiplePaths()
+    {
+        // Two paths each with 192 CRC capacity, but only request 288 CRC (3 invites)
+        long flow192CRC = 192_000_000_000_000L;
+        var path1 = CreatePath(Source, Sink, Token1, flow192CRC);
+        var path2 = CreatePath(Source, Sink, Token2, flow192CRC);
+        var paths = new List<List<SimpleEdge>> { path1, path2 };
+
+        long targetFlow = 3 * Quanta96CRC; // Want 3 invites (288 CRC)
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, Sink, Quanta96CRC, targetFlow);
+
+        // First path provides 2 quanta (192), second provides 1 quanta (96) = 3 total
+        Assert.That(result, Has.Count.EqualTo(2));
+        long totalFlow = result.Sum(p => p[0].Flow);
+        Assert.That(totalFlow, Is.EqualTo(3 * Quanta96CRC));
+    }
+
+    /// <summary>
+    /// Helper to create a single-edge path from source to destination
+    /// </summary>
+    private static List<SimpleEdge> CreatePath(int from, int to, int token, long flow)
+    {
+        var edge = new SimpleEdge(from, to, token, long.MaxValue) { Flow = flow };
+        return new List<SimpleEdge> { edge };
+    }
+}

--- a/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -7,6 +7,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Circles.Pathfinder.Tests" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="Google.OrTools" Version="9.12.4544" />
         <PackageReference Include="Npgsql" Version="9.0.3" />
     </ItemGroup>

--- a/Circles.Pathfinder/DTOs/FlowRequest.cs
+++ b/Circles.Pathfinder/DTOs/FlowRequest.cs
@@ -13,6 +13,14 @@ public class FlowRequest
     public List<SimulatedBalance>? SimulatedBalances { get; set; }
     public List<SimulatedTrust>? SimulatedTrusts { get; set; }
     public int? MaxTransfers { get; set; }
+
+    /// <summary>
+    /// When true, enforces 96 CRC quantization for sink-bound transfers (invitation module).
+    /// Each sink-bound transfer will be exactly N × 96 CRC.
+    /// The number of invites is derived from targetFlow: invites = targetFlow / 96 CRC.
+    /// Use max uint256 targetFlow to discover all possible invites.
+    /// </summary>
+    public bool? QuantizedMode { get; set; }
 }
 
 public class SimulatedBalance

--- a/Circles.Pathfinder/PathUtils.cs
+++ b/Circles.Pathfinder/PathUtils.cs
@@ -146,4 +146,84 @@ internal static class PathUtils
 
         return result;
     }
+
+    /// <summary>
+    /// Quantizes sink-bound paths so each delivers an exact multiple of quantaSize.
+    /// Paths with flow less than quantaSize are excluded.
+    /// Only paths ending at the actual sink are quantized; intermediate paths pass through unchanged.
+    /// </summary>
+    /// <param name="paths">List of paths from ExtractFlowPaths</param>
+    /// <param name="sink">The sink node ID</param>
+    /// <param name="quantaSize">The quantization unit (e.g., 96 CRC in 6-decimal precision)</param>
+    /// <param name="targetFlow">Target flow amount - determines max invites (targetFlow / quantaSize)</param>
+    /// <returns>List of quantized paths, may have fewer paths than input</returns>
+    public static List<List<SimpleEdge>> QuantizeSinkBoundFlows(
+        List<List<SimpleEdge>> paths,
+        int sink,
+        long quantaSize,
+        long targetFlow)
+    {
+        var result = new List<List<SimpleEdge>>();
+        long totalQuantizedFlow = 0;
+
+        foreach (var path in paths)
+        {
+            // Check if we've already reached the target
+            if (totalQuantizedFlow >= targetFlow)
+            {
+                break;
+            }
+
+            // Check if this path ends at the sink
+            if (path.Count == 0)
+            {
+                continue;
+            }
+
+            var lastEdge = path[^1];
+            bool endsSink = lastEdge.To == sink;
+
+            if (!endsSink)
+            {
+                // Non-sink-bound path - skip (only sink paths matter for invitations)
+                continue;
+            }
+
+            // Get the path's current flow (all edges in a path have the same flow value)
+            long pathFlow = path[0].Flow;
+
+            // Calculate how many full quanta we can extract from this path
+            long maxQuantaFromPath = pathFlow / quantaSize;
+
+            if (maxQuantaFromPath <= 0)
+            {
+                // Path has less than 1 quanta - exclude it
+                continue;
+            }
+
+            // Calculate how many more quanta we need to reach target
+            long quantaNeeded = (targetFlow - totalQuantizedFlow) / quantaSize;
+            long quantaToUse = Math.Min(maxQuantaFromPath, quantaNeeded);
+
+            if (quantaToUse <= 0)
+            {
+                break;
+            }
+
+            // Create quantized path copy with exact multiple of quantaSize
+            long quantizedFlow = quantaToUse * quantaSize;
+            var quantizedPath = new List<SimpleEdge>(path.Count);
+
+            foreach (var edge in path)
+            {
+                var quantizedEdge = edge with { Flow = quantizedFlow };
+                quantizedPath.Add(quantizedEdge);
+            }
+
+            result.Add(quantizedPath);
+            totalQuantizedFlow += quantizedFlow;
+        }
+
+        return result;
+    }
 }

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -92,6 +92,23 @@ public class V2Pathfinder
         var simplePaths = PathUtils.ExtractFlowPaths(solved, sourceId, effSink);
 
         /* --------------------------------------------------------------------
+         * 2a. Optional quantization for invitation module (96 CRC chunks)
+         *     Only sink-bound transfers are quantized; intermediates pass through.
+         *     Number of invites is derived from targetFlow: invites = targetFlow / 96 CRC.
+         * ------------------------------------------------------------------ */
+        if (request.QuantizedMode == true)
+        {
+            // 96 CRC in 6-decimal precision = 96 * 10^12
+            const long InvitationQuanta = 96_000_000_000_000L;
+
+            simplePaths = PathUtils.QuantizeSinkBoundFlows(
+                simplePaths,
+                effSink,
+                InvitationQuanta,
+                tgt); // targetFlow determines how many invites to find
+        }
+
+        /* --------------------------------------------------------------------
          * 2b. Optional pruning to fit a transfer-step budget
          *      We keep the biggest-flow paths first and count "steps" after
          *      collapsing balance nodes (avatar→avatar per token).

--- a/Circles.Pathfinder/V2Pathfinder.cs
+++ b/Circles.Pathfinder/V2Pathfinder.cs
@@ -98,8 +98,8 @@ public class V2Pathfinder
          * ------------------------------------------------------------------ */
         if (request.QuantizedMode == true)
         {
-            // 96 CRC in 6-decimal precision = 96 * 10^12
-            const long InvitationQuanta = 96_000_000_000_000L;
+            // 96 CRC in 6-decimal precision = 96 * 10^6
+            const long InvitationQuanta = 96_000_000L;
 
             simplePaths = PathUtils.QuantizeSinkBoundFlows(
                 simplePaths,


### PR DESCRIPTION
## Summary

Adds a `quantizedMode` parameter to the pathfinder that ensures all sink-bound transfers are exactly **96 CRC** (for invitation module integration). Each 96 CRC transfer initiates one invitation.

### API Design

| quantizedMode | targetFlow | Behavior |
|---------------|------------|----------|
| `false` | any | Standard max-flow (no quantization) |
| `true` | `96 CRC` | Find 1 invite |
| `true` | `192 CRC` | Find 2 invites |
| `true` | `288 CRC` | Find 3 invites |
| `true` | max uint256 | Find ALL possible invites (discovery) |

### Usage Examples

**Find exactly 1 invite:**
```bash
curl -X POST '/findPath' -d '{
  "source": "0x...",
  "sink": "0xINVITATION_MODULE",
  "targetFlow": "96000000000000000000",
  "quantizedMode": true
}'
```

**Discovery - how many invites can I fund?**
```bash
curl -X POST '/findPath' -d '{
  "source": "0x...",
  "sink": "0xINVITATION_MODULE",
  "targetFlow": "115792089237316195423570985008687907853269984665640564039457584007913129639935",
  "quantizedMode": true
}'
```

### Changes

- `FlowRequest.QuantizedMode`: boolean parameter to enable the feature
- `PathUtils.QuantizeSinkBoundFlows()`: post-processes extracted paths to quantize sink-bound flows
- `V2Pathfinder`: integrates quantization after path extraction
- `Program.cs`: adds `quantizedMode` query param to GET `/findPath`
- `InternalsVisibleTo`: exposes internals for unit testing

## Test plan

- [x] Unit tests: 15 tests covering all edge cases (run with `dotnet test --filter QuantizedModeTests`)
- [ ] Manual test against staging with invitation module address
- [ ] Integration test with SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional quantized mode for path-finding requests. When enabled, sink-bound transfers are rounded down to quanta of 96 CRC units and aggregated up to the requested target, skipping amounts smaller than one quantum.

* **Tests**
  * Added comprehensive tests covering quantized-mode behaviour across single/multiple paths, rounding, limits, empty/non-sink paths and multi-hop scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->