### PR TITLE
feat: cache RegisteredAvatarIds and add wrapper→avatar mapping

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -218,7 +218,9 @@ public class NetworkStateUpdaterService : BackgroundService
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ConsentedAvatars));
+            new HashSet<int>(cap.ConsentedAvatars),
+            new HashSet<int>(cap.RegisteredAvatarIds),
+            new Dictionary<int, int>(cap.WrapperToAvatar));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -437,7 +439,9 @@ public class NetworkStateUpdaterService : BackgroundService
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ConsentedAvatars));
+            new HashSet<int>(cap.ConsentedAvatars),
+            new HashSet<int>(cap.RegisteredAvatarIds),
+            new Dictionary<int, int>(cap.WrapperToAvatar));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
     }
@@ -654,7 +658,9 @@ public class NetworkStateUpdaterService : BackgroundService
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ConsentedAvatars));
+            new HashSet<int>(cap.ConsentedAvatars),
+            new HashSet<int>(cap.RegisteredAvatarIds),
+            new Dictionary<int, int>(cap.WrapperToAvatar));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
     }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
@@ -640,6 +640,8 @@ public class ArithmeticSafetyTests
 
         public IEnumerable<string> LoadRegisteredAvatars()
             => Enumerable.Empty<string>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+            => Array.Empty<(string, string)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
@@ -157,7 +157,9 @@ public class CapacityGraphPoolTests
         var cachedGroups = new CachedGroupData(
             GroupNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>(),
-            ConsentedAvatars: new HashSet<int>());
+            ConsentedAvatars: new HashSet<int>(),
+            RegisteredAvatarIds: new HashSet<int>(),
+            WrapperToAvatar: new Dictionary<int, int>());
 
         pool.UpdateSnapshot(snap, cachedGroups);
 
@@ -393,7 +395,9 @@ public class CapacityGraphPoolTests
             {
                 [groupId] = new HashSet<int> { alice }
             },
-            ConsentedAvatars: new HashSet<int> { bob });
+            ConsentedAvatars: new HashSet<int> { bob },
+            RegisteredAvatarIds: new HashSet<int> { alice, bob, groupId },
+            WrapperToAvatar: new Dictionary<int, int>());
 
         pool.UpdateSnapshot(snap, cachedGroups);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -531,7 +531,9 @@ public class GraphFactoryTests
             {
                 { groupGId, new HashSet<int> { tokenBId } }
             },
-            ConsentedAvatars: new HashSet<int>());
+            ConsentedAvatars: new HashSet<int>(),
+            RegisteredAvatarIds: new HashSet<int>(),
+            WrapperToAvatar: new Dictionary<int, int>());
 
         var balance = MakeBalanceGraph((Alice, TokenA, 100));
         // TokenB has NO user trust edges and NO balance holders
@@ -567,7 +569,9 @@ public class GraphFactoryTests
             {
                 { groupGId, new HashSet<int> { tokenAId } }
             },
-            ConsentedAvatars: new HashSet<int>());
+            ConsentedAvatars: new HashSet<int>(),
+            RegisteredAvatarIds: new HashSet<int>(),
+            WrapperToAvatar: new Dictionary<int, int>());
 
         var balance = MakeBalanceGraph((Alice, TokenA, 100));
         var trust = MakeTrust((Bob, TokenA));
@@ -838,7 +842,9 @@ public class GraphFactoryTests
         var cached = new CachedGroupData(
             GroupNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>(),
-            ConsentedAvatars: new HashSet<int> { aliceId }
+            ConsentedAvatars: new HashSet<int> { aliceId },
+            RegisteredAvatarIds: new HashSet<int>(),
+            WrapperToAvatar: new Dictionary<int, int>()
         );
 
         var mock2 = new HelperMock();
@@ -941,6 +947,8 @@ public class GraphFactoryTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+            => Array.Empty<(string, string)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
@@ -175,4 +175,10 @@ public class FixtureLoadGraph : ILoadGraph
 
         return addresses;
     }
+
+    /// <summary>
+    /// Returns empty — fixture scenarios don't include wrapper data.
+    /// </summary>
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        => Array.Empty<(string, string)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -15,6 +15,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<(string GroupAddress, string TrustedToken)> _groupTrusts = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
+    private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
 
     /// <summary>
     /// Add a trust relationship using integer node IDs.
