### PR TITLE
fix: ensure all registered V2 avatars are valid pathfinder source/sink

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -592,4 +592,53 @@ public class PathfinderGraphControllerTests
         flags[31] = 0x01;
         _cache.ConsentedFlowFlags.Add(1000, alice, flags);
     }
+
+    // ── Avatars Section ─────────────────────────────────────────────────
+
+    [Fact]
+    public void GetGraph_ShouldIncludeAvatarsSection_WithAllRegisteredV2Avatars()
+    {
+        var alice = "0xalice0000000000000000000000000000000000";
+        var bob = "0xbob00000000000000000000000000000000000000";
+        var lonely = "0xlonely00000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, bob, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, lonely, ("Organization", 1704067200L));
+
+        var controller = CreateController();
+        var result = controller.GetGraph();
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as PathfinderGraphResponse;
+        response.Should().NotBeNull();
+        response!.Avatars.Should().NotBeNull();
+        response.Avatars!.Count.Should().Be(3);
+        response.Avatars.Should().Contain(alice);
+        response.Avatars.Should().Contain(bob);
+        response.Avatars.Should().Contain(lonely);
+    }
+
+    [Fact]
+    public void GetGraph_AvatarsInclude_ShouldBeFilterable()
+    {
+        var alice = "0xalice0000000000000000000000000000000000";
+        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
+
+        var controller = CreateController();
+
+        // Only request balances — avatars should be null
+        var result = controller.GetGraph(include: "balances");
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+        response!.Avatars.Should().BeNull();
+
+        // Explicitly request avatars
+        var result2 = controller.GetGraph(include: "avatars");
+        var ok2 = result2.Result as OkObjectResult;
+        var response2 = ok2!.Value as PathfinderGraphResponse;
+        response2!.Avatars.Should().NotBeNull();
+        response2.Avatars!.Count.Should().Be(1);
+    }
 }

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -175,7 +175,9 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderGroupTrustRow>? GroupTrusts,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-    IReadOnlyList<PathfinderConsentedFlowRow>? ConsentedFlow
+    IReadOnlyList<PathfinderConsentedFlowRow>? ConsentedFlow,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<string>? Avatars
 );
 
 public record PathfinderBalanceRow(

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -89,17 +89,19 @@ public class PathfinderGraphController : ControllerBase
                 Trust: sections.Contains("trust") ? BuildTrust(routerGroups!, avatarToWrappers!) : null,
                 Groups: sections.Contains("groups") ? BuildGroups(routerGroups!) : null,
                 GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(routerGroups!) : null,
-                ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow() : null
+                ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow() : null,
+                Avatars: sections.Contains("avatars") ? BuildAvatars() : null
             );
 
             _logger.LogDebug(
-                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}",
+                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}",
                 lastBlock,
                 response.Balances?.Count ?? 0,
                 response.Trust?.Count ?? 0,
                 response.Groups?.Count ?? 0,
                 response.GroupTrusts?.Count ?? 0,
-                response.ConsentedFlow?.Count ?? 0);
+                response.ConsentedFlow?.Count ?? 0,
+                response.Avatars?.Count ?? 0);
 
             return Ok(response);
         }
@@ -113,7 +115,7 @@ public class PathfinderGraphController : ControllerBase
     private static HashSet<string> ParseInclude(string? include)
     {
         if (string.IsNullOrWhiteSpace(include))
-            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow" };
+            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars" };
 
         return new HashSet<string>(
             include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -304,6 +306,19 @@ public class PathfinderGraphController : ControllerBase
         }
 
         return groupTrusts;
+    }
+
+    /// <summary>
+    /// Returns all registered V2 avatar addresses from the cache.
+    /// </summary>
+    private List<string> BuildAvatars()
+    {
+        var avatars = new List<string>(_caches.V2Avatars.Count);
+        foreach (var address in _caches.V2Avatars.ReadOnlyDictionary.Keys)
+        {
+            avatars.Add(address);
+        }
+        return avatars;
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
@@ -637,6 +637,9 @@ public class ArithmeticSafetyTests
                 throw new InvalidOperationException("Simulated DB failure in LoadConsentedFlowFlags");
             return Enumerable.Empty<(string, bool)>();
         }
