### PR TITLE
feat: add WrapperMappings to cache graph endpoint

### DIFF
--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -177,7 +177,9 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderConsentedFlowRow>? ConsentedFlow,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-    IReadOnlyList<string>? Avatars
+    IReadOnlyList<string>? Avatars,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderWrapperMappingRow>? WrapperMappings
 );
 
 public record PathfinderBalanceRow(
@@ -205,4 +207,9 @@ public record PathfinderGroupTrustRow(
 public record PathfinderConsentedFlowRow(
     string Avatar,
     bool HasConsentedFlow
+);
+
+public record PathfinderWrapperMappingRow(
+    string WrapperAddress,
+    string UnderlyingAvatar
 );

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -44,7 +44,7 @@ public class PathfinderGraphController : ControllerBase
 
     /// <summary>
     /// Returns the full pathfinder graph snapshot from in-memory caches.
-    /// Supports ?include=balances,trust,groups,groupTrusts,consentedFlow for selective loading.
+    /// Supports ?include=balances,trust,groups,groupTrusts,consentedFlow,avatars,wrapperMappings for selective loading.
     /// ETag is based on LastProcessedBlock for conditional 304 responses.
     /// </summary>
     [HttpGet("graph")]
@@ -90,18 +90,20 @@ public class PathfinderGraphController : ControllerBase
                 Groups: sections.Contains("groups") ? BuildGroups(routerGroups!) : null,
                 GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(routerGroups!) : null,
                 ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow() : null,
-                Avatars: sections.Contains("avatars") ? BuildAvatars() : null
+                Avatars: sections.Contains("avatars") ? BuildAvatars() : null,
+                WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings() : null
             );
 
             _logger.LogDebug(
-                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}",
+                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}, wrappers={Wrappers}",
                 lastBlock,
                 response.Balances?.Count ?? 0,
                 response.Trust?.Count ?? 0,
                 response.Groups?.Count ?? 0,
                 response.GroupTrusts?.Count ?? 0,
                 response.ConsentedFlow?.Count ?? 0,
-                response.Avatars?.Count ?? 0);
+                response.Avatars?.Count ?? 0,
+                response.WrapperMappings?.Count ?? 0);
 
             return Ok(response);
         }
@@ -115,7 +117,7 @@ public class PathfinderGraphController : ControllerBase
     private static HashSet<string> ParseInclude(string? include)
     {
         if (string.IsNullOrWhiteSpace(include))
-            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars" };
+            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars", "wrappermappings" };
 
         return new HashSet<string>(
             include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -319,6 +321,26 @@ public class PathfinderGraphController : ControllerBase
             avatars.Add(address);
         }
         return avatars;
+    }
+
+    /// <summary>
+    /// Builds wrapper→avatar mapping rows from the Erc20WrapperAddresses cache.
+    /// Only includes wrappers whose underlying avatar is registered.
+    /// </summary>
+    private List<PathfinderWrapperMappingRow> BuildWrapperMappings()
+    {
+        var mappings = new List<PathfinderWrapperMappingRow>();
+        foreach (var kvp in _caches.Erc20WrapperAddresses.ReadOnlyDictionary)
+        {
+            if (!_caches.V2Avatars.ContainsKey(kvp.Value.Avatar))
+                continue;
+
+            mappings.Add(new PathfinderWrapperMappingRow(
+                WrapperAddress: kvp.Key,
+                UnderlyingAvatar: kvp.Value.Avatar
+            ));
+        }
+        return mappings;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds `WrapperMappings` field to `PathfinderGraphResponse` — the last missing data source for fully cache-driven pathfinder operation
- `BuildWrapperMappings()` reads from `Erc20WrapperAddresses` cache, filters by registered avatars
- Included in default `?include=` set; pathfinder client already deserializes it via `PathfinderGraphSnapshotDto`

## Impact
When `USE_CACHE_GRAPH_SOURCE=true`, the pathfinder now gets all 7 data sources from the cache service with **zero SQL queries** (was 6/7, falling back to DB for wrapper mappings).

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — all 5 projects pass
- [ ] Deploy to staging, verify `/api/pathfinder/graph` response includes `wrapperMappings` array

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced graph data with wrapper-to-avatar mapping information now available in responses.

* **Bug Fixes**
  * Corrected public API parameter naming for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->