### PR TITLE
fix(index): Erc20WrapperTransfer events lost from TransferSummary in stream scopes

### DIFF
--- a/scripts/migrations/001-fix-wrapper-transfer-summary-dryrun.sql
+++ b/scripts/migrations/001-fix-wrapper-transfer-summary-dryrun.sql
@@ -1,0 +1,155 @@
+-- Dry-run: Preview what the migration would insert
+-- Run this FIRST on staging to verify correctness before running the real migration.
+-- Shows: affected transactions, missing TransferSummary rows, and row counts.
+
+-- Helper functions (same as migration)
+CREATE OR REPLACE FUNCTION pg_temp.fixed64_gamma_pow(day integer)
+RETURNS numeric AS $$
+DECLARE
+    base numeric := 18443079296116538654;
+    result numeric := 18446744073709551616;
+    two_64 numeric := 18446744073709551616;
+    n integer := day;
+BEGIN
+    WHILE n > 0 LOOP
+        IF n % 2 = 1 THEN
+            result := trunc(result * base / two_64);
+        END IF;
+        base := trunc(base * base / two_64);
+        n := n / 2;
+    END LOOP;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+CREATE OR REPLACE FUNCTION pg_temp.v2_day_from_timestamp(block_timestamp bigint)
+RETURNS integer AS $$
+BEGIN
+    RETURN floor((block_timestamp - 1675209600) / 86400)::integer;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Diagnostic 1: Count of affected transactions
+WITH stream_windows AS (
+    SELECT
+        sc."transactionHash",
+        sc."blockNumber",
+        sc."timestamp",
+        sc."transactionIndex",
+        (SELECT MAX(fss."logIndex")
+         FROM "CrcV2_FlowEdgesScopeSingleStarted" fss
+         WHERE fss."transactionHash" = sc."transactionHash"
+           AND fss."logIndex" < sc."logIndex"
+        ) AS stream_start_log,
+        sc."logIndex" AS stream_end_log
+    FROM "CrcV2_StreamCompleted" sc
+),
+wrapper_in_stream AS (
+    SELECT DISTINCT ewt."transactionHash"
+    FROM "CrcV2_Erc20WrapperTransfer" ewt
+    INNER JOIN stream_windows sw
+        ON ewt."transactionHash" = sw."transactionHash"
+        AND ewt."logIndex" > sw.stream_start_log
+        AND ewt."logIndex" < sw.stream_end_log
+    WHERE sw.stream_start_log IS NOT NULL
+)
+SELECT COUNT(*) AS affected_transactions FROM wrapper_in_stream;
+
+-- Diagnostic 2: Preview rows that would be inserted
+WITH stream_windows AS (
+    SELECT
+        sc."transactionHash",
+        sc."blockNumber",
+        sc."timestamp",
+        sc."transactionIndex",
+        (SELECT MAX(fss."logIndex")
+         FROM "CrcV2_FlowEdgesScopeSingleStarted" fss
+         WHERE fss."transactionHash" = sc."transactionHash"
+           AND fss."logIndex" < sc."logIndex"
+        ) AS stream_start_log,
+        sc."logIndex" AS stream_end_log
+    FROM "CrcV2_StreamCompleted" sc
+),
+wrapper_in_stream AS (
+    SELECT
+        ewt."blockNumber",
+        ewt."timestamp",
+        ewt."transactionIndex",
+        ewt."transactionHash",
+        ewt."from",
+        ewt."to",
+        ewt."amount",
+        ewt."tokenAddress"
+    FROM "CrcV2_Erc20WrapperTransfer" ewt
+    INNER JOIN stream_windows sw
+        ON ewt."transactionHash" = sw."transactionHash"
+        AND ewt."logIndex" > sw.stream_start_log
+        AND ewt."logIndex" < sw.stream_end_log
+    WHERE sw.stream_start_log IS NOT NULL
+),
+wrapper_converted AS (
+    SELECT
+        wis."blockNumber",
+        wis."timestamp",
+        wis."transactionIndex",
+        wis."transactionHash",
+        wis."from",
+        wis."to",
+        CASE
+            WHEN wd."circlesType" IS NOT NULL AND (wd."circlesType" & 1) = 1
+            THEN trunc(
+                pg_temp.fixed64_gamma_pow(pg_temp.v2_day_from_timestamp(wis."timestamp"))
+                * wis."amount" / 18446744073709551616
+            )
+            ELSE wis."amount"
+        END AS converted_amount,
+        CASE
+            WHEN wd."circlesType" IS NOT NULL AND (wd."circlesType" & 1) = 1
+            THEN 'inflationary'
+            ELSE 'demurraged'
+        END AS wrapper_type
+    FROM wrapper_in_stream wis
+    LEFT JOIN "CrcV2_ERC20WrapperDeployed" wd
+        ON wd."erc20Wrapper" = wis."tokenAddress"
+),
+aggregated AS (
+    SELECT
+        wc."blockNumber",
+        wc."transactionHash",
+        wc."from",
+        wc."to",
+        SUM(wc.converted_amount)::numeric AS total_amount,
+        COUNT(*) AS event_count,
+        string_agg(DISTINCT wc.wrapper_type, ', ') AS wrapper_types
+    FROM wrapper_converted wc
+    GROUP BY
+        wc."blockNumber",
+        wc."transactionHash",
+        wc."from",
+        wc."to"
+)
+SELECT
+    a.*,
+    CASE
+        WHEN EXISTS (
+            SELECT 1 FROM "CrcV2_TransferSummary" ts
+            WHERE ts."transactionHash" = a."transactionHash"
+              AND ts."from" = a."from"
+              AND ts."to" = a."to"
+        ) THEN 'ALREADY EXISTS (skip)'
+        ELSE 'WILL INSERT'
+    END AS action
+FROM aggregated a
+ORDER BY a."blockNumber", a."transactionHash", a."from", a."to";
+
+-- Diagnostic 3: Verify the specific transaction from the bug report
+SELECT
+    ts."blockNumber",
+    ts."transactionHash",
+    ts."from",
+    ts."to",
+    ts."amount",
+    ts."logIndex"
+FROM "CrcV2_TransferSummary" ts
+WHERE ts."transactionHash" = '0xe0cfdf0f0970a104aaa79b157b240ff95e02807a40a84b2ef6ff94d7dbc761b1'
+ORDER BY ts."logIndex";