@@ -135,12 +136,25 @@ public class MockLoadGraph : ILoadGraph
         return _registeredAvatars;
     }
 
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+    {
+        return _wrapperMappings;
+    }
+
     /// <summary>
     /// Register an avatar address so it appears in LoadRegisteredAvatars().
     /// </summary>
     public void AddRegisteredAvatar(string address)
     {
         _registeredAvatars.Add(address.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// Add a wrapper→avatar mapping for testing.
+    /// </summary>
+    public void AddWrapperMapping(string wrapperAddress, string underlyingAvatar)
+    {
+        _wrapperMappings.Add((wrapperAddress.ToLowerInvariant(), underlyingAvatar.ToLowerInvariant()));
     }
 
     /// <summary>
@@ -154,6 +168,7 @@ public class MockLoadGraph : ILoadGraph
         _groupTrusts.Clear();
         _consentedFlags.Clear();
         _registeredAvatars.Clear();
+        _wrapperMappings.Clear();
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -292,6 +292,12 @@ public class ProxyLoadGraph : ILoadGraph
         return results;
     }
 
+    /// <summary>
+    /// Returns empty — ProxyLoadGraph uses native-only queries (no wrappers in graph).
+    /// </summary>
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        => Array.Empty<(string, string)>();
+
     // Helper methods to extract values from JsonElement or raw objects
     private static string GetString(object? value)
     {

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -290,4 +290,7 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
 
     public IEnumerable<string>
         LoadRegisteredAvatars() => data.RegisteredAvatars;
+
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)>
+        LoadWrapperMappings() => Array.Empty<(string, string)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -707,5 +707,7 @@ public class IncrementalLoadGraphTests
 
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+            => Array.Empty<(string, string)>();
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -1368,6 +1368,8 @@ public class MutationKillerTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+            => Array.Empty<(string, string)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -37,6 +37,7 @@
         <None Remove="Data\Queries\stoppedAvatarsQuery.sql" />
         <None Remove="Data\Queries\stoppedAvatarsDeltaQuery.sql" />
         <None Remove="Data\Queries\blockHashQuery.sql" />
+        <None Remove="Data\Queries\wrapperMappingQuery.sql" />
         <EmbeddedResource Include="Data\Queries\balanceQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\groupQuery.sql" />
@@ -52,6 +53,7 @@
         <EmbeddedResource Include="Data\Queries\stoppedAvatarsQuery.sql" />
         <EmbeddedResource Include="Data\Queries\stoppedAvatarsDeltaQuery.sql" />
         <EmbeddedResource Include="Data\Queries\blockHashQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\wrapperMappingQuery.sql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -14,7 +14,8 @@ public record PathfinderGraphSnapshot(
     IReadOnlyList<PathfinderGraphGroupRow>? Groups,
     IReadOnlyList<PathfinderGraphGroupTrustRow>? GroupTrusts,
     IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow,
-    IReadOnlyList<string>? Avatars
+    IReadOnlyList<string>? Avatars,
+    IReadOnlyList<PathfinderGraphWrapperMappingRow>? WrapperMappings = null
 );
 
 public record PathfinderGraphBalanceRow(
@@ -42,6 +43,11 @@ public record PathfinderGraphGroupTrustRow(
 public record PathfinderGraphConsentedFlowRow(
     string Avatar,
     bool HasConsentedFlow
+);
+
+public record PathfinderGraphWrapperMappingRow(
+    string WrapperAddress,
+    string UnderlyingAvatar
 );
 
 /// <summary>
@@ -76,6 +82,9 @@ internal sealed class PathfinderGraphSnapshotDto
     [JsonPropertyName("avatars")]
     public List<string>? Avatars { get; set; }
 
+    [JsonPropertyName("wrapperMappings")]
+    public List<PathfinderGraphWrapperMappingRow>? WrapperMappings { get; set; }
+
     public PathfinderGraphSnapshot ToModel() => new(
         SchemaVersion,
         LastProcessedBlock,
@@ -85,5 +94,6 @@ internal sealed class PathfinderGraphSnapshotDto
         Groups,
         GroupTrusts,
         ConsentedFlow,
-        Avatars);
+        Avatars,
+        WrapperMappings);
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -69,4 +69,11 @@ public sealed class CacheLoadGraph : ILoadGraph
         foreach (var row in rows)
             yield return row.ToLowerInvariant();
     }
+
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+    {
+        var rows = _snapshot.WrapperMappings ?? [];
+        foreach (var row in rows)
+            yield return (row.WrapperAddress.ToLowerInvariant(), row.UnderlyingAvatar.ToLowerInvariant());
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -116,4 +116,10 @@ public class IncrementalLoadGraph : ILoadGraph
         foreach (var avatar in _avatarState.AvatarSet)
             yield return avatar;
     }
+
+    /// <summary>
+    /// Delegates to inner LoadGraph — wrapper deployment table is append-only, fast query.
+    /// </summary>
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        => _inner.LoadWrapperMappings();
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -20,7 +20,8 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<string> Groups,
         IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
-        IReadOnlyList<string> RegisteredAvatars
+        IReadOnlyList<string> RegisteredAvatars,
+        IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings
     );
 
     public interface ILoadGraph
@@ -36,6 +37,8 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags();
 
         IEnumerable<string> LoadRegisteredAvatars();
