### PR TITLE
feat: restore ERC20 wrappers + zero-SQL cache-feed pathfinder

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -155,6 +155,8 @@ services:
     depends_on:
       nethermind-gnosis:
         condition: service_healthy
+      cache-service:
+        condition: service_healthy
     restart: unless-stopped
     networks:
       - circles-gnosis
@@ -168,6 +170,10 @@ services:
       - POSTGRES_READONLY_CONNECTION_STRING=Server=postgres-gnosis;Port=5432;Database=postgres;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Application Name=pathfinder;
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
       - PATHFINDER_DISABLE_CONSENTED_FLOW=${PATHFINDER_DISABLE_CONSENTED_FLOW:-true}
+      # Cache-feed: pathfinder fetches graph from cache service instead of SQL
+      - USE_CACHE_GRAPH_SOURCE=${USE_CACHE_GRAPH_SOURCE:-true}
+      - CACHE_SERVICE_URL=http://cache-service:3001
+      - CACHE_GRAPH_FALLBACK_TO_DB=${CACHE_GRAPH_FALLBACK_TO_DB:-true}
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8080'"]
       interval: 30s

--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -1,0 +1,576 @@
+using System.Numerics;
+using Circles.Cache.Service.Caches;
+using Circles.Cache.Service.Controllers;
+using Circles.Cache.Service.Models;
+using Circles.Common;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+using FluentAssertions;
+
+namespace Circles.Cache.Service.Tests;
+
+/// <summary>
+/// Tests for PathfinderGraphController — the zero-SQL cache-feed endpoint.
+/// Covers: balance conversion + demurrage, wrapper trust derivation, consent bit extraction,
+/// ETag conditional requests, warmup gating, group filtering, and include param parsing.
+/// </summary>
+public class PathfinderGraphControllerTests
+{
+    private const string StandardTreasuryMint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
+    private const uint V2InflationDayZero = 1_675_209_600;
+
+    private readonly CacheContainer _cache;
+    private readonly CacheServiceState _state;
+
+    public PathfinderGraphControllerTests()
+    {
+        _cache = new CacheContainer(rollbackCapacity: 12);
+        _state = new CacheServiceState(rollbackCapacity: 12);
+        _state.LastProcessedBlock = 5000;
+        _state.WarmupComplete = true;
+        _state.ListenerConnected = true;
+    }
+
+    private PathfinderGraphController CreateController(string? ifNoneMatch = null)
+    {
+        var logger = new Mock<ILogger<PathfinderGraphController>>();
+        var controller = new PathfinderGraphController(_cache, _state, logger.Object);
+        var context = new DefaultHttpContext();
+        if (ifNoneMatch != null)
+            context.Request.Headers.IfNoneMatch = new StringValues(ifNoneMatch);
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return controller;
+    }
+
+    // ── Warmup / ETag ──────────────────────────────────────────────────
+
+    [Fact]
+    public void GetGraph_ShouldReturn503_WhenWarmupIncomplete()
+    {
+        _state.WarmupComplete = false;
+        var controller = CreateController();
+
+        var result = controller.GetGraph();
+
+        var obj = result.Result as ObjectResult;
+        obj.Should().NotBeNull();
+        obj!.StatusCode.Should().Be(503);
+    }
+
+    [Fact]
+    public void GetGraph_ShouldReturn304_WhenETagMatches()
+    {
+        var etag = $"\"{_state.LastProcessedBlock}\"";
+        var controller = CreateController(ifNoneMatch: etag);
+
+        var result = controller.GetGraph();
+
+        var status = result.Result as StatusCodeResult;
+        status.Should().NotBeNull();
+        status!.StatusCode.Should().Be(304);
+    }
+
+    [Fact]
+    public void GetGraph_ShouldReturnOk_WhenETagDoesNotMatch()
+    {
+        var controller = CreateController(ifNoneMatch: "\"999\"");
+
+        var result = controller.GetGraph();
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as PathfinderGraphResponse;
+        response.Should().NotBeNull();
+        response!.LastProcessedBlock.Should().Be(5000);
+        response.SchemaVersion.Should().Be(1);
+    }
+
+    // ── ParseInclude ───────────────────────────────────────────────────
+
+    [Fact]
+    public void GetGraph_ShouldReturnAllSections_WhenNoInclude()
+    {
+        SeedMinimalData();
+        var controller = CreateController();
+
+        var result = controller.GetGraph();
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().NotBeNull();
+        response.Trust.Should().NotBeNull();
+        response.Groups.Should().NotBeNull();
+        response.GroupTrusts.Should().NotBeNull();
+        response.ConsentedFlow.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetGraph_ShouldReturnOnlyRequestedSections()
+    {
+        SeedMinimalData();
+        var controller = CreateController();
+
+        var result = controller.GetGraph(include: "balances,groups");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().NotBeNull();
+        response.Groups.Should().NotBeNull();
+        response.Trust.Should().BeNull();
+        response.GroupTrusts.Should().BeNull();
+        response.ConsentedFlow.Should().BeNull();
+    }
+
+    // ── BuildBalances ──────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildBalances_ShouldConvertDecimalToAttoCirclesIntegerString()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 1.5m);
+        // Set a recent lastActivity so demurrage is minimal
+        var recentTimestamp = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 60;
+        _cache.V2LastActivity[$"{account}:{token}"] = recentTimestamp;
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().HaveCount(1);
+        var balance = response.Balances![0];
+        balance.Account.Should().Be(account);
+        balance.TokenAddress.Should().Be(token);
+
+        // Balance should be a valid integer string (no decimals, no scientific notation)
+        BigInteger.TryParse(balance.Balance, out var parsed).Should().BeTrue(
+            $"Balance '{balance.Balance}' should be a valid integer string");
+        parsed.Should().BeGreaterThan(BigInteger.Zero);
+
+        // 1.5 Circles = 1.5e18 attoCircles ≈ 1500000000000000000 (before demurrage)
+        // After demurrage (very recent), should be close but slightly less
+        var expected = CirclesConverter.CirclesToAttoCircles(1.5m);
+        parsed.Should().BeLessOrEqualTo(expected, "demurrage should only reduce the balance");
+        parsed.Should().BeGreaterThan(expected * 99 / 100, "1 minute of demurrage should be < 1%");
+    }
+
+    [Fact]
+    public void BuildBalances_ShouldSkipUnregisteredAvatars()
+    {
+        var unregistered = "0xunregistered000000000000000000000000000000";
+        var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        // NOT in V2Avatars — should be skipped
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{unregistered}:{token}", 100m);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildBalances_ShouldSkipZeroBalances()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 0m);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildBalances_ShouldMarkWrappedTokens()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var wrapperAddress = "0xwrapper00000000000000000000000000000000";
+        var underlyingAvatar = "0xunderlying0000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, underlyingAvatar, ("Human", 1704067200L));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 0)); // 0 = demurraged
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
+        _cache.V2LastActivity[$"{account}:{wrapperAddress}"] =
+            (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().HaveCount(1);
+        response.Balances![0].IsWrapped.Should().BeTrue();
+        response.Balances[0].CirclesType.Should().Be("demurraged");
+    }
+
+    [Fact]
+    public void BuildBalances_ShouldMarkStaticWrappedTokens()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var wrapperAddress = "0xstaticwrap0000000000000000000000000000";
+        var underlyingAvatar = "0xunderlying0000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, underlyingAvatar, ("Human", 1704067200L));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 1)); // 1 = static
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().HaveCount(1);
+        response.Balances![0].IsWrapped.Should().BeTrue();
+        response.Balances[0].CirclesType.Should().Be("static");
+    }
+
+    [Fact]
+    public void BuildBalances_ShouldFilterWrappersOfUnregisteredAvatars()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var wrapperAddress = "0xwrapper00000000000000000000000000000000";
+        var unregisteredAvatar = "0xunregistered000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        // underlyingAvatar NOT registered in V2Avatars
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (unregisteredAvatar, 0));
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().BeEmpty();
+    }
+
+    // ── BuildTrust ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildTrust_ShouldEmitNativeTrustEdges()
+    {
+        var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        // expiryTime in the far future
+        _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Trust.Should().ContainSingle(t => t.Truster == truster && t.Trustee == trustee);
+        response.Trust![0].Limit.Should().Be(100);
+    }
+
+    [Fact]
+    public void BuildTrust_ShouldSkipRevokedTrust()
+    {
+        var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        // expiryTime in the past → revoked
+        _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 1L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Trust.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildTrust_ShouldDeriveWrapperTrustEdges()
+    {
+        var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        var wrapperAddress = "0xwrapper00000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
+        // trustee has a wrapper deployed
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (trustee, 0));
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        // Should have 2 edges: native + wrapper
+        response!.Trust.Should().HaveCount(2);
+        response.Trust.Should().Contain(t => t.Truster == truster && t.Trustee == trustee);
+        response.Trust.Should().Contain(t => t.Truster == truster && t.Trustee == wrapperAddress);
+    }
+
+    [Fact]
+    public void BuildTrust_ShouldDeriveMultipleWrapperEdgesPerTrustee()
+    {
+        var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        var wrapper1 = "0xwrapper10000000000000000000000000000000";
+        var wrapper2 = "0xwrapper20000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
+        _cache.Erc20WrapperAddresses.Add(1000, wrapper1, (trustee, 0));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapper2, (trustee, 1));
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        // 1 native + 2 wrappers = 3
+        response!.Trust.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void BuildTrust_ShouldExcludeGroupTrusters()
+    {
+        var group = "0xgroup000000000000000000000000000000000000";
+        var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+
+        _cache.V2Avatars.Add(1000, group, ("Group", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.Groups.Add(1000, group, ("Test Group", StandardTreasuryMint, "TG"));
+        _cache.V2TrustRelations.Add(1000, $"{group}:{trustee}", 9999999999L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        // Group trusters are excluded from BuildTrust (handled in BuildGroupTrusts)
+        response!.Trust.Should().BeEmpty();
+    }
+
+    // ── BuildGroups ────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildGroups_ShouldOnlyIncludeRouterGroups()
+    {
+        var routerGroup = "0xroutergroup000000000000000000000000000000";
+        var otherGroup = "0xothergroup0000000000000000000000000000000";
+
+        _cache.Groups.Add(1000, routerGroup, ("Router Group", StandardTreasuryMint, "RG"));
+        _cache.Groups.Add(1000, otherGroup, ("Custom Group", "0xothermint", "CG"));
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "groups");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Groups.Should().HaveCount(1);
+        response.Groups![0].GroupAddress.Should().Be(routerGroup);
+    }
+
+    // ── BuildGroupTrusts ───────────────────────────────────────────────
+
+    [Fact]
+    public void BuildGroupTrusts_ShouldOnlyIncludeRouterGroupTrusters()
+    {
+        var routerGroup = "0xroutergroup000000000000000000000000000000";
+        var member = "0xmember00000000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, routerGroup, ("Group", 1704067200L));
+        _cache.V2Avatars.Add(1000, member, ("Human", 1704067200L));
+        _cache.Groups.Add(1000, routerGroup, ("Router Group", StandardTreasuryMint, "RG"));
+        _cache.V2TrustRelations.Add(1000, $"{routerGroup}:{member}", 9999999999L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "groupTrusts");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.GroupTrusts.Should().HaveCount(1);
+        response.GroupTrusts![0].GroupAddress.Should().Be(routerGroup);
+        response.GroupTrusts[0].TrustedToken.Should().Be(member);
+    }
+
+    [Fact]
+    public void BuildGroupTrusts_ShouldExcludeNonRouterGroups()
+    {
+        var nonRouterGroup = "0xnonrouter00000000000000000000000000000000";
+        var member = "0xmember00000000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, nonRouterGroup, ("Group", 1704067200L));
+        _cache.V2Avatars.Add(1000, member, ("Human", 1704067200L));
+        _cache.Groups.Add(1000, nonRouterGroup, ("Custom Group", "0xothermint", "CG"));
+        _cache.V2TrustRelations.Add(1000, $"{nonRouterGroup}:{member}", 9999999999L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "groupTrusts");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.GroupTrusts.Should().BeEmpty();
+    }
+
+    // ── BuildConsentedFlow ─────────────────────────────────────────────
+
+    [Fact]
+    public void BuildConsentedFlow_ShouldExtractBit0OfByte31()
+    {
+        var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+
+        // Create 32-byte flag with bit 0 of byte[31] set to 1
+        var flags = new byte[32];
+        flags[31] = 0x01; // consent = true
+        _cache.ConsentedFlowFlags.Add(1000, avatar, flags);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "consentedFlow");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow.Should().HaveCount(1);
+        response.ConsentedFlow![0].Avatar.Should().Be(avatar);
+        response.ConsentedFlow[0].HasConsentedFlow.Should().BeTrue();
+    }
+
+    [Fact]
+    public void BuildConsentedFlow_ShouldReturnFalse_WhenBit0IsZero()
+    {
+        var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+
+        var flags = new byte[32];
+        flags[31] = 0x00; // consent = false
+        _cache.ConsentedFlowFlags.Add(1000, avatar, flags);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "consentedFlow");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow.Should().HaveCount(1);
+        response.ConsentedFlow![0].HasConsentedFlow.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildConsentedFlow_ShouldHandleOnlyBit0_NotOtherBits()
+    {
+        var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+
+        var flags = new byte[32];
+        flags[31] = 0xFE; // all bits except bit 0 → consent = false
+        _cache.ConsentedFlowFlags.Add(1000, avatar, flags);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "consentedFlow");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow![0].HasConsentedFlow.Should().BeFalse();
+    }
+
+    [Fact]
+    public void BuildConsentedFlow_ShouldSkipShortFlagBytes()
+    {
+        var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+
+        // Only 16 bytes — should be skipped with warning
+        var shortFlags = new byte[16];
+        shortFlags[15] = 0x01;
+        _cache.ConsentedFlowFlags.Add(1000, avatar, shortFlags);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "consentedFlow");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void BuildConsentedFlow_ShouldSkipUnregisteredAvatars()
+    {
+        var unregistered = "0xunregistered000000000000000000000000000000";
+        var flags = new byte[32];
+        flags[31] = 0x01;
+        _cache.ConsentedFlowFlags.Add(1000, unregistered, flags);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "consentedFlow");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow.Should().BeEmpty();
+    }
+
+    // ── Full snapshot consistency ──────────────────────────────────────
+
+    [Fact]
+    public void GetGraph_FullSnapshot_ShouldIncludeAllSections()
+    {
+        SeedFullData();
+        var controller = CreateController();
+
+        var result = controller.GetGraph();
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().NotBeEmpty("seeded balance data");
+        response.Trust.Should().NotBeEmpty("seeded trust data");
+        response.Groups.Should().NotBeEmpty("seeded group data");
+        response.GroupTrusts.Should().NotBeEmpty("seeded group trust data");
+        response.ConsentedFlow.Should().NotBeEmpty("seeded consent data");
+    }
+
+    [Fact]
+    public void GetGraph_ShouldReturnBalancesWithDemurrageApplied()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 100m);
+
+        // lastActivity 30 days ago — should show noticeable demurrage
+        var thirtyDaysAgo = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds() - (30 * 86400);
+        _cache.V2LastActivity[$"{account}:{token}"] = thirtyDaysAgo;
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        var parsed = BigInteger.Parse(response!.Balances![0].Balance);
+        var rawAtto = CirclesConverter.CirclesToAttoCircles(100m);
+
+        // 30 days of 7%/year demurrage ≈ ~0.6% reduction
+        parsed.Should().BeLessThan(rawAtto, "30 days of demurrage should reduce the balance");
+        parsed.Should().BeGreaterThan(rawAtto * 98 / 100, "30 days should be < 2% demurrage");
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private void SeedMinimalData()
+    {
+        var addr = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        _cache.V2Avatars.Add(1000, addr, ("Human", 1704067200L));
+    }
+
+    private void SeedFullData()
+    {
+        var alice = "0xalice000000000000000000000000000000000000";
+        var bob = "0xbob00000000000000000000000000000000000000";
+        var group = "0xgroup000000000000000000000000000000000000";
+        var now = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, bob, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, group, ("Group", 1704067200L));
+
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{alice}:{bob}", 100m);
+        _cache.V2LastActivity[$"{alice}:{bob}"] = now;
+
+        _cache.V2TrustRelations.Add(1000, $"{alice}:{bob}", 9999999999L);
+        _cache.V2TrustRelations.Add(1000, $"{group}:{alice}", 9999999999L);
+
+        _cache.Groups.Add(1000, group, ("Test Group", StandardTreasuryMint, "TG"));
+
+        var flags = new byte[32];
+        flags[31] = 0x01;
+        _cache.ConsentedFlowFlags.Add(1000, alice, flags);
+    }
+}

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -156,3 +156,51 @@ public record ProfileContentResponse(
 /// Batch request for profile content
 /// </summary>
 public record ProfileContentBatchRequest(string[] Cids);
+
+// ─── Pathfinder Graph Snapshot DTOs ────────────────────────────────
+
+/// <summary>
+/// Canonical graph snapshot for the Pathfinder cache source endpoint.
+/// </summary>
+public record PathfinderGraphResponse(
+    int SchemaVersion,
+    long LastProcessedBlock,
+    long Timestamp,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderBalanceRow>? Balances,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderTrustRow>? Trust,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderGroupRow>? Groups,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderGroupTrustRow>? GroupTrusts,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderConsentedFlowRow>? ConsentedFlow
+);
+
+public record PathfinderBalanceRow(
+    string Balance,
+    string Account,
+    string TokenAddress,
+    long LastActivity,
+    bool IsWrapped,
+    string CirclesType
+);
+
+public record PathfinderTrustRow(
+    string Truster,
+    string Trustee,
+    int Limit
+);
+
+public record PathfinderGroupRow(string GroupAddress);
+
+public record PathfinderGroupTrustRow(
+    string GroupAddress,
+    string TrustedToken
+);
+
+public record PathfinderConsentedFlowRow(
+    string Avatar,
+    bool HasConsentedFlow
+);

--- a/src/Cache/Circles.Cache.Service/CacheContainer.cs
+++ b/src/Cache/Circles.Cache.Service/CacheContainer.cs
@@ -44,6 +44,10 @@ public class CacheContainer : IDisposable
     public RollbackCache<string, long> V1TrustRelations { get; private set; } = null!;
     public RollbackCache<string, long> V2TrustRelations { get; private set; } = null!;
 
+    // Consented flow flags (key: avatar address, value: flag bytes)
+    // Used by the pathfinder graph endpoint to determine consented flow status
+    public RollbackCache<string, byte[]> ConsentedFlowFlags { get; private set; } = null!;
+
     // Secondary Indexes for O(1) balance lookups
     // Maps address -> set of token IDs that address holds
     private readonly Dictionary<string, HashSet<string>> _v1BalancesByAddress = new();
@@ -88,7 +92,8 @@ public class CacheContainer : IDisposable
         V1BalancesByAccountAndToken,
         V2BalancesByAccountAndToken,
         V1TrustRelations,
-        V2TrustRelations
+        V2TrustRelations,
+        ConsentedFlowFlags
     };
 
     private void InitializeCaches()
