### PR TITLE
chore: consolidate .env.local.example into .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,9 @@
 # =============================================================================
 
 # PostgreSQL Database Configuration
-POSTGRES_PASSWORD=postgres
 POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres
 
 # User/Group IDs for file permissions
 # =============================================================================

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,0 @@
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=postgres

--- a/Circles.sln
+++ b/Circles.sln
@@ -99,7 +99,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{9F5E6384-8D91-7B30-BF94-463B36B69FC3}"
 	ProjectSection(SolutionItems) = preProject
 		.dockerignore = .dockerignore
-		.env.local.example = .env.local.example
+		.env.example = .env.example
 		.gitignore = .gitignore
 		.gitmodules = .gitmodules
 		all_tables.html = all_tables.html

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -313,7 +313,7 @@ Start services in separate terminals:
 
 Copy and customize environment variables for local development:
 ```bash
-cp .env.local.example .env.local
+cp .env.example .env.local
 # Edit .env.local with your settings
 source .env.local
 ./scripts/run-pathfinder.sh

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -918,7 +918,7 @@ All scripts support environment variables for customization.
 Create a `.env.local` file from the example:
 
 ```bash
-cp .env.local.example .env.local
+cp .env.example .env.local
 # Edit .env.local with your settings
 ```
 

--- a/scripts/run-index.sh
+++ b/scripts/run-index.sh
@@ -55,7 +55,7 @@ if [ ! -f "$NETHERMIND_BIN_DIR/nethermind" ]; then
 fi
 
 # Load environment variables
-ENV_FILE="$PROJECT_ROOT/.env.local.example"
+ENV_FILE="$PROJECT_ROOT/.env.local"
 if [ ! -f "$ENV_FILE" ]; then
     ENV_FILE="$PROJECT_ROOT/.env.example"
 fi

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -44,7 +44,7 @@ export PROFILE_SEARCH_TIMEOUT_SECONDS=30
 export EXTERNAL_PATHFINDER_URL="http://localhost:8080"
 ```
 
-See `.env.local.example` for full configuration options.
+See `.env.example` for full configuration options.
 
 ## JSON-RPC 2.0 API
 


### PR DESCRIPTION
## Summary
- Removes redundant `.env.local.example` — `.env.example` is now the single source of truth
- Added `POSTGRES_DB=postgres` to `.env.example` (only variable that was missing)
- Fixed `run-index.sh` to use `.env.local` with `.env.example` fallback (consistent with `run-pathfinder.sh` and `run-rpc.sh`)
- Updated all doc references (DEVELOPMENT.md, scripts/README.md, Rpc README, Circles.sln)

## Motivation
We had 2 `.env.example` files in the repo with overlapping content. Local dev workflow is: `cp .env.example .env.local` → edit → `source .env.local`.

## Test plan
- [ ] `./scripts/run-index.sh` still loads env correctly
- [ ] `./scripts/run-pathfinder.sh` and `./scripts/run-rpc.sh` unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated environment configuration templates by designating a single primary template for local setup.
  * Updated build scripts and documentation to reference the new consolidated configuration template.
  * Adjusted the environment file loading mechanism to use the updated template hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->