### PR TITLE
fix: cache service misclassifies all ERC1155 tokens as ERC20 wrappers

### DIFF
--- a/src/Cache/Circles.Cache.Service/CacheContainer.cs
+++ b/src/Cache/Circles.Cache.Service/CacheContainer.cs
@@ -126,6 +126,18 @@ public class CacheContainer : IDisposable
         {
             cache.DeleteAllGreaterOrEqualBlock(toBlock);
         }
+
+        // Prune V2LastActivity entries whose balance was rolled away.
+        // V2LastActivity is not a RollbackCache (timestamps change every transfer —
+        // tracking full history per-key would be too memory-intensive).
+        // Instead, we remove entries for keys no longer in the balance cache so stale
+        // timestamps from rolled-back blocks don't cause wrong demurrage calculations.
+        var balanceKeys = V2BalancesByAccountAndToken.ReadOnlyDictionary;
+        var staleKeys = V2LastActivity.Keys.Where(k => !balanceKeys.ContainsKey(k)).ToList();
+        foreach (var key in staleKeys)
+        {
+            V2LastActivity.TryRemove(key, out _);
+        }
     }
 
     /// <summary>

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -146,12 +146,9 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Determine token type from cached metadata
-                    // V2 tokenId can be:
-                    // 1. A numeric ID (ERC1155 - human or group token)
-                    // 2. A hex address (ERC20 wrapper)
-                    var isHexAddress = tokenId.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
-
+                    // Classify by checking the wrapper index first (O(1)).
+                    // Cache keys are hex addresses for BOTH ERC1155 and ERC20 wrappers,
+                    // so we can't use string format to distinguish them.
                     string? tokenType = null;
                     string? tokenOwner = null;
                     bool isGroup = false;
@@ -160,61 +157,46 @@ public class BalancesController : ControllerBase
                     bool isWrapped = false;
                     bool isInflationary = false;
 
-                    if (isHexAddress)
+                    var wrapperInfo = _caches.GetWrapperInfo(tokenId);
+
+                    if (wrapperInfo.HasValue)
                     {
-                        // ERC20 wrapper token - find the avatar that owns this wrapper
+                        // Confirmed ERC20 wrapper
                         isErc20 = true;
                         isWrapped = true;
-
-                        // O(1) reverse lookup using the pre-built index (includes circlesType)
-                        var wrapperInfo = _caches.GetWrapperInfo(tokenId);
-
-                        if (wrapperInfo.HasValue)
-                        {
-                            tokenOwner = wrapperInfo.Value.Avatar;
-                            // circlesType: 0 = demurraged, 1 = inflationary
-                            isInflationary = wrapperInfo.Value.CirclesType == 1;
-                            tokenType = isInflationary
-                                ? "CrcV2_ERC20WrapperDeployed_Inflationary"
-                                : "CrcV2_ERC20WrapperDeployed_Demurraged";
-                        }
-                        else
-                        {
-                            // Fallback: if not found in cache, use the wrapper address itself
-                            // and default to demurraged (safer assumption for balance calculations)
-                            tokenOwner = tokenId.ToLowerInvariant();
-                            isInflationary = false;
-                            tokenType = "CrcV2_ERC20WrapperDeployed_Demurraged";
-                        }
+                        tokenOwner = wrapperInfo.Value.Avatar;
+                        isInflationary = wrapperInfo.Value.CirclesType == 1;
+                        tokenType = isInflationary
+                            ? "CrcV2_ERC20WrapperDeployed_Inflationary"
+                            : "CrcV2_ERC20WrapperDeployed_Demurraged";
                     }
                     else
                     {
-                        // ERC1155 token - numeric tokenId represents avatar address
-                        // Convert tokenId to address and check if it's a human or group
+                        // ERC1155 token — resolve address and check avatar/group caches
                         isErc1155 = true;
+                        var tokenAddress = tokenId.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                            ? tokenId.ToLowerInvariant()
+                            : TokenIdToAddress(tokenId);
 
-                        // Convert numeric tokenId to address for lookup
-                        var tokenAddress = TokenIdToAddress(tokenId);
-
-                        // Check V2Avatars cache for Human
                         if (_caches.V2Avatars.TryGetValue(tokenAddress, out var avatarInfo))
                         {
-                            isGroup = avatarInfo.Type != "Human";
-                            tokenType = isGroup ? "CrcV2_RegisterGroup" : "CrcV2_RegisterHuman";
+                            // V2Avatars stores "Human" / "Organization" — groups are in the Groups cache
+                            isGroup = false;
+                            tokenType = avatarInfo.Type == "Human" ? "CrcV2_RegisterHuman" : "CrcV2_RegisterOrganization";
                         }
                         else if (_caches.Groups.TryGetValue(tokenAddress, out _))
                         {
-                            // It's a group
                             isGroup = true;
                             tokenType = "CrcV2_RegisterGroup";
                         }
                         else
                         {
-                            // Default to group if not found (safer assumption)
+                            // Unknown token — not in V2Avatars or Groups cache.
+                            // Could be deregistered avatar, migration artifact, or cache lag.
+                            _logger.LogWarning("Unknown V2 ERC1155 token {TokenAddress} for account {Account} — defaulting to group", tokenAddress, addressLower);
                             isGroup = true;
                             tokenType = "CrcV2_RegisterGroup";
                         }
-
                         tokenOwner = tokenAddress;
                     }
 
