### PR TITLE
fix: add 4 missing OpenRPC property descriptions

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -1880,6 +1880,9 @@ public static class OpenRpcGenerator
         { ("PagedResponse_InvitedAccountInfo", "results"), "Array of invited account info objects for the current page." },
         { ("PagedResponse_InvitedAccountInfo", "hasMore"), "True if more results exist beyond this page." },
         { ("PagedResponse_InvitedAccountInfo", "nextCursor"), "Opaque cursor for the next page." },
+        { ("PagedResponse_EnrichedTransaction", "results"), "Array of enriched transaction objects for the current page." },
+        { ("PagedResponse_EnrichedTransaction", "hasMore"), "True if more results exist beyond this page." },
+        { ("PagedResponse_EnrichedTransaction", "nextCursor"), "Opaque cursor for the next page." },
 
         // ── PagedEventsResponse ─────────────────────────────────────────────
         { ("PagedEventsResponse", "events"), "Array of event objects for the current page." },
@@ -2006,6 +2009,9 @@ public static class OpenRpcGenerator
         { ("FilterPredicateDto", "column"), "Column name to filter on." },
         { ("FilterPredicateDto", "filterType"), "Comparison operator: 'Equals', 'NotEquals', 'GreaterThan', 'LessThan', 'GreaterThanOrEquals', 'LessThanOrEquals', 'Like', 'NotLike', 'In', 'NotIn'." },
         { ("FilterPredicateDto", "value"), "Value to compare against. Type must match the column type." },
+
+        // ── IFilterPredicateDto ─────────────────────────────────────────────
+        { ("IFilterPredicateDto", "type"), "Discriminator for filter predicate polymorphism. Value: 'FilterPredicate'." },
 
         // ── GroupQueryParams ────────────────────────────────────────────────
         { ("GroupQueryParams", "nameStartsWith"), "Filter groups whose name starts with this prefix (case-insensitive)." },


### PR DESCRIPTION
## Summary
- Add descriptions for `PagedResponse_EnrichedTransaction` (results, hasMore, nextCursor)
- Add description for `IFilterPredicateDto.type`
- Completes 258/258 property description coverage (was 254/258 from #223)

## Test plan
- [x] Build passes
- [ ] Verify 0 missing descriptions on staging via `rpc.discover`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pagination support for enriched transaction queries with improved schema definitions
  * Improved filter predicate handling in API responses for better data filtering capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->