### PR TITLE
fix: use hex tokenAddress instead of decimal tokenId in V2 cache keys

### DIFF
--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -585,7 +585,7 @@ public class CacheWarmupService : BackgroundService
         const string sql = @"
             SELECT
                 account,
-                ""tokenId"",
+                ""tokenAddress"",
                 ""totalBalance"",
                 ""lastActivity""
             FROM ""V_CrcV2_BalancesByAccountAndToken""
@@ -604,7 +604,7 @@ public class CacheWarmupService : BackgroundService
         while (await reader.ReadAsync(ct))
         {
             var account = reader.GetString(0).ToLowerInvariant();
-            var tokenId = reader.GetString(1); // tokenId is already a string in the view
+            var tokenAddress = reader.GetString(1).ToLowerInvariant();
             var totalBalanceBig = reader.GetFieldValue<BigInteger>(2);
             var lastActivity = reader.GetInt64(3);
 
@@ -621,7 +621,7 @@ public class CacheWarmupService : BackgroundService
             }
             if (balance > 0)
             {
-                var key = $"{account}:{tokenId}";
+                var key = $"{account}:{tokenAddress}";
                 balances[key] = balance;
                 lastActivities[key] = lastActivity;
             }
@@ -934,7 +934,7 @@ public class CacheWarmupService : BackgroundService
                 SELECT
                     ""from"",
                     ""to"",
-                    id,
+                    ""tokenAddress"",
                     value,
                     ""blockNumber"",
                     ""transactionIndex"",
@@ -947,7 +947,7 @@ public class CacheWarmupService : BackgroundService
                 SELECT
                     ""from"",
                     ""to"",
-                    id,
+                    ""tokenAddress"",
                     value,
                     ""blockNumber"",
                     ""transactionIndex"",
@@ -973,7 +973,7 @@ public class CacheWarmupService : BackgroundService
         {
             var from = reader.GetString(0);
             var to = reader.GetString(1);
-            var tokenId = reader.GetFieldValue<BigInteger>(2).ToString();
+            var tokenAddress = reader.GetString(2).ToLowerInvariant();
             var valueBig = reader.GetFieldValue<BigInteger>(3);
             var blockNumber = reader.GetInt64(4);
 
@@ -1003,13 +1003,13 @@ public class CacheWarmupService : BackgroundService
 
             if (from != "0x0000000000000000000000000000000000000000")
             {
-                var fromKey = $"{from.ToLowerInvariant()}:{tokenId}";
+                var fromKey = $"{from.ToLowerInvariant()}:{tokenAddress}";
                 currentBalances[fromKey] = currentBalances.GetValueOrDefault(fromKey, 0m) - amount;
             }
 
             if (to != "0x0000000000000000000000000000000000000000")
             {
-                var toKey = $"{to.ToLowerInvariant()}:{tokenId}";
+                var toKey = $"{to.ToLowerInvariant()}:{tokenAddress}";
                 currentBalances[toKey] = currentBalances.GetValueOrDefault(toKey, 0m) + amount;
             }
 


### PR DESCRIPTION
## Summary
- Cache warmup stored V2 balance entries keyed by **decimal tokenId** (e.g. `"108659033..."`) but trust data uses **hex addresses** (e.g. `"0x0004df..."`)
- `AddressIdPool` is a string dictionary — different formats get different IDs → balance nodes and trust nodes **completely disconnected** in the pathfinder graph → **maxFlow=0**
- Secondary: `Erc20WrapperAddresses` lookup by decimal tokenId always failed → wrapper detection broken

## Fix
- Warmup SQL: `SELECT "tokenAddress"` instead of `"tokenId"` from `V_CrcV2_BalancesByAccountAndToken` view
- Incremental SQL: `SELECT "tokenAddress"` instead of numeric `id` column from `CrcV2_TransferSingle`/`CrcV2_TransferBatch`
- Reader: `GetString().ToLowerInvariant()` instead of `GetFieldValue<BigInteger>().ToString()`
- Also eliminates `BigInteger` overflow risk on token ID conversion path

## Components Touched
- `CacheWarmupService.cs` only (8 lines changed)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [ ] All existing PathfinderGraphControllerTests pass (they already use hex)
- [ ] Deploy to staging, verify findPath returns maxFlow > 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal token handling consistency in the cache service to enhance system reliability and maintainability. No changes to user-facing functionality or APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->