### PR TITLE
fix: OpenRPC playground — servers array + hide default examples

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -755,6 +755,13 @@ public static class OpenRpcGenerator
             }
         };
 
+        // Servers array tells the OpenRPC playground where to POST JSON-RPC requests
+        doc.Servers =
+        [
+            new OpenRpcServer { Name = "Staging", Url = "https://staging.circlesubi.network" },
+            new OpenRpcServer { Name = "Production", Url = "https://rpc.aboutcircles.com" }
+        ];
+
         var interfaceType = typeof(ICirclesRpcModule);
 
         foreach (var (rpcName, csharpName, tag, summary, description) in MethodMappings)

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcModels.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcModels.cs
@@ -17,9 +17,23 @@ public class OpenRpcDocument
     [JsonPropertyName("methods")]
     public List<OpenRpcMethod> Methods { get; set; } = [];
 
+    [JsonPropertyName("servers")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public List<OpenRpcServer>? Servers { get; set; }
+
     [JsonPropertyName("components")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public OpenRpcComponents? Components { get; set; }
+}
+
+public class OpenRpcServer
+{
+    [JsonPropertyName("name")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
 }
 
 public class OpenRpcInfo

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -82,7 +82,19 @@ app.MapGet("/openrpc", (HttpContext ctx) =>
     </head>
     <body>
       <iframe id="pg"></iframe>
-      <script>document.getElementById('pg').src='https://playground.open-rpc.org/?schemaUrl='+encodeURIComponent(location.origin+'/openrpc.json');</script>
+      <script>
+        var base = 'https://playground.open-rpc.org/';
+        var params = new URLSearchParams({
+          schemaUrl: location.origin + '/openrpc.json',
+          'uiSchema[appBar][ui:examplesDropdown]': 'false',
+          'uiSchema[appBar][ui:title]': 'Circles RPC',
+          'uiSchema[appBar][ui:input]': 'false',
+          'uiSchema[appBar][ui:darkMode]': 'false',
+          'uiSchema[methods][ui:defaultExpanded]': 'false',
+          'uiSchema[params][ui:defaultExpanded]': 'false'
+        });
+        document.getElementById('pg').src = base + '?' + params.toString();
+      </script>
     </body>
     </html>
     """;


### PR DESCRIPTION
## Summary
- Add `servers` field to OpenRPC spec so the playground knows where to POST JSON-RPC requests (was getting 405 because it sent to the schema URL)
- Hide built-in petstore/example APIs from playground sidebar via `uiSchema` params  
- Clean up playground embed with custom title and hidden URL bar

## Test plan
- [ ] `/openrpc` — playground loads without petstore examples in sidebar
- [ ] Execute a method in playground — should POST to staging RPC, not return 405
- [ ] `/openrpc.json` — verify `servers` array present with staging + production URLs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Staging and Production server endpoints to API documentation for improved accessibility
  * Enhanced the interactive API playground interface with additional UI customisation options, including dark mode toggle, expandable method sections, and example dropdown functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->