### PR TITLE
fix: register group-trusted tokens as graph nodes

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -491,6 +491,57 @@ public class GraphFactoryTests
         Assert.That(mintEdges[0].InitialCapacity, Is.EqualTo(long.MaxValue));
     }
 
+    [Test]
+    public void GroupTrustedToken_IsAvatarNode_EvenWithNoUserTrust_DbPath()
+    {
+        // Token T is ONLY reachable via group trust (G trusts T).
+        // No user-to-user trust mentions T, no balance holder is T.
+        // Before fix: T was in GroupTrustedTokens but NOT in AvatarNodes → "Sink isn't in the graph snapshot"
+        var mock = new MockLoadGraph
+        {
+            Groups = new List<string> { GroupG },
+            GroupTrusts = new List<(string, string)> { (GroupG, TokenA) }
+        };
+        var factory = MakeFactory(mock);
+        var balance = MakeBalanceGraph((Alice, TokenA, 300));
+        // Only Alice→TokenA trust; TokenA appears as trustee, but the key test is
+        // that group-trusted tokens also get AddAvatar() called
+        var trust = MakeTrust((Alice, TokenA));
+
+        var cg = factory.CreateCapacityGraph(balance, trust);
+
+        int tokenAId = AddressIdPool.IdOf(TokenA);
+        Assert.That(cg.AvatarNodes.ContainsKey(tokenAId), Is.True,
+            "Group-trusted token should be a valid avatar node (DB path)");
+    }
+
+    [Test]
+    public void GroupTrustedToken_IsAvatarNode_EvenWithNoUserTrust_CachedPath()
+    {
+        // Same scenario but via cached group data path
+        var factory = MakeFactory(); // no DB groups
+
+        int groupGId = AddressIdPool.IdOf(GroupG);
+        int tokenBId = AddressIdPool.IdOf(TokenB);
+
+        var cached = new CachedGroupData(
+            GroupNodes: new HashSet<int> { groupGId },
+            GroupTrustedTokens: new Dictionary<int, HashSet<int>>
+            {
+                { groupGId, new HashSet<int> { tokenBId } }
+            },
+            ConsentedAvatars: new HashSet<int>());
+
+        var balance = MakeBalanceGraph((Alice, TokenA, 100));
+        // TokenB has NO user trust edges and NO balance holders
+        var trust = MakeTrust((Alice, TokenA));
+
+        var cg = factory.CreateCapacityGraph(balance, trust, request: null, cachedGroupData: cached);
+
+        Assert.That(cg.AvatarNodes.ContainsKey(tokenBId), Is.True,
+            "Group-trusted token should be a valid avatar node (cached path)");
+    }
+
     #endregion
 
     #region CachedGroupData
@@ -577,6 +628,32 @@ public class GraphFactoryTests
         Assert.That(cg.ConsentedAvatars.Contains(aliceId), Is.True);
         // Only the valid address should be added (1 entry)
         Assert.That(cg.ConsentedAvatars.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void SimulatedConsentedAvatar_IsAvatarNode_EvenWithNoBalanceOrTrust()
+    {
+        // A simulated consented avatar that has no balance and no trust edges
+        // should still be registered as an avatar node (consistency with STEP 1b/1c)
+        var factory = MakeFactory();
+        var balance = MakeBalanceGraph(); // empty
+        var trust = MakeTrust();          // empty
+
+        // Bob has no economic activity but is injected as consented
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Alice,
+            SimulatedConsentedAvatars = new List<string> { Bob }
+        };
+
+        var cg = factory.CreateCapacityGraph(balance, trust, request);
+
+        int bobId = AddressIdPool.IdOf(Bob);
+        Assert.That(cg.AvatarNodes.ContainsKey(bobId), Is.True,
+            "Simulated consented avatar should be registered as avatar node");
+        Assert.That(cg.ConsentedAvatars.Contains(bobId), Is.True,
+            "Simulated consented avatar should be in ConsentedAvatars set");
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -154,6 +154,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 }
 
                 var avatarId = AddressIdPool.IdOf(normalized);
+                capacityGraph.AddAvatar(avatarId);
                 capacityGraph.ConsentedAvatars.Add(avatarId);
                 addedCount++;
             }
@@ -528,7 +529,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             foreach (var groupId in cached.GroupNodes)
                 capacityGraph.AddGroup(groupId);
             foreach (var (groupId, tokens) in cached.GroupTrustedTokens)
+            {
                 capacityGraph.GroupTrustedTokens[groupId] = new HashSet<int>(tokens);
+                foreach (var tokenId in tokens)
+                    capacityGraph.AddAvatar(tokenId);  // Ensure group-trusted tokens are valid graph nodes
+            }
             _logger.LogDebug("Used cached group data: {GroupCount} groups, {TrustCount} group-trust entries",
                 cached.GroupNodes.Count, cached.GroupTrustedTokens.Count);
             return;
@@ -556,6 +561,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             }
 
             trustedSet.Add(tokenId);
+            capacityGraph.AddAvatar(tokenId);  // Ensure group-trusted tokens are valid graph nodes
         }
     }
 


### PR DESCRIPTION
## Summary
- Group-trusted tokens were added to `GroupTrustedTokens` metadata but never registered via `AddAvatar()`, making them invisible as source/sink candidates → "Sink isn't in the graph snapshot" for addresses only reachable via group trust (e.g., payment gateways trusted by groups)
- Fixed both DB-direct and cached code paths in `LoadGroupsAndTrackRouter()`
- Also fixed simulated consented avatars not being registered as avatar nodes (consistency with simulated balances/trusts)

## Root Cause
```
GraphFactory.LoadGroupsAndTrackRouter():
  → Adds tokenId to GroupTrustedTokens[groupId]
  → Does NOT call capacityGraph.AddAvatar(tokenId)  ← BUG
```

## Test plan
- [x] 3 new unit tests: DB path, cached path, simulated consented avatar registration
- [x] 38/38 GraphFactoryTests pass
- [x] 613/613 full pathfinder tests pass (0 failures)
- [ ] Deploy to staging2, verify source→sink path for affected org returns maxFlow > 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved issues where group-trusted tokens and simulated consented avatars were not properly represented in the graph system, preventing missing-node errors during routing operations.

* **Tests**
  * Expanded test coverage for avatar node creation, group trust scenarios, and consent flows to ensure robust handling across various configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->