--- a/scripts/migrations/001-fix-wrapper-transfer-summary.sql
+++ b/scripts/migrations/001-fix-wrapper-transfer-summary.sql
@@ -1,0 +1,174 @@
+-- Migration: Fix missing Erc20WrapperTransfer events in TransferSummary
+--
+-- Bug: Erc20WrapperTransfer events occurring inside Hub stream scopes
+-- (between FlowEdgesScopeSingleStarted and StreamCompleted) were captured
+-- in streamEvents but never aggregated into TransferSummary rows.
+-- StreamCompleted only reflects Hub ERC1155 flows, not wrapper contract transfers.
+--
+-- This migration INSERTs the missing TransferSummary rows with zero downtime.
+-- Safe to run multiple times (idempotent via NOT EXISTS guard).
+--
+-- Run AFTER deploying the code fix to TransferSummaryAggregator.cs.
+-- New blocks indexed after the code fix will be correct automatically.
+-- This migration only backfills historical data.
+
+BEGIN;
+
+-- Step 1: Create a temporary function to compute Fixed64.Pow(GAMMA_64, day)
+-- Replicates the C# Fixed64.Pow exponentiation-by-squaring on Q64.64 fixed-point.
+-- Needed for inflationary wrapper value conversion (circlesType = 1).
+CREATE OR REPLACE FUNCTION pg_temp.fixed64_gamma_pow(day integer)
+RETURNS numeric AS $$
+DECLARE
+    base numeric := 18443079296116538654;         -- GAMMA_64
+    result numeric := 18446744073709551616;        -- 2^64 (Q64.64 identity = 1.0)
+    two_64 numeric := 18446744073709551616;        -- 2^64
+    n integer := day;
+BEGIN
+    WHILE n > 0 LOOP
+        IF n % 2 = 1 THEN
+            result := trunc(result * base / two_64);
+        END IF;
+        base := trunc(base * base / two_64);
+        n := n / 2;
+    END LOOP;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Step 2: Compute the V2 day from a block timestamp
+-- V2_INFLATION_DAY_ZERO_UNIX = 1675209600 (2023-02-01 00:00 UTC)
+-- Uses the block timestamp (not NOW()) so the conversion matches what the
+-- indexer would have computed at the time the block was processed.
+CREATE OR REPLACE FUNCTION pg_temp.v2_day_from_timestamp(block_timestamp bigint)
+RETURNS integer AS $$
+BEGIN
+    RETURN floor((block_timestamp - 1675209600) / 86400)::integer;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Step 3: Insert missing TransferSummary rows
+WITH
+-- 3a: Identify stream windows: (txHash, stream_start_logIndex, stream_end_logIndex)
+-- A stream starts at FlowEdgesScopeSingleStarted and ends at StreamCompleted.
+-- We pair each StreamCompleted with the MAX FlowEdgesScopeSingleStarted logIndex
+-- that is less than the StreamCompleted logIndex in the same transaction.
+stream_windows AS (
+    SELECT
+        sc."transactionHash",
+        sc."blockNumber",
+        sc."timestamp",
+        sc."transactionIndex",
+        (
+            SELECT MAX(fss."logIndex")
+            FROM "CrcV2_FlowEdgesScopeSingleStarted" fss
+            WHERE fss."transactionHash" = sc."transactionHash"
+              AND fss."logIndex" < sc."logIndex"
+        ) AS stream_start_log,
+        sc."logIndex" AS stream_end_log
+    FROM "CrcV2_StreamCompleted" sc
+),
+
+-- 3b: Find Erc20WrapperTransfer events inside stream windows
+wrapper_in_stream AS (
+    SELECT
+        ewt."blockNumber",
+        ewt."timestamp",
+        ewt."transactionIndex",
+        ewt."transactionHash",
+        ewt."from",
+        ewt."to",
+        ewt."amount",
+        ewt."tokenAddress"
+    FROM "CrcV2_Erc20WrapperTransfer" ewt
+    INNER JOIN stream_windows sw
+        ON ewt."transactionHash" = sw."transactionHash"
+        AND ewt."logIndex" > sw.stream_start_log
+        AND ewt."logIndex" < sw.stream_end_log
+    WHERE sw.stream_start_log IS NOT NULL
+),
+
+-- 3c: Convert inflationary wrapper amounts (circlesType = 1)
+-- Demurraged wrappers (circlesType = 0 or 2): use raw amount
+-- Inflationary wrappers (circlesType = 1 or 3): apply InflationaryToDemurrage
+wrapper_converted AS (
+    SELECT
+        wis."blockNumber",
+        wis."timestamp",
+        wis."transactionIndex",
+        wis."transactionHash",
+        wis."from",
+        wis."to",
+        CASE
+            WHEN wd."circlesType" IS NOT NULL AND (wd."circlesType" & 1) = 1
+            THEN trunc(
+                pg_temp.fixed64_gamma_pow(pg_temp.v2_day_from_timestamp(wis."timestamp"))
+                * wis."amount" / 18446744073709551616  -- 2^64
+            )
+            ELSE wis."amount"
+        END AS converted_amount
+    FROM wrapper_in_stream wis
+    LEFT JOIN "CrcV2_ERC20WrapperDeployed" wd
+        ON wd."erc20Wrapper" = wis."tokenAddress"
+),
+
+-- 3d: Aggregate by (tx, from, to)
+aggregated AS (
+    SELECT
+        wc."blockNumber",
+        wc."timestamp",
+        wc."transactionIndex",
+        wc."transactionHash",
+        wc."from",
+        wc."to",
+        SUM(wc.converted_amount)::numeric AS total_amount
+    FROM wrapper_converted wc
+    GROUP BY
+        wc."blockNumber",
+        wc."timestamp",
+        wc."transactionIndex",
+        wc."transactionHash",
+        wc."from",
+        wc."to"
+),
+
+-- 3e: Compute synthetic logIndex values that don't collide with existing rows.
+-- Existing TransferSummary rows use negative logIndex values.
+-- We need to find the minimum existing logIndex per transaction and go below it.
+with_log_index AS (
+    SELECT
+        a.*,
+        COALESCE(
+            (SELECT MIN(ts."logIndex") FROM "CrcV2_TransferSummary" ts
+             WHERE ts."transactionHash" = a."transactionHash"),
+            0
+        ) - ROW_NUMBER() OVER (
+            PARTITION BY a."transactionHash"
+            ORDER BY a."from", a."to"
+        ) AS synthetic_log_index
+    FROM aggregated a
+)
+
+-- 3f: Insert only rows that don't already exist (idempotent)
+INSERT INTO "CrcV2_TransferSummary"
+    ("blockNumber", "timestamp", "transactionIndex", "logIndex", "transactionHash", "from", "to", "amount", "events")
+SELECT
+    wli."blockNumber",
+    wli."timestamp",
+    wli."transactionIndex",
+    wli.synthetic_log_index::integer,
+    wli."transactionHash",
+    wli."from",
+    wli."to",
+    wli.total_amount,
+    '[]'::text  -- events JSON not used by RPC queries; supplementary only
+FROM with_log_index wli
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM "CrcV2_TransferSummary" ts
+    WHERE ts."transactionHash" = wli."transactionHash"
+      AND ts."from" = wli."from"
+      AND ts."to" = wli."to"
+);
+
+COMMIT;

