### PR TITLE
fix(deps): revert Int256 1.5.0 → 1.3.6 to match Nethermind base image

### DIFF
--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
 
     <!-- Numerics for Circles calculations -->
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
   </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
+++ b/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
+++ b/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
+++ b/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
+++ b/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
+++ b/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
@@ -21,7 +21,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
       <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
     </ItemGroup>
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -38,7 +38,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -56,7 +56,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
-        <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+        <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
     </ItemGroup>
 
 </Project>

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nethereum.Util" Version="5.0.0" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Reverts `Nethermind.Numerics.Int256` from `1.5.0` back to `1.3.6` across all 12 `.csproj` files
- Removes newly-added direct Int256 reference from `Circles.Index.Query.csproj` (transitive via `Circles.Common` is sufficient)
- Fixes crash-loop caused by assembly version mismatch with `nethermind/nethermind:1.36.0` base image

## Context

PR #154 bumped Int256 to 1.5.0 without upgrading the Nethermind base image (still `1.36.0`). The base image ships `Nethermind.Int256.dll` at version 1.3.x. When the plugin loads Int256 1.5.0, the CLR throws `FileLoadException` because the assembly versions don't match, crash-looping Nethermind and taking down the entire RPC + Pathfinder stack.

**Impact**: nethermind → rpc → pathfinder all down on staging. `crc-backers` and `oic` services failing RPC health checks.

## Files changed (12)

11 files: `Version="1.5.0"` → `Version="1.3.6"`  
1 file (`Circles.Index.Query.csproj`): removed entire `PackageReference` line (was added new by #154, not needed — transitive dep)

## Test plan

- [x] `dotnet restore` succeeds
- [x] `dotnet build` succeeds (pre-push hook verified)
- [ ] After merge: redeploy staging via `make deploy-gnosis HOST=staging2`
- [ ] Verify `nethermind-gnosis` starts and stays running
- [ ] Verify `rpc` and `pathfinder` transition to "Up"
- [ ] Verify `crc-backers` / `oic` RPC health checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions across multiple services to maintain compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->