+
+        IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings();
     }
 
     public class LoadGraph : ILoadGraph
@@ -252,10 +255,11 @@ namespace Circles.Pathfinder.Data
             var groupTrusts = LoadGroupTrustsInternal(connection, tx);
             var consentedFlags = LoadConsentedFlowFlagsInternal(connection, tx);
             var registeredAvatars = LoadRegisteredAvatarsInternal(connection, tx);
+            var wrapperMappings = LoadWrapperMappingsInternal(connection, tx);
 
             tx.Commit();
 
-            return new LoadAllResult(balances, trust, groups, groupTrusts, consentedFlags, registeredAvatars);
+            return new LoadAllResult(balances, trust, groups, groupTrusts, consentedFlags, registeredAvatars, wrapperMappings);
         }
 
         private List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
@@ -409,6 +413,28 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("registered_avatars", sw.Elapsed);
+            return results;
+        }
+
+        private List<(string WrapperAddress, string UnderlyingAvatar)>
+            LoadWrapperMappingsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
+        {
+            var query = LoadQueryFromResource("wrapperMappingQuery.sql");
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar)>(10_000);
+
+            var sw = Stopwatch.StartNew();
+
+            using var command = new NpgsqlCommand(query, connection, tx);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("wrapper_mappings", sw.Elapsed);
             return results;
         }
 
@@ -820,6 +846,29 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("registered_avatars", sw.Elapsed);
+            return results;
+        }
+
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        {
+            var query = LoadQueryFromResource("wrapperMappingQuery.sql");
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar)>(10_000);
+
+            var sw = Stopwatch.StartNew();
+            using var connection = new NpgsqlConnection(_connectionString);
+            connection.Open();
+
+            using var command = new NpgsqlCommand(query, connection);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("wrapper_mappings", sw.Elapsed);
             return results;
         }
     }

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
@@ -1,0 +1,2 @@
+SELECT "erc20Wrapper", avatar
+FROM "CrcV2_ERC20WrapperDeployed"

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -10,7 +10,9 @@ namespace Circles.Pathfinder.Graphs;
 public sealed record CachedGroupData(
     HashSet<int> GroupNodes,
     Dictionary<int, HashSet<int>> GroupTrustedTokens,
-    HashSet<int> ConsentedAvatars);
+    HashSet<int> ConsentedAvatars,
+    HashSet<int> RegisteredAvatarIds,
+    Dictionary<int, int> WrapperToAvatar);
 
 public class CapacityGraph : IGraph<CapacityEdge>
 {
@@ -30,6 +32,13 @@ public class CapacityGraph : IGraph<CapacityEdge>
 
     // Track avatars that have enabled consented flow
     public HashSet<int> ConsentedAvatars { get; set; } = new HashSet<int>();
+
+    // Track all registered V2 avatar IDs (cached to avoid per-request DB queries)
+    public HashSet<int> RegisteredAvatarIds { get; } = new HashSet<int>();
+
+    // Reverse mapping: ERC20 wrapper contract address ID → underlying avatar address ID
+    // Used at DTO output layer to resolve wrapper addresses to registered avatars
+    public Dictionary<int, int> WrapperToAvatar { get; } = new Dictionary<int, int>();
 
     // Trust lookup for consented flow validation (truster -> set of trustees)
     public IReadOnlyDictionary<int, HashSet<int>>? TrustLookup { get; set; }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -110,8 +110,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         // Ensure ALL registered avatars are valid source/sink candidates
         foreach (var avatar in loadGraph.LoadRegisteredAvatars())
         {
-            capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
+            var id = AddressIdPool.IdOf(avatar.ToLowerInvariant());
+            capacityGraph.AddAvatar(id);
+            capacityGraph.RegisteredAvatarIds.Add(id);
         }
+
+        // Load wrapper→avatar mappings (for DTO output resolution)
+        LoadWrapperMappings(capacityGraph, cachedGroupData);
 
         // Load groups and track router node
         LoadGroupsAndTrackRouter(capacityGraph, cachedGroupData);
@@ -166,9 +171,15 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
         // STEP 1a: Ensure ALL registered avatars are valid source/sink candidates
-        foreach (var avatar in loadGraph.LoadRegisteredAvatars())
+        if (cachedGroupData?.RegisteredAvatarIds != null)
         {
-            capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
+            foreach (var avatarId in cachedGroupData.RegisteredAvatarIds)
+                capacityGraph.AddAvatar(avatarId);
+        }
+        else
+        {
+            foreach (var avatar in loadGraph.LoadRegisteredAvatars())
+                capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
         }
 
         // STEP 1b: Add avatars referenced by simulated balances (holders + tokens)
@@ -190,13 +201,16 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             }
         }
 
