### PR TITLE
perf: parallelize cache warmup SQL loads

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
@@ -10,6 +10,8 @@ namespace Circles.Cache.Service.Tests;
 
 public class CacheWarmupServiceTests
 {
+    private static readonly NpgsqlDataSource DummyDataSource =
+        NpgsqlDataSource.Create("Host=localhost;Database=dummy");
     [Fact]
     public async Task RetriesUntilSuccessAndMarksWarmupComplete()
     {
@@ -64,7 +66,7 @@ public class CacheWarmupServiceTests
             CacheServiceState state,
             CacheContainer caches,
             int? failuresBeforeSuccess)
-            : base(NullLogger<CacheWarmupService>.Instance, settings, state, caches)
+            : base(NullLogger<CacheWarmupService>.Instance, settings, state, caches, DummyDataSource)
         {
             _failuresBeforeSuccess = failuresBeforeSuccess;
         }
@@ -107,6 +109,8 @@ public class CacheWarmupServiceTests
 
 public class NotificationListenerServiceTests
 {
+    private static readonly NpgsqlDataSource DummyDataSource =
+        NpgsqlDataSource.Create("Host=localhost;Database=dummy");
     [Fact]
     public async Task ProcessesNewBlocksWhenHeadAdvances()
     {
@@ -199,7 +203,7 @@ public class NotificationListenerServiceTests
             CacheServiceState state,
             CacheContainer caches,
             List<(long BlockNumber, string BlockHash)> blocks)
-            : base(NullLogger<NotificationListenerService>.Instance, settings, state, caches)
+            : base(NullLogger<NotificationListenerService>.Instance, settings, state, caches, DummyDataSource)
         {
             _blocks = blocks;
         }
@@ -355,7 +359,7 @@ public class NotificationListenerServiceTests
             CacheContainer caches,
             List<(long BlockNumber, string BlockHash)> blocks,
             Func<bool> shouldFail)
-            : base(NullLogger<NotificationListenerService>.Instance, settings, state, caches)
+            : base(NullLogger<NotificationListenerService>.Instance, settings, state, caches, DummyDataSource)
         {
             _blocks = blocks;
             _shouldFail = shouldFail;

--- a/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
@@ -8,6 +8,7 @@ using Moq;
 using Xunit;
 using FluentAssertions;
 using System.Net;
+using Npgsql;
 
 namespace Circles.Cache.Service.Tests;
 
@@ -30,7 +31,8 @@ public class ControllerTests
 
         // Create IpfsContentCache with dummy connection string (won't be used in tests)
         var ipfsLogger = new Mock<ILogger<IpfsContentCache>>();
-        _ipfsCache = new IpfsContentCache("Host=localhost;Database=test", maxEntries: 100, ipfsLogger.Object);
+        var dummyDataSource = NpgsqlDataSource.Create("Host=localhost;Database=test");
+        _ipfsCache = new IpfsContentCache(dummyDataSource, maxEntries: 100, ipfsLogger.Object);
     }
 
     /// <summary>

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -85,36 +85,54 @@ public class CacheWarmupService : BackgroundService
 
         long warmupTarget = 0;
 
+        // Phase 1: Wait for database and initial sync on a shared connection
         await WithReadonlyConnectionAsync(async (conn, token) =>
         {
             await WaitForInitialSyncAsync(conn, token);
-
             ClearCaches();
-
             warmupTarget = await GetDatabaseHeadAsync(conn, token);
-            _state.WarmupTargetBlock = warmupTarget;
-            _logger.LogInformation("Warmup target block set to: {Block}", warmupTarget);
+        }, stoppingToken);
 
-            _logger.LogInformation("Starting warmup replay up to block {Block}...", warmupTarget);
+        _state.WarmupTargetBlock = warmupTarget;
+        _logger.LogInformation("Starting warmup replay up to block {Block}...", warmupTarget);
 
-            await ReplayV1EventsAsync(conn, warmupTarget, token);
-            await ReplayV2EventsAsync(conn, warmupTarget, token);
-            await LoadGroupMembershipsAsync(conn, warmupTarget, token);
-            await LoadTrustRelationsAsync(conn, warmupTarget, token);
-            await LoadConsentedFlowFlagsAsync(conn, warmupTarget, token);
-            await LoadAvatarMetadataAsync(conn, warmupTarget, token);
-            await LoadV2ShortNamesAsync(conn, warmupTarget, token);
-            await LoadBalancesAsync(conn, token);
+        // Phase 2: Load all data in parallel — each task opens its own pooled connection
+        var warmupSw = System.Diagnostics.Stopwatch.StartNew();
 
-            _logger.LogInformation("Rebuilding secondary indexes...");
-            _caches.RebuildSecondaryIndexes();
-            _logger.LogInformation("Secondary indexes rebuilt");
+        await Task.WhenAll(
+            TimedLoadAsync("V1 events", ct => WithReadonlyConnectionAsync(
+                (c, t) => ReplayV1EventsAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("V2 events", ct => WithReadonlyConnectionAsync(
+                (c, t) => ReplayV2EventsAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("group memberships", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadGroupMembershipsAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("trust relations", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadTrustRelationsAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("consented flow flags", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadConsentedFlowFlagsAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("avatar metadata", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadAvatarMetadataAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("short names", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadV2ShortNamesAsync(c, warmupTarget, t), ct), stoppingToken),
+            TimedLoadAsync("balances", ct => WithReadonlyConnectionAsync(
+                (c, t) => LoadBalancesAsync(c, t), ct), stoppingToken)
+        );
 
-            _state.LastProcessedBlock = warmupTarget;
-            _logger.LogInformation("========================================");
-            _logger.LogInformation("✓ Warmup replay completed at block {Block}", warmupTarget);
-            _logger.LogInformation("========================================");
+        warmupSw.Stop();
+        _logger.LogInformation("All data loaded in {Elapsed:n1}s (parallel)", warmupSw.Elapsed.TotalSeconds);
 
+        _logger.LogInformation("Rebuilding secondary indexes...");
+        _caches.RebuildSecondaryIndexes();
+        _logger.LogInformation("Secondary indexes rebuilt");
+
+        _state.LastProcessedBlock = warmupTarget;
+        _logger.LogInformation("========================================");
+        _logger.LogInformation("✓ Warmup replay completed at block {Block}", warmupTarget);
+        _logger.LogInformation("========================================");
+
+        // Phase 3: Initialize ring buffer and catch up on a shared connection
+        await WithReadonlyConnectionAsync(async (conn, token) =>
+        {
             await InitializeBlockRingBufferAsync(conn, warmupTarget, token);
 
             var currentHead = await GetDatabaseHeadAsync(conn, token);
@@ -148,6 +166,15 @@ public class CacheWarmupService : BackgroundService
     {
         await using var conn = await _readonlyDataSource.OpenConnectionAsync(ct);
         await action(conn, ct);
+    }
+
+    private async Task TimedLoadAsync(string name, Func<CancellationToken, Task> load, CancellationToken ct)
+    {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        _logger.LogInformation("Loading {Name}...", name);
+        await load(ct);
+        sw.Stop();
+        _logger.LogInformation("Loaded {Name} in {Elapsed:n1}s", name, sw.Elapsed.TotalSeconds);
     }
 
     protected virtual Task DelayAfterFailureAsync(CancellationToken ct)


### PR DESCRIPTION
## Summary
- Parallelizes 8 independent SQL loads during cache warmup using `Task.WhenAll()`, each with its own pooled connection
- Adds `TimedLoadAsync` wrapper for per-section elapsed time logging
- Three-phase warmup: sync init → parallel data load → sync gap processing

## Test plan
- [x] Build succeeds (0 errors)
- [x] All cache service tests pass (80+ passed, 22 skipped staging-dependent)
- [ ] Deploy to staging and compare warmup duration in logs (before: sequential, after: parallel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved cache warmup process to use parallel data loading for enhanced performance during cache initialisation.

* **Tests**
  * Updated test infrastructure to support improved cache initialisation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->