+
+        public IEnumerable<string> LoadRegisteredAvatars()
+            => Enumerable.Empty<string>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheFeedIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheFeedIntegrationTests.cs
@@ -46,7 +46,8 @@ public class CacheFeedIntegrationTests
             },
             Groups: Array.Empty<PathfinderGraphGroupRow>(),
             GroupTrusts: Array.Empty<PathfinderGraphGroupTrustRow>(),
-            ConsentedFlow: Array.Empty<PathfinderGraphConsentedFlowRow>()
+            ConsentedFlow: Array.Empty<PathfinderGraphConsentedFlowRow>(),
+            Avatars: new[] { Alice, Bob }
         );
 
         var loadGraph = new CacheLoadGraph(snapshot);
@@ -94,7 +95,8 @@ public class CacheFeedIntegrationTests
             },
             Groups: null,
             GroupTrusts: null,
-            ConsentedFlow: null
+            ConsentedFlow: null,
+            Avatars: null
         );
 
         var cacheLoadGraph = new CacheLoadGraph(snapshot);
@@ -146,7 +148,8 @@ public class CacheFeedIntegrationTests
             },
             Groups: null,
             GroupTrusts: null,
-            ConsentedFlow: null
+            ConsentedFlow: null,
+            Avatars: null
         );
 
         var loadGraph = new CacheLoadGraph(snapshot);
@@ -178,7 +181,7 @@ public class CacheFeedIntegrationTests
             1, 100, 0,
             new[] { new PathfinderGraphBalanceRow(amount1, Alice, Bob, 0, false, "demurraged") },
             new[] { new PathfinderGraphTrustRow(Bob, Alice, 100) },
-            null, null, null);
+            null, null, null, null);
 
         var loadGraph = new CacheLoadGraph(snapshot1);
         Assert.That(loadGraph.LastProcessedBlock, Is.EqualTo(100));
@@ -198,7 +201,7 @@ public class CacheFeedIntegrationTests
                 new PathfinderGraphTrustRow(Bob, Alice, 100),
                 new PathfinderGraphTrustRow(Charlie, Bob, 100)
             },
-            null, null, null);
+            null, null, null, null);
 
         loadGraph.ReplaceSnapshot(snapshot2);
 
@@ -229,7 +232,8 @@ public class CacheFeedIntegrationTests
             {
                 new PathfinderGraphConsentedFlowRow(Alice, true),
                 new PathfinderGraphConsentedFlowRow(Bob, false)
-            });
+            },
+            null);
 
         var loadGraph = new CacheLoadGraph(snapshot);
 
@@ -238,5 +242,77 @@ public class CacheFeedIntegrationTests
         Assert.That(consentFlags, Has.Count.EqualTo(2));
         Assert.That(consentFlags.Any(c => c.Avatar == Alice.ToLowerInvariant() && c.HasConsentedFlow), Is.True);
         Assert.That(consentFlags.Any(c => c.Avatar == Bob.ToLowerInvariant() && !c.HasConsentedFlow), Is.True);
