### PR TITLE
fix: include group trustees in cache service BuildTrust

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -333,6 +333,25 @@ public class PathfinderGraphControllerTests
     }
 
     [Fact]
+    public void BuildTrust_ShouldIncludeEdgesWhereGroupIsTrustee()
+    {
+        var org = "0xorg00000000000000000000000000000000000000";
+        var group = "0xgroup000000000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, org, ("Organization", 1704067200L));
+        // Group is NOT in V2Avatars — only in Groups cache (like production)
+        _cache.Groups.Add(1000, group, ("Gnosis Group", StandardTreasuryMint, "GG"));
+        _cache.V2TrustRelations.Add(1000, $"{org}:{group}", 9999999999L);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "trust");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        // Org trusting a router group should produce a trust edge
+        response!.Trust.Should().ContainSingle(t => t.Truster == org && t.Trustee == group);
+    }
+
+    [Fact]
     public void BuildTrust_ShouldExcludeGroupTrusters()
     {
         var group = "0xgroup000000000000000000000000000000000000";

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -225,8 +225,9 @@ public class PathfinderGraphController : ControllerBase
             if (expiryTime > 0 && expiryTime <= now)
                 continue;
 
-            // Both must be registered avatars
-            if (!_caches.V2Avatars.ContainsKey(truster) || !_caches.V2Avatars.ContainsKey(trustee))
+            // Both must be registered (avatars or groups)
+            if (!_caches.V2Avatars.ContainsKey(truster) ||
+                (!_caches.V2Avatars.ContainsKey(trustee) && !routerGroups.Contains(trustee)))
                 continue;
 
             // Skip group trusters — they're handled separately in GroupTrusts


### PR DESCRIPTION
## Summary
- Cache service's `BuildTrust()` checked `V2Avatars` for both truster and trustee, but groups live in the `Groups` cache — not `V2Avatars`
- Trust edges where the trustee is a router group (e.g. org `0x6bfd...` trusting Gnosis group `0xc19bc...`) were silently dropped
- This made payment gateways and orgs that only trust groups unreachable via the cache-fed pathfinder ("Sink isn't in the graph snapshot")
- Fix: also check `routerGroups.Contains(trustee)` as fallback in the registration filter
- Added test: `BuildTrust_ShouldIncludeEdgesWhereGroupIsTrustee`

## Test plan
- [x] 27/27 PathfinderGraphController unit tests pass (including new test)
- [ ] Deploy cache-service + pathfinder to staging2
- [ ] Verify `findMaxFlow` for source `0xde374ece...` → sink `0x6bfd9329...` returns maxFlow > 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage for trust relationships where groups serve as trustees.

* **Improvements**
  * Trust graph now includes group addresses as eligible trustees, expanding coverage beyond registered avatars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->