### PR TITLE
feat: connection pool monitoring for Pathfinder and Cache Service

### DIFF
--- a/src/Cache/Circles.Cache.Service/CacheMetrics.cs
+++ b/src/Cache/Circles.Cache.Service/CacheMetrics.cs
@@ -95,4 +95,21 @@ public static class CacheMetrics
                 LabelNames = new[] { "version" },
                 Buckets = Histogram.ExponentialBuckets(0.001, 2, 10) // 1ms to ~1s
             });
+
+    // Connection pool metrics
+    public static readonly Gauge DbPoolIdleConnections = Prometheus.Metrics
+        .CreateGauge("circles_cache_db_pool_idle_connections",
+            "Number of idle connections in the Npgsql pool");
+
+    public static readonly Gauge DbPoolBusyConnections = Prometheus.Metrics
+        .CreateGauge("circles_cache_db_pool_busy_connections",
+            "Number of busy/in-use connections in the Npgsql pool");
+
+    public static readonly Gauge DbPoolTotalConnections = Prometheus.Metrics
+        .CreateGauge("circles_cache_db_pool_total_connections",
+            "Total number of connections (idle + busy) in the Npgsql pool");
+
+    public static readonly Gauge DbPoolMaxConnections = Prometheus.Metrics
+        .CreateGauge("circles_cache_db_pool_max_connections",
+            "Maximum pool size configured for the Npgsql pool");
 }