+    }
+
+    /// <summary>
+    /// Registered avatar with no balances and no trust edges should still
+    /// be present in the capacity graph's AvatarNodes — enabling it as a
+    /// valid source/sink (returns maxFlow=0 instead of "not in graph" error).
+    /// </summary>
+    [Test]
+    public void CacheFeed_RegisteredAvatarWithNoData_ShouldBeInCapacityGraph()
+    {
+        var amount = CirclesConverter.CirclesToAttoCircles(100m).ToString();
+        var lonely = "0xdddd000000000000000000000000000000000004";
+
+        var snapshot = new PathfinderGraphSnapshot(
+            SchemaVersion: 1,
+            LastProcessedBlock: 10000,
+            Timestamp: DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            Balances: new[]
+            {
+                new PathfinderGraphBalanceRow(amount, Alice, Bob, DateTimeOffset.UtcNow.ToUnixTimeSeconds(), false, "demurraged")
+            },
+            Trust: new[]
+            {
+                new PathfinderGraphTrustRow(Bob, Alice, 100)
+            },
+            Groups: null,
+            GroupTrusts: null,
+            ConsentedFlow: null,
+            // "lonely" is registered but has no balances/trust
+            Avatars: new[] { Alice, Bob, lonely }
+        );
+
+        var loadGraph = new CacheLoadGraph(snapshot);
+        var factory = new GraphFactory(Router, loadGraph);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+        var capacityGraph = factory.CreateCapacityGraph(bg, trustLookup);
+
+        var lonelyId = AddressIdPool.IdOf(lonely.ToLowerInvariant());
+        Assert.That(capacityGraph.AvatarNodes.ContainsKey(lonelyId), Is.True,
+            "Registered avatar with no balances/trust should still be in AvatarNodes");
+    }
+
+    /// <summary>
+    /// Registered avatar via MockLoadGraph (DB path) should also appear in AvatarNodes.
+    /// </summary>
+    [Test]
+    public void MockLoadGraph_RegisteredAvatarWithNoData_ShouldBeInCapacityGraph()
+    {
+        var mockLoadGraph = new MockLoadGraph();
+        var lonely = "0xdddd000000000000000000000000000000000005";
+
+        // Add some normal graph data
+        mockLoadGraph.AddTrust(Alice, Bob);
+        mockLoadGraph.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(Bob.ToLowerInvariant()),
+            200_000_000);
+
+        // Register lonely avatar (no balance, no trust)
+        mockLoadGraph.AddRegisteredAvatar(lonely);
+
+        var factory = new GraphFactory(Router, mockLoadGraph);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+        var capacityGraph = factory.CreateCapacityGraph(bg, trustLookup);
+
+        var lonelyId = AddressIdPool.IdOf(lonely.ToLowerInvariant());
+        Assert.That(capacityGraph.AvatarNodes.ContainsKey(lonelyId), Is.True,
+            "Registered avatar with no balances/trust should still be in AvatarNodes (DB path)");
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheGraphClientTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheGraphClientTests.cs
@@ -181,7 +181,7 @@ public class CacheGraphClientTests
     [Test]
     public void CacheGraphFetchResult_Success_ShouldHaveCorrectState()
     {
-        var snapshot = new PathfinderGraphSnapshot(1, 5000, 0, null, null, null, null, null);
+        var snapshot = new PathfinderGraphSnapshot(1, 5000, 0, null, null, null, null, null, null);
         var result = CacheGraphFetchResult.Success(snapshot, "\"5000\"", 1024);
 
         Assert.That(result.IsNotModified, Is.False);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheLoadGraphTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheLoadGraphTests.cs
@@ -203,6 +203,7 @@ public class CacheLoadGraphTests
             Trust: trust,
             Groups: groups,
             GroupTrusts: groupTrusts,
-            ConsentedFlow: consent);
+            ConsentedFlow: consent,
+            Avatars: null);
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -698,6 +698,7 @@ public class GraphFactoryTests
         public IEnumerable<string> LoadGroups() => Groups;
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
+        public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
@@ -131,4 +131,48 @@ public class FixtureLoadGraph : ILoadGraph
             yield return (avatar, true);
         }
     }
