### PR TITLE
perf: staging bottleneck fixes from k6 load testing

### DIFF
--- a/Circles.sln
+++ b/Circles.sln
@@ -124,6 +124,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{DCB6FCB8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circles.TrustMissingAvatars", "src\Tools\Circles.TrustMissingAvatars\Circles.TrustMissingAvatars.csproj", "{EDA7A6B7-03F5-4203-A24B-84921B3069A8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circles.Index.CirclesViews.Tests", "src\Index\Circles.Index.CirclesViews.Tests\Circles.Index.CirclesViews.Tests.csproj", "{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -565,6 +567,18 @@ Global
 		{EDA7A6B7-03F5-4203-A24B-84921B3069A8}.Release|x64.Build.0 = Release|Any CPU
 		{EDA7A6B7-03F5-4203-A24B-84921B3069A8}.Release|x86.ActiveCfg = Release|Any CPU
 		{EDA7A6B7-03F5-4203-A24B-84921B3069A8}.Release|x86.Build.0 = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|x64.Build.0 = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -613,5 +627,6 @@ Global
 		{80C84B1E-06FF-42C1-BD9B-DDA5DFF1A3AD} = {664289F4-DCD6-D41D-7163-C693306A2F35}
 		{DCB6FCB8-FF92-AC57-0842-1F72A354D6B1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{EDA7A6B7-03F5-4203-A24B-84921B3069A8} = {DCB6FCB8-FF92-AC57-0842-1F72A354D6B1}
+		{9DA038DE-C0B1-425F-8F7E-4B1773E0B2EA} = {664289F4-DCD6-D41D-7163-C693306A2F35}
 	EndGlobalSection
 EndGlobal

--- a/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+        <PackageReference Include="NUnit" Version="4.5.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.11.2"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Circles.Index.CirclesViews\Circles.Index.CirclesViews.csproj" />
+      <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Index/Circles.Index.CirclesViews.Tests/DatabaseSchemaIndexTests.cs
+++ b/src/Index/Circles.Index.CirclesViews.Tests/DatabaseSchemaIndexTests.cs
@@ -1,0 +1,82 @@
+namespace Circles.Index.CirclesViews.Tests;
+
+/// <summary>
+/// Regression tests ensuring performance-critical indexes are registered in DatabaseSchema.
+/// Each test guards against accidental removal of an index that was added to fix a
+/// specific query performance issue identified during load testing.
+/// </summary>
+[TestFixture, Parallelizable]
+public class DatabaseSchemaIndexTests
+{
+    private DatabaseSchema _schema = null!;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        _schema = new DatabaseSchema();
+    }
+
+    [Test]
+    public void Indexes_ContainsErc20WrapperTransferFromIndex()
+    {
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_Erc20WrapperTransfer_from_tokenAddress"),
+            "Missing index on CrcV2_Erc20WrapperTransfer(from, tokenAddress) — " +
+            "required for getTokenBalances OR clause performance");
+    }
+
+    [Test]
+    public void Indexes_ContainsTransferSingleFromIndex()
+    {
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_TransferSingle_from_tokenAddress"),
+            "Missing index on CrcV2_TransferSingle(from, tokenAddress) — " +
+            "required for BalancesByAccountAndToken view performance");
+    }
+
+    [Test]
+    public void Indexes_ContainsTransferBatchFromIndex()
+    {
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_TransferBatch_from_tokenAddress"),
+            "Missing index on CrcV2_TransferBatch(from, tokenAddress) — " +
+            "required for BalancesByAccountAndToken view performance");
+    }
+
+    [Test]
+    public void Indexes_ContainsCreateVaultGroupIndex()
+    {
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_CreateVault_group"),
+            "Missing index on CrcV2_CreateVault(group) — " +
+            "required for circles_query CreateVault lookups");
+    }
+
+    /// <summary>
+    /// Ensure each new index targets the correct table and columns.
+    /// Guards against copy-paste errors where the index name is correct but the SQL is wrong.
+    /// </summary>
+    [TestCase("idx_CrcV2_Erc20WrapperTransfer_from_tokenAddress", "CrcV2_Erc20WrapperTransfer", "\"from\", \"tokenAddress\"")]
+    [TestCase("idx_CrcV2_TransferSingle_from_tokenAddress", "CrcV2_TransferSingle", "\"from\", \"tokenAddress\"")]
+    [TestCase("idx_CrcV2_TransferBatch_from_tokenAddress", "CrcV2_TransferBatch", "\"from\", \"tokenAddress\"")]
+    [TestCase("idx_CrcV2_CreateVault_group", "CrcV2_CreateVault", "\"group\"")]
+    public void Indexes_SqlTargetsCorrectTableAndColumns(string indexName, string tableName, string columns)
+    {
+        var sql = _schema.Indexes[indexName];
+        Assert.That(sql, Does.Contain(tableName),
+            $"Index {indexName} SQL does not reference expected table {tableName}");
+        Assert.That(sql, Does.Contain(columns),
+            $"Index {indexName} SQL does not contain expected columns {columns}");
+    }
+
+    /// <summary>
+    /// Ensure complementary 'to' indexes still exist alongside the new 'from' indexes.
+    /// These are the original indexes — removing them would break the 'to' side of queries.
+    /// </summary>
+    [Test]
+    public void Indexes_ComplementaryToIndexesStillExist()
+    {
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_Erc20WrapperTransfer_to_tokenAddress"),
+            "Original 'to' index for Erc20WrapperTransfer was removed");
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_TransferSingle_to_tokenAddress"),
+            "Original 'to' index for TransferSingle was removed");
+        Assert.That(_schema.Indexes.ContainsKey("idx_CrcV2_TransferBatch_to_tokenAddress"),
+            "Original 'to' index for TransferBatch was removed");
+    }
+}

