### PR TITLE
fix(index): remove silent flowVertices[0] fallback in DeriveToAddress (D4)

### DIFF
--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -677,16 +677,16 @@ run_test "sdk" "circles_searchProfileByAddressOrName (by address prefix)" "curl 
 run_test "sdk" "circles_searchProfileByAddressOrName (by text)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_searchProfileByAddressOrName\",\"params\":[\"berlin\",10,0,[\"CrcV2_RegisterHuman\"]],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
 # Transfer Data (calldata bytes from ERC-1155 transfers)
-# params: [address, fromBlock?, toBlock?, direction?, counterparty?, limit?, cursor?]
+# params: [address, direction?, counterparty?, fromBlock?, toBlock?, limit?, cursor?]
 run_test "sdk" "circles_getTransferData (addr only)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
-run_test "sdk" "circles_getTransferData (block range)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",43000000,44000000],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "sdk" "circles_getTransferData (block range)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",null,null,43000000,44000000],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
-run_test "sdk" "circles_getTransferData (sent)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",null,null,\"sent\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "sdk" "circles_getTransferData (sent)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"sent\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
-run_test "sdk" "circles_getTransferData (received)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",null,null,\"received\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "sdk" "circles_getTransferData (received)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"received\"],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
-run_test "sdk" "circles_getTransferData (with counterparty)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",null,null,\"sent\",\"$HIGH_ACTIVITY_ADDR_2\",10],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "sdk" "circles_getTransferData (with counterparty)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"method\":\"circles_getTransferData\",\"params\":[\"$HIGH_ACTIVITY_ADDR_1\",\"sent\",\"$HIGH_ACTIVITY_ADDR_2\",null,null,10],\"id\":1}' -H \"Content-Type: application/json\" $RPC_URL"
 
 ######################################################################
 # Query Methods

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferCalldataParserTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferCalldataParserTests.cs
@@ -361,6 +361,60 @@ public class TransferCalldataParserTests
         Assert.That(results, Has.Count.EqualTo(2), "Should skip stream with empty data");
     }
 
+    // ─────────────────────── D4 Bug Fix: Out-of-Bounds Coordinate Handling ───────────────────────
+
+    [Test]
+    public void OperateFlowMatrix_OutOfBoundsCoordinate_SkipsStream()
+    {
+        // Receiver coordinate (99) exceeds flowVertices.Length (3)
+        // Before fix: silently returned flowVertices[0] (wrong address)
+        // After fix: returns null → stream is skipped
+        var charlie = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+        var calldata = BuildOperateFlowMatrixCalldata(
+            flowVertices: new[] { Alice, Bob, charlie },  // length = 3
+            streams: new[]
+            {
+                new StreamData(
+                    sourceCoordinate: 0,
+                    flowEdgeIds: new ulong[] { 0 },
+                    data: new byte[] { 0x01, 0x02 }
+                )
+            },
+            // Edge 0: receiver coordinate = 99 (out of bounds for flowVertices[3])
+            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x63 }  // 0x63 = 99
+        );
+
+        var results = TransferCalldataParser.ParseCalldata(calldata).ToList();
+
+        Assert.That(results, Is.Empty, "Stream with OOB receiver coordinate should be skipped, not fall back to flowVertices[0]");
+    }
+
+    [Test]
+    public void OperateFlowMatrix_OutOfBoundsPackedCoordinates_SkipsStream()
+    {
+        // flowEdgeId=5 → byte offset 30, needs 6 bytes → requires packedCoordinates.Length >= 36
+        // But we only provide 6 bytes (one edge triplet)
+        // Before fix: silently returned flowVertices[0] (wrong address)
+        // After fix: returns null → stream is skipped
+        var calldata = BuildOperateFlowMatrixCalldata(
+            flowVertices: new[] { Alice, Bob },
+            streams: new[]
+            {
+                new StreamData(
+                    sourceCoordinate: 0,
+                    flowEdgeIds: new ulong[] { 5 },  // edge ID 5 → offset 30, OOB
+                    data: new byte[] { 0xab }
+                )
+            },
+            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }  // only 6 bytes
+        );
+
+        var results = TransferCalldataParser.ParseCalldata(calldata).ToList();
+
+        Assert.That(results, Is.Empty, "Stream with OOB packed coordinates should be skipped, not fall back to flowVertices[0]");
+    }
+
     // ─────────────────────── Real Calldata Tests (Hex Encoded) ───────────────────────
 
     /// <summary>

--- a/src/Index/Circles.Index.CirclesV2/TransferCalldataParser.cs
+++ b/src/Index/Circles.Index.CirclesV2/TransferCalldataParser.cs
@@ -215,7 +215,9 @@ public static class TransferCalldataParser
         // Derive 'to' from the first flow edge
         // Each packed coordinate is 2 bytes (uint16), so flowEdgeId * 2 is the byte offset
         // The coordinate at that position indexes into flowVertices
-        string to = DeriveToAddress(flowEdgeIds[0], packedCoordinates, flowVertices);
+        string? to = DeriveToAddress(flowEdgeIds[0], packedCoordinates, flowVertices);
+        if (to == null)
+            return null;
 
         return (from, to, dataBytes);
     }
@@ -232,25 +234,20 @@ public static class TransferCalldataParser
     /// The flowEdgeId indexes these 6-byte triplets.
     /// We want the receiver coordinate (third uint16 in the triplet).
     /// </summary>
-    private static string DeriveToAddress(UInt256 flowEdgeId, byte[] packedCoordinates, string[] flowVertices)
+    private static string? DeriveToAddress(UInt256 flowEdgeId, byte[] packedCoordinates, string[] flowVertices)
     {
         // Each flow edge triplet is 6 bytes: circlesId (2) + sender (2) + receiver (2)
         // flowEdgeId indexes these 6-byte triplets
         int byteOffset = (int)flowEdgeId * 6;
 
         if (byteOffset + 6 > packedCoordinates.Length)
-        {
-            // Fall back to first vertex if we can't derive
-            return flowVertices.Length > 0 ? flowVertices[0] : "";
-        }
+            return null;
 
         // Receiver coordinate is at bytes [byteOffset + 4, byteOffset + 6) (big-endian uint16)
         ushort receiverCoord = (ushort)((packedCoordinates[byteOffset + 4] << 8) | packedCoordinates[byteOffset + 5]);
 
         if (receiverCoord >= flowVertices.Length)
-        {
-            return flowVertices.Length > 0 ? flowVertices[0] : "";
-        }
+            return null;
 
         return flowVertices[receiverCoord];
     }


### PR DESCRIPTION
## Summary

- **D4 bug fix**: `DeriveToAddress()` silently fell back to `flowVertices[0]` when a packed coordinate or receiver index was out of bounds, producing wrong `to` addresses in `CrcV2_TransferData` events. Now returns `null` → `ParseStream` skips the malformed stream entirely.
- **test-rpc.sh**: Fixed param order in `circles_getTransferData` curl commands to match the reordered signature from 22ffc82f (`address, direction?, counterparty?, fromBlock?, toBlock?`).
- **2 regression tests** added: `OperateFlowMatrix_OutOfBoundsCoordinate_SkipsStream`, `OperateFlowMatrix_OutOfBoundsPackedCoordinates_SkipsStream`.

## Test plan

- [x] `dotnet test --filter TransferCalldataParser` — 22/22 pass
- [ ] Verify test-rpc.sh against staging after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transfer data parsing to properly handle out-of-bounds conditions and reject invalid transfers instead of applying fallback defaults, ensuring data integrity.

* **Tests**
  * Added test coverage for out-of-bounds transfer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->