+
+    /// <summary>
+    /// Derives all unique addresses from the fixture subgraph.
+    /// In fixture scenarios, every address that appears is implicitly registered.
+    /// </summary>
+    public IEnumerable<string> LoadRegisteredAvatars()
+    {
+        var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (_subgraph.Balances != null)
+        {
+            foreach (var b in _subgraph.Balances)
+            {
+                addresses.Add(b.Holder.ToLowerInvariant());
+                addresses.Add(b.Token.ToLowerInvariant());
+            }
+        }
+
+        if (_subgraph.Trust != null)
+        {
+            foreach (var t in _subgraph.Trust)
+            {
+                if (t.Length >= 2)
+                {
+                    addresses.Add(t[0].ToLowerInvariant());
+                    addresses.Add(t[1].ToLowerInvariant());
+                }
+            }
+        }
+
+        if (_subgraph.Groups != null)
+        {
+            foreach (var g in _subgraph.Groups)
+                addresses.Add(g.ToLowerInvariant());
+        }
+
+        if (_subgraph.ConsentedAvatars != null)
+        {
+            foreach (var a in _subgraph.ConsentedAvatars)
+                addresses.Add(a.ToLowerInvariant());
+        }
+
+        return addresses;
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -14,6 +14,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<string> _groups = new();
     private readonly List<(string GroupAddress, string TrustedToken)> _groupTrusts = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
+    private readonly List<string> _registeredAvatars = new();
 
     /// <summary>
     /// Add a trust relationship using integer node IDs.
@@ -129,6 +130,19 @@ public class MockLoadGraph : ILoadGraph
         return _consentedFlags;
     }
 
+    public IEnumerable<string> LoadRegisteredAvatars()
+    {
+        return _registeredAvatars;
+    }
+
+    /// <summary>
+    /// Register an avatar address so it appears in LoadRegisteredAvatars().
+    /// </summary>
+    public void AddRegisteredAvatar(string address)
+    {
+        _registeredAvatars.Add(address.ToLowerInvariant());
+    }
+
     /// <summary>
     /// Clears all data for reuse.
     /// </summary>
@@ -139,6 +153,7 @@ public class MockLoadGraph : ILoadGraph
         _groups.Clear();
         _groupTrusts.Clear();
         _consentedFlags.Clear();
+        _registeredAvatars.Clear();
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -124,6 +124,11 @@ public class ProxyLoadGraph : ILoadGraph
           AND g."blockNumber" <= {0}
         """;
 
+    private const string RegisteredAvatarsQueryTemplate = """
+        SELECT avatar FROM "V_CrcV2_Avatars"
+        WHERE "blockNumber" <= {0}
+        """;
+
     private const string ConsentedFlowQueryTemplate = """
         SELECT DISTINCT ON (avatar) avatar, flag
         FROM "CrcV2_SetAdvancedUsageFlag"
@@ -268,6 +273,22 @@ public class ProxyLoadGraph : ILoadGraph
             results.Add((avatar, hasConsented));
         }
 
+        return results;
+    }
+
+    public IEnumerable<string> LoadRegisteredAvatars()
+    {
+        var query = string.Format(RegisteredAvatarsQueryTemplate, _client.BlockNumber);
+        var response = _client.ExecuteQueryAsync(query, maxRows: 100000).GetAwaiter().GetResult();
+        var results = new List<string>();
+
+        foreach (var row in response.Rows)
+        {
+            var avatar = GetString(row[0]);
+            results.Add(avatar.ToLowerInvariant());
+        }
+
+        Console.WriteLine($"ProxyLoadGraph: RegisteredAvatars query returned {results.Count} rows");
         return results;
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -188,12 +188,14 @@ public static class SharedGraphCache
         var groups = sourceLoader.LoadGroups().ToList();
         var groupTrusts = sourceLoader.LoadGroupTrusts().ToList();
         var consentedFlags = sourceLoader.LoadConsentedFlowFlags().ToList();
+        var registeredAvatars = sourceLoader.LoadRegisteredAvatars().ToList();
 
         sw.Stop();
         Console.WriteLine($"[SharedGraphCache] Block {blockNumber}: " +
             $"{trust.Count} trust edges, " +
             $"{balances.Count} balances, " +
             $"{groups.Count} groups, " +
+            $"{registeredAvatars.Count} avatars, " +
             $"{consentedFlags.Count(f => f.HasConsentedFlow)} consented — " +
             $"loaded in {sw.ElapsedMilliseconds}ms");
 
@@ -206,6 +208,7 @@ public static class SharedGraphCache
             Groups = groups,
             GroupTrusts = groupTrusts,
             ConsentedFlags = consentedFlags,
+            RegisteredAvatars = registeredAvatars,
             Session = session
         };
     }