--- a/src/Cache/Circles.Cache.Service/IpfsContentCache.cs
+++ b/src/Cache/Circles.Cache.Service/IpfsContentCache.cs
@@ -12,7 +12,7 @@ namespace Circles.Cache.Service.Caches;
 public sealed class IpfsContentCache
 {
     private readonly MemoryCache _cache;
-    private readonly string _connectionString;
+    private readonly NpgsqlDataSource _dataSource;
     private readonly ILogger<IpfsContentCache> _logger;
     private readonly int _maxEntries;
 
@@ -20,9 +20,9 @@ public sealed class IpfsContentCache
     private long _hits;
     private long _misses;
 
-    public IpfsContentCache(string connectionString, int maxEntries, ILogger<IpfsContentCache> logger)
+    public IpfsContentCache(NpgsqlDataSource dataSource, int maxEntries, ILogger<IpfsContentCache> logger)
     {
-        _connectionString = connectionString;
+        _dataSource = dataSource;
         _maxEntries = maxEntries;
         _logger = logger;
         _cache = new MemoryCache(new MemoryCacheOptions
@@ -124,8 +124,7 @@ public sealed class IpfsContentCache
     {
         const string sql = "SELECT payload FROM ipfs_files WHERE cid = @cid";
 
-        await using var connection = new NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
+        await using var connection = await _dataSource.OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand(sql, connection);
         cmd.Parameters.AddWithValue("cid", cid);
 
@@ -143,8 +142,7 @@ public sealed class IpfsContentCache
             LEFT JOIN ipfs_files f ON f.cid = u._cid
             ORDER BY u._index";
 
-        await using var connection = new NpgsqlConnection(_connectionString);
-        await connection.OpenAsync();
+        await using var connection = await _dataSource.OpenConnectionAsync();
         await using var cmd = new NpgsqlCommand(sql, connection);
         cmd.Parameters.AddWithValue("cids", cids);
 

--- a/src/Cache/Circles.Cache.Service/Program.cs
+++ b/src/Cache/Circles.Cache.Service/Program.cs
@@ -29,13 +29,21 @@ builder.Services.Configure<HostOptions>(options =>
 var settings = CacheServiceSettings.FromEnvironment();
 builder.Services.AddSingleton(settings);
 
+// Build NpgsqlDataSource for readonly connection pooling
+var readonlyDsBuilder = new NpgsqlDataSourceBuilder(settings.EffectiveReadonlyConnectionString);
+readonlyDsBuilder.ConnectionStringBuilder.MinPoolSize = 2;
+readonlyDsBuilder.ConnectionStringBuilder.MaxPoolSize = 20;
+readonlyDsBuilder.ConnectionStringBuilder.ConnectionIdleLifetime = 300; // 5 min
+var readonlyDataSource = readonlyDsBuilder.Build();
+builder.Services.AddSingleton(readonlyDataSource);
+
 // Register cache infrastructure
 builder.Services.AddSingleton(sp => new CacheServiceState(settings.RollbackCapacity));
 builder.Services.AddSingleton(sp => new CacheContainer(settings.RollbackCapacity));
 builder.Services.AddSingleton(sp =>
 {
     var logger = sp.GetRequiredService<ILogger<IpfsContentCache>>();
-    return new IpfsContentCache(settings.EffectiveReadonlyConnectionString, settings.IpfsCacheMaxEntries, logger);
+    return new IpfsContentCache(readonlyDataSource, settings.IpfsCacheMaxEntries, logger);
 });
 
 // Register background services
@@ -97,6 +105,9 @@ logger.LogInformation("PostgreSQL Connection: {ConnectionString}",
     MaskConnectionString(settings.PostgresConnectionString));
 logger.LogInformation("PostgreSQL Readonly Connection: {ConnectionString}",
     MaskConnectionString(settings.PostgresReadonlyConnectionString));
+logger.LogInformation("PostgreSQL Pool: min={MinPool}, max={MaxPool}",
+    readonlyDsBuilder.ConnectionStringBuilder.MinPoolSize,
+    readonlyDsBuilder.ConnectionStringBuilder.MaxPoolSize);
 logger.LogInformation("PG Notify Channel: {Channel}", settings.PgNotifyChannel);
 logger.LogInformation("Rollback Capacity: {Capacity} blocks", settings.RollbackCapacity);
 logger.LogInformation("Max Catchup Lag: {Lag} blocks", settings.MaxCatchupLag);
@@ -118,15 +129,14 @@ app.MapMetrics();
 
 // Health check endpoints
 app.MapHealthChecks("/live");
-app.MapGet("/ready", async (CacheServiceState state, CacheServiceSettings settings) =>
+app.MapGet("/ready", async (CacheServiceState state, NpgsqlDataSource dataSource) =>
 {
     // Query actual DB head from database
     long dbHead = state.LastProcessedBlock; // Default to current if query fails
 
     try
     {
-        await using var conn = new Npgsql.NpgsqlConnection(settings.PostgresReadonlyConnectionString);
-        await conn.OpenAsync();
+        await using var conn = await dataSource.OpenConnectionAsync();
         await using var cmd = new Npgsql.NpgsqlCommand("SELECT COALESCE(MAX(\"blockNumber\"), 0) FROM \"System_Block\"", conn);
         var result = await cmd.ExecuteScalarAsync();
         if (result != null && result != DBNull.Value)

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -15,6 +15,7 @@ public class CacheWarmupService : BackgroundService
     private readonly CacheServiceSettings _settings;
     private readonly CacheServiceState _state;
     private readonly CacheContainer _caches;
+    private readonly NpgsqlDataSource _readonlyDataSource;
 
     protected CacheServiceSettings Settings => _settings;
     protected CacheServiceState State => _state;
@@ -28,12 +29,14 @@ public class CacheWarmupService : BackgroundService
         ILogger<CacheWarmupService> logger,
         CacheServiceSettings settings,
         CacheServiceState state,
-        CacheContainer caches)
+        CacheContainer caches,
+        NpgsqlDataSource readonlyDataSource)
     {
         _logger = logger;
         _settings = settings;
         _state = state;
         _caches = caches;
+        _readonlyDataSource = readonlyDataSource;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -143,8 +146,7 @@ public class CacheWarmupService : BackgroundService
         Func<NpgsqlConnection, CancellationToken, Task> action,
         CancellationToken ct)
     {
-        await using var conn = new NpgsqlConnection(_settings.EffectiveReadonlyConnectionString);
-        await conn.OpenAsync(ct);
+        await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
         await action(conn, ct);
     }
 
@@ -162,8 +164,7 @@ public class CacheWarmupService : BackgroundService
         {
             try
             {
-                await using var conn = new NpgsqlConnection(_settings.EffectiveReadonlyConnectionString);
-                await conn.OpenAsync(ct);
+                await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
                 await using var cmd = new NpgsqlCommand("SELECT 1", conn);
                 await cmd.ExecuteScalarAsync(ct);
                 _logger.LogInformation("PostgreSQL is ready");

--- a/src/Cache/Circles.Cache.Service/Services/MetricsUpdateService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/MetricsUpdateService.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.Metrics;
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Metrics;
 using Npgsql;
@@ -10,26 +11,58 @@ namespace Circles.Cache.Service.Services;
 public class MetricsUpdateService : BackgroundService
 {
     private readonly ILogger<MetricsUpdateService> _logger;
-    private readonly CacheServiceSettings _settings;
     private readonly CacheServiceState _state;
     private readonly CacheContainer _caches;
+    private readonly NpgsqlDataSource _readonlyDataSource;
     private readonly TimeSpan _updateInterval = TimeSpan.FromSeconds(10);
+
+    // Pool state tracked via MeterListener on Npgsql's System.Diagnostics.Metrics
+    private int _idleConnections;
+    private int _usedConnections;
 
     public MetricsUpdateService(
         ILogger<MetricsUpdateService> logger,
-        CacheServiceSettings settings,
         CacheServiceState state,
-        CacheContainer caches)
+        CacheContainer caches,
+        NpgsqlDataSource readonlyDataSource)
     {
         _logger = logger;
-        _settings = settings;
         _state = state;
         _caches = caches;
+        _readonlyDataSource = readonlyDataSource;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation("Metrics update service started");
+
+        // Set max pool gauge from connection string
+        var csb = new NpgsqlConnectionStringBuilder(_readonlyDataSource.ConnectionString);
+        CacheMetrics.DbPoolMaxConnections.Set(csb.MaxPoolSize);
+
+        // Listen for Npgsql pool metrics via System.Diagnostics.Metrics
+        using var meterListener = new MeterListener();
+        meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == "Npgsql" && instrument.Name == "db.client.connections.usage")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        meterListener.SetMeasurementEventCallback<int>((instrument, measurement, tags, state) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "state")
+                {
+                    if (tag.Value?.ToString() == "idle")
+                        Interlocked.Exchange(ref _idleConnections, measurement);
+                    else if (tag.Value?.ToString() == "used")
+                        Interlocked.Exchange(ref _usedConnections, measurement);
+                }
+            }
+        });
+        meterListener.Start();
 
         while (!stoppingToken.IsCancellationRequested)
         {
@@ -53,11 +86,17 @@ public class MetricsUpdateService : BackgroundService
         CacheMetrics.WarmupComplete.Set(_state.WarmupComplete ? 1 : 0);
         CacheMetrics.ListenerConnected.Set(_state.ListenerConnected ? 1 : 0);
 
+        // Update pool metrics
+        var idle = Volatile.Read(ref _idleConnections);
+        var used = Volatile.Read(ref _usedConnections);
+        CacheMetrics.DbPoolIdleConnections.Set(idle);
+        CacheMetrics.DbPoolBusyConnections.Set(used);
+        CacheMetrics.DbPoolTotalConnections.Set(idle + used);
+
         // Get database head to calculate lag
         try
         {
-            await using var conn = new NpgsqlConnection(_settings.EffectiveReadonlyConnectionString);
-            await conn.OpenAsync(ct);
+            await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
             await using var cmd = new NpgsqlCommand(
                 "SELECT COALESCE(MAX(\"blockNumber\"), 0) FROM \"System_Block\"", conn);
             var result = await cmd.ExecuteScalarAsync(ct);

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -17,6 +17,7 @@ public class NotificationListenerService : BackgroundService
     private readonly CacheServiceSettings _settings;
     private readonly CacheServiceState _state;
     private readonly CacheContainer _caches;
+    private readonly NpgsqlDataSource _readonlyDataSource;
 
     protected CacheServiceSettings Settings => _settings;
     protected CacheServiceState State => _state;
@@ -26,12 +27,14 @@ public class NotificationListenerService : BackgroundService
         ILogger<NotificationListenerService> logger,
         CacheServiceSettings settings,
         CacheServiceState state,
-        CacheContainer caches)
+        CacheContainer caches,
+        NpgsqlDataSource readonlyDataSource)
     {
         _logger = logger;
         _settings = settings;
         _state = state;
         _caches = caches;
+        _readonlyDataSource = readonlyDataSource;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -294,8 +297,7 @@ public class NotificationListenerService : BackgroundService
         Func<NpgsqlConnection, CancellationToken, Task> action,
         CancellationToken ct)
     {
-        await using var conn = new NpgsqlConnection(_settings.EffectiveReadonlyConnectionString);
-        await conn.OpenAsync(ct);
+        await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
         await action(conn, ct);
     }
 
@@ -333,8 +335,7 @@ public class NotificationListenerService : BackgroundService
 
     protected virtual async Task ProcessBlockRangeAsync(long fromBlock, long toBlock, CancellationToken ct)
     {
-        await using var conn = new NpgsqlConnection(_settings.EffectiveReadonlyConnectionString);
-        await conn.OpenAsync(ct);
+        await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
 
         // Process V1 events in this range
         await ProcessV1EventsAsync(conn, fromBlock, toBlock, ct);

--- a/src/Pathfinder/Circles.Pathfinder.Host/DbConnectivityHealthCheck.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/DbConnectivityHealthCheck.cs
@@ -9,12 +9,12 @@ namespace Circles.Pathfinder.Host;
 /// </summary>
 public sealed class DbConnectivityHealthCheck : IHealthCheck
 {
-    private readonly string _connectionString;
+    private readonly NpgsqlDataSource _dataSource;
     private readonly ILogger<DbConnectivityHealthCheck> _log;
 
-    public DbConnectivityHealthCheck(Settings settings, ILogger<DbConnectivityHealthCheck> log)
+    public DbConnectivityHealthCheck(NpgsqlDataSource dataSource, ILogger<DbConnectivityHealthCheck> log)
     {
-        _connectionString = settings.IndexReadonlyDbConnectionString;
+        _dataSource = dataSource;
         _log = log;
     }
 
@@ -24,8 +24,7 @@ public sealed class DbConnectivityHealthCheck : IHealthCheck
     {
         try
         {
-            await using var conn = new NpgsqlConnection(_connectionString);
-            await conn.OpenAsync(ct);
+            await using var conn = await _dataSource.OpenConnectionAsync(ct);
 
             await using var cmd = new NpgsqlCommand("SELECT 1", conn);
             cmd.CommandTimeout = 5;

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -172,4 +172,22 @@ internal static class GraphUpdateMetrics
     public static readonly Counter CacheGraphErrorsTotal = Metrics.CreateCounter(
         "circles_pathfinder_cache_graph_errors_total",
         "Total number of cache graph fetch errors");
+
+    // ─── Connection pool metrics ────────────────────────────────────────
+
+    public static readonly Gauge DbPoolIdleConnections = Metrics.CreateGauge(
+        "circles_db_pool_idle_connections",
+        "Number of idle connections in the Npgsql pool");
+
+    public static readonly Gauge DbPoolBusyConnections = Metrics.CreateGauge(
+        "circles_db_pool_busy_connections",
+        "Number of busy/in-use connections in the Npgsql pool");
+
+    public static readonly Gauge DbPoolTotalConnections = Metrics.CreateGauge(
+        "circles_db_pool_total_connections",
+        "Total number of connections (idle + busy) in the Npgsql pool");
+
+    public static readonly Gauge DbPoolMaxConnections = Metrics.CreateGauge(
+        "circles_db_pool_max_connections",
+        "Maximum pool size configured for the Npgsql pool");
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/LogStatsService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/LogStatsService.cs
@@ -1,25 +1,79 @@
+using System.Diagnostics.Metrics;
+using Npgsql;
+
 namespace Circles.Pathfinder.Host;
 
 public sealed class LogStatsService : BackgroundService
 {
     private readonly ILogger<LogStatsService> _log;
+    private readonly NpgsqlDataSource _dataSource;
     private readonly PeriodicTimer _timer = new(Constants.StatsInterval);
 
-    public LogStatsService(ILogger<LogStatsService> log) => _log = log;
+    // Pool state tracked via MeterListener on Npgsql's System.Diagnostics.Metrics
+    private int _idleConnections;
+    private int _usedConnections;
+    private MeterListener? _meterListener;
+
+    public LogStatsService(ILogger<LogStatsService> log, NpgsqlDataSource dataSource)
+    {
+        _log = log;
+        _dataSource = dataSource;
+    }
 
     protected override async Task ExecuteAsync(CancellationToken stop)
     {
-        while (await _timer.WaitForNextTickAsync(stop))
-        {
-            var (cnt, avg, p95) = LatencyStats.Snapshot();
-            if (cnt == 0)
-            {
-                continue;
-            }
+        // Set max pool gauge from connection string
+        var csb = new NpgsqlConnectionStringBuilder(_dataSource.ConnectionString);
+        GraphUpdateMetrics.DbPoolMaxConnections.Set(csb.MaxPoolSize);
 
-            _log.LogInformation(
-                "Stats roll-up – requests={Count} avg={Avg:n1} ms p95={P95:n1} ms",
-                cnt, avg, p95);
+        // Listen for Npgsql pool metrics via System.Diagnostics.Metrics
+        _meterListener = new MeterListener();
+        _meterListener.InstrumentPublished = (instrument, listener) =>
+        {
+            if (instrument.Meter.Name == "Npgsql" && instrument.Name == "db.client.connections.usage")
+            {
+                listener.EnableMeasurementEvents(instrument);
+            }
+        };
+        _meterListener.SetMeasurementEventCallback<int>((instrument, measurement, tags, state) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "state")
+                {
+                    if (tag.Value?.ToString() == "idle")
+                        Interlocked.Exchange(ref _idleConnections, measurement);
+                    else if (tag.Value?.ToString() == "used")
+                        Interlocked.Exchange(ref _usedConnections, measurement);
+                }
+            }
+        });
+        _meterListener.Start();
+
+        try
+        {
+            while (await _timer.WaitForNextTickAsync(stop))
+            {
+                // Update pool Prometheus gauges
+                var idle = Volatile.Read(ref _idleConnections);
+                var used = Volatile.Read(ref _usedConnections);
+                GraphUpdateMetrics.DbPoolIdleConnections.Set(idle);
+                GraphUpdateMetrics.DbPoolBusyConnections.Set(used);
+                GraphUpdateMetrics.DbPoolTotalConnections.Set(idle + used);
+
+                // Existing latency stats
+                var (cnt, avg, p95) = LatencyStats.Snapshot();
+                if (cnt == 0)
+                    continue;
+
+                _log.LogInformation(
+                    "Stats roll-up – requests={Count} avg={Avg:n1} ms p95={P95:n1} ms | pool: idle={PoolIdle} used={PoolUsed}",
+                    cnt, avg, p95, idle, used);
+            }
+        }
+        finally
+        {
+            _meterListener?.Dispose();
         }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -26,11 +26,18 @@ var settings = new Circles.Pathfinder.Host.Settings();
 Console.WriteLine("Starting Pathfinder service...");
 Console.WriteLine($"* Max concurrent requests: {settings.MaxConcurrentRequests}");
 
-var csb = new NpgsqlConnectionStringBuilder(settings.IndexReadonlyDbConnectionString);
-Console.WriteLine($"* DB Host: {csb.Host}");
-Console.WriteLine($"* DB User: {csb.Username}");
-Console.WriteLine($"* DB Name: {csb.Database}");
-Console.WriteLine($"* DB Port: {csb.Port}");
+// Build NpgsqlDataSource with explicit pool configuration
+var dsBuilder = new NpgsqlDataSourceBuilder(settings.IndexReadonlyDbConnectionString);
+dsBuilder.ConnectionStringBuilder.MinPoolSize = 2;
+dsBuilder.ConnectionStringBuilder.MaxPoolSize = 20;
+dsBuilder.ConnectionStringBuilder.ConnectionIdleLifetime = 300; // 5 min
+var dataSource = dsBuilder.Build();
+
+Console.WriteLine($"* DB Host: {dsBuilder.ConnectionStringBuilder.Host}");
+Console.WriteLine($"* DB User: {dsBuilder.ConnectionStringBuilder.Username}");
+Console.WriteLine($"* DB Name: {dsBuilder.ConnectionStringBuilder.Database}");
+Console.WriteLine($"* DB Port: {dsBuilder.ConnectionStringBuilder.Port}");
+Console.WriteLine($"* DB Pool: min={dsBuilder.ConnectionStringBuilder.MinPoolSize}, max={dsBuilder.ConnectionStringBuilder.MaxPoolSize}");
 Console.WriteLine($"* Nethermind RPC URL: {settings.NethermindRpcUrl}");
 Console.WriteLine($"* Consented flow: {(settings.ExcludeConsentedIntermediaries ? "DISABLED (intermediaries excluded)" : "enabled (validate rules)")}");
 Console.WriteLine($"* Graph source: {(settings.UseCacheGraphSource ? $"CACHE ({settings.CacheServiceUrl})" : "DATABASE")}");
@@ -55,11 +62,12 @@ builder.Services.AddSingleton(settings);
 builder.Services.AddSingleton<Circles.Common.Settings>(provider => provider.GetRequiredService<Circles.Pathfinder.Host.Settings>().CommonSettings);
 builder.Services.AddSingleton<Circles.Pathfinder.Settings>(provider => provider.GetRequiredService<Circles.Pathfinder.Host.Settings>());
 builder.Services.AddSingleton(semaphore);
+builder.Services.AddSingleton(dataSource);
 builder.Services.AddSingleton<NetworkState>();
 builder.Services.AddSingleton<SnapshotCache>();
 builder.Services.AddSingleton<LoadGraph>(provider =>
 {
-    var lg = new LoadGraph(settings, provider.GetRequiredService<ILoggerFactory>().CreateLogger<LoadGraph>());
+    var lg = new LoadGraph(dataSource, settings, provider.GetRequiredService<ILoggerFactory>().CreateLogger<LoadGraph>());
     // O4: Wire DB query duration metric
     lg.OnQueryCompleted = (queryName, elapsed) =>
         GraphUpdateMetrics.DbQueryDuration.WithLabels(queryName).Observe(elapsed.TotalSeconds);

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -289,8 +289,7 @@ public class NetworkStateUpdaterService : BackgroundService
         // Load fresh state from DB inside a single REPEATABLE READ transaction.
         // This guarantees all 4 queries see a consistent DB snapshot, preventing
         // phantom inconsistencies where balances reflect block N but trusts reflect N+1.
-        using var conn = new NpgsqlConnection(loadGraph.ConnectionString);
-        conn.Open();
+        using var conn = loadGraph.DataSource.OpenConnection();
         using var tx = conn.BeginTransaction(IsolationLevel.RepeatableRead);
         var rawBalances = loadGraph.LoadRawBalances(conn, tx);
         var rawTrusts = loadGraph.LoadRawTrusts(conn, tx);

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -41,9 +41,10 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings();
     }
 
-    public class LoadGraph : ILoadGraph
+    public class LoadGraph : ILoadGraph, IDisposable
     {
-        private readonly string _connectionString;
+        private readonly NpgsqlDataSource _dataSource;
+        private readonly bool _ownsDataSource;
         private readonly Settings _settings;
         private readonly ILogger _logger;
 
@@ -53,9 +54,26 @@ namespace Circles.Pathfinder.Data
         /// </summary>
         public Action<string, TimeSpan>? OnQueryCompleted { get; set; }
 
+        /// <summary>
+        /// Creates a LoadGraph using an externally-managed NpgsqlDataSource (preferred for DI).
+        /// The caller is responsible for disposing the data source.
+        /// </summary>
+        public LoadGraph(NpgsqlDataSource dataSource, Settings settings, ILogger<LoadGraph>? logger = null)
+        {
+            _dataSource = dataSource;
+            _ownsDataSource = false;
+            _settings = settings;
+            _logger = logger ?? NullLogger<LoadGraph>.Instance;
+        }
+
+        /// <summary>
+        /// Creates a LoadGraph from a connection string (creates its own NpgsqlDataSource).
+        /// Used by tests and callers that don't have DI.
+        /// </summary>
         public LoadGraph(string connectionString, Settings settings, ILogger<LoadGraph>? logger = null)
         {
-            _connectionString = connectionString;
+            _dataSource = NpgsqlDataSource.Create(connectionString);
+            _ownsDataSource = true;
             _settings = settings;
             _logger = logger ?? NullLogger<LoadGraph>.Instance;
         }
@@ -63,6 +81,12 @@ namespace Circles.Pathfinder.Data
         public LoadGraph(Settings settings, ILogger<LoadGraph>? logger = null)
             : this(GetConnectionStringFromSettings(settings), settings, logger)
         {
+        }
+
+        public void Dispose()
+        {
+            if (_ownsDataSource)
+                _dataSource.Dispose();
         }
 
         private static string GetConnectionStringFromSettings(Settings settings)
@@ -119,8 +143,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>(50_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(balanceQuery, connection);
             command.CommandTimeout = _settings.PathfinderBalanceTimeoutSeconds;
@@ -162,8 +185,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string Truster, string Trustee, int Limit)>(200_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(trustQuery, connection);
             command.CommandTimeout = _settings.PathfinderTrustTimeoutSeconds;
@@ -189,8 +211,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<string>(1_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(groupQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
@@ -215,8 +236,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string GroupAddress, string TrustedToken)>(5_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
@@ -245,8 +265,7 @@ namespace Circles.Pathfinder.Data
         /// </summary>
         public LoadAllResult LoadAll()
         {
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
             using var tx = connection.BeginTransaction(System.Data.IsolationLevel.RepeatableRead);
 
             var balances = LoadV2BalancesInternal(connection, tx);
@@ -444,10 +463,10 @@ namespace Circles.Pathfinder.Data
         // ──────────────────────────────────────────────────────────────────
 
         /// <summary>
-        /// Expose connection string so callers can open a shared REPEATABLE READ
+        /// Expose data source so callers can open a shared REPEATABLE READ
         /// transaction across multiple full-state queries.
         /// </summary>
-        public string ConnectionString => _connectionString;
+        public NpgsqlDataSource DataSource => _dataSource;
 
         public IEnumerable<(string Balance, string Account, string TokenAddress, long LastActivity)>
             LoadRawBalances() => LoadRawBalances(null, null);
@@ -459,7 +478,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string, string, string, long)>();
 
             var sw = Stopwatch.StartNew();
-            var conn = sharedConn ?? new NpgsqlConnection(_connectionString);
+            var conn = sharedConn ?? _dataSource.CreateConnection();
             try
             {
                 if (sharedConn == null) conn.Open();
@@ -498,7 +517,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string, string, long, long, int, int)>();
 
             var sw = Stopwatch.StartNew();
-            var conn = sharedConn ?? new NpgsqlConnection(_connectionString);
+            var conn = sharedConn ?? _dataSource.CreateConnection();
             try
             {
                 if (sharedConn == null) conn.Open();
@@ -538,7 +557,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string, string)>();
 
             var sw = Stopwatch.StartNew();
-            var conn = sharedConn ?? new NpgsqlConnection(_connectionString);
+            var conn = sharedConn ?? _dataSource.CreateConnection();
             try
             {
                 if (sharedConn == null) conn.Open();
@@ -569,8 +588,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(long, string, string, string, string)>();
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderBalanceTimeoutSeconds;
@@ -600,8 +618,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(long, int, int, string, string, long)>();
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderTrustTimeoutSeconds;
@@ -631,8 +648,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string, string)>();
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
@@ -657,7 +673,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<string>();
 
             var sw = Stopwatch.StartNew();
-            var conn = sharedConn ?? new NpgsqlConnection(_connectionString);
+            var conn = sharedConn ?? _dataSource.CreateConnection();
             try
             {
                 if (sharedConn == null) conn.Open();
@@ -685,8 +701,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<string>();
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
@@ -715,8 +730,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string, string, string, long)>();
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderBalanceTimeoutSeconds;
@@ -748,8 +762,7 @@ namespace Circles.Pathfinder.Data
             var query = LoadQueryFromResource("blockHashQuery.sql");
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = 10;
@@ -768,7 +781,7 @@ namespace Circles.Pathfinder.Data
             var query = LoadQueryFromResource("maxBlockTimestampQuery.sql");
 
             var sw = Stopwatch.StartNew();
-            var conn = sharedConn ?? new NpgsqlConnection(_connectionString);
+            var conn = sharedConn ?? _dataSource.CreateConnection();
             try
             {
                 if (sharedConn == null) conn.Open();
@@ -794,8 +807,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string Avatar, bool HasConsentedFlow)>(10_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderTrustTimeoutSeconds;
@@ -831,8 +843,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<string>(20_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(
                 "SELECT avatar FROM \"V_CrcV2_Avatars\"", connection);
@@ -855,8 +866,7 @@ namespace Circles.Pathfinder.Data
             var results = new List<(string WrapperAddress, string UnderlyingAvatar)>(10_000);
 
             var sw = Stopwatch.StartNew();
-            using var connection = new NpgsqlConnection(_connectionString);
-            connection.Open();
+            using var connection = _dataSource.OpenConnection();
 
             using var command = new NpgsqlCommand(query, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;


### PR DESCRIPTION
## Summary
- Replace raw `new NpgsqlConnection(connString)` with `NpgsqlDataSource` (Npgsql 7+ recommended pattern) in both Pathfinder and Cache Service
- Explicit pool configuration: min=2, max=20, idle lifetime=5min (was Npgsql defaults 0-100)
- Pool monitoring via `System.Diagnostics.Metrics` MeterListener on Npgsql's `db.client.connections.usage`
- 8 new Prometheus gauges: `circles_{db,cache_db}_pool_{idle,busy,total,max}_connections`
- Pool stats included in LogStatsService periodic log output
- LISTEN connection intentionally kept as raw `NpgsqlConnection` (long-lived, shouldn't pool)

## Files changed (12)
- **Pathfinder**: LoadGraph.cs (NpgsqlDataSource injection), Program.cs (pool config), LogStatsService.cs (MeterListener), GraphUpdateMetrics.cs (gauges), DbConnectivityHealthCheck.cs, NetworkStateUpdaterService.cs
- **Cache Service**: Program.cs (readonly DataSource), MetricsUpdateService.cs (MeterListener + gauges), CacheWarmupService.cs, NotificationListenerService.cs, IpfsContentCache.cs, CacheMetrics.cs

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — all 5 projects pass (668 pathfinder, 18 query, 0 fail)
- [ ] Deploy to staging, verify pool metrics at `/metrics` endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive monitoring metrics for database connection pool states, providing visibility into idle, busy, total, and maximum connection usage.

* **Chores**
  * Refactored database connection provisioning and management infrastructure to optimise resource allocation and improve system stability across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->