### PR TITLE
fix: implement rpc.discover + fix OpenRPC playground transport

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -85,10 +85,9 @@ app.MapGet("/openrpc", (HttpContext ctx) =>
       <script>
         var base = 'https://playground.open-rpc.org/';
         var params = new URLSearchParams({
-          schemaUrl: location.origin + '/openrpc.json',
+          url: location.origin,
           'uiSchema[appBar][ui:examplesDropdown]': 'false',
           'uiSchema[appBar][ui:title]': 'Circles RPC',
-          'uiSchema[appBar][ui:input]': 'false',
           'uiSchema[appBar][ui:darkMode]': 'false',
           'uiSchema[methods][ui:defaultExpanded]': 'false',
           'uiSchema[params][ui:defaultExpanded]': 'false'
@@ -404,6 +403,9 @@ app.MapPost("/", async (
     {
         object rpcResult = request.Method switch
         {
+            // OpenRPC discovery — returns the spec so playgrounds can auto-discover methods
+            "rpc.discover" => OpenRpcGenerator.Generate(),
+
             // Balance & Token Methods
             "circles_getTotalBalance" => await HandleGetTotalBalance(request, rpcModule),
             "circlesV2_getTotalBalance" => await HandleV2GetTotalBalance(request, rpcModule),


### PR DESCRIPTION
## Summary
- Add `rpc.discover` method — returns the OpenRPC document for auto-discovery
- Switch playground from `schemaUrl=.../openrpc.json` to `url=<origin>` so it uses transport mode
- This fixes the Inspector: it now has the correct transport URL and can execute JSON-RPC requests

## Test plan
- [ ] `POST / {"method":"rpc.discover"}` returns the OpenRPC document
- [ ] `/openrpc` playground — Inspector URL field pre-populated with staging URL
- [ ] Execute a method in Inspector — should return actual RPC result, no 405
- [ ] Method list populated from discovered spec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OpenRPC discovery support to enable schema discovery via the rpc.discover method.

* **Improvements**
  * Updated OpenRPC playground initialisation parameters for better compatibility and streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->