@@ -255,6 +258,7 @@ public class CachedGraphData
     public List<string> Groups { get; init; } = [];
     public List<(string GroupAddress, string TrustedToken)> GroupTrusts { get; init; } = [];
     public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; init; } = [];
+    public List<string> RegisteredAvatars { get; init; } = [];
     public TestEnvironmentClient Session { get; init; } = null!;
 
     /// <summary>
@@ -283,4 +287,7 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
 
     public IEnumerable<(string Avatar, bool HasConsentedFlow)>
         LoadConsentedFlowFlags() => data.ConsentedFlags;
+
+    public IEnumerable<string>
+        LoadRegisteredAvatars() => data.RegisteredAvatars;
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -706,5 +706,6 @@ public class IncrementalLoadGraphTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrustEntries;
 
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
+        public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -1367,6 +1367,7 @@ public class MutationKillerTests
         public IEnumerable<string> LoadGroups() => Groups;
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
+        public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -13,7 +13,8 @@ public record PathfinderGraphSnapshot(
     IReadOnlyList<PathfinderGraphTrustRow>? Trust,
     IReadOnlyList<PathfinderGraphGroupRow>? Groups,
     IReadOnlyList<PathfinderGraphGroupTrustRow>? GroupTrusts,
-    IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow
+    IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow,
+    IReadOnlyList<string>? Avatars
 );
 
 public record PathfinderGraphBalanceRow(
@@ -72,6 +73,9 @@ internal sealed class PathfinderGraphSnapshotDto
     [JsonPropertyName("consentedFlow")]
     public List<PathfinderGraphConsentedFlowRow>? ConsentedFlow { get; set; }
 
+    [JsonPropertyName("avatars")]
+    public List<string>? Avatars { get; set; }
+
     public PathfinderGraphSnapshot ToModel() => new(
         SchemaVersion,
         LastProcessedBlock,
@@ -80,5 +84,6 @@ internal sealed class PathfinderGraphSnapshotDto
         Trust,
         Groups,
         GroupTrusts,
-        ConsentedFlow);
+        ConsentedFlow,
+        Avatars);
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -62,4 +62,11 @@ public sealed class CacheLoadGraph : ILoadGraph
         foreach (var row in rows)
             yield return (row.Avatar.ToLowerInvariant(), row.HasConsentedFlow);
     }
+
+    public IEnumerable<string> LoadRegisteredAvatars()
+    {
+        var rows = _snapshot.Avatars ?? [];
+        foreach (var row in rows)
+            yield return row.ToLowerInvariant();
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -155,4 +155,13 @@ public class IncrementalLoadGraph : ILoadGraph
     /// </summary>
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
         => _inner.LoadConsentedFlowFlags();
+
+    /// <summary>
+    /// Returns all registered, non-stopped avatars from in-memory state.
+    /// </summary>
+    public IEnumerable<string> LoadRegisteredAvatars()
+    {
+        foreach (var avatar in _avatarState.AvatarSet)
+            yield return avatar;
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -11,7 +11,7 @@ using Npgsql;
 namespace Circles.Pathfinder.Data
 {
     /// <summary>
-    /// Result of <see cref="LoadGraph.LoadAll"/> — all 5 ILoadGraph queries executed
+    /// Result of <see cref="LoadGraph.LoadAll"/> — all 6 ILoadGraph queries executed
     /// in a single REPEATABLE READ transaction.
     /// </summary>
     public sealed record LoadAllResult(
@@ -19,7 +19,8 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<(string Truster, string Trustee, int Limit)> Trust,
         IReadOnlyList<string> Groups,
         IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts,
-        IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags
+        IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
+        IReadOnlyList<string> RegisteredAvatars
     );
 
     public interface ILoadGraph
@@ -33,6 +34,8 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts();
 
         IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags();
+
+        IEnumerable<string> LoadRegisteredAvatars();
     }
 
     public class LoadGraph : ILoadGraph
@@ -294,12 +297,12 @@ namespace Circles.Pathfinder.Data
         }
 
         // ──────────────────────────────────────────────────────────────────
-        // Batched load: all 5 ILoadGraph queries in a single connection
+        // Batched load: all 6 ILoadGraph queries in a single connection
         // ──────────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Executes all 5 ILoadGraph queries on a single REPEATABLE READ connection,
-        /// eliminating 4 extra connection open/close round-trips per graph refresh.
+        /// Executes all 6 ILoadGraph queries on a single REPEATABLE READ connection,
+        /// eliminating 5 extra connection open/close round-trips per graph refresh.
         /// </summary>
         public LoadAllResult LoadAll()
         {
@@ -312,10 +315,11 @@ namespace Circles.Pathfinder.Data
             var groups = LoadGroupsInternal(connection, tx);
             var groupTrusts = LoadGroupTrustsInternal(connection, tx);
             var consentedFlags = LoadConsentedFlowFlagsInternal(connection, tx);
+            var registeredAvatars = LoadRegisteredAvatarsInternal(connection, tx);
 
             tx.Commit();
 
-            return new LoadAllResult(balances, trust, groups, groupTrusts, consentedFlags);
+            return new LoadAllResult(balances, trust, groups, groupTrusts, consentedFlags, registeredAvatars);
         }
 
         private List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
@@ -472,6 +476,27 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("consented_flow", sw.Elapsed);
+            return results;
+        }
+
+        private List<string> LoadRegisteredAvatarsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
+        {
+            var results = new List<string>(20_000);
+
+            var sw = Stopwatch.StartNew();
+
+            using var command = new NpgsqlCommand(
+                "SELECT avatar FROM \"V_CrcV2_Avatars\"", connection, tx);
+            command.CommandTimeout = _settings.PathfinderTrustTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add(reader.GetString(0));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("registered_avatars", sw.Elapsed);
             return results;
         }
 
