### PR TITLE
feat(rpc): add circles_getTransferData convenience method

### DIFF
--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -676,6 +676,15 @@ run_test "sdk" "circles_searchProfileByAddressOrName (by address prefix)" "curl 
 
 run_test "sdk" "circles_searchProfileByAddressOrName (by text)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_searchProfileByAddressOrName\",\"params\":[\"berlin\",10,0,[\"CrcV2_RegisterHuman\"]],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
+# Transfer Data (calldata bytes from ERC-1155 transfers)
+run_test "sdk" "circles_getTransferData (addr only)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+
+run_test "sdk" "circles_getTransferData (sent)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"sent\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+
+run_test "sdk" "circles_getTransferData (received)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"received\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+
+run_test "sdk" "circles_getTransferData (with counterparty)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"sent\",\"$HIGH_ACTIVITY_ADDR_2\",10],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+
 ######################################################################
 # Query Methods
 ######################################################################

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -405,6 +405,126 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         );
     }
 
+    public async Task<PagedResponse<TransferDataRow>> GetTransferData(
+        string address,
+        string? direction = null,
+        string? counterparty = null,
+        int limit = 50,
+        string? cursor = null)
+    {
+        var addr = address.ToLower();
+        limit = Math.Clamp(limit, 1, 1000);
+
+        if (direction != null && direction != "sent" && direction != "received")
+            throw new ArgumentException("direction must be 'sent', 'received', or null");
+
+        await using var connection = await CreateConnectionAsync();
+        var (cursorBlock, cursorTxIndex, cursorLogIndex) = CursorUtils.DecodeCursor(cursor);
+        var hasCursor = cursorBlock.HasValue;
+
+        // Build WHERE clause
+        var conditions = new List<string>();
+        var parameters = new List<NpgsqlParameter>();
+
+        var counterAddr = counterparty?.ToLower();
+
+        if (direction == "sent")
+        {
+            conditions.Add(@"""from"" = @addr");
+            parameters.Add(new NpgsqlParameter("addr", addr));
+            if (counterAddr != null)
+            {
+                conditions.Add(@"""to"" = @counterparty");
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+        }
+        else if (direction == "received")
+        {
+            conditions.Add(@"""to"" = @addr");
+            parameters.Add(new NpgsqlParameter("addr", addr));
+            if (counterAddr != null)
+            {
+                conditions.Add(@"""from"" = @counterparty");
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+        }
+        else // both directions
+        {
+            if (counterAddr != null)
+            {
+                // (from=addr AND to=counter) OR (from=counter AND to=addr)
+                conditions.Add(@"(""from"" = @addr AND ""to"" = @counterparty) OR (""from"" = @counterparty AND ""to"" = @addr)");
+                parameters.Add(new NpgsqlParameter("addr", addr));
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+            else
+            {
+                conditions.Add(@"(""from"" = @addr OR ""to"" = @addr)");
+                parameters.Add(new NpgsqlParameter("addr", addr));
+            }
+        }
+
+        if (hasCursor)
+        {
+            conditions.Add(
+                @"(""blockNumber"", ""transactionIndex"", ""logIndex"") < (@cursorBlock, @cursorTxIndex, @cursorLogIndex)");
+            parameters.Add(new NpgsqlParameter("cursorBlock", cursorBlock!.Value));
+            parameters.Add(new NpgsqlParameter("cursorTxIndex", cursorTxIndex!.Value));
+            parameters.Add(new NpgsqlParameter("cursorLogIndex", cursorLogIndex!.Value));
+        }
+
+        var where = string.Join(" AND ", conditions.Select((c, i) =>
+            // Wrap the OR clause in parens so AND binds correctly
+            c.Contains(" OR ") ? $"({c})" : c));
+
+        var sql = $@"
+            SELECT ""blockNumber"", ""timestamp"", ""transactionIndex"", ""logIndex"",
+                   ""transactionHash"", ""from"", ""to"", ""data""
+            FROM ""CrcV2_TransferData""
+            WHERE {where}
+            ORDER BY ""blockNumber"" DESC, ""transactionIndex"" DESC, ""logIndex"" DESC
+            LIMIT @limit";
+
+        parameters.Add(new NpgsqlParameter("limit", limit + 1));
+
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        cmd.Parameters.AddRange(parameters.ToArray());
+
+        var results = new List<TransferDataRow>();
+        await using var reader = await cmd.ExecuteReaderAsync();
+        while (await reader.ReadAsync())
+        {
+            var dataBytes = reader.GetFieldValue<byte[]>(7);
+            results.Add(new TransferDataRow(
+                BlockNumber: reader.GetInt64(0),
+                Timestamp: reader.GetInt64(1),
+                TransactionIndex: reader.GetInt32(2),
+                LogIndex: reader.GetInt32(3),
+                TransactionHash: reader.GetString(4),
+                From: reader.GetString(5),
+                To: reader.GetString(6),
+                Data: "0x" + Convert.ToHexString(dataBytes).ToLower()
+            ));
+        }
+
+        var hasMore = results.Count > limit;
+        if (hasMore)
+            results.RemoveAt(results.Count - 1);
+
+        string? nextCursor = null;
+        if (hasMore && results.Count > 0)
+        {
+            var last = results[^1];
+            nextCursor = CursorUtils.EncodeCursor(last.BlockNumber, last.TransactionIndex, last.LogIndex);
+        }
+
+        return new PagedResponse<TransferDataRow>(
+            Results: results.ToArray(),
+            HasMore: hasMore,
+            NextCursor: nextCursor
+        );
+    }
+
     public async Task<JsonElement> GetNetworkSnapshot()
     {
         if (string.IsNullOrEmpty(_settings.ExternalPathfinderUrl))

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -298,6 +298,22 @@ public interface ICirclesRpcModule
     Task<PagedResponse<TokenHolderRow>> GetTokenHolders(string tokenAddress, int limit = 100, string? cursor = null);
 
     /// <summary>
+    /// Gets transfer data (calldata bytes) for ERC-1155 transfers involving an address.
+    /// Convenience method for querying CrcV2_TransferData without raw filterPredicates.
+    /// </summary>
+    /// <param name="address">Primary address to filter</param>
+    /// <param name="direction">"sent" (from=addr), "received" (to=addr), or null (both)</param>
+    /// <param name="counterparty">If set, AND with specific counterparty</param>
+    /// <param name="limit">Max results (default 50, max 1000)</param>
+    /// <param name="cursor">Cursor for pagination (base64 encoded block:tx:log)</param>
+    Task<PagedResponse<TransferDataRow>> GetTransferData(
+        string address,
+        string? direction = null,
+        string? counterparty = null,
+        int limit = 50,
+        string? cursor = null);
+
+    /// <summary>
     /// Finds common trust connections between two addresses.
     /// For V2 humans, uses "safer" paths (outgoing → incoming).
     /// For V2 groups and V1, uses shared outgoing trusts.
@@ -514,6 +530,20 @@ public record TransactionHistoryRow(
     [property: JsonPropertyName("attoCrc")] string AttoCrc,
     [property: JsonPropertyName("staticCircles")] string StaticCircles,
     [property: JsonPropertyName("staticAttoCircles")] string StaticAttoCircles
+);
+
+/// <summary>
+/// Transfer data row containing calldata bytes from ERC-1155 transfers.
+/// </summary>
+public record TransferDataRow(
+    [property: JsonPropertyName("blockNumber")] long BlockNumber,
+    [property: JsonPropertyName("timestamp")] long Timestamp,
+    [property: JsonPropertyName("transactionIndex")] int TransactionIndex,
+    [property: JsonPropertyName("logIndex")] int LogIndex,
+    [property: JsonPropertyName("transactionHash")] string TransactionHash,
+    [property: JsonPropertyName("from")] string From,
+    [property: JsonPropertyName("to")] string To,
+    [property: JsonPropertyName("data")] string Data  // hex-encoded bytes
 );
 
 /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -273,6 +273,7 @@ app.MapPost("/", async (
             "circles_getGroupMembers" => await ReflectionHandler(request, rpcModule),
             "circles_getGroupMemberships" => await ReflectionHandler(request, rpcModule),
             "circles_getTransactionHistory" => await ReflectionHandler(request, rpcModule),
+            "circles_getTransferData" => await ReflectionHandler(request, rpcModule),
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
             // System & Query Methods


### PR DESCRIPTION
## Summary
- New RPC method `circles_getTransferData` for querying `CrcV2_TransferData` (calldata bytes from ERC-1155 transfers)
- Replaces error-prone `circles_events` + raw `filterPredicates` for this common use case
- API: `circles_getTransferData(address, direction?, counterparty?, limit?, cursor?)`

## API Design
| Params | Query |
|--------|-------|
| `["0xA"]` | `from=A OR to=A` |
| `["0xA", "sent"]` | `from=A` |
| `["0xA", "received"]` | `to=A` |
| `["0xA", "sent", "0xB"]` | `from=A AND to=B` |
| `["0xA", null, "0xB"]` | `(from=A AND to=B) OR (from=B AND to=A)` |

Returns `PagedResponse<TransferDataRow>` with cursor-based pagination (limit capped at 1000).

## Files Changed
- `ICirclesRpcModule.cs` — `TransferDataRow` DTO + method signature
- `CirclesRpcModule.cs` — Implementation with parameterized SQL
- `Program.cs` — Route registration via `ReflectionHandler`
- `test-rpc.sh` — 4 test cases (basic, sent, received, counterparty)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] Existing RPC tests pass (22 pass, 0 fail)
- [x] Deployed to staging and verified all 8 filter/pagination modes
- [ ] Regression test via `./scripts/test-rpc.sh https://staging.circlesubi.network`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GetTransferData RPC endpoint for querying ERC-1155 transfer calldata with filtering by address, direction (sent/received), and counterparty, including pagination support.

* **Tests**
  * Expanded RPC test coverage with additional test cases for transfer data retrieval across various filter scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->