@@ -330,14 +312,10 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Skip demurrage for inflationary wrappers (static amounts)
-                    var isHexAddress = tokenId.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
-                    var isInflationary = false;
-                    if (isHexAddress)
-                    {
-                        var wrapperInfo = _caches.GetWrapperInfo(tokenId);
-                        isInflationary = wrapperInfo?.CirclesType == 1;
-                    }
+                    // Only inflationary wrappers skip demurrage (static amounts).
+                    // GetWrapperInfo returns null for ERC1155 tokens → isInflationary=false → demurrage applied correctly.
+                    var wrapperInfo = _caches.GetWrapperInfo(tokenId);
+                    var isInflationary = wrapperInfo?.CirclesType == 1;
 
                     total += isInflationary ? balance : ApplyV2Demurrage(key, balance);
                 }
@@ -401,14 +379,10 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Skip demurrage for inflationary wrappers (static amounts)
-                    var isHexAddress = tokenId.StartsWith("0x", StringComparison.OrdinalIgnoreCase);
-                    var isInflationary = false;
-                    if (isHexAddress)
-                    {
-                        var wrapperInfo = _caches.GetWrapperInfo(tokenId);
-                        isInflationary = wrapperInfo?.CirclesType == 1;
-                    }
+                    // Only inflationary wrappers skip demurrage (static amounts).
+                    // GetWrapperInfo returns null for ERC1155 tokens → isInflationary=false → demurrage applied correctly.
+                    var wrapperInfo = _caches.GetWrapperInfo(tokenId);
+                    var isInflationary = wrapperInfo?.CirclesType == 1;
 
                     v2Total += isInflationary ? balance : ApplyV2Demurrage(key, balance);
                 }

--- a/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
@@ -117,14 +117,16 @@ public class TokensController : ControllerBase
             );
         }
 
