### PR TITLE
fix: test suite green + V_CrcV2_Groups CTE optimization

### DIFF
--- a/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
@@ -52,7 +52,7 @@ AS
             "transactionIndex" DESC,
             "logIndex"         DESC
     ),
-    member_counts AS (
+    member_counts AS MATERIALIZED (
         SELECT sub.truster as "group", count(*) as "memberCount"
         FROM (
             SELECT ct.truster, ct.trustee,

--- a/src/Pathfinder/Circles.Pathfinder.Tests/TestEnvironmentIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/TestEnvironmentIntegrationTests.cs
@@ -48,6 +48,8 @@ public class TestEnvironmentIntegrationTests
     [OneTimeTearDown]
     public async Task Teardown()
     {
+        if (_client == null!) return;
+
         if (_sessionId != null)
         {
             try


### PR DESCRIPTION
## Summary
- **Fix TearDown NullReferenceException**: `TestEnvironmentIntegrationTests.Teardown()` called `_client.Dispose()` when `_client` was never initialized (because `Assert.Ignore` in `OneTimeSetUp` skips all tests but NUnit still runs `OneTimeTearDown`). This was the sole cause of `test.sh` reporting failures.
- **Add MATERIALIZED to V_CrcV2_Groups**: The `member_counts` CTE computes a `row_number()` window function over `CrcV2_Trust` joined with `CrcV2_RegisterGroup`. All other trust-deduplication CTEs (`V_CrcV2_GroupMemberships`, `V_TrustScores_Current`) already use `MATERIALIZED` — this aligns `V_CrcV2_Groups` with the same pattern.

## Test plan
- [x] Full test suite passes: 5/5 projects, 0 failures
- [x] 933 pathfinder tests (668 executed + 265 skipped for TEST_ENV_URL)
- [x] SQL change is additive (MATERIALIZED hint only affects query planner)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimised database query execution.

* **Tests**
  * Improved test cleanup robustness to prevent potential errors during teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->