--- a/src/Index/Circles.Index.CirclesV2.Tests/CalldataUnwrapperTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/CalldataUnwrapperTests.cs
@@ -398,13 +398,15 @@ public class CalldataUnwrapperTests
     [Test]
     public void UnwrapAndParse_DirectOperateFlowMatrix_PassesThrough()
     {
+        // packedCoordinates: each flow edge is 6 bytes (circlesId:2 + sender:2 + receiver:2)
+        // Edge 0: circlesId=0, sender=0 (Alice), receiver=1 (Bob)
         var calldata = BuildOperateFlowMatrixCalldata(
             flowVertices: new[] { Alice, Bob },
             streams: new[]
             {
                 new StreamData(0, new ulong[] { 0 }, new byte[] { 0xca, 0xfe })
             },
-            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x01 }
+            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }
         );
 
         var results = CalldataUnwrapper.UnwrapAndParse(calldata).ToList();
@@ -677,13 +679,14 @@ public class CalldataUnwrapperTests
         // Full chain: handleOps → UserOp.callData [executeUserOpWithErrorString] → multiSend → [operateFlowMatrix]
         // This is the actual call path for Safe accounts using 4337 module
 
+        // packedCoordinates: 6 bytes per edge (circlesId:2 + sender:2 + receiver:2)
         var operateFlowMatrix = BuildOperateFlowMatrixCalldata(
             flowVertices: new[] { Alice, Bob },
             streams: new[]
             {
                 new StreamData(0, new ulong[] { 0 }, new byte[] { 0x74, 0x78, 0x64, 0x61, 0x74, 0x61 }) // "txdata"
             },
-            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x01 }
+            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }
         );
 
         var multiSend = BuildMultiSendCalldata(new[]
@@ -763,13 +766,14 @@ public class CalldataUnwrapperTests
     public void UnwrapAndParse_TypicalERC4337Pattern_ExtractsData()
     {
         // Typical ERC-4337 flow: EntryPoint.handleOps → Safe.execTransaction → Hub.operateFlowMatrix
+        // packedCoordinates: 6 bytes per edge (circlesId:2 + sender:2 + receiver:2)
         var operateFlowMatrix = BuildOperateFlowMatrixCalldata(
             flowVertices: new[] { Alice, Bob, Charlie },
             streams: new[]
             {
                 new StreamData(0, new ulong[] { 0 }, new byte[] { 0x50, 0x41, 0x59 }) // "PAY"
             },
-            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x01 }
+            packedCoordinates: new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01 }
         );
 
         var execTransaction = BuildExecTransactionCalldata(operateFlowMatrix);

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
@@ -443,6 +443,345 @@ public class TransferSummaryAggregatorTests
         Assert.That(result.StreamEvents.OfType<StreamCompleted>().Count(), Is.EqualTo(1));
     }
 
