### PR TITLE
fix: Pathfinder Scalar UI mixed content — forwarded headers + HTTPS

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -29,6 +29,7 @@
     </ItemGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -10,6 +10,7 @@ using Circles.Pathfinder.Host;
 using Circles.Pathfinder.Host.State;
 using Circles.Pathfinder.Nodes;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -81,6 +82,7 @@ builder.Services.AddSingleton<CapacityGraphPool>(provider =>
         provider.GetRequiredService<ILoggerFactory>().CreateLogger<GraphFactory>()));
 builder.Services.AddSingleton<V2Pathfinder>();
 builder.Services.AddSingleton<FindPathHandler>();
+builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddHostedService<NetworkStateUpdaterService>();
 builder.Services.AddHostedService<LogStatsService>();
@@ -148,11 +150,27 @@ builder.Services
 // OpenAPI documentation
 builder.Services.AddOpenApi(options =>
 {
-    options.AddDocumentTransformer((document, _, _) =>
+    options.AddDocumentTransformer((document, context, _) =>
     {
         document.Info.Title = "Circles Pathfinder API";
         document.Info.Version = "1.0.0";
         document.Info.Description = "REST API for computing transitive transfer paths through the Circles trust network using Google OR-Tools.";
+
+        // Use the request's scheme+host so the Scalar "Try it" client sends requests to the correct URL.
+        // Behind Caddy's `handle_path /pathfinder/*`, the prefix is stripped — we must add it back.
+        // X-Forwarded-* headers provide the public scheme/host when behind a reverse proxy.
+        var request = context.ApplicationServices.GetRequiredService<IHttpContextAccessor>().HttpContext?.Request;
+        if (request != null)
+        {
+            var scheme = request.Scheme; // "https" when ForwardedHeaders processes X-Forwarded-Proto
+            var host = request.Host.ToString();
+            var basePath = Environment.GetEnvironmentVariable("PATHFINDER_BASE_PATH") ?? "/pathfinder";
+            document.Servers =
+            [
+                new Microsoft.OpenApi.OpenApiServer { Url = $"{scheme}://{host}{basePath}" }
+            ];
+        }
+
         return Task.CompletedTask;
     });
 });
@@ -167,6 +185,13 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 
 var app = builder.Build();
 
+var forwardedHeadersOptions = new ForwardedHeadersOptions
+{
+    ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+};
+forwardedHeadersOptions.KnownIPNetworks.Clear(); // Trust all proxies (Docker network)
+forwardedHeadersOptions.KnownProxies.Clear();
+app.UseForwardedHeaders(forwardedHeadersOptions);
 app.UseCors();
 app.UseHttpMetrics();
 app.UseResponseCompression();


### PR DESCRIPTION
## Summary
- Configure `ForwardedHeaders` middleware so Pathfinder sees HTTPS scheme from Caddy's `X-Forwarded-Proto`
- Generate OpenAPI server URL with correct scheme + `/pathfinder` base path
- Fixes "Failed to fetch" / mixed content errors in Scalar "Try it" client

## Test plan
- [ ] `/pathfinder/scalar/v1` — Scalar UI loads
- [ ] `/pathfinder/openapi/v1.json` — `servers[0].url` starts with `https://`
- [ ] Execute `/findPath` from Scalar UI — no mixed content error