### PR TITLE
fix(index): classify scope events as stream events in TransferSummary

### DIFF
--- a/scripts/migrations/001-fix-transfer-summary-scope-events.sql
+++ b/scripts/migrations/001-fix-transfer-summary-scope-events.sql
@@ -1,0 +1,68 @@
+-- Migration: Fix FlowEdgesScopeSingleStarted/LastEnded misclassification
+-- in CrcV2_TransferSummary events JSON column.
+--
+-- Bug: FlowEdgesScopeSingleStarted was added to nonStreamEvents instead of
+-- streamEvents, and FlowEdgesScopeLastEnded had no handler (fell through to
+-- non-stream bucket). This means:
+--   - Non-stream rows contain scope events that don't belong there
+--   - Stream rows are missing their scope boundary events
+--
+-- This migration:
+--   1. Extracts scope events from non-stream rows
+--   2. Removes them from non-stream rows' JSON arrays
+--   3. Prepends them to stream rows' JSON arrays (matched by transactionHash)
+--
+-- Safe to run multiple times (idempotent) — skips rows already fixed.
+-- Estimated: ~504k non-stream rows + ~314k stream rows affected.
+
+BEGIN;
+
+-- Step 1: Build a temp table of scope events per transaction
+CREATE TEMP TABLE scope_events_by_tx AS
+SELECT
+    "transactionHash",
+    "blockNumber",
+    -- Collect scope events (FlowEdgesScopeSingleStarted + FlowEdgesScopeLastEnded)
+    json_agg(elem ORDER BY (elem->>'LogIndex')::int) AS scope_events,
+    -- Rebuild non-stream array without scope events
+    json_agg(elem ORDER BY (elem->>'LogIndex')::int)
+        FILTER (WHERE elem->>'$type' NOT IN ('CrcV2_FlowEdgesScopeSingleStarted', 'CrcV2_FlowEdgesScopeLastEnded'))
+        AS cleaned_events
+FROM "CrcV2_TransferSummary",
+     json_array_elements(events::json) AS elem
+WHERE events::text LIKE '%FlowEdgesScopeSingleStarted%'
+  AND events::text NOT LIKE '%StreamCompleted%'
+GROUP BY "transactionHash", "blockNumber";
+
+-- Index for join performance
+CREATE INDEX ON scope_events_by_tx ("transactionHash", "blockNumber");
+
+-- Step 2: Update non-stream rows — remove scope events from their JSON
+UPDATE "CrcV2_TransferSummary" ts
+SET events = COALESCE(se.cleaned_events::text, '[]')
+FROM scope_events_by_tx se
+WHERE ts."transactionHash" = se."transactionHash"
+  AND ts."blockNumber" = se."blockNumber"
+  AND ts.events::text LIKE '%FlowEdgesScopeSingleStarted%'
+  AND ts.events::text NOT LIKE '%StreamCompleted%';
+
+-- Step 3: Update stream rows — prepend scope events to their JSON
+-- Uses json concatenation: scope_events || existing_events
+UPDATE "CrcV2_TransferSummary" ts
+SET events = (
+    SELECT json_agg(elem ORDER BY (elem->>'LogIndex')::int)::text
+    FROM (
+        SELECT elem FROM json_array_elements(se.scope_events) AS elem
+        UNION ALL
+        SELECT elem FROM json_array_elements(ts.events::json) AS elem
+    ) combined(elem)
+)
+FROM scope_events_by_tx se
+WHERE ts."transactionHash" = se."transactionHash"
+  AND ts."blockNumber" = se."blockNumber"
+  AND ts.events::text LIKE '%StreamCompleted%';
+
+-- Cleanup
+DROP TABLE scope_events_by_tx;
+
+COMMIT;

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
@@ -54,9 +54,9 @@ public class TransferSummaryAggregatorTests
     }
 
     [Test]
-    public void AggregateAll_FlowEdgesScopeSingleStarted_AddedToNonStreamEvents()
+    public void AggregateAll_FlowEdgesScopeSingleStarted_AddedToStreamEvents()
     {
-        // This test works because FlowEdgesScopeSingleStarted doesn't trigger AddNonStreamTransfers
+        // FlowEdgesScopeSingleStarted is a stream boundary event and belongs in streamEvents
         var events = new IIndexedEventV2[]
         {
             CreateFlowEdgesScopeSingleStarted(1, 0)
@@ -64,8 +64,9 @@ public class TransferSummaryAggregatorTests
 
         var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
 
-        Assert.That(result.NonStreamEvents, Has.Count.EqualTo(1));
-        Assert.That(result.NonStreamEvents[0], Is.InstanceOf<FlowEdgesScopeSingleStarted>());
+        Assert.That(result.StreamEvents, Has.Count.EqualTo(1));
+        Assert.That(result.StreamEvents[0], Is.InstanceOf<FlowEdgesScopeSingleStarted>());
+        Assert.That(result.NonStreamEvents, Is.Empty);
     }
 
     [Test]
@@ -377,7 +378,9 @@ public class TransferSummaryAggregatorTests
 
         var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
 
-        Assert.That(result.StreamEvents, Has.Count.EqualTo(3));
+        // 4 events: FlowEdgesScopeSingleStarted + 2 TransferSingle + StreamCompleted
+        Assert.That(result.StreamEvents, Has.Count.EqualTo(4));
+        Assert.That(result.StreamEvents.OfType<FlowEdgesScopeSingleStarted>().Count(), Is.EqualTo(1));
         Assert.That(result.StreamEvents.OfType<TransferSingle>().Count(), Is.EqualTo(2));
         Assert.That(result.StreamEvents.OfType<StreamCompleted>().Count(), Is.EqualTo(1));
     }

--- a/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
+++ b/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
@@ -46,7 +46,14 @@ public static class TransferSummaryAggregator
             if (e is FlowEdgesScopeSingleStarted)
             {
                 inStream = true;
-                nonStreamEvents.Add(e);
+                streamEvents.Add(e);
+                continue;
+            }
+
+            if (e is FlowEdgesScopeLastEnded)
+            {
+                streamEvents.Add(e);
+                inStream = false;
                 continue;
             }
 


### PR DESCRIPTION
## Summary
- `FlowEdgesScopeSingleStarted` was added to `nonStreamEvents` instead of `streamEvents` — misclassifying the scope boundary in `TransferSummary` JSON
- `FlowEdgesScopeLastEnded` had no handler, falling through to whichever bucket `inStream` happened to be in
- Cherry-picked from jaensen's PR #145 (`c65db8ef`), with test updates for the corrected behavior

## Impact
- **Transfer amounts/sums**: Unaffected — this is event classification only
- **Events JSON column**: `FlowEdgesScopeSingleStarted` appears in non-stream rows' JSON instead of stream rows'
- **Staging numbers**: ~504k non-stream rows affected, ~314k stream rows missing scope events

## SQL Migration
Included at `scripts/migrations/001-fix-transfer-summary-scope-events.sql` — fixes existing data without a full reindex by moving scope events between JSON arrays matched by `transactionHash`. Idempotent.

## Test plan
- [x] 19/19 TransferSummaryAggregatorTests pass (updated assertions for corrected behavior)
- [ ] Run SQL migration on staging to verify data fix
- [ ] Spot-check a few transactions to confirm scope events moved correctly