-        // STEP 1d: Load groups and track router node for post-processing
+        // STEP 1d: Load wrapper→avatar mappings
+        LoadWrapperMappings(capacityGraph, cachedGroupData);
+
+        // STEP 1e: Load groups and track router node for post-processing
         LoadGroupsAndTrackRouter(capacityGraph, cachedGroupData);
 
-        // STEP 1e: Load consented flow flags
+        // STEP 1f: Load consented flow flags
         LoadConsentedFlowFlags(capacityGraph, cachedGroupData);
 
-        // STEP 1f: Add simulated consented avatars (for testing)
+        // STEP 1g: Add simulated consented avatars (for testing)
         if (request?.SimulatedConsentedAvatars != null && request.SimulatedConsentedAvatars.Count > 0)
         {
             int addedCount = 0;
@@ -624,6 +638,27 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             trustedSet.Add(tokenId);
             capacityGraph.AddAvatar(tokenId);  // Ensure group-trusted tokens are valid graph nodes
         }
+    }
+
+    // Load ERC20 wrapper→avatar reverse mappings for DTO output resolution
+    private void LoadWrapperMappings(CapacityGraph capacityGraph, CachedGroupData? cached = null)
+    {
+        if (cached != null)
+        {
+            foreach (var (wrapperId, avatarId) in cached.WrapperToAvatar)
+                capacityGraph.WrapperToAvatar[wrapperId] = avatarId;
+            _logger.LogDebug("Used cached wrapper mappings: {Count} entries", cached.WrapperToAvatar.Count);
+            return;
+        }
+
+        foreach (var (wrapperAddr, avatarAddr) in loadGraph.LoadWrapperMappings())
+        {
+            int wrapperId = AddressIdPool.IdOf(wrapperAddr.ToLowerInvariant());
+            int avatarId = AddressIdPool.IdOf(avatarAddr.ToLowerInvariant());
+            capacityGraph.WrapperToAvatar[wrapperId] = avatarId;
+        }
+
+        _logger.LogDebug("Loaded {Count} wrapper→avatar mappings from DB", capacityGraph.WrapperToAvatar.Count);
     }
 
     // Load consented flow flags — exceptions propagate to caller (CreateCapacityGraph)

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -375,11 +375,16 @@ public class V2Pathfinder
             if (e.From == ctx.SinkId && e.To == ctx.SinkId)
                 continue;
 
+            // Resolve wrapper contract address → underlying registered avatar
+            // Hub.sol rejects wrapper addresses as flow vertices (CirclesAvatarMustBeRegistered)
+            int resolvedToken = ctx.Graph.WrapperToAvatar.TryGetValue(e.Token, out int avatarId)
+                ? avatarId : e.Token;
+
             ctx.Transfers.Add(new TransferPathStep
             {
                 From = AddressIdPool.StringOf(e.From),
                 To = AddressIdPool.StringOf(e.To),
-                TokenOwner = AddressIdPool.StringOf(e.Token),
+                TokenOwner = AddressIdPool.StringOf(resolvedToken),
                 Value = CirclesConverter
                     .BlowUpToUInt256(e.Flow)
                     .ToString(CultureInfo.InvariantCulture)


### PR DESCRIPTION
## Summary

- **A1**: Cache `RegisteredAvatarIds` in `CachedGroupData` — eliminates 1 DB query (~20K rows) per filtered pathfinding request. Previously `LoadRegisteredAvatars()` hit PostgreSQL on every ad-hoc graph build.
- **B1**: Add ERC20 wrapper→avatar reverse mapping — loads `CrcV2_ERC20WrapperDeployed` into `CachedGroupData.WrapperToAvatar`, resolves wrapper contract addresses to underlying registered avatars at the DTO output layer in `V2Pathfinder.BuildTransferDtos()`. Prevents Hub.sol `CirclesAvatarMustBeRegistered` reverts when wrapped tokens appear as flow vertices.

## Changes

18 files across 3 layers:
- **Data layer**: `ILoadGraph` + 6 implementations + `CacheGraphModels` — new `LoadWrapperMappings()` method
- **Graph layer**: `CachedGroupData` record + `CapacityGraph` + `GraphFactory` — caches per block, populates on graph build
- **Output layer**: `V2Pathfinder.BuildTransferDtos()` — single 2-line resolution at exit point

## Test plan

- [x] Build: 0 errors
- [x] Tests: 668 passed, 0 failed, 265 skipped (staging/Anvil-dependent)
- [x] Code review: no issues found
- [x] All 11 ILoadGraph implementations updated
- [x] All 8 CachedGroupData constructor sites updated
- [ ] Deploy to staging and verify pathfinder responds correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for ERC20 wrapper token mappings to correctly identify underlying avatars.
  * Enhanced tracking of registered avatars within the system.

* **Tests**
  * Updated test infrastructure to support wrapper mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->