@@ -860,6 +885,29 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("consented_flow", sw.Elapsed);
+            return results;
+        }
+
+        public IEnumerable<string> LoadRegisteredAvatars()
+        {
+            var results = new List<string>(20_000);
+
+            var sw = Stopwatch.StartNew();
+            using var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+
+            using var command = new NpgsqlCommand(
+                "SELECT avatar FROM \"V_CrcV2_Avatars\"", connection);
+            command.CommandTimeout = _settings.PathfinderTrustTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add(reader.GetString(0));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("registered_avatars", sw.Elapsed);
             return results;
         }
     }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -110,6 +110,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         // STEP 1: Add all avatar nodes from both graphs
         AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
+        // STEP 1a: Ensure ALL registered avatars are valid source/sink candidates
+        // (avatars with no balances/trust are still valid — they just have maxFlow=0)
+        foreach (var avatar in loadGraph.LoadRegisteredAvatars())
+        {
+            capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
+        }
+
         // STEP 1b: Add avatars referenced by simulated balances (holders + tokens)
         var simulated = NormalizeSimulatedBalances(request?.SimulatedBalances);
         foreach (var sb in simulated)


### PR DESCRIPTION
## Summary
- Registered avatars with no balances or trust edges were invisible to the pathfinder graph, causing "not in graph snapshot" errors instead of returning maxFlow=0
- Added `LoadRegisteredAvatars()` to `ILoadGraph` interface and all 8 implementations (DB, cache, incremental, fixture, proxy, and 3 test mocks)
- GraphFactory STEP 1a: calls `AddAvatar()` for every registered avatar after loading trust/balance nodes
- Cache service: serves new `Avatars` section in `/api/pathfinder/graph` endpoint (filterable via `?include=avatars`)

## Test plan
- [x] 2 new pathfinder tests: registered avatar with no data appears in AvatarNodes (cache + mock paths)
- [x] 2 new cache controller tests: Avatars section included by default, filterable via include param
- [x] 613 existing pathfinder tests pass, 29 cache service tests pass
- [ ] Deploy to staging2, verify with real request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Graph responses now include an Avatars section containing registered avatar addresses.
  * Graph queries support filtering to include or exclude avatars via query parameters.
  * System now properly loads and tracks all registered avatars within the graph.

* **Tests**
  * Added comprehensive unit tests validating avatar section inclusion and filtering behaviour in graph responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->