-        // 2. Check V2 Avatar/Group token (ERC1155) - avatar address IS the token address
+        // 2. Check V2 Avatar token (ERC1155) - avatar address IS the token address
+        // V2Avatars stores "Human" / "Organization" (groups are in the Groups cache)
         if (_caches.V2Avatars.TryGetValue(tokenAddressLower, out var v2Avatar))
         {
-            var isGroup = v2Avatar.Type == "CrcV2_RegisterGroup";
+            var isGroup = false; // V2Avatars only contains humans and organizations, not groups
+            var tokenType = v2Avatar.Type == "Human" ? "CrcV2_RegisterHuman" : "CrcV2_RegisterOrganization";
             return new TokenInfoResponse(
                 TokenAddress: tokenAddressLower,
                 TokenOwner: tokenAddressLower, // For V2, token owner is the avatar itself
-                TokenType: v2Avatar.Type,
+                TokenType: tokenType,
                 Version: 2,
                 IsErc20: false,
                 IsErc1155: true,

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -657,8 +657,11 @@ public class CacheWarmupService : BackgroundService
     {
         _logger.LogInformation("Loading ERC20 wrapper balances...");
 
-        // Aggregate wrapper transfers to get current balances
-        // This is faster than replaying transfers one by one because it's a single SQL aggregation
+        var warmupBlock = _state.WarmupTargetBlock;
+
+        // Aggregate wrapper transfers up to the warmup target block.
+        // Without the block filter, transfers arriving during warmup would be double-counted
+        // when gap processing re-applies them as deltas on top of the seeded balances.
         const string sql = @"
             WITH account_balances AS (
                 SELECT
@@ -672,6 +675,7 @@ public class CacheWarmupService : BackgroundService
                     SELECT DISTINCT x FROM (VALUES (t.""to""), (t.""from"")) AS v(x)
                     WHERE x != '0x0000000000000000000000000000000000000000'
                 ) AS accounts(account)
+                WHERE t.""blockNumber"" <= @warmupBlock
                 GROUP BY account, ""tokenAddress""
                 HAVING SUM(CASE WHEN account = t.""to"" THEN t.amount ELSE 0 END) -
                        SUM(CASE WHEN account = t.""from"" THEN t.amount ELSE 0 END) > 0
@@ -680,6 +684,7 @@ public class CacheWarmupService : BackgroundService
             FROM account_balances";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("warmupBlock", warmupBlock);
         cmd.CommandTimeout = 300;
 
         try
@@ -764,11 +769,15 @@ public class CacheWarmupService : BackgroundService
     /// </summary>
     private async Task LoadErc20WrapperBalancesSimpleAsync(NpgsqlConnection conn, CancellationToken ct)
     {
+        var warmupBlock = _state.WarmupTargetBlock;
+
         const string sql = @"
             SELECT ""from"", ""to"", ""tokenAddress"", amount, ""timestamp""
-            FROM ""CrcV2_Erc20WrapperTransfer""";
+            FROM ""CrcV2_Erc20WrapperTransfer""
+            WHERE ""blockNumber"" <= @warmupBlock";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("warmupBlock", warmupBlock);
         cmd.CommandTimeout = 300;
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
@@ -1174,10 +1183,8 @@ public class CacheWarmupService : BackgroundService
 
         // Load V1 trust relations using Seed() for efficiency
         // V1 trust has a "limit" field (0-100 percentage) that we store as the value
-        // NOTE: We intentionally include limit=0 entries (untrusts) to match production behavior.
-        // The V_CrcV1_TrustRelations view filters "limit > 0", but production RPC doesn't use it.
-        // Semantically, limit=0 means "untrusted" and arguably shouldn't be returned, but we need
-        // production parity for now. TODO: Consider filtering limit=0 in both places in future.
+        // Filter out limit=0 entries (untrusts) to match incremental path behavior
+        // (NotificationListenerService.ProcessV1TrustAsync removes limit=0 entries)
         const string v1Sql = @"
             SELECT ""user"" as truster, ""canSendTo"" as trustee, ""limit""
             FROM (
@@ -1186,7 +1193,7 @@ public class CacheWarmupService : BackgroundService
                                           ORDER BY ""blockNumber"" DESC, ""transactionIndex"" DESC, ""logIndex"" DESC) as rn
                 FROM ""CrcV1_Trust""
             ) t
-            WHERE rn = 1";
+            WHERE rn = 1 AND ""limit"" > 0";
 
         var v1TrustData = new Dictionary<string, long>();
 

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -715,12 +715,11 @@ public class NotificationListenerService : BackgroundService
                 {
                     if (currentBlock != -1)
                     {
-                        // Add balances for the previous block
+                        // Flush balances for the previous block (index-before-balance ordering)
                         foreach (var kvp in currentBalances)
                         {
-                            _caches.V1BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                            // Update secondary index for fast lookups
                             _caches.UpdateBalanceIndex(kvp.Key, isV1: true, kvp.Value);
+                            _caches.V1BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
                         }
                     }
                     currentBlock = blockNumber;
@@ -756,14 +755,13 @@ public class NotificationListenerService : BackgroundService
             }
         }
 
-        // Add balances for the last block
+        // Flush balances for the last block (index-before-balance ordering)
         if (currentBlock != -1)
         {
             foreach (var kvp in currentBalances)
             {
-                _caches.V1BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                // Update secondary index for fast lookups
                 _caches.UpdateBalanceIndex(kvp.Key, isV1: true, kvp.Value);
+                _caches.V1BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
             }
         }
 
@@ -843,12 +841,14 @@ public class NotificationListenerService : BackgroundService
                 {
                     if (currentBlock != -1)
                     {
-                        // Add balances for the previous block
+                        // Flush balances for the previous block.
+                        // Update secondary index BEFORE writing balance so concurrent reads
+                        // see the token in the index before the balance appears (worst case:
+                        // momentary 0-balance entry, not an invisible balance).
                         foreach (var kvp in currentBalances)
                         {
-                            _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                            // Update secondary index for fast lookups
                             _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
+                            _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
                         }
                     }
                     currentBlock = blockNumber;
@@ -886,14 +886,13 @@ public class NotificationListenerService : BackgroundService
             }
         }
 
-        // Add balances for the last block
+        // Flush balances for the last block (index-before-balance ordering)
         if (currentBlock != -1)
         {
             foreach (var kvp in currentBalances)
             {
-                _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                // Update secondary index for fast lookups
                 _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
+                _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
             }
         }
 
@@ -949,12 +948,11 @@ public class NotificationListenerService : BackgroundService
                 {
                     if (currentBlock != -1)
                     {
-                        // Add balances for the previous block
+                        // Flush balances for the previous block (index-before-balance ordering)
                         foreach (var kvp in currentBalances)
                         {
-                            _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                            // Update secondary index for fast lookups
                             _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
+                            _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
                         }
                     }
                     currentBlock = blockNumber;
@@ -992,14 +990,13 @@ public class NotificationListenerService : BackgroundService
             }
         }
 
-        // Add balances for the last block
+        // Flush balances for the last block (index-before-balance ordering)
         if (currentBlock != -1)
         {
             foreach (var kvp in currentBalances)
             {
-                _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                // Update secondary index for fast lookups
                 _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
+                _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
             }
         }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `BalancesController` used `tokenId.StartsWith("0x")` to distinguish ERC1155 from ERC20 wrappers, but cache keys are hex addresses for BOTH types. All tokens hit the wrapper branch → `GetWrapperInfo` returned null → fallback hardcoded everything as "ERC20 Wrapper (Demurraged)"
- **Additional fixes** from full RPC+Cache audit (6 bugs, 1 inconsistency, 1 code smell)

## Changes

| ID | Severity | Fix |
|----|----------|-----|
| Original | **Critical** | Wrapper-index-first lookup replaces `isHexAddress` heuristic |
| BUG-03 | **High** | ERC20 wrapper warmup SQL had no block filter → double-counted balances during gap processing |
| BUG-01 | Medium | V2Avatars type string mismatch ("Human"/"Organization" vs "CrcV2_RegisterGroup") |
| BUG-04 | Medium | V2LastActivity not pruned on chain reorg → stale timestamps → wrong demurrage |
| BUG-02 | Medium | Non-atomic balance writes + index updates → brief invisible-balance window |
| INCON-02 | Moderate | V1 trust warmup included limit=0 entries but incremental path removed them |
| SMELL-01 | Low | Unknown V2 ERC1155 tokens now log warning instead of silent default |

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test` — 748 passed, 0 failed
- [ ] Deploy to staging1/2 and compare `circles_getTokenBalances` output with production (`rpc.aboutcircles.com`)
- [ ] Verify group tokens show `tokenType: "CrcV2_RegisterGroup"` (not `"CrcV2_ERC20WrapperDeployed_Demurraged"`)
- [ ] Verify `isGroup`, `isWrapped`, `isErc1155`, `isErc20` flags match production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token type detection and balance calculations for accurate balance reporting
  * Enhanced cache consistency during warmup operations by enforcing block number filtering
  * Corrected classification logic for user accounts versus groups in the system
  * Optimised balance update ordering to prevent temporary data inconsistencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->