--- a/src/Index/Circles.Index.CirclesViews.Tests/DemurrageFunctionStabilityTests.cs
+++ b/src/Index/Circles.Index.CirclesViews.Tests/DemurrageFunctionStabilityTests.cs
@@ -1,0 +1,84 @@
+using System.Reflection;
+
+namespace Circles.Index.CirclesViews.Tests;
+
+/// <summary>
+/// Regression tests ensuring the PL/pgSQL demurrage functions are marked as STABLE.
+/// Without STABLE, PostgreSQL cannot cache NOW() across repeated calls within a single
+/// statement — causing millions of unnecessary EXTRACT(EPOCH FROM NOW()) evaluations
+/// in views like GroupMintRedeem and BalancesByAccountAndToken.
+/// </summary>
+[TestFixture, Parallelizable]
+public class DemurrageFunctionStabilityTests
+{
+    private string _balancesSql = null!;
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        var assembly = typeof(DatabaseSchema).Assembly;
+        var resourceName = assembly.GetManifestResourceNames()
+            .First(n => n.Contains("V_CrcV2_BalancesByAccountAndToken"));
+
+        using var stream = assembly.GetManifestResourceStream(resourceName)!;
+        using var reader = new StreamReader(stream);
+        _balancesSql = reader.ReadToEnd();
+    }
+
+    [Test]
+    public void CrcDay_IsMarkedStable()
+    {
+        // Find the crc_day function definition and verify it ends with STABLE
+        var crcDayBlock = ExtractFunctionBlock(_balancesSql, "crc_day");
+        Assert.That(crcDayBlock, Does.Contain("LANGUAGE plpgsql STABLE"),
+            "crc_day function must be marked STABLE for PostgreSQL to cache NOW() " +
+            "within a single statement execution");
+    }
+
+    [Test]
+    public void CrcDemurrage_IsMarkedStable()
+    {
+        var crcDemurrageBlock = ExtractFunctionBlock(_balancesSql, "crc_demurrage");
+        Assert.That(crcDemurrageBlock, Does.Contain("LANGUAGE plpgsql STABLE"),
+            "crc_demurrage function must be marked STABLE for PostgreSQL to cache NOW() " +
+            "within a single statement execution");
+    }
+
+    [Test]
+    public void NoPlpgsqlFunctionsWithoutStable()
+    {
+        // Ensure no PL/pgSQL function definition exists without STABLE
+        // This catches future regressions if someone adds a new function
+        var lines = _balancesSql.Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i].Trim();
+            if (line.Contains("LANGUAGE plpgsql", StringComparison.OrdinalIgnoreCase)
+                && !line.Contains("STABLE", StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Fail($"Line {i + 1} has plpgsql function without STABLE: {line}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Extracts the SQL block for a specific function from CREATE FUNCTION ... $$ ... $$ LANGUAGE ...
+    /// </summary>
+    private static string ExtractFunctionBlock(string sql, string functionName)
+    {
+        var idx = sql.IndexOf($"FUNCTION {functionName}(", StringComparison.OrdinalIgnoreCase);
+        if (idx < 0)
+            idx = sql.IndexOf($"FUNCTION {functionName} (", StringComparison.OrdinalIgnoreCase);
+
+        Assert.That(idx, Is.GreaterThanOrEqualTo(0), $"Could not find function {functionName} in SQL");
+
+        // Find the closing $$ LANGUAGE plpgsql line after the function
+        var rest = sql.Substring(idx);
+        var langIdx = rest.IndexOf("LANGUAGE plpgsql", StringComparison.OrdinalIgnoreCase);
+        Assert.That(langIdx, Is.GreaterThan(0), $"Could not find LANGUAGE plpgsql after {functionName}");
+
+        // Include enough to capture STABLE if present
+        var endIdx = Math.Min(langIdx + 50, rest.Length);
+        return rest.Substring(0, endIdx);
+    }
+}

--- a/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
@@ -156,6 +156,24 @@ public class DatabaseSchema : IDatabaseSchema
             {
                 "idx_history_avatar_snapshot",
                 "CREATE INDEX IF NOT EXISTS idx_history_avatar_snapshot ON trust_scores_history(avatar, snapshot_date DESC);"
+            },
+            // Performance: cover the `from` side of OR clauses in getTokenBalances / BalancesByAccountAndToken
+            {
+                "idx_CrcV2_Erc20WrapperTransfer_from_tokenAddress",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_Erc20WrapperTransfer_from_tokenAddress\" ON public.\"CrcV2_Erc20WrapperTransfer\" (\"from\", \"tokenAddress\");"
+            },
+            {
+                "idx_CrcV2_TransferSingle_from_tokenAddress",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_TransferSingle_from_tokenAddress\" ON public.\"CrcV2_TransferSingle\" (\"from\", \"tokenAddress\");"
+            },
+            {
+                "idx_CrcV2_TransferBatch_from_tokenAddress",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_TransferBatch_from_tokenAddress\" ON public.\"CrcV2_TransferBatch\" (\"from\", \"tokenAddress\");"
+            },
+            // Performance: cover circles_query lookups on CreateVault by group
+            {
+                "idx_CrcV2_CreateVault_group",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_CreateVault_group\" ON public.\"CrcV2_CreateVault\" (\"group\");"
             }
         };
 

--- a/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_BalancesByAccountAndToken.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_BalancesByAccountAndToken.sql
@@ -13,7 +13,7 @@ DECLARE
 BEGIN
     RETURN ("timestamp" - "inflationDayZero") / DEMURRAGE_WINDOW;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;
 
 CREATE OR REPLACE FUNCTION crc_demurrage("inflationDayZero" bigint, "timestamp" bigint, "value" numeric)
     RETURNS numeric AS $$
@@ -27,7 +27,7 @@ BEGIN
     _day_now := crc_day("inflationDayZero", _now);
     return (value * POWER(_gamma, _day_now - _day_last_interaction));
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql STABLE;
 
 create or replace view public."V_CrcV2_BalancesByAccountAndToken"
             (account, "tokenId", "tokenAddress", "lastActivity", "totalBalance", "demurragedTotalBalance") as

--- a/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
@@ -18,7 +18,7 @@ public class Settings : Pathfinder.Settings
 
     public int MaxConcurrentRequests = Environment.GetEnvironmentVariable("MAX_CONCURRENT_REQUESTS") != null
         ? int.Parse(Environment.GetEnvironmentVariable("MAX_CONCURRENT_REQUESTS")!)
-        : Environment.ProcessorCount * 2;
+        : Math.Max(Environment.ProcessorCount * 2, 8);
 
     /// <summary>
     /// When true, the pathfinder fetches graph data from the Cache Service instead of DB.

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HostSettingsRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HostSettingsRegressionTests.cs
@@ -1,0 +1,51 @@
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Regression tests for pathfinder host settings defaults.
+/// Guards the minimum concurrency floor identified during load testing.
+/// </summary>
+[TestFixture, Parallelizable]
+public class HostSettingsRegressionTests
+{
+    [SetUp]
+    public void ClearEnvVars()
+    {
+        Environment.SetEnvironmentVariable("MAX_CONCURRENT_REQUESTS", null);
+        Environment.SetEnvironmentVariable("NETHERMIND_RPC_URL", "http://localhost:8545");
+        // Common.Settings requires a Postgres connection string
+        Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING", "Host=localhost;Database=test;Username=test;Password=test");
+    }
+
+    [Test]
+    public void MaxConcurrentRequests_HasMinimumFloorOf8()
+    {
+        var settings = new Host.Settings();
+        Assert.That(settings.MaxConcurrentRequests, Is.GreaterThanOrEqualTo(8),
+            "MaxConcurrentRequests must be at least 8 even on low-core machines. " +
+            "On a 2-core VM, ProcessorCount*2=4 was too low — caused 503 rejections.");
+    }
+
+    [Test]
+    public void MaxConcurrentRequests_ScalesWithProcessorCount()
+    {
+        var settings = new Host.Settings();
+        var expected = Math.Max(Environment.ProcessorCount * 2, 8);
+        Assert.That(settings.MaxConcurrentRequests, Is.EqualTo(expected),
+            "Default should be Math.Max(ProcessorCount * 2, 8)");
+    }
+
+    [Test]
+    public void MaxConcurrentRequests_CanBeOverriddenViaEnvVar()
+    {
+        Environment.SetEnvironmentVariable("MAX_CONCURRENT_REQUESTS", "32");
+        try
+        {
+            var settings = new Host.Settings();
+            Assert.That(settings.MaxConcurrentRequests, Is.EqualTo(32));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("MAX_CONCURRENT_REQUESTS", null);
+        }
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SettingsRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SettingsRegressionTests.cs
@@ -1,0 +1,41 @@
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Regression tests for pathfinder settings defaults.
+/// These guard against accidental changes to tuned values identified during load testing.
+/// </summary>
+[TestFixture, Parallelizable]
+public class SettingsRegressionTests
+{
+    [SetUp]
+    public void ClearEnvVars()
+    {
+        // Ensure env vars don't interfere with default checks
+        Environment.SetEnvironmentVariable("PATHFINDER_SOLVER_TIMEOUT_SECONDS", null);
+        Environment.SetEnvironmentVariable("MAX_CONCURRENT_REQUESTS", null);
+    }
+
+    [Test]
+    public void SolverTimeoutSeconds_DefaultIs10()
+    {
+        var settings = new Settings();
+        Assert.That(settings.SolverTimeoutSeconds, Is.EqualTo(10),
+            "Default solver timeout should be 10s (reduced from 30s). " +
+            "A 30s timeout blocks semaphore slots too long for user-facing requests.");
+    }
+
+    [Test]
+    public void SolverTimeoutSeconds_CanBeOverriddenViaEnvVar()
+    {
+        Environment.SetEnvironmentVariable("PATHFINDER_SOLVER_TIMEOUT_SECONDS", "5");
+        try
+        {
+            var settings = new Settings();
+            Assert.That(settings.SolverTimeoutSeconds, Is.EqualTo(5));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATHFINDER_SOLVER_TIMEOUT_SECONDS", null);
+        }
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -54,7 +54,7 @@ public class Settings
     public int SolverTimeoutSeconds { get; set; } =
         Environment.GetEnvironmentVariable("PATHFINDER_SOLVER_TIMEOUT_SECONDS") != null
         ? int.Parse(Environment.GetEnvironmentVariable("PATHFINDER_SOLVER_TIMEOUT_SECONDS")!)
-        : 30;
+        : 10;
 
     /// <summary>
     /// Master switch for incremental graph updates.

--- a/src/Rpc/Circles.Rpc.Host.Tests/QueryCommandTimeoutTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/QueryCommandTimeoutTests.cs
@@ -1,0 +1,94 @@
+using System.Reflection;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Regression test ensuring the circles_query handler sets CommandTimeout.
+/// Without a timeout, complex view queries (GroupMintRedeem, GroupWrapUnWrap)
+/// can hang indefinitely, blocking database connections.
+///
+/// This is a source-level check because instantiating CirclesRpcModule requires
+/// Nethermind runtime which isn't always available in CI.
+/// </summary>
+[TestFixture, Parallelizable]
+public class QueryCommandTimeoutTests
+{
+    [Test]
+    public void CirclesRpcModule_QueryMethod_SetsCommandTimeout()
+    {
+        // Read the source file and verify CommandTimeout is set near the Query method's NpgsqlCommand
+        var assembly = typeof(CirclesRpcModule).Assembly;
+        var sourceDir = FindSourceDirectory(assembly);
+
+        if (sourceDir == null)
+        {
+            // Fallback: check via reflection that Settings has the property
+            var settingsType = typeof(Settings);
+            var field = settingsType.GetField("DatabaseQueryTimeoutSeconds",
+                BindingFlags.Public | BindingFlags.Instance);
+            Assert.That(field, Is.Not.Null,
+                "Settings.DatabaseQueryTimeoutSeconds field must exist for CommandTimeout to work");
+            return;
+        }
+
+        var sourceFile = Path.Combine(sourceDir, "CirclesRpcModule.cs");
+        if (!File.Exists(sourceFile))
+        {
+            Assert.Inconclusive("Could not find CirclesRpcModule.cs source to verify CommandTimeout");
+            return;
+        }
+
+        var source = File.ReadAllText(sourceFile);
+
+        // The Query method creates NpgsqlCommand with finalSql. Verify CommandTimeout is set.
+        // Look for the pattern: new NpgsqlCommand(finalSql, ...) followed by CommandTimeout
+        var queryMethodIndex = source.IndexOf("var finalSql = $\"SELECT {columns} FROM {tableName}",
+            StringComparison.Ordinal);
+        Assert.That(queryMethodIndex, Is.GreaterThan(0),
+            "Could not find the Query method's finalSql construction");
+
+        // Check that CommandTimeout appears within the next 200 characters
+        var regionAfterFinalSql = source.Substring(queryMethodIndex,
+            Math.Min(500, source.Length - queryMethodIndex));
+        Assert.That(regionAfterFinalSql, Does.Contain("CommandTimeout"),
+            "The circles_query handler must set CommandTimeout on NpgsqlCommand to prevent " +
+            "indefinite hangs on complex view queries");
+        Assert.That(regionAfterFinalSql, Does.Contain("DatabaseQueryTimeoutSeconds"),
+            "CommandTimeout should use the configurable DatabaseQueryTimeoutSeconds setting, " +
+            "not a hardcoded value");
+    }
+
+    [Test]
+    public void Settings_DatabaseQueryTimeoutSeconds_DefaultIs30()
+    {
+        // Common.Settings requires POSTGRES_CONNECTION_STRING
+        Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING",
+            "Host=localhost;Database=test;Username=test;Password=test");
+        try
+        {
+            var settings = new Settings();
+            Assert.That(settings.DatabaseQueryTimeoutSeconds, Is.EqualTo(30),
+                "Default query timeout should be 30 seconds");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING", null);
+        }
+    }
+
+    private static string? FindSourceDirectory(Assembly assembly)
+    {
+        // Walk up from test assembly output to find the RPC host source
+        var assemblyDir = Path.GetDirectoryName(assembly.Location);
+        if (assemblyDir == null) return null;
+
+        // Try common relative path from test output to source
+        var candidates = new[]
+        {
+            Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", "..", "..", "Circles.Rpc.Host")),
+            Path.GetFullPath(Path.Combine(assemblyDir, "..", "..", "..", "..", "..", "Rpc", "Circles.Rpc.Host")),
+        };
+
+        return candidates.FirstOrDefault(Directory.Exists);
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -3098,6 +3098,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
         await using var connection = await CreateConnectionAsync();
         await using var command = new NpgsqlCommand(finalSql, connection);
+        command.CommandTimeout = _settings.DatabaseQueryTimeoutSeconds;
         command.Parameters.AddRange(parameters.ToArray());
 
         var results = new List<object?[]>();


### PR DESCRIPTION
## Summary

Addresses three staging bottlenecks identified by k6 load testing (PR #8):

- **`circles_query` (8.4s p95, 19-31% failure):** Missing indexes on `from` columns force sequential scans in `getTokenBalances` and `BalancesByAccountAndToken` view. PL/pgSQL demurrage functions without `STABLE` prevent PostgreSQL from caching `NOW()` — causing millions of redundant evaluations in GroupMintRedeem views. Query handler had no `CommandTimeout`, allowing indefinite hangs.
- **`circles_getTokenBalances` (1.11s p95):** Same missing `from` indexes and non-STABLE functions.
- **`circlesV2_findPath` (436ms staging):** Solver timeout of 30s blocks semaphore slots too long; concurrency floor too low on 2-core VMs.

### Changes

| File | Change |
|------|--------|
| `V_CrcV2_BalancesByAccountAndToken.sql` | Mark `crc_day()` and `crc_demurrage()` as `STABLE` |
| `DatabaseSchema.cs` | Add 4 indexes: `from,tokenAddress` on 3 transfer tables + `group` on CreateVault |
| `CirclesRpcModule.cs` | Add `CommandTimeout` to `circles_query` handler |
| `Pathfinder/Settings.cs` | Reduce solver timeout 30s → 10s |
| `Pathfinder.Host/Settings.cs` | Add `Math.Max(ProcessorCount*2, 8)` floor |

### Tests

19 regression tests across 3 projects:
- `CirclesViews.Tests` (new): index existence, SQL targets, STABLE marking
- `Pathfinder.Tests`: solver timeout default, concurrency floor, env var overrides
- `Rpc.Host.Tests`: CommandTimeout presence, settings default

## Test plan

- [x] All 19 new regression tests pass
- [x] Pre-push build succeeds
- [ ] Deploy to staging, re-run k6 `comparison-quick.js`
- [ ] Verify `circles_query` p95 < 3s (from 8.4s)
- [ ] Verify `circles_getTokenBalances` p95 < 500ms (from 1.11s)
- [ ] Verify GroupMintRedeem/WrapUnWrap failure rate < 10% (from 26-31%)