### PR TITLE
refactor: parameterize router address in SQL (Phase 2)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -97,15 +97,15 @@ public class ProxyLoadGraph : ILoadGraph
         WHERE t2."group" IS NULL
         """;
 
-    // Group query with temporal filter
+    // Group query with temporal filter — {1} = router address from Settings.GroupRouterAddress
     private const string GroupQueryTemplate = """
         SELECT "group" AS group_address
         FROM "CrcV2_RegisterGroup"
-        WHERE "mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842')
+        WHERE "mint" = LOWER('{1}')
           AND "blockNumber" <= {0}
         """;
 
-    // Group trust query with temporal filter: uses same trust_state CTE
+    // Group trust query with temporal filter: uses same trust_state CTE — {1} = router address
     private const string GroupTrustQueryTemplate = """
         WITH trust_state AS (
             SELECT truster, trustee, "expiryTime",
@@ -120,7 +120,7 @@ public class ProxyLoadGraph : ILoadGraph
         SELECT t.truster AS group_address, t.trustee AS trusted_token
         FROM active_trust t
         INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
-        WHERE g."mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842')
+        WHERE g."mint" = LOWER('{1}')
           AND g."blockNumber" <= {0}
         """;
 
@@ -226,7 +226,7 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<string> LoadGroups()
     {
-        var query = string.Format(GroupQueryTemplate, _client.BlockNumber);
+        var query = string.Format(GroupQueryTemplate, _client.BlockNumber, _settings.GroupRouterAddress);
         var response = _client.ExecuteQueryAsync(query, maxRows: 10000).GetAwaiter().GetResult();
         var results = new List<string>();
 
@@ -241,7 +241,7 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber);
+        var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber, _settings.GroupRouterAddress);
         var response = _client.ExecuteQueryAsync(query, maxRows: 100000).GetAwaiter().GetResult();
         var results = new List<(string GroupAddress, string TrustedToken)>();
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -145,7 +145,7 @@ public class IncrementalLoadGraph : ILoadGraph
     /// </summary>
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        // Use router-filtered groups from DB (matches groupTrustQuery.sql's WHERE mint = '0xCDFc...')
+        // Use router-filtered groups from DB (matches groupQuery.sql parameterized by GroupRouterAddress)
         var routerGroups = new HashSet<string>(_inner.LoadGroups().Select(g => g.ToLowerInvariant()));
         return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp);
     }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -257,6 +257,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -282,6 +283,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -420,6 +422,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -442,6 +445,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
@@ -1,4 +1,4 @@
-SELECT  
+SELECT
     "group" as group_address
-FROM "CrcV2_RegisterGroup" 
-WHERE "mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842');
+FROM "CrcV2_RegisterGroup"
+WHERE "mint" = LOWER($1);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,6 +1,6 @@
-SELECT 
+SELECT
     t.truster as group_address,
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
 INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
-WHERE g."mint" = LOWER('0xCDFc5135AEC0aFbf102C108e7f5C8A88C6112842');
+WHERE g."mint" = LOWER($1);

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -91,4 +91,13 @@ public class Settings
             "false",
             StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// Address of the V2 base group router contract used to filter groups and group trusts.
+    /// Previously hardcoded in SQL; now parameterized to avoid silent data loss if the router changes.
+    /// Reads V2_BASE_GROUP_ROUTER env var (same as Common.Settings.BaseGroupRouter).
+    /// </summary>
+    public string GroupRouterAddress { get; set; } =
+        Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.ToLowerInvariant()
+        ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded router address in `groupQuery.sql` and `groupTrustQuery.sql` with `$1` parameter
- Pass router address from `Settings.GroupRouterAddress` (env var `V2_BASE_GROUP_ROUTER`)
- Addresses Bug Class A (data leakage if router changes)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh pathfinder` — 625 pass, 0 fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * The group router address is now configurable through the V2_BASE_GROUP_ROUTER environment variable, replacing hardcoded values.

* **Bug Fixes**
  * Updated query operations to dynamically use the configured router address through parameterised values across group and group trust queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->