@@ -111,6 +116,7 @@ public class CacheContainer : IDisposable
 
         V1TrustRelations = new RollbackCache<string, long>("V1TrustRelations");
         V2TrustRelations = new RollbackCache<string, long>("V2TrustRelations");
+        ConsentedFlowFlags = new RollbackCache<string, byte[]>("ConsentedFlowFlags");
     }
 
 

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -1,0 +1,347 @@
+using Circles.Cache.Service.Caches;
+using Circles.Cache.Service.Models;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Circles.Cache.Service.Controllers;
+
+/// <summary>
+/// Serves the full pathfinder graph snapshot from in-memory caches (zero SQL).
+/// The pathfinder fetches this periodically to build its capacity graph.
+/// Supports ETag-based conditional requests and selective section inclusion.
+/// </summary>
+[ApiController]
+[Route("api/pathfinder")]
+public class PathfinderGraphController : ControllerBase
+{
+    private readonly CacheContainer _caches;
+    private readonly CacheServiceState _state;
+    private readonly ILogger<PathfinderGraphController> _logger;
+
+    /// <summary>
+    /// Standard treasury mint address — only groups with this mint policy
+    /// participate in the pathfinder's transitive transfer routing.
+    /// </summary>
+    private const string StandardTreasuryMint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
+
+    private const int SchemaVersion = 1;
+
+    public PathfinderGraphController(
+        CacheContainer caches,
+        CacheServiceState state,
+        ILogger<PathfinderGraphController> logger)
+    {
+        _caches = caches;
+        _state = state;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the full pathfinder graph snapshot from in-memory caches.
+    /// Supports ?include=balances,trust,groups,groupTrusts,consentedFlow for selective loading.
+    /// ETag is based on LastProcessedBlock for conditional 304 responses.
+    /// </summary>
+    [HttpGet("graph")]
+    public ActionResult<PathfinderGraphResponse> GetGraph([FromQuery] string? include = null)
+    {
+        if (!_state.WarmupComplete)
+        {
+            return StatusCode(503, new { error = "Cache warmup in progress" });
+        }
+
+        var lastBlock = _state.LastProcessedBlock;
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var etag = $"\"{lastBlock}\"";
+
+        // ETag-based conditional request
+        if (Request.Headers.IfNoneMatch.ToString() == etag)
+        {
+            return StatusCode(304);
+        }
+
+        // Parse include filter (default: all sections)
+        var sections = ParseInclude(include);
+
+        Response.Headers.ETag = etag;
+        Response.Headers.CacheControl = "no-cache";
+
+        try
+        {
+            // Pre-compute shared lookups once per request
+            var routerGroups = sections.Contains("trust") || sections.Contains("groups") || sections.Contains("grouptrusts")
+                ? GetRouterFilteredGroups()
+                : null;
+            var avatarToWrappers = sections.Contains("trust")
+                ? BuildAvatarToWrappersIndex()
+                : null;
+
+            var response = new PathfinderGraphResponse(
+                SchemaVersion: SchemaVersion,
+                LastProcessedBlock: lastBlock,
+                Timestamp: timestamp,
+                Balances: sections.Contains("balances") ? BuildBalances() : null,
+                Trust: sections.Contains("trust") ? BuildTrust(routerGroups!, avatarToWrappers!) : null,
+                Groups: sections.Contains("groups") ? BuildGroups(routerGroups!) : null,
+                GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(routerGroups!) : null,
+                ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow() : null
+            );
+
+            _logger.LogDebug(
+                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}",
+                lastBlock,
+                response.Balances?.Count ?? 0,
+                response.Trust?.Count ?? 0,
+                response.Groups?.Count ?? 0,
+                response.GroupTrusts?.Count ?? 0,
+                response.ConsentedFlow?.Count ?? 0);
+
+            return Ok(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error building pathfinder graph snapshot");
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
+
+    private static HashSet<string> ParseInclude(string? include)
+    {
+        if (string.IsNullOrWhiteSpace(include))
+            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow" };
+
+        return new HashSet<string>(
+            include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(s => s.ToLowerInvariant()));
+    }
+
+    /// <summary>
+    /// Builds balance rows from V2BalancesByAccountAndToken.
+    /// Only includes balances for registered V2 avatars.
+    /// Marks wrapper tokens and includes circlesType metadata.
+    /// </summary>
+    private List<PathfinderBalanceRow> BuildBalances()
+    {
+        var balances = new List<PathfinderBalanceRow>();
+
+        foreach (var kvp in _caches.V2BalancesByAccountAndToken.ReadOnlyDictionary)
+        {
+            if (kvp.Value <= 0)
+                continue;
+
+            var separatorIndex = kvp.Key.IndexOf(':');
+            if (separatorIndex < 0)
+                continue;
+
+            var account = kvp.Key[..separatorIndex];
+            var tokenAddress = kvp.Key[(separatorIndex + 1)..];
+
+            // Only include balances for registered V2 avatars
+            if (!_caches.V2Avatars.ContainsKey(account))
+                continue;
+
+            // Determine if this is a wrapper token
+            var isWrapped = false;
+            var circlesType = "Demurrage"; // default for native ERC1155
+
+            if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var wrapperInfo))
+            {
+                isWrapped = true;
+                // Verify the underlying avatar is registered
+                if (!_caches.V2Avatars.ContainsKey(wrapperInfo.Avatar))
+                    continue;
+
+                // circlesType: 0 = demurraged, 1 = inflationary/static
+                circlesType = wrapperInfo.CirclesType == 1 ? "Static" : "Demurrage";
+            }
+
+            // Get last activity timestamp for demurrage calculation
+            _caches.V2LastActivity.TryGetValue(kvp.Key, out var lastActivity);
+
+            balances.Add(new PathfinderBalanceRow(
+                Balance: kvp.Value.ToString(),
+                Account: account,
+                TokenAddress: tokenAddress,
+                LastActivity: lastActivity,
+                IsWrapped: isWrapped,
+                CirclesType: circlesType
+            ));
+        }
+
+        return balances;
+    }
+
+    /// <summary>
+    /// Builds trust rows from V2TrustRelations.
+    /// Filters: registered avatars only, non-revoked, non-group trusters.
+    /// Derives wrapper trust edges: if trustee has a wrapper, emit (truster, wrapperAddress) too.
+    /// </summary>
+    private List<PathfinderTrustRow> BuildTrust(
+        HashSet<string> routerGroups,
+        Dictionary<string, List<string>> avatarToWrappers)
+    {
+        var trust = new List<PathfinderTrustRow>();
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        foreach (var kvp in _caches.V2TrustRelations.ReadOnlyDictionary)
+        {
+            var separatorIndex = kvp.Key.IndexOf(':');
+            if (separatorIndex < 0)
+                continue;
+
+            var truster = kvp.Key[..separatorIndex];
+            var trustee = kvp.Key[(separatorIndex + 1)..];
+            var expiryTime = kvp.Value;
+
+            // Skip revoked trust (expiryTime == 0 means indefinite/never set which is active)
+            if (expiryTime > 0 && expiryTime <= now)
+                continue;
+
+            // Both must be registered avatars
+            if (!_caches.V2Avatars.ContainsKey(truster) || !_caches.V2Avatars.ContainsKey(trustee))
+                continue;
+
+            // Skip group trusters — they're handled separately in GroupTrusts
+            if (routerGroups.Contains(truster))
+                continue;
+
+            // Native trust edge
+            trust.Add(new PathfinderTrustRow(
+                Truster: truster,
+                Trustee: trustee,
+                Limit: 100
+            ));
+
+            // Derive wrapper trust edges: O(1) lookup via pre-built reverse index
+            if (avatarToWrappers.TryGetValue(trustee, out var wrapperAddresses))
+            {
+                foreach (var wrapperAddr in wrapperAddresses)
+                {
+                    trust.Add(new PathfinderTrustRow(
+                        Truster: truster,
+                        Trustee: wrapperAddr,
+                        Limit: 100
+                    ));
+                }
+            }
+        }
+
+        return trust;
+    }
+
+    /// <summary>
+    /// Builds group rows — only groups using the standard treasury (router).
+    /// </summary>
+    private static List<PathfinderGroupRow> BuildGroups(HashSet<string> routerGroups)
+    {
+        var groups = new List<PathfinderGroupRow>(routerGroups.Count);
+        foreach (var groupAddr in routerGroups)
+        {
+            groups.Add(new PathfinderGroupRow(GroupAddress: groupAddr));
+        }
+        return groups;
+    }
+
+    /// <summary>
+    /// Builds group trust rows — trust edges where truster is a router-filtered group.
+    /// </summary>
+    private List<PathfinderGroupTrustRow> BuildGroupTrusts(HashSet<string> routerGroups)
+    {
+        var groupTrusts = new List<PathfinderGroupTrustRow>();
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        foreach (var kvp in _caches.V2TrustRelations.ReadOnlyDictionary)
+        {
+            var separatorIndex = kvp.Key.IndexOf(':');
+            if (separatorIndex < 0)
+                continue;
+
+            var truster = kvp.Key[..separatorIndex];
+            var trustee = kvp.Key[(separatorIndex + 1)..];
+            var expiryTime = kvp.Value;
+
+            // Only group trusters from the router-filtered set
+            if (!routerGroups.Contains(truster))
+                continue;
+
+            // Skip revoked trust
+            if (expiryTime > 0 && expiryTime <= now)
+                continue;
+
+            groupTrusts.Add(new PathfinderGroupTrustRow(
+                GroupAddress: truster,
+                TrustedToken: trustee
+            ));
+        }
+
+        return groupTrusts;
+    }
+
+    /// <summary>
+    /// Builds consented flow rows from the ConsentedFlowFlags cache.
+    /// Extracts bit 0 of byte[31] to determine consent status.
+    /// </summary>
+    private List<PathfinderConsentedFlowRow> BuildConsentedFlow()
+    {
+        var consent = new List<PathfinderConsentedFlowRow>();
+
+        foreach (var kvp in _caches.ConsentedFlowFlags.ReadOnlyDictionary)
+        {
+            // Only include flags for registered V2 avatars (mirrors BuildBalances/BuildTrust filters)
+            if (!_caches.V2Avatars.ContainsKey(kvp.Key))
+                continue;
+
+            var flagBytes = kvp.Value;
+
+            if (flagBytes.Length < 32)
+            {
+                _logger.LogWarning("ConsentedFlowFlags for avatar {Avatar} has unexpected length {Length}", kvp.Key, flagBytes.Length);
+                continue;
+            }
+
+            // bytes32 flag — bit 0 of the last byte (index 31) indicates consented flow
+            var hasConsent = (flagBytes[31] & 0x01) != 0;
+
+            consent.Add(new PathfinderConsentedFlowRow(
+                Avatar: kvp.Key,
+                HasConsentedFlow: hasConsent
+            ));
+        }
+
+        return consent;
+    }
+
+    /// <summary>
+    /// Builds a reverse index: avatar address → list of wrapper addresses.
+    /// Used for O(1) wrapper trust edge derivation instead of O(N) scan.
+    /// </summary>
+    private Dictionary<string, List<string>> BuildAvatarToWrappersIndex()
+    {
+        var index = new Dictionary<string, List<string>>();
+        foreach (var kvp in _caches.Erc20WrapperAddresses.ReadOnlyDictionary)
+        {
+            var avatar = kvp.Value.Avatar;
+            if (!index.TryGetValue(avatar, out var wrappers))
+            {
+                wrappers = new List<string>(1);
+                index[avatar] = wrappers;
+            }
+            wrappers.Add(kvp.Key); // wrapper address
+        }
+        return index;
+    }
+
+    /// <summary>
+    /// Returns the set of group addresses that use the standard treasury.
+    /// </summary>
+    private HashSet<string> GetRouterFilteredGroups()
+    {
+        var result = new HashSet<string>();
+        foreach (var kvp in _caches.Groups.ReadOnlyDictionary)
+        {
+            if (kvp.Value.Mint.Equals(StandardTreasuryMint, StringComparison.OrdinalIgnoreCase))
+            {
+                result.Add(kvp.Key);
+            }
+        }
+        return result;
+    }
+}

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -1,5 +1,8 @@
+using System.Globalization;
+using System.Numerics;
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
+using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Circles.Cache.Service.Controllers;
@@ -24,6 +27,10 @@ public class PathfinderGraphController : ControllerBase
     private const string StandardTreasuryMint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
 
     private const int SchemaVersion = 1;
+
+    /// <summary>V2 Hub epoch: 2023-02-01 00:00 UTC</summary>
+    private const uint V2InflationDayZero = 1_675_209_600;
+    private const long SecondsPerDay = 86_400;
 
     public PathfinderGraphController(
         CacheContainer caches,
@@ -115,12 +122,14 @@ public class PathfinderGraphController : ControllerBase
 
     /// <summary>
     /// Builds balance rows from V2BalancesByAccountAndToken.
-    /// Only includes balances for registered V2 avatars.
-    /// Marks wrapper tokens and includes circlesType metadata.
+    /// Converts cached decimal balances to attoCircles integer strings (matching LoadGraph output).
+    /// Applies demurrage from lastActivity → now for demurraged balances.
+    /// Converts static (inflationary) balances to demurraged equivalent at target day.
     /// </summary>
     private List<PathfinderBalanceRow> BuildBalances()
     {
         var balances = new List<PathfinderBalanceRow>();
+        var targetDay = CirclesConverter.DayFromTimestamp(DateTimeOffset.UtcNow, V2InflationDayZero);
 
         foreach (var kvp in _caches.V2BalancesByAccountAndToken.ReadOnlyDictionary)
         {
@@ -140,29 +149,50 @@ public class PathfinderGraphController : ControllerBase
 
             // Determine if this is a wrapper token
             var isWrapped = false;
-            var circlesType = "Demurrage"; // default for native ERC1155
+            var isStatic = false;
 
             if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var wrapperInfo))
             {
                 isWrapped = true;
-                // Verify the underlying avatar is registered
                 if (!_caches.V2Avatars.ContainsKey(wrapperInfo.Avatar))
                     continue;
-
-                // circlesType: 0 = demurraged, 1 = inflationary/static
-                circlesType = wrapperInfo.CirclesType == 1 ? "Static" : "Demurrage";
+                isStatic = wrapperInfo.CirclesType == 1;
             }
 
-            // Get last activity timestamp for demurrage calculation
+            // Convert decimal Circles → attoCircles BigInteger
+            var attoBalance = CirclesConverter.CirclesToAttoCircles(kvp.Value);
+            if (attoBalance == BigInteger.Zero)
+                continue;
+
+            // Get last activity timestamp
             _caches.V2LastActivity.TryGetValue(kvp.Key, out var lastActivity);
 
+            if (isStatic)
+            {
+                // Static (inflationary) → convert to demurraged equivalent at target day
+                attoBalance = CirclesConverter.InflationaryToDemurrage(attoBalance, targetDay);
+            }
+            else if (lastActivity >= V2InflationDayZero)
+            {
+                // Demurraged: apply demurrage from lastActivity → now
+                var lastActivityDay = (ulong)(lastActivity - V2InflationDayZero) / (ulong)SecondsPerDay;
+                var daysDelta = targetDay > lastActivityDay ? targetDay - lastActivityDay : 0;
+                if (daysDelta > 0)
+                {
+                    attoBalance = CirclesConverter.InflationaryToDemurrage(attoBalance, daysDelta);
+                }
+            }
+
+            if (attoBalance == BigInteger.Zero)
+                continue;
+
             balances.Add(new PathfinderBalanceRow(
-                Balance: kvp.Value.ToString(),
+                Balance: attoBalance.ToString(CultureInfo.InvariantCulture),
                 Account: account,
                 TokenAddress: tokenAddress,
                 LastActivity: lastActivity,
                 IsWrapped: isWrapped,
-                CirclesType: circlesType
+                CirclesType: isStatic ? "static" : "demurraged"
             ));
         }
 

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -98,6 +98,7 @@ public class CacheWarmupService : BackgroundService
             await ReplayV2EventsAsync(conn, warmupTarget, token);
             await LoadGroupMembershipsAsync(conn, warmupTarget, token);
             await LoadTrustRelationsAsync(conn, warmupTarget, token);
+            await LoadConsentedFlowFlagsAsync(conn, warmupTarget, token);
             await LoadAvatarMetadataAsync(conn, warmupTarget, token);
             await LoadV2ShortNamesAsync(conn, warmupTarget, token);
             await LoadBalancesAsync(conn, token);
@@ -1237,6 +1238,34 @@ public class CacheWarmupService : BackgroundService
 
         _caches.V2TrustRelations.Seed(v2TrustData, _state.WarmupTargetBlock);
         _logger.LogInformation("Loaded {Count} V2 trust relations", v2TrustData.Count);
+    }
+
+    protected virtual async Task LoadConsentedFlowFlagsAsync(NpgsqlConnection conn, long toBlock, CancellationToken ct)
+    {
+        _logger.LogInformation("Loading consented flow flags...");
+
+        const string sql = @"
+            SELECT DISTINCT ON (avatar) avatar, flag
+            FROM ""CrcV2_SetAdvancedUsageFlag""
+            WHERE ""blockNumber"" <= @toBlock
+            ORDER BY avatar, ""blockNumber"" DESC, ""transactionIndex"" DESC, ""logIndex"" DESC";
+
+        var flags = new Dictionary<string, byte[]>();
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("toBlock", toBlock);
+        cmd.CommandTimeout = 300;
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var avatar = reader.GetString(0).ToLowerInvariant();
+            var flag = (byte[])reader.GetValue(1);
+            flags[avatar] = flag;
+        }
+
+        _caches.ConsentedFlowFlags.Seed(flags, _state.WarmupTargetBlock);
+        _logger.LogInformation("Loaded {Count} consented flow flags", flags.Count);
     }
 
     protected virtual async Task LoadAvatarMetadataAsync(NpgsqlConnection conn, long toBlock, CancellationToken ct)

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -450,6 +450,9 @@ public class NotificationListenerService : BackgroundService
 
         // Process V2 RegisterShortName (for short name mappings)
         await ProcessV2RegisterShortNameAsync(conn, fromBlock, toBlock, ct);
