### PR TITLE
refactor: rename DisableConsentedFlow → ExcludeConsentedIntermediaries (Phase 4)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -32,7 +32,7 @@ Console.WriteLine($"* DB User: {csb.Username}");
 Console.WriteLine($"* DB Name: {csb.Database}");
 Console.WriteLine($"* DB Port: {csb.Port}");
 Console.WriteLine($"* Nethermind RPC URL: {settings.NethermindRpcUrl}");
-Console.WriteLine($"* Consented flow: {(settings.DisableConsentedFlow ? "DISABLED (intermediaries excluded)" : "enabled (validate rules)")}");
+Console.WriteLine($"* Consented flow: {(settings.ExcludeConsentedIntermediaries ? "DISABLED (intermediaries excluded)" : "enabled (validate rules)")}");
 Console.WriteLine($"* Graph source: {(settings.UseCacheGraphSource ? $"CACHE ({settings.CacheServiceUrl})" : "DATABASE")}");
 if (settings.UseCacheGraphSource)
 {
@@ -270,7 +270,7 @@ app.MapGet("/findMaxFlow", async (
             ExcludedToTokens = excludedToTokens?.ToList(),
             WithWrap = withWrap,
             SimulatedBalances = sim,
-            SimulatedConsentedAvatars = settings.DisableConsentedFlow ? null : simulatedConsentedAvatars?.ToList()
+            SimulatedConsentedAvatars = settings.ExcludeConsentedIntermediaries ? null : simulatedConsentedAvatars?.ToList()
         };
 
         using (var h = await pool.Rent(request, balanceGraph, trustGraph))
@@ -394,7 +394,7 @@ app.MapGet("/findPath", async (
             ExcludedToTokens = excludedToTokens?.ToList(),
             WithWrap = withWrap,
             SimulatedBalances = sim,
-            SimulatedConsentedAvatars = settings.DisableConsentedFlow ? null : simulatedConsentedAvatars?.ToList(),
+            SimulatedConsentedAvatars = settings.ExcludeConsentedIntermediaries ? null : simulatedConsentedAvatars?.ToList(),
             MaxTransfers = maxTransfers,
             QuantizedMode = quantizedMode,
             DebugShowIntermediateSteps = debugShowIntermediateSteps
@@ -477,7 +477,7 @@ app.MapPost("/findPath", async (
     request.Sink = request.Sink?.ToLowerInvariant();
 
     // When consented flow is disabled, ignore simulated consent data
-    if (settings.DisableConsentedFlow)
+    if (settings.ExcludeConsentedIntermediaries)
         request.SimulatedConsentedAvatars = null;
 
     if (string.IsNullOrEmpty(request.TargetFlow) || !UInt256.TryParse(request.TargetFlow, out var targetFlow))

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -84,11 +84,28 @@ public class Settings
     /// for the risky multi-hop case. Default: true (conservative).
     /// When false, the existing consent validation logic runs (PathHasConsentViolation
     /// + ValidateConsentedFlow safety net).
+    /// Reads PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES first, falls back to
+    /// PATHFINDER_DISABLE_CONSENTED_FLOW for backward compatibility.
     /// </summary>
-    public bool DisableConsentedFlow { get; set; } =
-        !string.Equals(
-            Environment.GetEnvironmentVariable("PATHFINDER_DISABLE_CONSENTED_FLOW"),
-            "false",
-            StringComparison.OrdinalIgnoreCase);
+    public bool ExcludeConsentedIntermediaries { get; set; } =
+        Environment.GetEnvironmentVariable("PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES") != null
+            ? !string.Equals(
+                Environment.GetEnvironmentVariable("PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES"),
+                "false",
+                StringComparison.OrdinalIgnoreCase)
+            : !string.Equals(
+                Environment.GetEnvironmentVariable("PATHFINDER_DISABLE_CONSENTED_FLOW"),
+                "false",
+                StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Backward-compatible alias for <see cref="ExcludeConsentedIntermediaries"/>.
+    /// </summary>
+    [Obsolete("Use ExcludeConsentedIntermediaries instead. Will be removed in a future release.")]
+    public bool DisableConsentedFlow
+    {
+        get => ExcludeConsentedIntermediaries;
+        set => ExcludeConsentedIntermediaries = value;
+    }
 
 }

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -238,10 +238,10 @@ public class V2Pathfinder
         /* --------------------------------------------------------------------
          * 5c. Validate consented flow - filter edges that violate consent rules.
          *     Router edges are skipped by this validation (lines 332-337).
-         *     When DisableConsentedFlow is on, intermediaries are already
+         *     When ExcludeConsentedIntermediaries is on, intermediaries are already
          *     excluded in CollapseBalanceNodes — skip the safety net entirely.
          * ------------------------------------------------------------------ */
-        var validatedEdges = _settings.DisableConsentedFlow
+        var validatedEdges = _settings.ExcludeConsentedIntermediaries
             ? processedEdges  // intermediaries already excluded — no validation needed
             : ValidateConsentedFlow(processedEdges, capacityGraph);
 
@@ -250,7 +250,7 @@ public class V2Pathfinder
             int routerEdges = processedEdges.Count - aggregated.Edges.Count;
             _logger.LogInformation("[{ReqId}] Router: +{RouterEdges} edges | Consent: mode={Mode}, pathsDropped={PathsDropped}, safetyNetRejected={Rejected}",
                 reqId, Math.Max(0, routerEdges),
-                _settings.DisableConsentedFlow ? "exclude-intermediaries" : "validate-rules",
+                _settings.ExcludeConsentedIntermediaries ? "exclude-intermediaries" : "validate-rules",
                 consentDroppedPaths, consentSafetyNetRejected);
         }
 
@@ -602,7 +602,7 @@ public class V2Pathfinder
         {
             var pathEdges = CollapseSinglePathToEdges(path, capacityGraph);
 
-            if (_settings.DisableConsentedFlow)
+            if (_settings.ExcludeConsentedIntermediaries)
             {
                 // Conservative: exclude paths through consented intermediaries entirely
                 if (PathHasConsentedIntermediary(pathEdges, capacityGraph, sourceId, sinkId))
@@ -632,7 +632,7 @@ public class V2Pathfinder
         {
             _logger.LogInformation("[CollapseBalanceNodes] Dropped {DroppedPaths}/{TotalPaths} paths due to consent {Mode}",
                 droppedPaths, pathsWithFlow.Count,
-                _settings.DisableConsentedFlow ? "intermediary exclusion" : "violations");
+                _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
         }
 
         /* ---------------- materialise collapsed edges ---------------------- */
@@ -760,7 +760,7 @@ public class V2Pathfinder
 
     /* ------------------------------------------------------------------------
      * Check if a collapsed path routes through any consented avatar as an
-     * intermediary (i.e. NOT source or sink). Used when DisableConsentedFlow
+     * intermediary (i.e. NOT source or sink). Used when ExcludeConsentedIntermediaries
      * is true — instead of validating consent rules, we simply exclude
      * consented avatars from intermediary positions entirely.
      * --------------------------------------------------------------------- */


### PR DESCRIPTION
## Summary
- New property `ExcludeConsentedIntermediaries` with env var `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES`
- Backward-compatible: old env var + old property (marked `[Obsolete]`) still work
- Eliminates triple-negative naming confusion (Bug Class C)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh pathfinder` — 625 pass, 0 fail