### PR TITLE
perf: optimize balanceQuery.sql — 24s to 7s (71% faster)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
@@ -1,121 +1,126 @@
-with static_token_transfers as (
-    select t."blockNumber"
-         , t."timestamp"
-         , t."transactionIndex"
-         , t."logIndex"
-         , t."transactionHash"
+-- Optimized balance query for the pathfinder graph.
+-- Changes from the original:
+--   1. MATERIALIZED registered_avatars CTE — avoids expanding V_CrcV2_Avatars 7× (each expansion joins
+--      3 registration tables + metadata). The pathfinder only needs the avatar address for filtering.
+--   2. Removed ORDER BY from wrapper CTEs — downstream only aggregates with sum(); ordering is wasted I/O
+--      (was causing ~350MB of external-merge disk sorts).
+--   3. Inlined V_CrcV2_BalancesByAccountAndToken for the native balance path — skips the crc_demurrage()
+--      SQL function call (pathfinder applies its own C# demurrage via DemurrageCalculator.Apply).
+--      Also drops the redundant `id` group key (tokenAddress uniquely determines id in CrcV2).
+--   4. Removed final ORDER BY — C# reads into an unordered List<>.
+--   5. Trimmed wrapper CTEs to only SELECT the 4 columns needed downstream (was selecting 9 including
+--      blockNumber, transactionIndex, logIndex, transactionHash that were never read).
+
+with registered_avatars as materialized (
+    select organization as avatar from "CrcV2_RegisterOrganization"
+    union all
+    select "group" as avatar from "CrcV2_RegisterGroup"
+    union all
+    select avatar from "CrcV2_RegisterHuman"
+),
+
+-- Static ERC20 wrapper transfers (circlesType = 1)
+static_wrapper_transfers as (
+    select t."timestamp"
          , t."tokenAddress"
          , t."from"
          , t."to"
          , t."amount"
     from "CrcV2_Erc20WrapperTransfer" t
-             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 1 and d."erc20Wrapper" = t."tokenAddress"
-             inner join "V_CrcV2_Avatars" a on a.avatar = d.avatar
-    order by t."blockNumber", t."transactionIndex", t."logIndex"
-), static_from_transfers as (
-    select t1."timestamp"
-         , t1."tokenAddress"
-         , t1."from" as "account"
-         , -t1."amount" as diff
-    from static_token_transfers t1
-             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
-), static_to_transfers as (
-    select t1."timestamp"
-         , t1."tokenAddress"
-         , t1."to" as "account"
-         , t1."amount" as diff
-    from static_token_transfers t1
-             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
-), static_sum as (
-    select sum(diff) AS static_balance
+    join "CrcV2_ERC20WrapperDeployed" d
+        on d."circlesType" = 1 and d."erc20Wrapper" = t."tokenAddress"
+    join registered_avatars a on a.avatar = d.avatar
+),
+static_sum as (
+    select sum(diff) as balance
          , account
          , "tokenAddress"
-         , max("timestamp") AS "timestamp"
+         , max("timestamp") as "lastActivity"
          , true as "isWrapped"
          , 'static' as "circlesType"
     from (
-             select *
-             from static_from_transfers
-             union all
-             select *
-             from static_to_transfers
-         ) as t
-    group by account
-           , "tokenAddress"
+        select t."timestamp", t."tokenAddress", t."from" as account, -t."amount" as diff
+        from static_wrapper_transfers t
+        join registered_avatars ra on ra.avatar = t."from"
+        union all
+        select t."timestamp", t."tokenAddress", t."to" as account, t."amount" as diff
+        from static_wrapper_transfers t
+        join registered_avatars ra on ra.avatar = t."to"
+    ) as t
+    group by account, "tokenAddress"
 ),
 
-demurraged_wrapped_token_transfers as (
-    select t."blockNumber"
-         , t."timestamp"
-         , t."transactionIndex"
-         , t."logIndex"
-         , t."transactionHash"
+-- Demurraged ERC20 wrapper transfers (circlesType = 0)
+demurraged_wrapper_transfers as (
+    select t."timestamp"
          , t."tokenAddress"
          , t."from"
          , t."to"
          , t."amount"
     from "CrcV2_Erc20WrapperTransfer" t
-             join "CrcV2_ERC20WrapperDeployed" d on d."circlesType" = 0 and d."erc20Wrapper" = t."tokenAddress"
-             inner join "V_CrcV2_Avatars" a on a.avatar = d.avatar
-    order by t."blockNumber", t."transactionIndex", t."logIndex"
-), demurraged_wrapped_from_transfers as (
-    select t1."timestamp"
-         , t1."tokenAddress"
-         , t1."from" as "account"
-         , -t1."amount" as diff
-    from demurraged_wrapped_token_transfers t1
-             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."from"
-), demurraged_wrapped_to_transfers as (
-    select t1."timestamp"
-         , t1."tokenAddress"
-         , t1."to" as "account"
-         , t1."amount" as diff
-    from demurraged_wrapped_token_transfers t1
-             inner join "V_CrcV2_Avatars" t2 on t2.avatar = t1."to"
-), demurraged_wrapped_sum as (
-    select sum(diff) AS inflationary_balance
+    join "CrcV2_ERC20WrapperDeployed" d
+        on d."circlesType" = 0 and d."erc20Wrapper" = t."tokenAddress"
+    join registered_avatars a on a.avatar = d.avatar
+),
+demurraged_sum as (
+    select sum(diff) as balance
          , account
          , "tokenAddress"
-         , max("timestamp") AS "lastActivity"
+         , max("timestamp") as "lastActivity"
          , true as "isWrapped"
          , 'demurraged' as "circlesType"
     from (
-             select *
-             from demurraged_wrapped_from_transfers
-             union all
-             select *
-             from demurraged_wrapped_to_transfers
-         ) as t
-    group by account
-           , "tokenAddress"
+        select t."timestamp", t."tokenAddress", t."from" as account, -t."amount" as diff
+        from demurraged_wrapper_transfers t
+        join registered_avatars ra on ra.avatar = t."from"
+        union all
+        select t."timestamp", t."tokenAddress", t."to" as account, t."amount" as diff
+        from demurraged_wrapper_transfers t
+        join registered_avatars ra on ra.avatar = t."to"
+    ) as t
+    group by account, "tokenAddress"
 ),
 
-all_transfers as (
-    select "static_balance" as balance
-         , "account"
-         , "tokenAddress"
-         , "timestamp" as "lastActivity"
-         , "isWrapped"
-         , "circlesType"
-    from static_sum
+-- Native (unwrapped) ERC1155 balances — inlined from V_CrcV2_BalancesByAccountAndToken.
+-- Skips crc_demurrage() (C# applies its own) and the redundant `id` group key.
+native_tx as (
+    select "timestamp", "from" as account, "tokenAddress", -value as delta
+    from "CrcV2_TransferSingle"
+    where "from" <> '0x0000000000000000000000000000000000000000'
     union all
-    select "inflationary_balance" as balance
-         , "account"
-         , "tokenAddress"
-         , "lastActivity"
-         , "isWrapped"
-         , "circlesType"
-    from demurraged_wrapped_sum
+    select "timestamp", "to" as account, "tokenAddress", value as delta
+    from "CrcV2_TransferSingle"
+    where "to" <> '0x0000000000000000000000000000000000000000'
     union all
-    select
-        b."totalBalance" as balance
-         ,b."account"
-         ,b."tokenAddress"
-         ,b."lastActivity"
-         ,false AS "isWrapped"
-         ,'demurraged' AS "circlesType"
-    from "V_CrcV2_BalancesByAccountAndToken" b
-    inner join "V_CrcV2_Avatars" a on a.avatar = b."account"
+    select "timestamp", "from" as account, "tokenAddress", -value as delta
+    from "CrcV2_TransferBatch"
+    where "from" <> '0x0000000000000000000000000000000000000000'
+    union all
+    select "timestamp", "to" as account, "tokenAddress", value as delta
+    from "CrcV2_TransferBatch"
+    where "to" <> '0x0000000000000000000000000000000000000000'
+),
+-- Aggregate ALL accounts first (cheaper sort without join overhead), then filter to registered.
+-- The GroupAggregate sorts 10.8M rows regardless, but avoiding a Merge Join on 10.8M rows
+-- before the sort lets the planner use HashAggregate or parallel strategies more freely.
+native_agg as (
+    select account
+         , "tokenAddress"
+         , sum(delta) as balance
+         , max("timestamp") as "lastActivity"
+    from native_tx
+    group by account, "tokenAddress"
+    having sum(delta) > 0
+),
+native_sum as (
+    select balance
+         , n.account
+         , n."tokenAddress"
+         , n."lastActivity"
+         , false as "isWrapped"
+         , 'demurraged' as "circlesType"
+    from native_agg n
+    join registered_avatars ra on ra.avatar = n.account
 )
 
 select balance::text
@@ -124,6 +129,11 @@ select balance::text
      , "lastActivity"
      , "isWrapped"
      , "circlesType"
-from all_transfers
-where balance > 0
-order by balance, account, "tokenAddress";
+from (
+    select * from static_sum
+    union all
+    select * from demurraged_sum
+    union all
+    select * from native_sum
+) all_balances
+where balance > 0;


### PR DESCRIPTION
## Summary

EXPLAIN ANALYZE on staging revealed the pathfinder balance loading query took **24.2 seconds**. After optimization: **7.1 seconds** (71% faster).

### Changes
1. **Inlined V_CrcV2_BalancesByAccountAndToken** — the view scanned `CrcV2_TransferSingle` twice (10.8M rows), sorted 1.5GB on disk, then applied `crc_demurrage()` which C# recomputes via `DemurrageCalculator.Apply()`. Removed the SQL demurrage and the redundant `id` group key.
2. **Aggregate-then-join for native balances** — moved the `registered_avatars` join from before GroupAggregate (10.8M rows) to after (110K rows). This alone cut the native path from ~10s to ~4s.
3. **MATERIALIZED registered_avatars CTE** — avoids expanding `V_CrcV2_Avatars` 7 times (each joining 3 registration tables + metadata lookup).
4. **Removed ORDER BY from wrapper CTEs** — downstream `sum()` aggregation doesn't need ordering. Saved ~350MB of external-merge disk sorts.
5. **Removed final ORDER BY** — C# reads into an unordered `List<>`.

### Verification
- Row count: **99,712** from both old and new queries (exact match)
- `tokenAddress` uniquely determines `id` in CrcV2 (0 exceptions across all data)
- Trust query profiled separately: 2.2s — not a bottleneck

## Test plan
- [x] All 5 test projects pass (933 pathfinder tests)
- [x] EXPLAIN ANALYZE before/after on staging
- [x] Row count parity verified on staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimised balance query performance through streamlined data retrieval and consolidated balance calculation processes for improved system responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->