+    // ─────────────────────── Erc20WrapperTransfer in Stream Tests ───────────────────────
+    // These tests verify the fix for wrapper transfers being swallowed inside streams.
+    // StreamCompleted only reflects Hub ERC1155 flows; wrapper transfers must be aggregated separately.
+
+    [Test]
+    public void AggregateAll_Erc20WrapperTransferInStream_AggregatedToNonStreamSums()
+    {
+        // Core bug fix: Erc20WrapperTransfer inside a stream must produce a non-stream summary row
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateFlowEdgesScopeLastEnded(),
+            CreateErc20WrapperTransfer(Bob, Charlie, 200UL, WrapperDemurraged),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            // StreamCompleted creates the stream summary (Alice→Bob)
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(1));
+            var streamTotal = result.StreamTransfers.Totals.First();
+            Assert.That(streamTotal.Key.From, Is.EqualTo(Alice));
+            Assert.That(streamTotal.Key.To, Is.EqualTo(Bob));
+
+            // Erc20WrapperTransfer creates the non-stream summary (Bob→Charlie)
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(1));
+            var nonStreamTotal = result.NonStreamTransfers.Totals.First();
+            Assert.That(nonStreamTotal.Key.From, Is.EqualTo(Bob));
+            Assert.That(nonStreamTotal.Key.To, Is.EqualTo(Charlie));
+            Assert.That(nonStreamTotal.Value.ToString(), Is.EqualTo("200"));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_Erc20WrapperTransferInStream_AppearsInBothEventLists()
+    {
+        // Erc20WrapperTransfer in stream must appear in BOTH streamEvents (for ordering)
+        // AND nonStreamEvents (for aggregation visibility)
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateErc20WrapperTransfer(Alice, Bob, 100UL, WrapperDemurraged),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StreamEvents.OfType<Erc20WrapperTransfer>().Count(), Is.EqualTo(1));
+            Assert.That(result.NonStreamEvents.OfType<Erc20WrapperTransfer>().Count(), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_Erc20InflationaryWrapperInStream_AppliesConversion()
+    {
+        // Inflationary wrapper conversion must work even when inside a stream
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateErc20WrapperTransfer(Alice, Bob, 1_000_000_000_000_000_000UL, WrapperInflationary),
+            CreateStreamCompleted(Alice, Bob, 1_000_000_000_000_000_000UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        var total = result.NonStreamTransfers.Totals.First();
+        // Inflationary → AttoStaticCircles conversion should change the value
+        Assert.That(total.Value.ToString(), Is.Not.EqualTo("1000000000000000000"));
+    }
+
+    [Test]
+    public void AggregateAll_MultipleWrapperTransfersInStream_AggregatesBySenderReceiver()
+    {
+        // Multiple Erc20WrapperTransfer events with same from/to should sum
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateFlowEdgesScopeLastEnded(),
+            CreateErc20WrapperTransfer(Bob, Charlie, 200UL, WrapperDemurraged),
+            CreateErc20WrapperTransfer(Bob, Charlie, 300UL, WrapperDemurraged),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(1));
+            var total = result.NonStreamTransfers.Totals.First();
+            Assert.That(total.Key.From, Is.EqualTo(Bob));
+            Assert.That(total.Key.To, Is.EqualTo(Charlie));
+            Assert.That(total.Value.ToString(), Is.EqualTo("500"));
+            Assert.That(total.Transfers, Is.EqualTo(2));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_TransferSingleInStream_NotAggregatedToNonStream()
+    {
+        // Regression: TransferSingle in stream must NOT leak to non-stream (captured by StreamCompleted)
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(1));
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(0));
+            Assert.That(result.NonStreamEvents, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void AggregateAll_TransferBatchInStream_NotAggregatedToNonStream()
+    {
+        // Regression: TransferBatch in stream must NOT leak to non-stream
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferBatch(ZeroAddress, Alice, 0, 200UL),
+            CreateStreamCompleted(Alice, Bob, 200UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(1));
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(0));
+            Assert.That(result.NonStreamEvents, Is.Empty);
+        });
+    }
+
+    [Test]
+    public void AggregateAll_GroupMintInStream_NotAggregatedToNonStream()
+    {
+        // Regression: GroupMint in stream must NOT leak to non-stream
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateFlowEdgesScopeLastEnded(),
+            CreateGroupMint(Alice, Bob, Group, 100UL),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            // GroupMint is in stream events
+            Assert.That(result.StreamEvents.OfType<GroupMint>().Count(), Is.EqualTo(1));
+            // But NOT in non-stream events
+            Assert.That(result.NonStreamEvents.OfType<GroupMint>().Count(), Is.EqualTo(0));
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(0));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_RealWorldGroupMintFlow_CapturesAllLegs()
+    {
+        // Mirrors the real transaction (0xe0cfdf0f...) that triggered this bug:
+        // Stream: 0xc7d3df → org (personal CRC via Hub)
+        // Wrapper: org → 0xf48554 (wrapped ERC20 forwarding)
+        // GroupMint: org mints group tokens (not a transfer)
+        const string Org = "0xd4dd7ba300000000000000000000000000000001";
+        const string Sender = "0xc7d3df0000000000000000000000000000000001";
+        const string FinalRecipient = "0xf4855400000000000000000000000000000001";
+        const string Router = "0x8586b40000000000000000000000000000000001";
+
+        var events = new IIndexedEventV2[]
+        {
+            // Stream starts
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            // Hub ERC1155 transfers (captured by StreamCompleted)
+            CreateTransferSingle(ZeroAddress, Sender, 50UL), // demurrage burn
+            CreateTransferSingle(Sender, Org, 1_000_000_000_000_000_000UL),
+            CreateFlowEdgesScopeLastEnded(),
+            // Post-scope: more Hub transfers + wrapper + group mint
+            CreateTransferSingle(Org, Router, 500_000_000_000_000_000UL),
+            CreateTransferSingle(Router, Group, 500_000_000_000_000_000UL), // collateral
+            CreateTransferSingle(ZeroAddress, Org, 500_000_000_000_000_000UL), // group mint
+            CreateTransferSingle(Org, WrapperDemurraged, 500_000_000_000_000_000UL), // wrap
+            // ERC20 wrapper transfers (NOT captured by StreamCompleted!)
+            CreateErc20WrapperTransfer(ZeroAddress, Router, 500_000_000_000_000_000UL, WrapperDemurraged),
+            CreateErc20WrapperTransfer(Router, Org, 500_000_000_000_000_000UL, WrapperDemurraged),
+            CreateErc20WrapperTransfer(Org, FinalRecipient, 500_000_000_000_000_000UL, WrapperDemurraged),
+            // Group mint event (not a transfer type)
+            CreateGroupMint(Sender, Org, Group, 500_000_000_000_000_000UL),
+            // StreamCompleted: only the Hub-level summary
+            CreateStreamCompleted(Sender, Org, 1_000_000_000_000_000_000UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            // Stream summary: Sender → Org (from StreamCompleted)
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(1));
+            var streamTotal = result.StreamTransfers.Totals.First();
+            Assert.That(streamTotal.Key.From, Is.EqualTo(Sender));
+            Assert.That(streamTotal.Key.To, Is.EqualTo(Org));
+            Assert.That(streamTotal.Value.ToString(), Is.EqualTo("1000000000000000000"));
+
+            // Non-stream summary: 3 Erc20WrapperTransfer rows
+            var nonStreamTotals = result.NonStreamTransfers.Totals.ToList();
+            Assert.That(nonStreamTotals.Count, Is.EqualTo(3));
+
+            // Verify the critical outgoing leg: Org → FinalRecipient
+            var orgToRecipient = nonStreamTotals.FirstOrDefault(t =>
+                t.Key.From == Org && t.Key.To == FinalRecipient);
+            Assert.That(orgToRecipient, Is.Not.Null, "Org → FinalRecipient wrapper transfer must be visible");
+            Assert.That(orgToRecipient!.Value.ToString(), Is.EqualTo("500000000000000000"));
+
+            // GroupMint must NOT create a non-stream total
+            Assert.That(result.NonStreamEvents.OfType<GroupMint>().Count(), Is.EqualTo(0));
+
+            // All events in stream
+            Assert.That(result.StreamEvents, Has.Count.EqualTo(13));
+            // Only Erc20WrapperTransfer in non-stream events
+            Assert.That(result.NonStreamEvents.Count, Is.EqualTo(3));
+            Assert.That(result.NonStreamEvents.All(e => e is Erc20WrapperTransfer), Is.True);
+        });
+    }
+
+    [Test]
+    public void AggregateAll_WrapperTransferBetweenStreams_StaysNonStream()
+    {
+        // Erc20WrapperTransfer between two streams should still be non-stream (not affected by fix)
+        var events = new IIndexedEventV2[]
+        {
+            // Stream 1
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateStreamCompleted(Alice, Bob, 100UL),
+            // Non-stream wrapper transfer
+            CreateErc20WrapperTransfer(Bob, Charlie, 200UL, WrapperDemurraged),
+            // Stream 2
+            CreateFlowEdgesScopeSingleStarted(2, 1),
+            CreateTransferSingle(Charlie, Alice, 50UL),
+            CreateStreamCompleted(Charlie, Alice, 50UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(2));
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(1));
+            var wrapperTotal = result.NonStreamTransfers.Totals.First();
+            Assert.That(wrapperTotal.Key.From, Is.EqualTo(Bob));
+            Assert.That(wrapperTotal.Key.To, Is.EqualTo(Charlie));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_WrapperTransferBeforeScopeStart_StaysNonStream()
+    {
+        // Wrapper transfer before any stream starts — baseline non-stream behavior
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, 100UL, WrapperDemurraged),
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Charlie, 50UL),
+            CreateStreamCompleted(Alice, Charlie, 50UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.NonStreamTransfers.Totals.Count(), Is.EqualTo(1));
+            Assert.That(result.NonStreamEvents.OfType<Erc20WrapperTransfer>().Count(), Is.EqualTo(1));
+            Assert.That(result.StreamTransfers.Totals.Count(), Is.EqualTo(1));
+        });
+    }
+
+    [Test]
+    public void AggregateAll_WrapperAndHubTransferSameDirectionInStream_NotDoubleCounted()
+    {
+        // When both a TransferSingle and Erc20WrapperTransfer go Alice→Bob in the same stream,
+        // only the wrapper should appear in nonStreamSums (TransferSingle covered by StreamCompleted)
+        var events = new IIndexedEventV2[]
+        {
+            CreateFlowEdgesScopeSingleStarted(1, 0),
+            CreateTransferSingle(Alice, Bob, 100UL),
+            CreateErc20WrapperTransfer(Alice, Bob, 200UL, WrapperDemurraged),
+            CreateStreamCompleted(Alice, Bob, 100UL)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+
+        Assert.Multiple(() =>
+        {
+            // Stream: 100 (from StreamCompleted)
+            var streamTotal = result.StreamTransfers.Totals.First();
+            Assert.That(streamTotal.Value.ToString(), Is.EqualTo("100"));
+
+            // Non-stream: 200 (from Erc20WrapperTransfer only — NOT 300)
+            var nonStreamTotal = result.NonStreamTransfers.Totals.First();
+            Assert.That(nonStreamTotal.Value.ToString(), Is.EqualTo("200"));
+        });
+    }
+
+    // ─────────────────────── E2E Tests (Require DB) ───────────────────────
+
+    [Test]
+    [Explicit("Requires staging database — set CIRCLES_CONNECTION_STRING or source docker/.env")]
+    public void E2E_WrapperTransferSummary_Transaction0xe0cfdf0f()
+    {
+        // Verify the specific transaction that triggered the bug.
+        // After reindex, TransferSummary for tx 0xe0cfdf0f... should contain both:
+        //   1. Stream leg: 0xc7d3df → org
+        //   2. Wrapper leg: org → 0xf48554
+        var connectionString = Environment.GetEnvironmentVariable("CIRCLES_CONNECTION_STRING");
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            Assert.Ignore("CIRCLES_CONNECTION_STRING not set");
+            return;
+        }
+
+        Console.WriteLine("To verify after reindex, run:");
+        Console.WriteLine(@"  SELECT * FROM ""V_CrcV2_TransferSummary"" WHERE ""transactionHash"" = '0xe0cfdf0f0970a104aaa79b157b240ff95e02807a40a84b2ef6ff94d7dbc761b1';");
+        Console.WriteLine("Expected: at least 2 rows (stream + wrapper transfer)");
+
+        Assert.Pass("Manual verification — see console output for query");
+    }
+
     // ─────────────────────── Helper Methods ───────────────────────
 
     private static TransferSingle CreateTransferSingle(string from, string to, ulong value, string? tokenId = null)