+
+        // Process V2 SetAdvancedUsageFlag (for consented flow)
+        await ProcessV2SetAdvancedUsageFlagAsync(conn, fromBlock, toBlock, ct);
     }
 
     private async Task ProcessV2RegisterHumanAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
@@ -1162,6 +1165,38 @@ public class NotificationListenerService : BackgroundService
         if (count > 0)
         {
             _logger.LogDebug("Processed {Count} V2 short name registrations", count);
+        }
+    }
+
+    private async Task ProcessV2SetAdvancedUsageFlagAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
+    {
+        const string sql = @"
+            SELECT f.""blockNumber"", f.avatar, f.flag
+            FROM ""CrcV2_SetAdvancedUsageFlag"" f
+            WHERE f.""blockNumber"" >= @fromBlock AND f.""blockNumber"" <= @toBlock
+            ORDER BY f.""blockNumber"", f.""transactionIndex"", f.""logIndex""";
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
+        cmd.Parameters.AddWithValue("toBlock", toBlock);
+
+        var count = 0;
+        await using (var reader = await cmd.ExecuteReaderAsync(ct))
+        {
+            while (await reader.ReadAsync(ct))
+            {
+                var blockNumber = reader.GetInt64(0);
+                var avatar = reader.GetString(1).ToLowerInvariant();
+                var flag = (byte[])reader.GetValue(2);
+
+                _caches.ConsentedFlowFlags.Add(blockNumber, avatar, flag);
+                count++;
+            }
+        }
+
+        if (count > 0)
+        {
+            _logger.LogDebug("Processed {Count} V2 advanced usage flag updates", count);
         }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -147,4 +147,29 @@ internal static class GraphUpdateMetrics
     public static readonly Counter ReorgDetectedTotal = Metrics.CreateCounter(
         "circles_graph_reorg_detected_total",
         "Total reorgs detected via block hash comparison");
+
+    // ─── Cache graph source metrics ──────────────────────────────────
+
+    public static readonly Counter PathfinderGraphSourceTotal = Metrics.CreateCounter(
+        "circles_pathfinder_graph_source",
+        "Pathfinder graph data source usage",
+        new CounterConfiguration { LabelNames = new[] { "source" } });
+
+    public static readonly Histogram CacheGraphFetchDuration = Metrics.CreateHistogram(
+        "circles_pathfinder_cache_graph_fetch_duration_seconds",
+        "Cache graph fetch duration in seconds",
+        new HistogramConfiguration { Buckets = Histogram.ExponentialBuckets(0.01, 2, 12) });
+
+    public static readonly Histogram CacheGraphPayloadBytes = Metrics.CreateHistogram(
+        "circles_pathfinder_cache_graph_payload_bytes",
+        "Cache graph payload size in bytes",
+        new HistogramConfiguration { Buckets = Histogram.ExponentialBuckets(1024, 2, 12) });
+
+    public static readonly Counter CacheGraphNotModifiedTotal = Metrics.CreateCounter(
+        "circles_pathfinder_cache_graph_not_modified_total",
+        "Total number of cache graph 304 Not Modified responses");
+
+    public static readonly Counter CacheGraphErrorsTotal = Metrics.CreateCounter(
+        "circles_pathfinder_cache_graph_errors_total",
+        "Total number of cache graph fetch errors");
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -33,7 +33,12 @@ Console.WriteLine($"* DB Name: {csb.Database}");
 Console.WriteLine($"* DB Port: {csb.Port}");
 Console.WriteLine($"* Nethermind RPC URL: {settings.NethermindRpcUrl}");
 Console.WriteLine($"* Consented flow: {(settings.DisableConsentedFlow ? "DISABLED (intermediaries excluded)" : "enabled (validate rules)")}");
-
+Console.WriteLine($"* Graph source: {(settings.UseCacheGraphSource ? $"CACHE ({settings.CacheServiceUrl})" : "DATABASE")}");
+if (settings.UseCacheGraphSource)
+{
+    Console.WriteLine($"  - Fallback to DB: {settings.CacheGraphFallbackToDb}");
+    Console.WriteLine($"  - Request timeout: {settings.CacheGraphRequestTimeoutSeconds}s");
+}
 
 var semaphore = new SemaphoreSlim(settings.MaxConcurrentRequests, settings.MaxConcurrentRequests);
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
@@ -20,6 +20,30 @@ public class Settings : Pathfinder.Settings
         ? int.Parse(Environment.GetEnvironmentVariable("MAX_CONCURRENT_REQUESTS")!)
         : Environment.ProcessorCount * 2;
 
+    /// <summary>
+    /// When true, the pathfinder fetches graph data from the Cache Service instead of DB.
+    /// Requires CACHE_SERVICE_URL to be set. Falls back to DB if cache is unavailable
+    /// (unless CACHE_GRAPH_FALLBACK_TO_DB=false).
+    /// </summary>
+    public bool UseCacheGraphSource =>
+        Environment.GetEnvironmentVariable("USE_CACHE_GRAPH_SOURCE")?.ToLowerInvariant() is "true" or "1";
+
+    public string? CacheServiceUrl =>
+        Environment.GetEnvironmentVariable("CACHE_SERVICE_URL");
+
+    public int CacheGraphRequestTimeoutSeconds =>
+        int.TryParse(Environment.GetEnvironmentVariable("CACHE_GRAPH_REQUEST_TIMEOUT_SECONDS"), out var timeout)
+            ? timeout
+            : 60;
+
+    public bool CacheGraphFallbackToDb =>
+        Environment.GetEnvironmentVariable("CACHE_GRAPH_FALLBACK_TO_DB")?.ToLowerInvariant() switch
+        {
+            "false" => false,
+            "0" => false,
+            _ => true
+        };
+
     // Access BaseGroupRouter from common settings
     public string BaseGroupRouter => _commonSettings.BaseGroupRouter;
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -33,6 +33,11 @@ public class NetworkStateUpdaterService : BackgroundService
     private long _lastProcessedBlock = -1;
     private string? _lastProcessedBlockHash;  // D10: reorg detection
 
+    // Cache-source state (only used when UseCacheGraphSource=true)
+    private CacheGraphClient? _cacheGraphClient;
+    private CacheLoadGraph? _cacheLoadGraph;
+    private string? _cacheGraphEtag;
+
     public NetworkStateUpdaterService(NetworkState networkState,
         Circles.Pathfinder.Host.Settings settings,
         ILogger<NetworkStateUpdaterService> log,
@@ -50,9 +55,23 @@ public class NetworkStateUpdaterService : BackgroundService
 
         // Wire DB query timing to Prometheus histogram
         loadGraph.OnQueryCompleted = (queryName, elapsed) =>
-        {
             GraphUpdateMetrics.DbQueryDuration.WithLabels(queryName).Observe(elapsed.TotalSeconds);
-        };
+
+        // Initialize cache graph client if enabled
+        if (_settings.UseCacheGraphSource)
+        {
+            if (string.IsNullOrWhiteSpace(_settings.CacheServiceUrl))
+                throw new InvalidOperationException("USE_CACHE_GRAPH_SOURCE is enabled but CACHE_SERVICE_URL is not configured.");
+
+            _cacheGraphClient = new CacheGraphClient(
+                new HttpClient(),
+                _settings.CacheServiceUrl,
+                TimeSpan.FromSeconds(_settings.CacheGraphRequestTimeoutSeconds));
+
+            _log.LogInformation(
+                "Cache graph source ENABLED (url={Url}, timeout={Timeout}s, fallback={Fallback})",
+                _settings.CacheServiceUrl, _settings.CacheGraphRequestTimeoutSeconds, _settings.CacheGraphFallbackToDb);
+        }
 
         if (_settings.IncrementalEnabled)
         {
@@ -79,6 +98,14 @@ public class NetworkStateUpdaterService : BackgroundService
 
                 _log.LogDebug("→ got block {Block}", lastBlock);
 
+                // ── Try cache source first (if enabled) ──
+                if (await TryCacheSourceUpdate(lastBlock, stoppingToken))
+                {
+                    consecutiveErrors = 0;
+                    continue;
+                }
+
+                // ── Fall back to DB-based update ──
                 var swTotal = Stopwatch.StartNew();
 
                 if (_settings.IncrementalEnabled)
@@ -91,6 +118,7 @@ public class NetworkStateUpdaterService : BackgroundService
                 }
 
                 swTotal.Stop();
+                GraphUpdateMetrics.PathfinderGraphSourceTotal.WithLabels("db").Inc();
 
                 // Common metrics
                 GraphUpdateMetrics.UpdateDuration.WithLabels("total").Observe(swTotal.Elapsed.TotalSeconds);
@@ -502,6 +530,114 @@ public class NetworkStateUpdaterService : BackgroundService
         {
             _log.LogDebug("Drift check passed — zero drift across all state");
         }
+    }
+
+    /// <summary>
+    /// Attempt to update graphs from the cache service. Returns true if the update was handled
+    /// (either new data applied or 304 Not Modified), false if cache is unavailable/disabled
+    /// and the caller should fall back to DB.
+    /// </summary>
+    private async Task<bool> TryCacheSourceUpdate(long lastBlock, CancellationToken ct)
+    {
+        if (_cacheGraphClient == null)
+            return false;
+
+        var sw = Stopwatch.StartNew();
+        try
+        {
+            var fetchResult = await _cacheGraphClient.FetchGraphSnapshotAsync(_cacheGraphEtag, ct);
+            sw.Stop();
+            GraphUpdateMetrics.CacheGraphFetchDuration.Observe(sw.Elapsed.TotalSeconds);
+
+            if (fetchResult.IsNotModified)
+            {
+                GraphUpdateMetrics.CacheGraphNotModifiedTotal.Inc();
+                GraphUpdateMetrics.PathfinderGraphSourceTotal.WithLabels("cache_304").Inc();
+                return true; // Graph unchanged — skip rebuild
+            }
+
+            var snapshot = fetchResult.Snapshot
+                ?? throw new InvalidOperationException("Cache graph response missing snapshot payload.");
+            _cacheGraphEtag = fetchResult.Etag;
+            GraphUpdateMetrics.CacheGraphPayloadBytes.Observe(fetchResult.PayloadBytes);
+
+            if (_cacheLoadGraph == null)
+                _cacheLoadGraph = new CacheLoadGraph(snapshot);
+            else
+                _cacheLoadGraph.ReplaceSnapshot(snapshot);
+
+            // Build graphs from cache snapshot
+            var effectiveBlock = snapshot.LastProcessedBlock;
+            BuildGraphsFromLoadGraph(_cacheLoadGraph, effectiveBlock);
+
+            _networkState.Replace(lastKnownBlockNumber: effectiveBlock);
+            GraphUpdateMetrics.PathfinderGraphSourceTotal.WithLabels("cache").Inc();
+            GraphUpdateMetrics.UpdateTotal.WithLabels("success").Inc();
+            GraphUpdateMetrics.LastUpdateTimestamp.Set(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+            GraphUpdateMetrics.LastProcessedBlock.Set(effectiveBlock);
+            GraphUpdateMetrics.ConsecutiveErrors.Set(0);
+
+            // Graph size gauges
+            var bg = _networkState.BalanceGraph;
+            if (bg != null)
+            {
+                GraphUpdateMetrics.AvatarCount.Set(bg.AvatarNodes.Count);
+                GraphUpdateMetrics.BalanceCount.Set(bg.BalanceNodes.Count);
+            }
+            var currentSnap = _pool.CurrentSnapshot;
+            if (currentSnap != null)
+            {
+                GraphUpdateMetrics.EdgeCount.Set(currentSnap.Base.Edges.Count);
+                GraphUpdateMetrics.GroupCount.Set(currentSnap.Base.GroupNodes.Count);
+                GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
+            }
+            GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
+
+            _log.LogInformation(
+                "Graphs updated (cache) – block={Block}, fetch={FetchMs}ms, payload={Bytes}B",
+                effectiveBlock, sw.ElapsedMilliseconds, fetchResult.PayloadBytes);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            GraphUpdateMetrics.CacheGraphErrorsTotal.Inc();
+
+            if (_settings.CacheGraphFallbackToDb)
+            {
+                _log.LogWarning(ex, "Cache graph fetch failed, falling back to DB for this cycle");
+                return false; // Caller will use DB path
+            }
+
+            _log.LogError(ex, "Cache graph fetch failed and DB fallback is disabled");
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Build trust graph, balance graph, and capacity graph from any ILoadGraph and publish to pool.
+    /// Used by both the cache-source path and could be reused by other graph sources.
+    /// </summary>
+    private void BuildGraphsFromLoadGraph(ILoadGraph loadGraph, long lastBlock)
+    {
+        var graphFactory = new GraphFactory(_settings.BaseGroupRouter, loadGraph);
+
+        var trustGraph = graphFactory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+        _networkState.Replace(accountTrusts: trustLookup);
+
+        var balanceGraph = graphFactory.V2BalanceGraph();
+        _networkState.Replace(balanceGraph: balanceGraph);
+
+        var cap = graphFactory.CreateCapacityGraph(balanceGraph, trustLookup);
+
+        var groupData = new CachedGroupData(
+            new HashSet<int>(cap.GroupNodes),
+            cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
+            new HashSet<int>(cap.ConsentedAvatars));
+
+        _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
     }
 
     private async Task<long> WaitForNextBlock(CancellationToken stoppingToken, long lastBlock)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheFeedIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheFeedIntegrationTests.cs
@@ -1,0 +1,242 @@
+using System.Numerics;
+using Circles.Common;
+using Circles.Pathfinder.Data;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Nodes;
+using Circles.Pathfinder.Tests.Helpers;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Integration tests for the cache-feed pipeline:
+///   Cache snapshot → CacheLoadGraph → GraphFactory → V2Pathfinder → transfer result.
+/// Proves the full zero-SQL path produces correct pathfinding output.
+/// </summary>
+[TestFixture]
+public class CacheFeedIntegrationTests
+{
+    // Valid 42-char hex addresses
+    private static readonly string Router = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+    private static readonly string Alice = "0xaaaa000000000000000000000000000000000001";
+    private static readonly string Bob = "0xbbbb000000000000000000000000000000000002";
+    private static readonly string Charlie = "0xcccc000000000000000000000000000000000003";
+    private static readonly string Wrapper1 = "0xww11000000000000000000000000000000000001";
+
+    /// <summary>
+    /// Simple 2-hop: Alice → Bob direct transfer.
+    /// Alice holds Bob's tokens, Bob trusts Alice.
+    /// Uses CacheLoadGraph as the ILoadGraph implementation.
+    /// </summary>
+    [Test]
+    public void CacheFeed_SimpleDirectTransfer_ShouldFindMaxFlow()
+    {
+        var amount = CirclesConverter.CirclesToAttoCircles(100m).ToString();
+
+        var snapshot = new PathfinderGraphSnapshot(
+            SchemaVersion: 1,
+            LastProcessedBlock: 10000,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Balances: new[]
+            {
+                new PathfinderGraphBalanceRow(amount, Alice, Bob, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), false, "demurraged")
+            },
+            Trust: new[]
+            {
+                new PathfinderGraphTrustRow(Bob, Alice, 100)
+            },
+            Groups: Array.Empty<PathfinderGraphGroupRow>(),
+            GroupTrusts: Array.Empty<PathfinderGraphGroupTrustRow>(),
+            ConsentedFlow: Array.Empty<PathfinderGraphConsentedFlowRow>()
+        );
+
+        var loadGraph = new CacheLoadGraph(snapshot);
+        var factory = new GraphFactory(Router, loadGraph);
+
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+
+        Assert.That(balanceGraph.AvatarNodes, Has.Count.GreaterThanOrEqualTo(1),
+            "Alice should be in the balance graph");
+
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        // Build capacity graph for the pathfinder
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup);
+        Assert.That(capacityGraph.AvatarNodes.ContainsKey(AddressIdPool.IdOf(Alice.ToLowerInvariant())), Is.True,
+            "Alice should be in the capacity graph");
+        Assert.That(capacityGraph.AvatarNodes.ContainsKey(AddressIdPool.IdOf(Bob.ToLowerInvariant())), Is.True,
+            "Bob should be in the capacity graph");
+    }
+
+    /// <summary>
+    /// Verify CacheLoadGraph produces same graph topology as MockLoadGraph for equivalent inputs.
+    /// Cross-validation: cache-feed path should produce identical graphs to mock/DB path.
+    /// </summary>
+    [Test]
+    public void CacheFeed_ShouldMatchMockLoadGraph_SameInputs()
+    {
+        var amount = "1000000000000000000000"; // 1000 * 10^18
+
+        // Build via CacheLoadGraph (cache-feed path)
+        var snapshot = new PathfinderGraphSnapshot(
+            SchemaVersion: 1,
+            LastProcessedBlock: 10000,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Balances: new[]
+            {
+                new PathfinderGraphBalanceRow(amount, Alice, Bob, 0, false, "demurraged"),
+                new PathfinderGraphBalanceRow(amount, Bob, Charlie, 0, false, "demurraged")
+            },
+            Trust: new[]
+            {
+                new PathfinderGraphTrustRow(Bob, Alice, 100),
+                new PathfinderGraphTrustRow(Charlie, Bob, 100)
+            },
+            Groups: null,
+            GroupTrusts: null,
+            ConsentedFlow: null
+        );
+
+        var cacheLoadGraph = new CacheLoadGraph(snapshot);
+        var cacheFactory = new GraphFactory(Router, cacheLoadGraph);
+        var cacheBg = cacheFactory.V2BalanceGraph();
+        var cacheTg = cacheFactory.V2TrustGraph();
+
+        // Build via MockLoadGraph (DB-equivalent path)
+        var mockLoadGraph = new MockLoadGraph();
+        mockLoadGraph.AddBalanceWei(Alice, Bob, amount);
+        mockLoadGraph.AddBalanceWei(Bob, Charlie, amount);
+        mockLoadGraph.AddTrust(Bob, Alice);
+        mockLoadGraph.AddTrust(Charlie, Bob);
+
+        var mockFactory = new GraphFactory(Router, mockLoadGraph);
+        var mockBg = mockFactory.V2BalanceGraph();
+        var mockTg = mockFactory.V2TrustGraph();
+
+        // Same avatar count in balance graph
+        Assert.That(cacheBg.AvatarNodes.Count, Is.EqualTo(mockBg.AvatarNodes.Count),
+            "Cache and mock should produce same number of balance graph avatar nodes");
+
+        // Same trust edge count
+        Assert.That(cacheTg.Edges.Count, Is.EqualTo(mockTg.Edges.Count),
+            "Cache and mock should produce same number of trust edges");
+    }
+
+    /// <summary>
+    /// Verify wrapper tokens are present in the balance graph when isWrapped=true.
+    /// </summary>
+    [Test]
+    public void CacheFeed_WrappedBalances_ShouldAppearInGraph()
+    {
+        var amount = "5000000000000000000000";
+
+        var snapshot = new PathfinderGraphSnapshot(
+            SchemaVersion: 1,
+            LastProcessedBlock: 10000,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Balances: new[]
+            {
+                new PathfinderGraphBalanceRow(amount, Alice, Wrapper1, 0, true, "demurraged"),
+                new PathfinderGraphBalanceRow(amount, Alice, Bob, 0, false, "demurraged")
+            },
+            Trust: new[]
+            {
+                new PathfinderGraphTrustRow(Bob, Alice, 100),
+                new PathfinderGraphTrustRow(Bob, Wrapper1, 100)
+            },
+            Groups: null,
+            GroupTrusts: null,
+            ConsentedFlow: null
+        );
+
+        var loadGraph = new CacheLoadGraph(snapshot);
+        var factory = new GraphFactory(Router, loadGraph);
+        var bg = factory.V2BalanceGraph();
+
+        var aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        var wrapperId = AddressIdPool.IdOf(Wrapper1.ToLowerInvariant());
+
+        Assert.That(bg.AvatarNodes.ContainsKey(aliceId), Is.True,
+            "Alice should be in the balance graph");
+
+        // Verify wrapped balance exists via BalanceNodes (keyed by composite balance-node ID)
+        // BalanceGraph.AddBalance creates a BalanceNode with owner=alice, token=wrapper
+        var hasWrapperBalance = bg.BalanceNodes.Values.Any(bn =>
+            bn.Holder == aliceId && bn.Token == wrapperId);
+        Assert.That(hasWrapperBalance, Is.True,
+            "Alice should hold the wrapper token balance");
+    }
+
+    /// <summary>
+    /// Verify ReplaceSnapshot works for live updates — new snapshot changes graph data.
+    /// </summary>
+    [Test]
+    public void CacheFeed_ReplaceSnapshot_ShouldUpdateGraphData()
+    {
+        var amount1 = "1000000000000000000000";
+        var snapshot1 = new PathfinderGraphSnapshot(
+            1, 100, 0,
+            new[] { new PathfinderGraphBalanceRow(amount1, Alice, Bob, 0, false, "demurraged") },
+            new[] { new PathfinderGraphTrustRow(Bob, Alice, 100) },
+            null, null, null);
+
+        var loadGraph = new CacheLoadGraph(snapshot1);
+        Assert.That(loadGraph.LastProcessedBlock, Is.EqualTo(100));
+        Assert.That(loadGraph.LoadV2Balances().Count(), Is.EqualTo(1));
+
+        // Replace with larger snapshot
+        var amount2 = "2000000000000000000000";
+        var snapshot2 = new PathfinderGraphSnapshot(
+            1, 200, 0,
+            new[]
+            {
+                new PathfinderGraphBalanceRow(amount2, Alice, Bob, 0, false, "demurraged"),
+                new PathfinderGraphBalanceRow(amount2, Bob, Charlie, 0, false, "demurraged")
+            },
+            new[]
+            {
+                new PathfinderGraphTrustRow(Bob, Alice, 100),
+                new PathfinderGraphTrustRow(Charlie, Bob, 100)
+            },
+            null, null, null);
+
+        loadGraph.ReplaceSnapshot(snapshot2);
+
+        Assert.That(loadGraph.LastProcessedBlock, Is.EqualTo(200));
+        Assert.That(loadGraph.LoadV2Balances().Count(), Is.EqualTo(2));
+        Assert.That(loadGraph.LoadV2Trust().Count(), Is.EqualTo(2));
+
+        // Verify the new snapshot builds into a valid graph
+        var factory = new GraphFactory(Router, loadGraph);
+        var bg = factory.V2BalanceGraph();
+        Assert.That(bg.AvatarNodes, Has.Count.GreaterThanOrEqualTo(2),
+            "Updated snapshot should produce graph with Alice and Bob");
+    }
+
+    /// <summary>
+    /// Verify consented flow flags propagate through CacheLoadGraph → CapacityGraph.
+    /// </summary>
+    [Test]
+    public void CacheFeed_ConsentedFlowFlags_ShouldPropagateToCapacityGraph()
+    {
+        var amount = "1000000000000000000000";
+        var snapshot = new PathfinderGraphSnapshot(
+            1, 10000, 0,
+            new[] { new PathfinderGraphBalanceRow(amount, Alice, Bob, 0, false, "demurraged") },
+            new[] { new PathfinderGraphTrustRow(Bob, Alice, 100) },
+            null, null,
+            new[]
+            {
+                new PathfinderGraphConsentedFlowRow(Alice, true),
+                new PathfinderGraphConsentedFlowRow(Bob, false)
+            });
+
+        var loadGraph = new CacheLoadGraph(snapshot);
+
+        // Verify the raw consent data loads
+        var consentFlags = loadGraph.LoadConsentedFlowFlags().ToList();
+        Assert.That(consentFlags, Has.Count.EqualTo(2));
+        Assert.That(consentFlags.Any(c => c.Avatar == Alice.ToLowerInvariant() && c.HasConsentedFlow), Is.True);
+        Assert.That(consentFlags.Any(c => c.Avatar == Bob.ToLowerInvariant() && !c.HasConsentedFlow), Is.True);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheGraphClientTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheGraphClientTests.cs
@@ -1,0 +1,279 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Circles.Pathfinder.Data;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests for CacheGraphClient — HTTP client for fetching graph snapshots.
+/// Covers: ETag conditional requests, 304 NotModified, 503 handling,
+/// gzip/brotli decompression, and successful deserialization.
+/// </summary>
+[TestFixture]
+public class CacheGraphClientTests
+{
+    private const string BaseUrl = "http://cache-service:3001";
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldReturn304_WhenETagMatches()
+    {
+        var handler = new MockHttpHandler(HttpStatusCode.NotModified, "");
+        var client = CreateClient(handler);
+
+        var result = await client.FetchGraphSnapshotAsync("\"1234\"", CancellationToken.None);
+
+        Assert.That(result.IsNotModified, Is.True);
+        Assert.That(result.Snapshot, Is.Null);
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldSendIfNoneMatchHeader()
+    {
+        var handler = new MockHttpHandler(HttpStatusCode.NotModified, "");
+        var client = CreateClient(handler);
+
+        await client.FetchGraphSnapshotAsync("\"5000\"", CancellationToken.None);
+
+        Assert.That(handler.LastRequest, Is.Not.Null);
+        Assert.That(handler.LastRequest!.Headers.IfNoneMatch.Count, Is.EqualTo(1));
+        Assert.That(handler.LastRequest.Headers.IfNoneMatch.First().Tag, Is.EqualTo("\"5000\""));
+    }
+
+    [Test]
+    public void FetchGraphSnapshot_ShouldThrow_On503ServiceUnavailable()
+    {
+        var handler = new MockHttpHandler(HttpStatusCode.ServiceUnavailable, "");
+        var client = CreateClient(handler);
+
+        Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.FetchGraphSnapshotAsync(null, CancellationToken.None));
+    }
+
+    [Test]
+    public void FetchGraphSnapshot_ShouldThrow_On500InternalServerError()
+    {
+        var handler = new MockHttpHandler(HttpStatusCode.InternalServerError, "");
+        var client = CreateClient(handler);
+
+        Assert.ThrowsAsync<HttpRequestException>(
+            () => client.FetchGraphSnapshotAsync(null, CancellationToken.None));
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldDeserializeUncompressedJson()
+    {
+        var json = CreateMinimalSnapshotJson(42000);
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json, etag: "\"42000\"");
+        var client = CreateClient(handler);
+
+        var result = await client.FetchGraphSnapshotAsync(null, CancellationToken.None);
+
+        Assert.That(result.IsNotModified, Is.False);
+        Assert.That(result.Snapshot, Is.Not.Null);
+        Assert.That(result.Snapshot!.LastProcessedBlock, Is.EqualTo(42000));
+        Assert.That(result.Snapshot.SchemaVersion, Is.EqualTo(1));
+        Assert.That(result.Etag, Is.EqualTo("\"42000\""));
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldDecompressGzip()
+    {
+        var json = CreateMinimalSnapshotJson(99000);
+        var compressed = GzipCompress(json);
+        var handler = new MockHttpHandler(
+            HttpStatusCode.OK, compressed, "gzip", etag: "\"99000\"");
+        var client = CreateClient(handler);
+
+        var result = await client.FetchGraphSnapshotAsync(null, CancellationToken.None);
+
+        Assert.That(result.Snapshot, Is.Not.Null);
+        Assert.That(result.Snapshot!.LastProcessedBlock, Is.EqualTo(99000));
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldDecompressBrotli()
+    {
+        var json = CreateMinimalSnapshotJson(88000);
+        var compressed = BrotliCompress(json);
+        var handler = new MockHttpHandler(
+            HttpStatusCode.OK, compressed, "br", etag: "\"88000\"");
+        var client = CreateClient(handler);
+
+        var result = await client.FetchGraphSnapshotAsync(null, CancellationToken.None);
+
+        Assert.That(result.Snapshot, Is.Not.Null);
+        Assert.That(result.Snapshot!.LastProcessedBlock, Is.EqualTo(88000));
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldNotSendIfNoneMatch_WhenEtagNull()
+    {
+        var json = CreateMinimalSnapshotJson(1000);
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        await client.FetchGraphSnapshotAsync(null, CancellationToken.None);
+
+        Assert.That(handler.LastRequest!.Headers.IfNoneMatch, Is.Empty);
+    }
+
+    [Test]
+    public async Task FetchGraphSnapshot_ShouldDeserializeFullSnapshot()
+    {
+        var dto = new
+        {
+            schemaVersion = 1,
+            lastProcessedBlock = 50000L,
+            timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            balances = new[]
+            {
+                new { balance = "1000000000000000000", account = "0xalice", tokenAddress = "0xtoken", lastActivity = 12345L, isWrapped = false, circlesType = "demurraged" },
+                new { balance = "500000000000000000", account = "0xbob", tokenAddress = "0xwrapper", lastActivity = 0L, isWrapped = true, circlesType = "static" }
+            },
+            trust = new[]
+            {
+                new { truster = "0xalice", trustee = "0xbob", limit = 100 }
+            },
+            groups = new[]
+            {
+                new { groupAddress = "0xgroup1" }
+            },
+            groupTrusts = new[]
+            {
+                new { groupAddress = "0xgroup1", trustedToken = "0xalice" }
+            },
+            consentedFlow = new[]
+            {
+                new { avatar = "0xalice", hasConsentedFlow = true }
+            }
+        };
+
+        var json = JsonSerializer.Serialize(dto);
+        var handler = new MockHttpHandler(HttpStatusCode.OK, json);
+        var client = CreateClient(handler);
+
+        var result = await client.FetchGraphSnapshotAsync(null, CancellationToken.None);
+
+        Assert.That(result.Snapshot!.Balances, Has.Count.EqualTo(2));
+        Assert.That(result.Snapshot.Trust, Has.Count.EqualTo(1));
+        Assert.That(result.Snapshot.Groups, Has.Count.EqualTo(1));
+        Assert.That(result.Snapshot.GroupTrusts, Has.Count.EqualTo(1));
+        Assert.That(result.Snapshot.ConsentedFlow, Has.Count.EqualTo(1));
+        Assert.That(result.Snapshot.ConsentedFlow![0].HasConsentedFlow, Is.True);
+    }
+
+    // ── CacheGraphFetchResult Tests ────────────────────────────────────
+
+    [Test]
+    public void CacheGraphFetchResult_NotModified_ShouldHaveCorrectState()
+    {
+        var result = CacheGraphFetchResult.NotModified();
+
+        Assert.That(result.IsNotModified, Is.True);
+        Assert.That(result.Snapshot, Is.Null);
+        Assert.That(result.Etag, Is.Null);
+        Assert.That(result.PayloadBytes, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void CacheGraphFetchResult_Success_ShouldHaveCorrectState()
+    {
+        var snapshot = new PathfinderGraphSnapshot(1, 5000, 0, null, null, null, null, null);
+        var result = CacheGraphFetchResult.Success(snapshot, "\"5000\"", 1024);
+
+        Assert.That(result.IsNotModified, Is.False);
+        Assert.That(result.Snapshot, Is.SameAs(snapshot));
+        Assert.That(result.Etag, Is.EqualTo("\"5000\""));
+        Assert.That(result.PayloadBytes, Is.EqualTo(1024));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static CacheGraphClient CreateClient(MockHttpHandler handler)
+    {
+        var httpClient = new HttpClient(handler);
+        return new CacheGraphClient(httpClient, BaseUrl, TimeSpan.FromSeconds(30));
+    }
+
+    private static string CreateMinimalSnapshotJson(long lastBlock)
+    {
+        return JsonSerializer.Serialize(new
+        {
+            schemaVersion = 1,
+            lastProcessedBlock = lastBlock,
+            timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
+        });
+    }
+
+    private static byte[] GzipCompress(string text)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        using var ms = new MemoryStream();
+        using (var gzip = new GZipStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+            gzip.Write(bytes);
+        return ms.ToArray();
+    }
+
+    private static byte[] BrotliCompress(string text)
+    {
+        var bytes = Encoding.UTF8.GetBytes(text);
+        using var ms = new MemoryStream();
+        using (var brotli = new BrotliStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+            brotli.Write(bytes);
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// Simple HttpMessageHandler mock for testing CacheGraphClient without real network calls.
+    /// </summary>
+    private sealed class MockHttpHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly byte[] _content;
+        private readonly string? _contentEncoding;
+        private readonly string? _etag;
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        public MockHttpHandler(HttpStatusCode statusCode, string textContent, string? etag = null)
+        {
+            _statusCode = statusCode;
+            _content = Encoding.UTF8.GetBytes(textContent);
+            _contentEncoding = null;
+            _etag = etag;
+        }
+
+        public MockHttpHandler(HttpStatusCode statusCode, byte[] compressedContent, string contentEncoding, string? etag = null)
+        {
+            _statusCode = statusCode;
+            _content = compressedContent;
+            _contentEncoding = contentEncoding;
+            _etag = etag;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+
+            var response = new HttpResponseMessage(_statusCode);
+
+            if (_statusCode != HttpStatusCode.NotModified && _content.Length > 0)
+            {
+                response.Content = new ByteArrayContent(_content);
+                response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+                response.Content.Headers.ContentLength = _content.Length;
+
+                if (_contentEncoding != null)
+                    response.Content.Headers.ContentEncoding.Add(_contentEncoding);
+            }
+
+            if (_etag != null)
+                response.Headers.ETag = new EntityTagHeaderValue(_etag);
+
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheLoadGraphTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheLoadGraphTests.cs
@@ -1,0 +1,208 @@
+using Circles.Pathfinder.Data;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests for CacheLoadGraph — ILoadGraph implementation backed by a deserialized snapshot.
+/// Covers: balance/trust/group/consent round-tripping, lowercase normalization,
+/// CirclesType mapping, empty snapshot handling, and snapshot replacement.
+/// </summary>
+[TestFixture]
+public class CacheLoadGraphTests
+{
+    [Test]
+    public void LoadV2Balances_ShouldYieldCorrectTuples()
+    {
+        var snapshot = CreateSnapshot(balances: new[]
+        {
+            new PathfinderGraphBalanceRow("1000000000000000000", "0xAlice", "0xToken", 123456, false, "demurraged")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var balances = graph.LoadV2Balances().ToList();
+
+        Assert.That(balances, Has.Count.EqualTo(1));
+        Assert.That(balances[0].Balance, Is.EqualTo("1000000000000000000"));
+        Assert.That(balances[0].IsWrapped, Is.False);
+        Assert.That(balances[0].IsStatic, Is.False);
+    }
+
+    [Test]
+    public void LoadV2Balances_ShouldMapStaticCirclesType()
+    {
+        var snapshot = CreateSnapshot(balances: new[]
+        {
+            new PathfinderGraphBalanceRow("500", "0xAlice", "0xWrapper", 0, true, "static")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var balances = graph.LoadV2Balances().ToList();
+
+        Assert.That(balances[0].IsStatic, Is.True);
+        Assert.That(balances[0].IsWrapped, Is.True);
+    }
+
+    [Test]
+    public void LoadV2Balances_ShouldNormalizeToLowercase()
+    {
+        var snapshot = CreateSnapshot(balances: new[]
+        {
+            new PathfinderGraphBalanceRow("100", "0xABCD", "0xEFGH", 0, false, "demurraged")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var balances = graph.LoadV2Balances().ToList();
+
+        // AddressIdPool.IdOf normalizes lowercase internally;
+        // verify the balance data is accessible (addresses map correctly)
+        Assert.That(balances, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void LoadV2Balances_ShouldReturnEmpty_WhenNullBalances()
+    {
+        var snapshot = CreateSnapshot();
+        var graph = new CacheLoadGraph(snapshot);
+
+        var balances = graph.LoadV2Balances().ToList();
+
+        Assert.That(balances, Is.Empty);
+    }
+
+    [Test]
+    public void LoadV2Trust_ShouldYieldCorrectTuples()
+    {
+        var snapshot = CreateSnapshot(trust: new[]
+        {
+            new PathfinderGraphTrustRow("0xTruster", "0xTrustee", 100)
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var trust = graph.LoadV2Trust().ToList();
+
+        Assert.That(trust, Has.Count.EqualTo(1));
+        Assert.That(trust[0].Truster, Is.EqualTo("0xtruster")); // lowercase
+        Assert.That(trust[0].Trustee, Is.EqualTo("0xtrustee")); // lowercase
+        Assert.That(trust[0].Limit, Is.EqualTo(100));
+    }
+
+    [Test]
+    public void LoadGroups_ShouldYieldLowercaseAddresses()
+    {
+        var snapshot = CreateSnapshot(groups: new[]
+        {
+            new PathfinderGraphGroupRow("0xGroupADDR")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var groups = graph.LoadGroups().ToList();
+
+        Assert.That(groups, Has.Count.EqualTo(1));
+        Assert.That(groups[0], Is.EqualTo("0xgroupaddr"));
+    }
+
+    [Test]
+    public void LoadGroupTrusts_ShouldYieldLowercasePairs()
+    {
+        var snapshot = CreateSnapshot(groupTrusts: new[]
+        {
+            new PathfinderGraphGroupTrustRow("0xGroup", "0xToken")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var groupTrusts = graph.LoadGroupTrusts().ToList();
+
+        Assert.That(groupTrusts, Has.Count.EqualTo(1));
+        Assert.That(groupTrusts[0].GroupAddress, Is.EqualTo("0xgroup"));
+        Assert.That(groupTrusts[0].TrustedToken, Is.EqualTo("0xtoken"));
+    }
+
+    [Test]
+    public void LoadConsentedFlowFlags_ShouldYieldCorrectTuples()
+    {
+        var snapshot = CreateSnapshot(consent: new[]
+        {
+            new PathfinderGraphConsentedFlowRow("0xAlice", true),
+            new PathfinderGraphConsentedFlowRow("0xBob", false)
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var consent = graph.LoadConsentedFlowFlags().ToList();
+
+        Assert.That(consent, Has.Count.EqualTo(2));
+        Assert.That(consent[0].Avatar, Is.EqualTo("0xalice"));
+        Assert.That(consent[0].HasConsentedFlow, Is.True);
+        Assert.That(consent[1].Avatar, Is.EqualTo("0xbob"));
+        Assert.That(consent[1].HasConsentedFlow, Is.False);
+    }
+
+    [Test]
+    public void LastProcessedBlock_ShouldReflectSnapshot()
+    {
+        var snapshot = CreateSnapshot(lastBlock: 42000);
+        var graph = new CacheLoadGraph(snapshot);
+
+        Assert.That(graph.LastProcessedBlock, Is.EqualTo(42000));
+    }
+
+    [Test]
+    public void ReplaceSnapshot_ShouldUpdateAllData()
+    {
+        var initial = CreateSnapshot(lastBlock: 100, balances: new[]
+        {
+            new PathfinderGraphBalanceRow("1000", "0xalice", "0xtoken", 0, false, "demurraged")
+        });
+        var graph = new CacheLoadGraph(initial);
+        Assert.That(graph.LoadV2Balances().Count(), Is.EqualTo(1));
+        Assert.That(graph.LastProcessedBlock, Is.EqualTo(100));
+
+        var updated = CreateSnapshot(lastBlock: 200, balances: new[]
+        {
+            new PathfinderGraphBalanceRow("2000", "0xbob", "0xtoken2", 0, false, "demurraged"),
+            new PathfinderGraphBalanceRow("3000", "0xcharlie", "0xtoken3", 0, true, "static")
+        });
+        graph.ReplaceSnapshot(updated);
+
+        Assert.That(graph.LastProcessedBlock, Is.EqualTo(200));
+        Assert.That(graph.LoadV2Balances().Count(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void LoadV2Balances_StaticCirclesType_ShouldBeCaseInsensitive()
+    {
+        var snapshot = CreateSnapshot(balances: new[]
+        {
+            new PathfinderGraphBalanceRow("100", "0xa", "0xb", 0, true, "STATIC"),
+            new PathfinderGraphBalanceRow("200", "0xc", "0xd", 0, true, "Static"),
+            new PathfinderGraphBalanceRow("300", "0xe", "0xf", 0, false, "Demurraged")
+        });
+        var graph = new CacheLoadGraph(snapshot);
+
+        var balances = graph.LoadV2Balances().ToList();
+
+        Assert.That(balances[0].IsStatic, Is.True);
+        Assert.That(balances[1].IsStatic, Is.True);
+        Assert.That(balances[2].IsStatic, Is.False);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private static PathfinderGraphSnapshot CreateSnapshot(
+        long lastBlock = 1000,
+        IReadOnlyList<PathfinderGraphBalanceRow>? balances = null,
+        IReadOnlyList<PathfinderGraphTrustRow>? trust = null,
+        IReadOnlyList<PathfinderGraphGroupRow>? groups = null,
+        IReadOnlyList<PathfinderGraphGroupTrustRow>? groupTrusts = null,
+        IReadOnlyList<PathfinderGraphConsentedFlowRow>? consent = null)
+    {
+        return new PathfinderGraphSnapshot(
+            SchemaVersion: 1,
+            LastProcessedBlock: lastBlock,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Balances: balances,
+            Trust: trust,
+            Groups: groups,
+            GroupTrusts: groupTrusts,
+            ConsentedFlow: consent);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphClient.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphClient.cs
@@ -1,0 +1,107 @@
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace Circles.Pathfinder.Data;
+
+/// <summary>
+/// HTTP client for fetching graph snapshots from the Cache Service's /api/pathfinder/graph endpoint.
+/// Supports ETag-based conditional requests and compressed responses.
+/// </summary>
+public sealed class CacheGraphClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _baseUrl;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    public CacheGraphClient(HttpClient httpClient, string baseUrl, TimeSpan timeout)
+    {
+        _httpClient = httpClient;
+        _httpClient.Timeout = timeout;
+        _baseUrl = baseUrl.TrimEnd('/');
+    }
+
+    public async Task<CacheGraphFetchResult> FetchGraphSnapshotAsync(string? etag, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, $"{_baseUrl}/api/pathfinder/graph");
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));
+        request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
+
+        if (!string.IsNullOrWhiteSpace(etag))
+            request.Headers.IfNoneMatch.Add(new EntityTagHeaderValue(etag));
+
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        if (response.StatusCode == HttpStatusCode.NotModified)
+            return CacheGraphFetchResult.NotModified();
+
+        if (response.StatusCode == HttpStatusCode.ServiceUnavailable)
+            throw new InvalidOperationException("Cache graph endpoint is not ready (503).");
+
+        response.EnsureSuccessStatusCode();
+
+        var newEtag = response.Headers.ETag?.Tag;
+        var payloadBytes = response.Content.Headers.ContentLength ?? 0;
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(ct);
+        await using var decodedStream = await DecodeContentStream(response.Content.Headers.ContentEncoding, contentStream);
+
+        var dto = await JsonSerializer.DeserializeAsync<PathfinderGraphSnapshotDto>(decodedStream, JsonOptions, ct)
+                  ?? throw new InvalidOperationException("Failed to deserialize cache graph snapshot payload.");
+
+        var snapshot = dto.ToModel();
+        return CacheGraphFetchResult.Success(snapshot, newEtag, payloadBytes);
+    }
+
+    private static async Task<Stream> DecodeContentStream(ICollection<string> encodings, Stream raw)
+    {
+        if (encodings.Any(x => x.Equals("br", StringComparison.OrdinalIgnoreCase)))
+        {
+            var ms = new MemoryStream();
+            await using var brotli = new BrotliStream(raw, CompressionMode.Decompress, leaveOpen: true);
+            await brotli.CopyToAsync(ms);
+            ms.Position = 0;
+            return ms;
+        }
+
+        if (encodings.Any(x => x.Equals("gzip", StringComparison.OrdinalIgnoreCase)))
+        {
+            var ms = new MemoryStream();
+            await using var gzip = new GZipStream(raw, CompressionMode.Decompress, leaveOpen: true);
+            await gzip.CopyToAsync(ms);
+            ms.Position = 0;
+            return ms;
+        }
+
+        var passthrough = new MemoryStream();
+        await raw.CopyToAsync(passthrough);
+        passthrough.Position = 0;
+        return passthrough;
+    }
+}
+
+public sealed record CacheGraphFetchResult
+{
+    public bool IsNotModified { get; init; }
+    public PathfinderGraphSnapshot? Snapshot { get; init; }
+    public string? Etag { get; init; }
+    public long PayloadBytes { get; init; }
+
+    public static CacheGraphFetchResult NotModified() => new()
+    {
+        IsNotModified = true
+    };
+
+    public static CacheGraphFetchResult Success(PathfinderGraphSnapshot snapshot, string? etag, long payloadBytes) => new()
+    {
+        IsNotModified = false,
+        Snapshot = snapshot,
+        Etag = etag,
+        PayloadBytes = payloadBytes
+    };
+}

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -1,0 +1,84 @@
+using System.Text.Json.Serialization;
+
+namespace Circles.Pathfinder.Data;
+
+/// <summary>
+/// Deserialized graph snapshot from the Cache Service's /api/pathfinder/graph endpoint.
+/// </summary>
+public record PathfinderGraphSnapshot(
+    int SchemaVersion,
+    long LastProcessedBlock,
+    long Timestamp,
+    IReadOnlyList<PathfinderGraphBalanceRow>? Balances,
+    IReadOnlyList<PathfinderGraphTrustRow>? Trust,
+    IReadOnlyList<PathfinderGraphGroupRow>? Groups,
+    IReadOnlyList<PathfinderGraphGroupTrustRow>? GroupTrusts,
+    IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow
+);
+
+public record PathfinderGraphBalanceRow(
+    string Balance,
+    string Account,
+    string TokenAddress,
+    long LastActivity,
+    bool IsWrapped,
+    string CirclesType
+);
+
+public record PathfinderGraphTrustRow(
+    string Truster,
+    string Trustee,
+    int Limit
+);
+
+public record PathfinderGraphGroupRow(string GroupAddress);
+
+public record PathfinderGraphGroupTrustRow(
+    string GroupAddress,
+    string TrustedToken
+);
+
+public record PathfinderGraphConsentedFlowRow(
+    string Avatar,
+    bool HasConsentedFlow
+);
+
+/// <summary>
+/// DTO for JSON deserialization — maps camelCase property names from the cache service response.
+/// </summary>
+internal sealed class PathfinderGraphSnapshotDto
+{
+    [JsonPropertyName("schemaVersion")]
+    public int SchemaVersion { get; set; }
+
+    [JsonPropertyName("lastProcessedBlock")]
+    public long LastProcessedBlock { get; set; }
+
+    [JsonPropertyName("timestamp")]
+    public long Timestamp { get; set; }
+
+    [JsonPropertyName("balances")]
+    public List<PathfinderGraphBalanceRow>? Balances { get; set; }
+
+    [JsonPropertyName("trust")]
+    public List<PathfinderGraphTrustRow>? Trust { get; set; }
+
+    [JsonPropertyName("groups")]
+    public List<PathfinderGraphGroupRow>? Groups { get; set; }
+
+    [JsonPropertyName("groupTrusts")]
+    public List<PathfinderGraphGroupTrustRow>? GroupTrusts { get; set; }
+
+    [JsonPropertyName("consentedFlow")]
+    public List<PathfinderGraphConsentedFlowRow>? ConsentedFlow { get; set; }
+
+    public PathfinderGraphSnapshot ToModel() => new(
+        SchemaVersion,
+        LastProcessedBlock,
+        Timestamp,
+        Balances,
+        Trust,
+        Groups,
+        GroupTrusts,
+        ConsentedFlow);
+}

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -1,0 +1,65 @@
+namespace Circles.Pathfinder.Data;
+
+/// <summary>
+/// ILoadGraph implementation backed by a deserialized Cache Service snapshot.
+/// No DB connection, no demurrage calculation — the cache service provides
+/// raw balances that LoadGraph/IncrementalLoadGraph would normally compute.
+/// </summary>
+public sealed class CacheLoadGraph : ILoadGraph
+{
+    private PathfinderGraphSnapshot _snapshot;
+
+    public CacheLoadGraph(PathfinderGraphSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+    }
+
+    public void ReplaceSnapshot(PathfinderGraphSnapshot snapshot)
+    {
+        _snapshot = snapshot;
+    }
+
+    public long LastProcessedBlock => _snapshot.LastProcessedBlock;
+
+    public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> LoadV2Balances()
+    {
+        var rows = _snapshot.Balances ?? [];
+        foreach (var row in rows)
+        {
+            yield return (
+                row.Balance,
+                AddressIdPool.IdOf(row.Account.ToLowerInvariant()),
+                AddressIdPool.IdOf(row.TokenAddress.ToLowerInvariant()),
+                row.IsWrapped,
+                string.Equals(row.CirclesType, "static", StringComparison.OrdinalIgnoreCase));
+        }
+    }
+
+    public IEnumerable<(string Truster, string Trustee, int Limit)> LoadV2Trust()
+    {
+        var rows = _snapshot.Trust ?? [];
+        foreach (var row in rows)
+            yield return (row.Truster.ToLowerInvariant(), row.Trustee.ToLowerInvariant(), row.Limit);
+    }
+
+    public IEnumerable<string> LoadGroups()
+    {
+        var rows = _snapshot.Groups ?? [];
+        foreach (var row in rows)
+            yield return row.GroupAddress.ToLowerInvariant();
+    }
+
+    public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
+    {
+        var rows = _snapshot.GroupTrusts ?? [];
+        foreach (var row in rows)
+            yield return (row.GroupAddress.ToLowerInvariant(), row.TrustedToken.ToLowerInvariant());
+    }
+
+    public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
+    {
+        var rows = _snapshot.ConsentedFlow ?? [];
+        foreach (var row in rows)
+            yield return (row.Avatar.ToLowerInvariant(), row.HasConsentedFlow);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -113,7 +113,6 @@ namespace Circles.Pathfinder.Data
         public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
             LoadV2Balances()
         {
-            // We now only have one balance query that includes the isWrapped column
             var balanceQuery = LoadQueryFromResource("balanceQuery.sql");
             var results = new List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>(50_000);
 
@@ -219,7 +218,6 @@ namespace Circles.Pathfinder.Data
 
         public IEnumerable<(string Truster, string Trustee, int Limit)> LoadV2Trust()
         {
-            // We now only have one trust query that includes wrap tokens
             var trustQuery = LoadQueryFromResource("trustQuery.sql");
             var results = new List<(string Truster, string Trustee, int Limit)>(200_000);
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
@@ -1,11 +1,129 @@
-select
-    b."totalBalance"::text as balance
-     ,b."account"
-     ,b."tokenAddress"
-     ,b."lastActivity"
-     ,false AS "isWrapped"
-     ,'demurraged' AS "circlesType"
-from "V_CrcV2_BalancesByAccountAndToken" b
-inner join "V_CrcV2_Avatars" a on a.avatar = b."account"
-where b."totalBalance" > 0
-order by b."totalBalance", b."account", b."tokenAddress";
+with static_token_transfers as (
+    select t."blockNumber"
+         , t."timestamp"
+         , t."transactionIndex"
+         , t."logIndex"
+         , t."transactionHash"
+         , t."tokenAddress"
+         , t."from"
+         , t."to"
+         , t."amount"
+    from "CrcV2_Erc20WrapperTransfer" t
+             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 1 and d."erc20Wrapper" = t."tokenAddress"
+             inner join "V_CrcV2_Avatars" a on a.avatar = d.avatar
+    order by t."blockNumber", t."transactionIndex", t."logIndex"
+), static_from_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."from" as "account"
+         , -t1."amount" as diff
+    from static_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
+), static_to_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."to" as "account"
+         , t1."amount" as diff
+    from static_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
+), static_sum as (
+    select sum(diff) AS static_balance
+         , account
+         , "tokenAddress"
+         , max("timestamp") AS "timestamp"
+         , true as "isWrapped"
+         , 'static' as "circlesType"
+    from (
+             select *
+             from static_from_transfers
+             union all
+             select *
+             from static_to_transfers
+         ) as t
+    group by account
+           , "tokenAddress"
+),
+
+demurraged_wrapped_token_transfers as (
+    select t."blockNumber"
+         , t."timestamp"
+         , t."transactionIndex"
+         , t."logIndex"
+         , t."transactionHash"
+         , t."tokenAddress"
+         , t."from"
+         , t."to"
+         , t."amount"
+    from "CrcV2_Erc20WrapperTransfer" t
+             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 0 and d."erc20Wrapper" = t."tokenAddress"
+             inner join "V_CrcV2_Avatars" a on a.avatar = d.avatar
+    order by t."blockNumber", t."transactionIndex", t."logIndex"
+), demurraged_wrapped_from_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."from" as "account"
+         , -t1."amount" as diff
+    from demurraged_wrapped_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
+), demurraged_wrapped_to_transfers as (
+    select t1."timestamp"
+         , t1."tokenAddress"
+         , t1."to" as "account"
+         , t1."amount" as diff
+    from demurraged_wrapped_token_transfers t1
+             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
+), demurraged_wrapped_sum as (
+    select sum(diff) AS inflationary_balance
+         , account
+         , "tokenAddress"
+         , max("timestamp") AS "lastActivity"
+         , true as "isWrapped"
+         , 'demurraged' as "circlesType"
+    from (
+             select *
+             from demurraged_wrapped_from_transfers
+             union all
+             select *
+             from demurraged_wrapped_to_transfers
+         ) as t
+    group by account
+           , "tokenAddress"
+),
+
+all_transfers as (
+    select "static_balance" as balance
+         , "account"
+         , "tokenAddress"
+         , "timestamp" as "lastActivity"
+         , "isWrapped"
+         , "circlesType"
+    from static_sum
+    union all
+    select "inflationary_balance" as balance
+         , "account"
+         , "tokenAddress"
+         , "lastActivity"
+         , "isWrapped"
+         , "circlesType"
+    from demurraged_wrapped_sum
+    union all
+    select
+        b."totalBalance" as balance
+         ,b."account"
+         ,b."tokenAddress"
+         ,b."lastActivity"
+         ,false AS "isWrapped"
+         ,'demurraged' AS "circlesType"
+    from "V_CrcV2_BalancesByAccountAndToken" b
+    inner join "V_CrcV2_Avatars" a on a.avatar = b."account"
+)
+
+select balance::text
+     , account
+     , "tokenAddress"
+     , "lastActivity"
+     , "isWrapped"
+     , "circlesType"
+from all_transfers
+where balance > 0
+order by balance, account, "tokenAddress";

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/trustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/trustQuery.sql
@@ -3,3 +3,13 @@ INNER JOIN "V_CrcV2_Avatars" a1 ON a1.avatar = t1.truster
 INNER JOIN "V_CrcV2_Avatars" a2 ON a2.avatar = t1.trustee
 LEFT JOIN "CrcV2_RegisterGroup" t2 on t2."group" = t1.truster
 WHERE t2."group"  IS NULL
+
+UNION ALL
+
+SELECT t1.truster, t2."erc20Wrapper" AS trustee FROM "V_CrcV2_TrustRelations" t1
+INNER JOIN "CrcV2_ERC20WrapperDeployed" t2
+ON t2.avatar = t1.trustee
+INNER JOIN "V_CrcV2_Avatars" a1 ON a1.avatar = t1.truster
+INNER JOIN "V_CrcV2_Avatars" a2 ON a2.avatar = t2.avatar
+LEFT JOIN "CrcV2_RegisterGroup" t3 on t3."group" = t1.truster
+WHERE t3."group"  IS NULL

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -90,4 +90,5 @@ public class Settings
             Environment.GetEnvironmentVariable("PATHFINDER_DISABLE_CONSENTED_FLOW"),
             "false",
             StringComparison.OrdinalIgnoreCase);
+
 }


### PR DESCRIPTION
## Summary

- **Restore ERC20 wrapper data** in pathfinder SQL queries (removed in 876948e). The Circles SDK handles unwrap/rewrap client-side and needs wrapper balance + trust edges in the pathfinder response.
- **Zero-SQL cache-feed endpoint** (`GET /api/pathfinder/graph`) on Cache Service — serves the full pathfinder graph snapshot from in-memory caches. Pathfinder fetches this via HTTP instead of running SQL queries, with ETag-based conditional requests (304 on unchanged block).
- **Consented flow flags** added to CacheContainer — `CrcV2_SetAdvancedUsageFlag` loaded during warmup and updated incrementally via PG NOTIFY.

### Cache-feed architecture

```
Pathfinder  ──HTTP──▶  Cache Service  ──in-memory──▶  CacheContainer
   │                                                    (balances, trust, groups,
   │ fallback                                            wrappers, consent flags)
   ▼
 PostgreSQL (direct SQL — existing path preserved)
```

### Pathfinder graph source modes

| Mode | Env var | Behavior |
|------|---------|----------|
| **Cache** (new default) | `USE_CACHE_GRAPH_SOURCE=true` | Fetch from cache service, ETag 304 on no change |
| **DB fallback** | `CACHE_GRAPH_FALLBACK_TO_DB=true` | Auto-fallback to SQL on cache errors/503 |
| **DB only** (legacy) | `USE_CACHE_GRAPH_SOURCE=false` | Direct SQL queries (unchanged) |

### Key implementation details

- Balance conversion: cache stores `decimal` Circles → controller converts to `attoCircles` BigInteger strings with demurrage applied (matching SQL LoadGraph output)
- Wrapper trust derivation: pre-built reverse index (avatar → wrapper addresses) for O(1) lookup per trust edge
- Group filtering: only standard treasury mint groups (`0xcdfc...2842`) included
- Selective loading via `?include=balances,trust,groups,groupTrusts,consentedFlow`

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 579 passed, 0 failed
- [x] Deployed to staging1 — pathfinder shows "Graph source: CACHE", falls back to DB during warmup (503)
- [ ] Verify staging1 end-to-end after cache warmup completes
- [ ] Deploy to staging2 and verify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pathfinder can use a dedicated Cache Service as a graph data source with optional fallback to the database.
  * Consented-flow flags are now exposed in graph snapshots.

* **Observability**
  * Added metrics to monitor cache fetches, payload sizes, durations, and source usage.

* **Infrastructure**
  * Docker configuration updated to wait for cache-service health before starting relevant services.

* **Tests**
  * Comprehensive tests and integration coverage added for cache-driven graph feeds and client behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->