--- a/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
+++ b/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
@@ -67,6 +67,14 @@ public static class TransferSummaryAggregator
             if (inStream)
             {
                 streamEvents.Add(e);
+                // Erc20WrapperTransfer events come from wrapper contracts, not the Hub.
+                // StreamCompleted only reflects Hub ERC1155 flows and doesn't capture these.
+                // Aggregate them separately so they appear in TransferSummary.
+                if (e is Erc20WrapperTransfer)
+                {
+                    AddNonStreamTransfers(nonStreamSums, e, erc20WrapperAddresses);
+                    nonStreamEvents.Add(e);
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary

- **Bug**: `Erc20WrapperTransfer` events inside Hub stream scopes (between `FlowEdgesScopeSingleStarted` and `StreamCompleted`) were swallowed — captured in `streamEvents` but never aggregated into `TransferSummary` rows. `StreamCompleted` only reflects Hub ERC1155 flows; wrapper contract ERC20 transfers are invisible to it.
- **Fix**: When `inStream` and event is `Erc20WrapperTransfer`, also aggregate into `nonStreamSums`. Safe because `TransferSingle`/`TransferBatch` are covered by `StreamCompleted`, and `GroupMint` is not a transfer type.
- **CalldataUnwrapper fix**: 3 pre-existing test failures where `packedCoordinates` were 4 bytes but `DeriveToAddress` needs 6 bytes per flow edge (3 × uint16).
- **SQL migration**: Zero-downtime backfill of missing historical `TransferSummary` rows, including inflationary wrapper conversion using block timestamps.

## Files changed

| File | Change |
|------|--------|
| `TransferSummaryAggregator.cs` | 4-line fix: aggregate `Erc20WrapperTransfer` in stream context |
| `TransferSummaryAggregatorTests.cs` | 12 new tests (bug fix, regressions, real-world replay) |
| `CalldataUnwrapperTests.cs` | Fix 3 tests: 4-byte → 6-byte `packedCoordinates` |
| `scripts/migrations/001-fix-wrapper-transfer-summary.sql` | Zero-downtime INSERT migration |
| `scripts/migrations/001-fix-wrapper-transfer-summary-dryrun.sql` | Dry-run diagnostic queries |

## Deployment

1. Run dry-run SQL on staging to preview affected rows
2. Deploy code (new blocks auto-fixed)
3. Run migration SQL to backfill historical data
4. Verify bug-report tx `0xe0cfdf0f...` shows both legs

## Test plan

- [x] 85 tests pass, 0 failures (82 pass + 3 env-gated skips)
- [x] 12 new TransferSummaryAggregator tests covering the fix
- [x] 3 CalldataUnwrapper tests now pass (were failing)
- [ ] Dry-run migration on staging
- [ ] Verify `circles_getTransactionHistory("0xd4dd7ba3...")` shows both legs after migration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed missing transaction summaries for wrapper token transfers occurring within transaction streams, with backfill for historical data.

* **Tests**
  * Enhanced test coverage for wrapper transfer handling in transaction aggregation scenarios, including edge cases and inflationary wrapper conversions.
  * Updated test fixtures to align with latest data encoding formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->