### PR TITLE
perf: Phase 4 — DFS path extraction, materialized views, search optimization

### DIFF
--- a/src/Common/Circles.Common/IDatabaseSchema.cs
+++ b/src/Common/Circles.Common/IDatabaseSchema.cs
@@ -13,6 +13,12 @@ public interface IDatabaseSchema
     /// Must be written in an idempotent way, so that the same index can be created multiple times without error.
     /// </summary>
     public IDictionary<string, string> Indexes { get; }
+
+    /// <summary>
+    /// Raw SQL for table-returning functions (CREATE OR REPLACE FUNCTION).
+    /// Executed before views during migration. Default: empty.
+    /// </summary>
+    public IReadOnlyList<string> FunctionSql => Array.Empty<string>();
 }
 
 public abstract class BaseDatabaseSchema : IDatabaseSchema

--- a/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
@@ -66,6 +66,12 @@ public class DatabaseSchema : IDatabaseSchema
     public IEventDtoTableMap EventDtoTableMap { get; } = new EventDtoTableMap();
     public IDictionary<(string Namespace, string Table), EventSchema> Tables { get; }
 
+    /// <summary>
+    /// SQL function definitions (F_* files) to create before views.
+    /// These are table-returning functions that accept filter parameters for WHERE pushdown.
+    /// </summary>
+    public IReadOnlyList<string> FunctionSql { get; }
+
     public IDictionary<string, string> Indexes { get; } =
         new Dictionary<string, string>
         {
@@ -174,12 +180,48 @@ public class DatabaseSchema : IDatabaseSchema
             {
                 "idx_CrcV2_CreateVault_group",
                 "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_CreateVault_group\" ON public.\"CrcV2_CreateVault\" (\"group\");"
+            },
+            // Phase 4: V1 token→owner lookup for getTokenInfo
+            {
+                "idx_CrcV1_Signup_token",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV1_Signup_token\" ON public.\"CrcV1_Signup\" (token);"
+            },
+            // Phase 4: Wrapped token lookup for getTokenInfo
+            {
+                "idx_CrcV2_ERC20WrapperDeployed_erc20Wrapper",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_ERC20WrapperDeployed_erc20Wrapper\" ON public.\"CrcV2_ERC20WrapperDeployed\" (\"erc20Wrapper\");"
+            },
+            // Phase 4: Index on TransferSummary("to") for receive count matview refresh
+            {
+                "idx_CrcV2_TransferSummary_to",
+                "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_TransferSummary_to\" ON public.\"CrcV2_TransferSummary\" (\"to\");"
             }
         };
 
     public DatabaseSchema()
     {
+        FunctionSql = DiscoverFunctionSql();
         Tables = DiscoverAndBuildSchemas();
+    }
+
+    /// <summary>
+    /// Discovers F_*.sql (functions) and M_*.sql (materialized views) files
+    /// and returns their raw SQL content for execution before regular views.
+    /// </summary>
+    private IReadOnlyList<string> DiscoverFunctionSql()
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        return assembly.GetManifestResourceNames()
+            .Where(name => name.EndsWith(".sql") &&
+                (name.StartsWith("Circles.Index.CirclesViews.queries.F_") ||
+                 name.StartsWith("Circles.Index.CirclesViews.queries.M_")))
+            .Select(name =>
+            {
+                using var stream = assembly.GetManifestResourceStream(name)!;
+                using var reader = new StreamReader(stream);
+                return reader.ReadToEnd();
+            })
+            .ToList();
     }
 
     private IDictionary<(string Namespace, string Table), EventSchema> DiscoverAndBuildSchemas()

--- a/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupMintRedeem_1d.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupMintRedeem_1d.sql
@@ -1,0 +1,102 @@
+CREATE OR REPLACE FUNCTION "F_CrcV2_GroupMintRedeem_1d"(_group text)
+RETURNS TABLE (
+    "group" text,
+    "timestamp" timestamp,
+    "minted" numeric,
+    "burned" numeric,
+    "supply" numeric,
+    "demurragedMinted" numeric,
+    "demurragedBurned" numeric,
+    "demurragedSupply" numeric
+) AS $$
+
+WITH
+	mint AS (
+    SELECT
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 4
+        UNION ALL
+         SELECT
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 4
+        ),
+
+	burn AS (
+         SELECT
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 3
+        UNION ALL
+         SELECT
+		 	date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 3
+        ),
+
+group_actions AS (
+	SELECT
+		"timestamp"
+		,"group"
+		,SUM("minted") AS "minted"
+		,SUM("burned") AS "burned"
+	FROM (
+		SELECT * FROM mint
+		UNION ALL
+		SELECT * FROM burn
+	)
+	GROUP BY 1, 2
+
+)
+
+SELECT
+	ga."group"
+	,ga."timestamp"
+	,ga."minted"
+	,ga."burned"
+	,ga."supply"
+	,floor(ga."minted" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedMinted"
+	,floor(ga."burned" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedBurned"
+	,floor(ga."supply" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedSupply"
+FROM (
+    SELECT
+        "group"
+        ,"timestamp"
+        ,"minted"
+        ,"burned"
+        ,SUM("minted" + "burned") OVER (PARTITION BY "group" ORDER BY "timestamp") AS "supply"
+    FROM
+        group_actions
+) ga;
+
+$$ LANGUAGE sql STABLE;

--- a/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupMintRedeem_1h.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupMintRedeem_1h.sql
@@ -1,0 +1,102 @@
+CREATE OR REPLACE FUNCTION "F_CrcV2_GroupMintRedeem_1h"(_group text)
+RETURNS TABLE (
+    "group" text,
+    "timestamp" timestamp,
+    "minted" numeric,
+    "burned" numeric,
+    "supply" numeric,
+    "demurragedMinted" numeric,
+    "demurragedBurned" numeric,
+    "demurragedSupply" numeric
+) AS $$
+
+WITH
+	mint AS (
+         SELECT
+		 	date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 4
+        UNION ALL
+         SELECT
+		 	date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,SUM(t1."value") AS "minted"
+			,0 			 AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   WHERE t1."from" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 4
+        ),
+
+	burn AS (
+         SELECT
+		 	date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+           FROM "CrcV2_TransferSingle" t1
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 3
+        UNION ALL
+         SELECT
+		 	date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+			,t1."tokenAddress" AS "group"
+            ,0			 AS "minted"
+			,-SUM(t1."value") AS "burned"
+         FROM "CrcV2_TransferBatch" t1
+		   WHERE t1."to" = '0x0000000000000000000000000000000000000000'::text
+		     AND t1."tokenAddress" = _group
+		   GROUP BY 1, 2, 3
+        ),
+
+group_actions AS (
+	SELECT
+		"timestamp"
+		,"group"
+		,SUM("minted") AS "minted"
+		,SUM("burned") AS "burned"
+	FROM (
+		SELECT * FROM mint
+		UNION ALL
+		SELECT * FROM burn
+	)
+	GROUP BY 1, 2
+
+)
+
+SELECT
+	ga."group"
+	,ga."timestamp"
+	,ga."minted"
+	,ga."burned"
+	,ga."supply"
+	,floor(ga."minted" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedMinted"
+	,floor(ga."burned" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedBurned"
+	,floor(ga."supply" * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
+		(EXTRACT(EPOCH FROM NOW())::bigint - 1675209600) / 86400
+		- (EXTRACT(EPOCH FROM ga."timestamp")::bigint - 1675209600) / 86400
+	)) AS "demurragedSupply"
+FROM (
+    SELECT
+        "group"
+        ,"timestamp"
+        ,"minted"
+        ,"burned"
+        ,SUM("minted" + "burned") OVER (PARTITION BY "group" ORDER BY "timestamp") AS "supply"
+    FROM
+        group_actions
+) ga;
+
+$$ LANGUAGE sql STABLE;

--- a/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupWrapUnWrap_1d.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupWrapUnWrap_1d.sql
@@ -1,0 +1,54 @@
+CREATE OR REPLACE FUNCTION "F_CrcV2_GroupWrapUnWrap_1d"(_group text)
+RETURNS TABLE (
+    "group" text,
+    "timestamp" timestamp,
+    "tokenAddress" text,
+    "tokenType" text,
+    "wrapAmount" numeric,
+    "unwrapAmount" numeric,
+    "wrapSupply" numeric
+) AS $$
+
+WITH
+
+group_wrap_tokens AS (
+	SELECT
+		date_trunc('day',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+		,t2."avatar" AS "group"
+		,t1."tokenAddress"
+		,CASE
+			WHEN t2."circlesType"=0 THEN 'Demurrage'
+			ELSE 'Inflation'
+		END AS "tokenType"
+		,SUM(
+			CASE
+				WHEN t1."from"='0x0000000000000000000000000000000000000000' THEN t1.amount
+				ELSE 0
+			END
+		) AS "wrapAmount"
+		,SUM(
+			CASE
+				WHEN t1."to"='0x0000000000000000000000000000000000000000' THEN -t1.amount
+				ELSE 0
+			END
+		) AS "unwrapAmount"
+	FROM public."CrcV2_Erc20WrapperTransfer" t1
+	INNER JOIN
+		"CrcV2_ERC20WrapperDeployed" t2
+		ON t2."erc20Wrapper" = t1."tokenAddress"
+	WHERE t2."avatar" = _group
+	GROUP BY 1, 2, 3, 4
+)
+
+SELECT
+	gwt."group"
+	,gwt."timestamp"
+	,gwt."tokenAddress"
+	,gwt."tokenType"
+	,gwt."wrapAmount"
+	,gwt."unwrapAmount"
+	,SUM(gwt."wrapAmount" + gwt."unwrapAmount") OVER (PARTITION BY gwt."group", gwt."tokenAddress" ORDER BY gwt."timestamp") AS "wrapSupply"
+FROM
+	group_wrap_tokens gwt;
+
+$$ LANGUAGE sql STABLE;

--- a/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupWrapUnWrap_1h.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/F_CrcV2_GroupWrapUnWrap_1h.sql
@@ -1,0 +1,54 @@
+CREATE OR REPLACE FUNCTION "F_CrcV2_GroupWrapUnWrap_1h"(_group text)
+RETURNS TABLE (
+    "group" text,
+    "timestamp" timestamp,
+    "tokenAddress" text,
+    "tokenType" text,
+    "wrapAmount" numeric,
+    "unwrapAmount" numeric,
+    "wrapSupply" numeric
+) AS $$
+
+WITH
+
+group_wrap_tokens AS (
+	SELECT
+		date_trunc('hour',TO_TIMESTAMP(t1."timestamp"))  AS "timestamp"
+		,t2."avatar" AS "group"
+		,t1."tokenAddress"
+		,CASE
+			WHEN t2."circlesType"=0 THEN 'Demurrage'
+			ELSE 'Inflation'
+		END AS "tokenType"
+		,SUM(
+			CASE
+				WHEN t1."from"='0x0000000000000000000000000000000000000000' THEN t1.amount
+				ELSE 0
+			END
+		) AS "wrapAmount"
+		,SUM(
+			CASE
+				WHEN t1."to"='0x0000000000000000000000000000000000000000' THEN -t1.amount
+				ELSE 0
+			END
+		) AS "unwrapAmount"
+	FROM public."CrcV2_Erc20WrapperTransfer" t1
+	INNER JOIN
+		"CrcV2_ERC20WrapperDeployed" t2
+		ON t2."erc20Wrapper" = t1."tokenAddress"
+	WHERE t2."avatar" = _group
+	GROUP BY 1, 2, 3, 4
+)
+
+SELECT
+	gwt."group"
+	,gwt."timestamp"
+	,gwt."tokenAddress"
+	,gwt."tokenType"
+	,gwt."wrapAmount"
+	,gwt."unwrapAmount"
+	,SUM(gwt."wrapAmount" + gwt."unwrapAmount") OVER (PARTITION BY gwt."group", gwt."tokenAddress" ORDER BY gwt."timestamp") AS "wrapSupply"
+FROM
+	group_wrap_tokens gwt;
+
+$$ LANGUAGE sql STABLE;

--- a/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_Avatars.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_Avatars.sql
@@ -1,0 +1,66 @@
+-- Materialized version of V_CrcV2_Avatars.
+-- V_CrcV2_Avatars is a 3-way UNION with a LATERAL subquery for metadata CID lookup.
+-- It is the most heavily-used view, called by: searchProfiles, getTokenInfo,
+-- getAvatarInfo, circles_query, and many view joins.
+--
+-- Materializing it avoids recomputing the UNION + LATERAL on every query.
+-- The regular view V_CrcV2_Avatars is retained for compatibility but consumers
+-- that don't need real-time data (like searchProfiles) should prefer this matview.
+--
+-- Refreshed periodically by NetworkStateUpdaterService.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS "M_CrcV2_Avatars"
+    ("blockNumber", "timestamp", "transactionIndex", "logIndex",
+     "transactionHash", type, "invitedBy", avatar, "tokenId", name, "cidV0Digest") AS
+WITH
+avatars AS (
+    SELECT "blockNumber", "timestamp", "transactionIndex", "logIndex",
+           "transactionHash",
+           NULL::text AS "invitedBy",
+           organization AS avatar,
+           NULL::text AS "tokenId",
+           name,
+           'CrcV2_RegisterOrganization' AS type
+    FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "blockNumber", "timestamp", "transactionIndex", "logIndex",
+           "transactionHash",
+           NULL::text AS "invitedBy",
+           "group" AS avatar,
+           "group" AS "tokenId",
+           name,
+           'CrcV2_RegisterGroup' AS type
+    FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT "blockNumber", "timestamp", "transactionIndex", "logIndex",
+           "transactionHash",
+           NULL::text AS "invitedBy",
+           avatar,
+           avatar AS "tokenId",
+           NULL::text AS name,
+           'CrcV2_RegisterHuman' AS type
+    FROM "CrcV2_RegisterHuman"
+)
+SELECT a."blockNumber", a."timestamp", a."transactionIndex", a."logIndex",
+       a."transactionHash", a.type, a."invitedBy", a.avatar, a."tokenId",
+       a.name, cid."cidV0Digest"
+FROM avatars a
+LEFT JOIN LATERAL (
+    SELECT "metadataDigest" AS "cidV0Digest"
+    FROM "CrcV2_UpdateMetadataDigest" m
+    WHERE m.avatar = a.avatar
+    ORDER BY m."blockNumber" DESC, m."transactionIndex" DESC, m."logIndex" DESC
+    LIMIT 1
+) cid ON true;
+
+-- Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_M_CrcV2_Avatars_pk"
+    ON "M_CrcV2_Avatars" (avatar);
+
+-- Lookup indexes for common query patterns
+CREATE INDEX IF NOT EXISTS "idx_M_CrcV2_Avatars_type"
+    ON "M_CrcV2_Avatars" (type);
+
+CREATE INDEX IF NOT EXISTS "idx_M_CrcV2_Avatars_cidV0Digest"
+    ON "M_CrcV2_Avatars" ("cidV0Digest")
+    WHERE "cidV0Digest" IS NOT NULL;

--- a/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_ReceiveCount.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_ReceiveCount.sql
@@ -1,0 +1,16 @@
+-- Pre-materialized receive counts for profile search ranking.
+-- Replaces the expensive full-table GROUP BY in circles_searchProfiles:
+--   SELECT "to", COUNT(*) FROM "CrcV2_TransferSummary" GROUP BY "to"
+-- which scans millions of rows on every search query.
+--
+-- Refreshed periodically by NetworkStateUpdaterService.
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS "M_CrcV2_ReceiveCount"
+    (avatar, receive_count) AS
+SELECT "to"::text AS avatar, COUNT(*) AS receive_count
+FROM "CrcV2_TransferSummary"
+GROUP BY "to";
+
+-- Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_M_CrcV2_ReceiveCount_pk"
+    ON "M_CrcV2_ReceiveCount" (avatar);

--- a/src/Index/Circles.Index.Postgres/PostgresDb.cs
+++ b/src/Index/Circles.Index.Postgres/PostgresDb.cs
@@ -159,6 +159,18 @@ public class PostgresDb : ReadonlyPostgresDb, IDatabase
 
             ddlSql.Clear();
 
+            // Create table-returning functions before views (functions may be used by query rewrite)
+            if (Schema.FunctionSql.Count > 0)
+            {
+                foreach (var funcSql in Schema.FunctionSql)
+                {
+                    Console.WriteLine("PostgresDb.Migrate: Creating function...");
+                    ddlSql.AppendLine(funcSql);
+                }
+                ExecuteNonQuery(connection, ddlSql.ToString());
+                ddlSql.Clear();
+            }
+
             foreach (var table in views)
             {
                 Console.WriteLine($"PostgresDb.Migrate: Creating DDL for view " + table + "...");

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -190,4 +190,29 @@ internal static class GraphUpdateMetrics
     public static readonly Gauge DbPoolMaxConnections = Metrics.CreateGauge(
         "circles_db_pool_max_connections",
         "Maximum pool size configured for the Npgsql pool");
+
+    // ─── Materialized view refresh metrics ──────────────────────────────
+
+    public static readonly Histogram MatViewRefreshDuration = Metrics.CreateHistogram(
+        "circles_matview_refresh_duration_seconds",
+        "Materialized view refresh duration in seconds",
+        new HistogramConfiguration
+        {
+            LabelNames = new[] { "view" },
+            Buckets = Histogram.ExponentialBuckets(0.1, 2, 12) // 0.1s to ~410s
+        });
+
+    public static readonly Counter MatViewRefreshTotal = Metrics.CreateCounter(
+        "circles_matview_refresh_total",
+        "Total materialized view refreshes",
+        new CounterConfiguration { LabelNames = new[] { "view" } });
+
+    public static readonly Counter MatViewRefreshErrors = Metrics.CreateCounter(
+        "circles_matview_refresh_errors_total",
+        "Total materialized view refresh errors",
+        new CounterConfiguration { LabelNames = new[] { "view" } });
+
+    public static readonly Gauge LastMatViewRefreshBlock = Metrics.CreateGauge(
+        "circles_matview_last_refresh_block",
+        "Block number of last materialized view refresh");
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Settings.cs
@@ -61,4 +61,34 @@ public class Settings : Pathfinder.Settings
     public string RouterAddress =>
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")
         ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    /// <summary>
+    /// When true, the pathfinder refreshes materialized views (BalancesByAccountAndToken, TrustScores)
+    /// periodically during full refresh cycles. Default: true.
+    /// </summary>
+    public bool MaterializedViewRefreshEnabled =>
+        Environment.GetEnvironmentVariable("MATVIEW_REFRESH_ENABLED")?.ToLowerInvariant() switch
+        {
+            "false" or "0" => false,
+            _ => true
+        };
+
+    /// <summary>
+    /// Minimum number of blocks between materialized view refreshes.
+    /// Default: 720 (~1 hour on Gnosis with 5s blocks).
+    /// Set to 0 to refresh on every full refresh cycle.
+    /// </summary>
+    public int MaterializedViewRefreshIntervalBlocks =>
+        int.TryParse(Environment.GetEnvironmentVariable("MATVIEW_REFRESH_INTERVAL_BLOCKS"), out var val)
+            ? val
+            : 720;
+
+    /// <summary>
+    /// Database connection string for materialized view refreshes.
+    /// Uses the same DB as the indexer (needs write access for REFRESH MATERIALIZED VIEW).
+    /// Falls back to IndexReadonlyDbConnectionString if not set.
+    /// </summary>
+    public string MaterializedViewDbConnectionString =>
+        Environment.GetEnvironmentVariable("MATVIEW_DB_CONNECTION_STRING")
+        ?? IndexReadonlyDbConnectionString;
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -33,6 +33,7 @@ public class NetworkStateUpdaterService : BackgroundService
     internal long _lastFullRefreshBlock = -1;
     internal long _lastProcessedBlock = -1;
     internal string? _lastProcessedBlockHash;  // D10: reorg detection
+    internal long _lastMatViewRefreshBlock = -1;
 
     // Cache-source state (only used when UseCacheGraphSource=true)
     private CacheGraphClient? _cacheGraphClient;
@@ -226,6 +227,9 @@ public class NetworkStateUpdaterService : BackgroundService
 
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
+
+        // Refresh materialized views periodically
+        RefreshMaterializedViewsIfDue(lastBlock);
 
         GraphUpdateMetrics.UpdateDuration.WithLabels("trust").Observe(swTrust.Elapsed.TotalSeconds);
         GraphUpdateMetrics.UpdateDuration.WithLabels("balance").Observe(swBalance.Elapsed.TotalSeconds);
@@ -449,6 +453,9 @@ public class NetworkStateUpdaterService : BackgroundService
 
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(incLoadGraph, lastBlock, groupData);
+
+        // Refresh materialized views periodically
+        RefreshMaterializedViewsIfDue(lastBlock);
     }
 
     /// <summary>
@@ -671,6 +678,9 @@ public class NetworkStateUpdaterService : BackgroundService
 
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
+
+        // Refresh materialized views periodically
+        RefreshMaterializedViewsIfDue(lastBlock);
     }
 
     /// <summary>
@@ -706,6 +716,57 @@ public class NetworkStateUpdaterService : BackgroundService
     }
 
     /// <summary>
+    /// Refreshes materialized views if enough blocks have elapsed since the last refresh.
+    /// Uses CONCURRENTLY to avoid blocking readers. Failures are logged but do not crash the service.
+    /// </summary>
+    internal void RefreshMaterializedViewsIfDue(long currentBlock)
+    {
+        if (!_settings.MaterializedViewRefreshEnabled)
+            return;
+
+        if (_lastMatViewRefreshBlock >= 0 &&
+            (currentBlock - _lastMatViewRefreshBlock) < _settings.MaterializedViewRefreshIntervalBlocks)
+            return;
+
+        var matViews = new[]
+        {
+            "M_CrcV2_BalancesByAccountAndToken",
+            "V_TrustScores_Current",
+            "M_CrcV2_Avatars",
+            "M_CrcV2_ReceiveCount"
+        };
+
+        foreach (var viewName in matViews)
+        {
+            try
+            {
+                var sw = Stopwatch.StartNew();
+                using var conn = Npgsql.NpgsqlDataSource
+                    .Create(_settings.MaterializedViewDbConnectionString)
+                    .OpenConnection();
+                using var cmd = conn.CreateCommand();
+                cmd.CommandText = $"REFRESH MATERIALIZED VIEW CONCURRENTLY \"{viewName}\"";
+                cmd.CommandTimeout = 300; // 5 minutes max
+                cmd.ExecuteNonQuery();
+                sw.Stop();
+
+                GraphUpdateMetrics.MatViewRefreshDuration.WithLabels(viewName).Observe(sw.Elapsed.TotalSeconds);
+                GraphUpdateMetrics.MatViewRefreshTotal.WithLabels(viewName).Inc();
+
+                _log.LogInformation("Refreshed materialized view {View} in {Ms} ms", viewName, sw.ElapsedMilliseconds);
+            }
+            catch (Exception ex)
+            {
+                GraphUpdateMetrics.MatViewRefreshErrors.WithLabels(viewName).Inc();
+                _log.LogWarning(ex, "Failed to refresh materialized view {View} — stale data until next refresh", viewName);
+            }
+        }
+
+        _lastMatViewRefreshBlock = currentBlock;
+        GraphUpdateMetrics.LastMatViewRefreshBlock.Set(currentBlock);
+    }
+
+    /// <summary>
     /// Reset all incremental state so the next DB fallback starts with a clean FullRefresh
     /// (first-run path) instead of comparing against stale accumulated state.
     /// Called after every successful cache-source update.
@@ -718,6 +779,7 @@ public class NetworkStateUpdaterService : BackgroundService
         _lastFullRefreshBlock = -1;
         _lastProcessedBlock = -1;
         _lastProcessedBlockHash = null;
+        // Note: don't reset _lastMatViewRefreshBlock — matview refresh cadence is independent
     }
 
     private async Task<long> WaitForNextBlock(CancellationToken stoppingToken, long lastBlock)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PathExtractionRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PathExtractionRegressionTests.cs
@@ -1,0 +1,826 @@
+using Circles.Pathfinder.Edges;
+using Circles.Pathfinder.Graphs;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Comprehensive regression tests for PathUtils.ExtractFlowPaths.
+/// This is mission-critical infrastructure — if path extraction is wrong,
+/// the entire Circles transfer system halts.
+///
+/// Test categories:
+/// 1. Invariant checks (flow conservation, path validity)
+/// 2. Topology stress tests (deep chains, wide fan-out, complex DAGs)
+/// 3. Adversarial inputs (cycles, self-loops, disconnected components)
+/// 4. Reference implementation comparison (flow-conserving inputs)
+/// 5. Determinism and mutation safety
+/// 6. Scale / performance
+/// 7. QuantizeSinkBoundFlows
+/// </summary>
+[TestFixture, Parallelizable]
+public class PathExtractionRegressionTests
+{
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    // ═══════════════════════════════════════════════════════════════════
+    // INVARIANT HELPERS
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Validates that every extracted path:
+    /// 1. Starts at source, ends at sink
+    /// 2. Is contiguous
+    /// 3. Has positive, uniform flow across all edges
+    /// 4. Contains no cycles
+    /// And that total flow == expectedTotalFlow.
+    /// </summary>
+    private static void AssertPathInvariants(
+        List<List<SimpleEdge>> paths,
+        int source,
+        int sink,
+        long expectedTotalFlow,
+        string context = "")
+    {
+        long totalFlow = 0;
+
+        for (int i = 0; i < paths.Count; i++)
+        {
+            var path = paths[i];
+            Assert.That(path, Is.Not.Empty, $"{context} Path {i} is empty");
+            Assert.That(path[0].From, Is.EqualTo(source), $"{context} Path {i} doesn't start at source");
+            Assert.That(path[^1].To, Is.EqualTo(sink), $"{context} Path {i} doesn't end at sink");
+
+            for (int j = 0; j < path.Count - 1; j++)
+            {
+                Assert.That(path[j].To, Is.EqualTo(path[j + 1].From),
+                    $"{context} Path {i} not contiguous at edge {j}");
+            }
+
+            var pathFlow = path[0].Flow;
+            Assert.That(pathFlow, Is.GreaterThan(0), $"{context} Path {i} has non-positive flow");
+
+            foreach (var edge in path)
+                Assert.That(edge.Flow, Is.EqualTo(pathFlow), $"{context} Path {i} inconsistent flow");
+
+            var visited = new HashSet<int> { path[0].From };
+            foreach (var edge in path)
+                Assert.That(visited.Add(edge.To), $"{context} Path {i} has cycle (revisits node {edge.To})");
+
+            totalFlow += pathFlow;
+        }
+
+        Assert.That(totalFlow, Is.EqualTo(expectedTotalFlow),
+            $"{context} Total flow {totalFlow} != expected {expectedTotalFlow}");
+    }
+
+    /// <summary>
+    /// Builds a flow-conserving network on a DAG (forward edges only, flow in == flow out at each node).
+    /// Uses a push-forward approach: assign random capacity to each edge, then compute actual flow
+    /// by pushing from source and capping at each node's available outgoing capacity.
+    /// </summary>
+    private static List<SimpleEdge> BuildFlowConservingDAG(int[] nodes, int token, Random rng)
+    {
+        var source = nodes[0];
+        var sink = nodes[^1];
+        int n = nodes.Length;
+
+        // Generate random forward edges
+        var edgeDefs = new List<(int from, int to, long capacity)>();
+        for (int i = 0; i < n - 1; i++)
+        {
+            for (int j = i + 1; j < n; j++)
+            {
+                if (rng.NextDouble() < 0.5)
+                    edgeDefs.Add((nodes[i], nodes[j], rng.Next(1, 100)));
+            }
+        }
+
+        // Ensure at least source→sink
+        if (!edgeDefs.Any(e => e.from == source))
+            edgeDefs.Add((source, sink, rng.Next(10, 50)));
+
+        // Build adjacency for topological flow assignment
+        var outEdges = new Dictionary<int, List<int>>(); // node → edge indices
+        for (int i = 0; i < edgeDefs.Count; i++)
+        {
+            if (!outEdges.ContainsKey(edgeDefs[i].from))
+                outEdges[edgeDefs[i].from] = new List<int>();
+            outEdges[edgeDefs[i].from].Add(i);
+        }
+
+        // Push flow forward: assign flow to each edge such that flow in == flow out at each node
+        var flows = new long[edgeDefs.Count];
+        var nodeInflow = new Dictionary<int, long>();
+        nodeInflow[source] = long.MaxValue; // source has unlimited supply
+
+        // Process nodes in topological order (forward indices = topological in a DAG)
+        for (int i = 0; i < n; i++)
+        {
+            var node = nodes[i];
+            if (!outEdges.ContainsKey(node)) continue;
+            if (!nodeInflow.ContainsKey(node) || nodeInflow[node] <= 0) continue;
+
+            long available = nodeInflow[node];
+            var outs = outEdges[node];
+
+            // Distribute available flow proportionally to edge capacities
+            long totalCap = outs.Sum(idx => edgeDefs[idx].capacity);
+            long assigned = 0;
+
+            for (int k = 0; k < outs.Count; k++)
+            {
+                int idx = outs[k];
+                long cap = edgeDefs[idx].capacity;
+                long flow;
+
+                if (k == outs.Count - 1)
+                    flow = Math.Min(cap, available - assigned); // Last edge gets remainder
+                else
+                    flow = Math.Min(cap, (long)(available * ((double)cap / totalCap)));
+
+                if (flow <= 0) continue;
+
+                flows[idx] = flow;
+                assigned += flow;
+
+                int to = edgeDefs[idx].to;
+                if (!nodeInflow.ContainsKey(to)) nodeInflow[to] = 0;
+                nodeInflow[to] += flow;
+            }
+        }
+
+        // Build edges with computed flows (only include edges with positive flow)
+        var result = new List<SimpleEdge>();
+        for (int i = 0; i < edgeDefs.Count; i++)
+        {
+            if (flows[i] > 0)
+            {
+                result.Add(new SimpleEdge(edgeDefs[i].from, edgeDefs[i].to, token, edgeDefs[i].capacity)
+                { Flow = flows[i] });
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Calculate total source outflow (expected total for flow-conserving network).
+    /// </summary>
+    private static long SourceOutflow(IEnumerable<SimpleEdge> edges, int source)
+        => edges.Where(e => e.From == source && e.Flow > 0).Sum(e => e.Flow);
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 1. EDGE CASES & BOUNDARY CONDITIONS
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SourceEqualsSink_ReturnsEmpty_NoOOM()
+    {
+        var node = Node(1);
+        var other = Node(2);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(node, other, token, 1000) { Flow = 100 },
+            new(other, node, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, node, node);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void AllEdgesZeroFlow_ReturnsEmpty()
+    {
+        var s = Node(1);
+        var t = Node(2);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(s, t, token, 1000) { Flow = 0 },
+            new(s, Node(3), token, 1000) { Flow = 0 }
+        };
+
+        Assert.That(PathUtils.ExtractFlowPaths(edges, s, t), Is.Empty);
+    }
+
+    [Test]
+    public void NegativeFlow_Ignored()
+    {
+        var s = Node(1);
+        var t = Node(2);
+        var edges = new List<SimpleEdge> { new(s, t, Node(100), 1000) { Flow = -50 } };
+        Assert.That(PathUtils.ExtractFlowPaths(edges, s, t), Is.Empty);
+    }
+
+    [Test]
+    public void SingleUnitFlow_ExtractsCorrectly()
+    {
+        var s = Node(1);
+        var t = Node(2);
+        var edges = new List<SimpleEdge> { new(s, t, Node(100), 1) { Flow = 1 } };
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        AssertPathInvariants(result, s, t, 1);
+    }
+
+    [Test]
+    public void VeryLargeFlow_NoOverflow()
+    {
+        var s = Node(1);
+        var t = Node(2);
+        long bigFlow = long.MaxValue / 2;
+        var edges = new List<SimpleEdge> { new(s, t, Node(100), bigFlow) { Flow = bigFlow } };
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        AssertPathInvariants(result, s, t, bigFlow);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 2. TOPOLOGY STRESS TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void DeepChain_50Nodes()
+    {
+        var token = Node(100);
+        var nodes = Enumerable.Range(1, 50).Select(Node).ToArray();
+
+        var edges = new List<SimpleEdge>();
+        for (int i = 0; i < 49; i++)
+            edges.Add(new SimpleEdge(nodes[i], nodes[i + 1], token, 1000) { Flow = 42 });
+
+        var result = PathUtils.ExtractFlowPaths(edges, nodes[0], nodes[^1]);
+        AssertPathInvariants(result, nodes[0], nodes[^1], 42);
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0], Has.Count.EqualTo(49));
+    }
+
+    [Test]
+    public void WideFanOut_20ParallelPaths()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>();
+        for (int i = 0; i < 20; i++)
+        {
+            var mid = Node(10 + i);
+            long flow = (i + 1) * 10;
+            edges.Add(new SimpleEdge(source, mid, token, 1000) { Flow = flow });
+            edges.Add(new SimpleEdge(mid, sink, token, 1000) { Flow = flow });
+        }
+
+        long expected = Enumerable.Range(1, 20).Sum() * 10L; // 2100
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, expected);
+        Assert.That(result, Has.Count.EqualTo(20));
+    }
+
+    [Test]
+    public void ComplexDAG_SharedMiddle()
+    {
+        // Source → A → M → Sink (100)
+        // Source → B → M → Sink (150)
+        // M→Sink carries 250
+        var source = Node(1);
+        var a = Node(2);
+        var b = Node(3);
+        var m = Node(4);
+        var sink = Node(5);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 1000) { Flow = 100 },
+            new(source, b, token, 1000) { Flow = 150 },
+            new(a, m, token, 1000) { Flow = 100 },
+            new(b, m, token, 1000) { Flow = 150 },
+            new(m, sink, token, 1000) { Flow = 250 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 250);
+    }
+
+    [Test]
+    public void DiamondWithAsymmetricFlows()
+    {
+        var source = Node(1);
+        var a = Node(2);
+        var b = Node(3);
+        var sink = Node(4);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 1000) { Flow = 30 },
+            new(source, b, token, 1000) { Flow = 70 },
+            new(a, sink, token, 1000) { Flow = 30 },
+            new(b, sink, token, 1000) { Flow = 70 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 100);
+        Assert.That(result, Has.Count.EqualTo(2));
+    }
+
+    [Test]
+    public void CascadingBottlenecks()
+    {
+        // S→A(300)→B(200)→C(100)→T(100) — only 100 can flow
+        var s = Node(1); var a = Node(2); var b = Node(3); var c = Node(4); var t = Node(5);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(s, a, token, 1000) { Flow = 300 },
+            new(a, b, token, 1000) { Flow = 200 },
+            new(b, c, token, 1000) { Flow = 100 },
+            new(c, t, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        AssertPathInvariants(result, s, t, 100);
+        Assert.That(result, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ComplexFlowConservingNetwork()
+    {
+        // Verified flow-conserving at every intermediate node
+        var source = Node(1);
+        var a = Node(2); var b = Node(3); var c = Node(4); var d = Node(5);
+        var sink = Node(6);
+        var token = Node(100);
+
+        // S→A:100, S→B:80
+        // A→C:60, A→D:40
+        // B→C:30, B→D:50
+        // C→T:90, D→T:90
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 200) { Flow = 100 },
+            new(source, b, token, 200) { Flow = 80 },
+            new(a, c, token, 200) { Flow = 60 },
+            new(a, d, token, 200) { Flow = 40 },
+            new(b, c, token, 200) { Flow = 30 },
+            new(b, d, token, 200) { Flow = 50 },
+            new(c, sink, token, 200) { Flow = 90 },
+            new(d, sink, token, 200) { Flow = 90 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 180);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 3. CYCLE & ADVERSARIAL TOPOLOGY TESTS
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SelfLoop_Ignored()
+    {
+        var s = Node(1); var t = Node(2); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(s, s, token, 1000) { Flow = 100 },  // Self-loop
+            new(s, t, token, 1000) { Flow = 50 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(50));
+    }
+
+    [Test]
+    public void MutualCycle_FindsValidPath()
+    {
+        var a = Node(1); var b = Node(2); var sink = Node(3); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(a, b, token, 1000) { Flow = 100 },
+            new(b, a, token, 1000) { Flow = 50 },
+            new(a, sink, token, 1000) { Flow = 75 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, a, sink);
+        Assert.That(result, Has.Count.GreaterThan(0));
+        foreach (var path in result)
+        {
+            Assert.That(path[0].From, Is.EqualTo(a));
+            Assert.That(path[^1].To, Is.EqualTo(sink));
+        }
+    }
+
+    [Test]
+    public void TriangleCycle_WithExitToSink()
+    {
+        var a = Node(1); var b = Node(2); var c = Node(3); var sink = Node(4); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(a, b, token, 1000) { Flow = 100 },
+            new(b, c, token, 1000) { Flow = 100 },
+            new(c, a, token, 1000) { Flow = 50 },
+            new(c, sink, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, a, sink);
+        Assert.That(result, Has.Count.GreaterThan(0));
+        Assert.That(result.Any(p => p.Count == 3), "Should find A→B→C→Sink path");
+    }
+
+    [Test]
+    public void DisconnectedComponents_OnlyReachable()
+    {
+        var s = Node(1); var t = Node(2); var x = Node(3); var y = Node(4); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(s, t, token, 1000) { Flow = 100 },
+            new(x, y, token, 1000) { Flow = 200 }  // Disconnected
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        AssertPathInvariants(result, s, t, 100);
+    }
+
+    [Test]
+    public void ReverseEdge_NotUsedForForwardPath()
+    {
+        var s = Node(1); var t = Node(2); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(t, s, token, 1000) { Flow = 100 },  // Wrong direction
+            new(s, t, token, 1000) { Flow = 50 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        AssertPathInvariants(result, s, t, 50);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 3b. DEAD-END BRANCH RECOVERY (reviewer-flagged, verified correct)
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void DeadEndBranch_ThenValidPath_FlowNotLost()
+    {
+        var source = Node(1); var a = Node(2); var b = Node(3); var sink = Node(4);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 1000) { Flow = 100 },
+            new(a, b, token, 1000) { Flow = 50 },   // dead end
+            new(a, sink, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 100);
+    }
+
+    [Test]
+    public void MultipleDeadEnds_ThenValidPath()
+    {
+        var source = Node(1); var a = Node(2); var b = Node(3); var c = Node(4); var sink = Node(5);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 1000) { Flow = 100 },
+            new(a, b, token, 1000) { Flow = 50 },
+            new(a, c, token, 1000) { Flow = 30 },
+            new(a, sink, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 100);
+    }
+
+    [Test]
+    public void NestedDeadEnd_ThenValidPath()
+    {
+        var source = Node(1); var a = Node(2); var b = Node(3); var c = Node(4); var sink = Node(5);
+        var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(source, a, token, 1000) { Flow = 100 },
+            new(a, b, token, 1000) { Flow = 50 },
+            new(b, c, token, 1000) { Flow = 30 },
+            new(a, sink, token, 1000) { Flow = 100 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        AssertPathInvariants(result, source, sink, 100);
+    }
+
+    [Test]
+    public void ParallelEdges_SameStructure_DifferentFlow()
+    {
+        // Two edges S→M with same Token/Capacity, different Flow.
+        // Verifies record equality correctly distinguishes them during removal.
+        var s = Node(1); var mid = Node(2); var t = Node(3); var token = Node(100);
+
+        var edges = new List<SimpleEdge>
+        {
+            new(s, mid, token, 1000) { Flow = 50 },
+            new(s, mid, token, 1000) { Flow = 30 },
+            new(mid, t, token, 1000) { Flow = 80 }
+        };
+
+        var result = PathUtils.ExtractFlowPaths(edges, s, t);
+        Assert.That(result.Sum(p => p[0].Flow), Is.EqualTo(80));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 4. REFERENCE IMPLEMENTATION COMPARISON (flow-conserving only)
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Naive BFS-based path extraction for comparison.
+    /// Both DFS and BFS must produce the same total flow on flow-conserving inputs.
+    /// </summary>
+    private static List<List<SimpleEdge>> ReferenceExtractFlowPaths(
+        IReadOnlyList<SimpleEdge> edges, int source, int sink)
+    {
+        if (source == sink) return new List<List<SimpleEdge>>();
+
+        var edgeCopies = edges.Select(e =>
+            new SimpleEdge(e.From, e.To, e.Token, e.Capacity) { Flow = e.Flow }).ToList();
+        var result = new List<List<SimpleEdge>>();
+
+        while (true)
+        {
+            var adj = new Dictionary<int, List<SimpleEdge>>();
+            foreach (var e in edgeCopies.Where(e => e.Flow > 0))
+            {
+                if (!adj.ContainsKey(e.From)) adj[e.From] = new List<SimpleEdge>();
+                adj[e.From].Add(e);
+            }
+
+            var parent = new Dictionary<int, SimpleEdge>();
+            var visited = new HashSet<int> { source };
+            var queue = new Queue<int>();
+            queue.Enqueue(source);
+            bool found = false;
+
+            while (queue.Count > 0 && !found)
+            {
+                var node = queue.Dequeue();
+                if (!adj.ContainsKey(node)) continue;
+                foreach (var e in adj[node])
+                {
+                    if (e.Flow > 0 && visited.Add(e.To))
+                    {
+                        parent[e.To] = e;
+                        if (e.To == sink) { found = true; break; }
+                        queue.Enqueue(e.To);
+                    }
+                }
+            }
+
+            if (!found) break;
+
+            var path = new List<SimpleEdge>();
+            var cur = sink;
+            while (cur != source)
+            {
+                path.Insert(0, parent[cur]);
+                cur = parent[cur].From;
+            }
+
+            long minFlow = path.Min(e => e.Flow);
+            result.Add(path.Select(e =>
+                new SimpleEdge(e.From, e.To, e.Token, e.Capacity) { Flow = minFlow }).ToList());
+
+            foreach (var e in path) e.Flow -= minFlow;
+        }
+
+        return result;
+    }
+
+    [Test]
+    public void ReferenceComparison_Diamond_FlowConserving()
+    {
+        var source = Node(1);
+        var left = Node(2); var right = Node(3); var sink = Node(4);
+        var token = Node(100);
+
+        var edges1 = new List<SimpleEdge>
+        {
+            new(source, left, token, 1000) { Flow = 50 },
+            new(source, right, token, 1000) { Flow = 75 },
+            new(left, sink, token, 1000) { Flow = 50 },
+            new(right, sink, token, 1000) { Flow = 75 }
+        };
+
+        var edges2 = edges1.Select(e =>
+            new SimpleEdge(e.From, e.To, e.Token, e.Capacity) { Flow = e.Flow }).ToList();
+
+        var totalDFS = PathUtils.ExtractFlowPaths(edges1, source, sink).Sum(p => p[0].Flow);
+        var totalRef = ReferenceExtractFlowPaths(edges2, source, sink).Sum(p => p[0].Flow);
+
+        Assert.That(totalDFS, Is.EqualTo(totalRef));
+    }
+
+    [Test, Repeat(50)]
+    public void ReferenceComparison_RandomFlowConservingDAG()
+    {
+        var rng = new Random(42 + TestContext.CurrentContext.CurrentRepeatCount);
+        var token = Node(100);
+
+        int n = rng.Next(4, 12);
+        var nodes = Enumerable.Range(1, n).Select(Node).ToArray();
+        var source = nodes[0];
+        var sink = nodes[^1];
+
+        var edges = BuildFlowConservingDAG(nodes, token, rng);
+
+        if (edges.Count == 0) return; // Degenerate case
+
+        long expected = SourceOutflow(edges, source);
+        if (expected <= 0) return;
+
+        // Clone for reference
+        var edges2 = edges.Select(e =>
+            new SimpleEdge(e.From, e.To, e.Token, e.Capacity) { Flow = e.Flow }).ToList();
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        var reference = ReferenceExtractFlowPaths(edges2, source, sink);
+
+        var totalDFS = result.Sum(p => p[0].Flow);
+        var totalRef = reference.Sum(p => p[0].Flow);
+
+        Assert.That(totalDFS, Is.EqualTo(totalRef),
+            $"Repeat {TestContext.CurrentContext.CurrentRepeatCount} (n={n}): DFS={totalDFS} != Ref={totalRef}");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 5. INPUT MUTATION SAFETY
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void OriginalEdges_FlowMutatedToZero()
+    {
+        var s = Node(1); var t = Node(2); var token = Node(100);
+        var edge = new SimpleEdge(s, t, token, 1000) { Flow = 100 };
+        PathUtils.ExtractFlowPaths(new List<SimpleEdge> { edge }, s, t);
+        Assert.That(edge.Flow, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void OriginalEdges_PartialConsumption()
+    {
+        var s = Node(1); var m = Node(2); var t = Node(3); var token = Node(100);
+        var e1 = new SimpleEdge(s, m, token, 1000) { Flow = 100 };
+        var e2 = new SimpleEdge(m, t, token, 1000) { Flow = 50 };
+
+        PathUtils.ExtractFlowPaths(new List<SimpleEdge> { e1, e2 }, s, t);
+        Assert.That(e2.Flow, Is.EqualTo(0));
+        Assert.That(e1.Flow, Is.EqualTo(50));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 6. DETERMINISM
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void SameInput_SameOutput_Deterministic()
+    {
+        var source = Node(1); var a = Node(2); var b = Node(3); var sink = Node(4);
+        var token = Node(100);
+
+        List<SimpleEdge> MakeEdges() => new()
+        {
+            new(source, a, token, 1000) { Flow = 100 },
+            new(source, b, token, 1000) { Flow = 200 },
+            new(a, sink, token, 1000) { Flow = 100 },
+            new(b, sink, token, 1000) { Flow = 200 }
+        };
+
+        var r1 = PathUtils.ExtractFlowPaths(MakeEdges(), source, sink);
+        var r2 = PathUtils.ExtractFlowPaths(MakeEdges(), source, sink);
+
+        Assert.That(r1.Count, Is.EqualTo(r2.Count));
+        for (int i = 0; i < r1.Count; i++)
+        {
+            Assert.That(r1[i].Count, Is.EqualTo(r2[i].Count));
+            for (int j = 0; j < r1[i].Count; j++)
+            {
+                Assert.That(r1[i][j].From, Is.EqualTo(r2[i][j].From));
+                Assert.That(r1[i][j].To, Is.EqualTo(r2[i][j].To));
+                Assert.That(r1[i][j].Flow, Is.EqualTo(r2[i][j].Flow));
+            }
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 7. SCALE / PERFORMANCE
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void Scale_100Nodes_50Paths()
+    {
+        var token = Node(500);
+        var source = Node(1); var sink = Node(200);
+
+        var edges = new List<SimpleEdge>();
+        for (int i = 0; i < 50; i++)
+        {
+            var mid = Node(300 + i);
+            long flow = (i + 1) * 10;
+            edges.Add(new SimpleEdge(source, mid, token, 10000) { Flow = flow });
+            edges.Add(new SimpleEdge(mid, sink, token, 10000) { Flow = flow });
+        }
+
+        var result = PathUtils.ExtractFlowPaths(edges, source, sink);
+        Assert.That(result, Has.Count.EqualTo(50));
+        long total = result.Sum(p => p[0].Flow);
+        Assert.That(total, Is.EqualTo(Enumerable.Range(1, 50).Sum() * 10L));
+    }
+
+    [Test]
+    public void Scale_DeepChain200()
+    {
+        var token = Node(500);
+        var nodes = Enumerable.Range(1, 200).Select(Node).ToArray();
+
+        var edges = new List<SimpleEdge>();
+        for (int i = 0; i < 199; i++)
+            edges.Add(new SimpleEdge(nodes[i], nodes[i + 1], token, 1000) { Flow = 77 });
+
+        var result = PathUtils.ExtractFlowPaths(edges, nodes[0], nodes[^1]);
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0], Has.Count.EqualTo(199));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // 8. QUANTIZE SINK BOUND FLOWS
+    // ═══════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void Quantize_EmptyPaths_ReturnsEmpty()
+    {
+        Assert.That(PathUtils.QuantizeSinkBoundFlows(new(), Node(1), 96, 960), Is.Empty);
+    }
+
+    [Test]
+    public void Quantize_ExactMultiple()
+    {
+        var sink = Node(2); var token = Node(100);
+        var path = new List<SimpleEdge> { new(Node(1), sink, token, 1000) { Flow = 288 } }; // 3*96
+
+        var result = PathUtils.QuantizeSinkBoundFlows(new() { path }, sink, 96, 960);
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0][0].Flow, Is.EqualTo(288));
+    }
+
+    [Test]
+    public void Quantize_FlowLessThanQuanta_Excluded()
+    {
+        var sink = Node(2); var token = Node(100);
+        var path = new List<SimpleEdge> { new(Node(1), sink, token, 1000) { Flow = 50 } };
+
+        Assert.That(PathUtils.QuantizeSinkBoundFlows(new() { path }, sink, 96, 960), Is.Empty);
+    }
+
+    [Test]
+    public void Quantize_RoundsDown()
+    {
+        var sink = Node(2); var token = Node(100);
+        var path = new List<SimpleEdge> { new(Node(1), sink, token, 1000) { Flow = 250 } };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(new() { path }, sink, 96, 960);
+        Assert.That(result[0][0].Flow, Is.EqualTo(192)); // 2*96
+    }
+
+    [Test]
+    public void Quantize_CapsAtTargetFlow()
+    {
+        var sink = Node(2); var token = Node(100);
+        var paths = new List<List<SimpleEdge>>
+        {
+            new() { new(Node(1), sink, token, 1000) { Flow = 960 } },
+            new() { new(Node(3), sink, token, 1000) { Flow = 960 } }
+        };
+
+        var result = PathUtils.QuantizeSinkBoundFlows(paths, sink, 96, 960);
+        Assert.That(result.Sum(p => p[0].Flow), Is.LessThanOrEqualTo(960));
+    }
+
+    [Test]
+    public void Quantize_NonSinkPath_Skipped()
+    {
+        var sink = Node(2); var token = Node(100);
+        var path = new List<SimpleEdge> { new(Node(1), Node(3), token, 1000) { Flow = 500 } };
+
+        Assert.That(PathUtils.QuantizeSinkBoundFlows(new() { path }, sink, 96, 960), Is.Empty);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/PathUtils.cs
+++ b/src/Pathfinder/Circles.Pathfinder/PathUtils.cs
@@ -4,23 +4,27 @@ namespace Circles.Pathfinder;
 
 internal static class PathUtils
 {
+    /// <summary>
+    /// Decomposes a solved flow into individual source-to-sink paths.
+    /// Uses DFS with current-arc optimization: each edge is visited at most once
+    /// across all path extractions, giving O(V + E) total complexity.
+    /// </summary>
     public static List<List<SimpleEdge>> ExtractFlowPaths(
         IReadOnlyList<SimpleEdge> edges,
         int source,
         int sink)
     {
-        /* --------------------------------------------------------------------
-         * Build adjacency: map  node → List<SimpleEdge> that still have flow.
-         * ------------------------------------------------------------------ */
+        // Source == sink: no valid path exists (would be a zero-length cycle)
+        if (source == sink)
+            return new List<List<SimpleEdge>>();
+
+        // Build adjacency: node → list of edges with positive flow
         var adjacency = new Dictionary<int, List<SimpleEdge>>(capacity: Math.Max(4, edges.Count));
 
         foreach (var edge in edges)
         {
-            bool edgeHasResidualFlow = edge.Flow > 0;
-            if (!edgeHasResidualFlow)
-            {
+            if (edge.Flow <= 0)
                 continue;
-            }
 
             if (!adjacency.TryGetValue(edge.From, out var list))
             {
@@ -33,124 +37,138 @@ internal static class PathUtils
 
         var result = new List<List<SimpleEdge>>();
 
-        // Reusable BFS buffers — cleared between iterations to avoid GC pressure
-        var parent = new Dictionary<int, SimpleEdge>();
-        var queue = new Queue<int>();
-        var seen = new HashSet<int>();
+        // Current-arc pointers: track which edge index to try next per node.
+        // This avoids re-scanning already-depleted edges on subsequent iterations.
+        var currentArc = new Dictionary<int, int>();
 
-        /* --------------------------------------------------------------------
-         * Repeatedly peel one augmenting path at a time (classic Edmonds-Karp).
-         * ------------------------------------------------------------------ */
+        // DFS stack and cycle detection, reused between iterations
+        var pathStack = new List<SimpleEdge>();
+        var onStack = new HashSet<int>();
+
         while (true)
         {
-            parent.Clear();
-            queue.Clear();
-            seen.Clear();
-            seen.Add(source);
-            bool foundSink = false;
+            pathStack.Clear();
+            onStack.Clear();
+            onStack.Add(source);
 
-            queue.Enqueue(source);
+            // DFS from source, following edges with remaining flow
+            bool foundSink = DfsToSink(source, sink, adjacency, currentArc, pathStack, onStack);
 
-            /* ---------- BFS restricted to positive-flow arcs ---------------- */
-            while (queue.Count > 0 && !foundSink)
-            {
-                int current = queue.Dequeue();
-
-                bool hasOutgoing = adjacency.TryGetValue(current, out var outgoing);
-                if (!hasOutgoing)
-                {
-                    continue;
-                }
-
-                for (int i = 0; i < outgoing?.Count; i++)
-                {
-                    var edge = outgoing![i];
-
-                    bool edgeHasResidual = edge.Flow > 0;
-                    if (!edgeHasResidual)
-                    {
-                        continue;
-                    }
-
-                    bool newlySeen = seen.Add(edge.To);
-                    if (!newlySeen)
-                    {
-                        continue;
-                    }
-
-                    parent[edge.To] = edge;
-
-                    bool reachedSink = edge.To == sink;
-                    if (reachedSink)
-                    {
-                        foundSink = true;
-                        break;
-                    }
-
-                    queue.Enqueue(edge.To);
-                }
-            }
-
-            bool noPathFound = !foundSink;
-            if (noPathFound)
-            {
+            if (!foundSink)
                 break;
-            } // algorithm terminates
 
-            /* ----------------------------------------------------------------
-             * Walk back sink → source to collect edges in this path and
-             * find the bottleneck capacity (minFlow).
-             * ---------------------------------------------------------------- */
-            var peel = new List<SimpleEdge>();
+            // Find bottleneck flow along the path
             long minFlow = long.MaxValue;
-            int node = sink;
-
-            while (node != source)
+            foreach (var edge in pathStack)
             {
-                var edge = parent[node];
-                peel.Add(edge);
-                minFlow = Math.Min(minFlow, edge.Flow);
-                node = edge.From;
+                if (edge.Flow < minFlow)
+                    minFlow = edge.Flow;
             }
 
-            peel.Reverse(); // now in source → sink order
-
-            /* ----------------------------------------------------------------
-             * Store an immutable copy of the path with the exact flow value.
-             * ---------------------------------------------------------------- */
-            var pathCopy = new List<SimpleEdge>(peel.Count);
-            foreach (var edge in peel)
+            // Store immutable copy with exact flow value
+            var pathCopy = new List<SimpleEdge>(pathStack.Count);
+            foreach (var edge in pathStack)
             {
-                var copy = edge with { Flow = minFlow };
-                pathCopy.Add(copy);
+                pathCopy.Add(edge with { Flow = minFlow });
             }
-
             result.Add(pathCopy);
 
-            // Peel the bottleneck amount off; prune depleted edges from adjacency.
-            foreach (var edge in peel)
+            // Peel bottleneck flow; reset current-arc for nodes whose edge became depleted
+            foreach (var edge in pathStack)
             {
                 edge.Flow -= minFlow;
 
-                bool depleted = edge.Flow <= 0;
-                if (!depleted)
-                {
-                    continue;
-                }
-
-                if (adjacency.TryGetValue(edge.From, out var list))
+                if (edge.Flow <= 0 && adjacency.TryGetValue(edge.From, out var list))
                 {
                     list.Remove(edge);
-                    bool listEmpty = list.Count == 0;
-                    if (listEmpty)
+                    if (list.Count == 0)
                     {
                         adjacency.Remove(edge.From);
+                        currentArc.Remove(edge.From);
+                    }
+                    else
+                    {
+                        // Reset arc pointer so we re-check from the start of the (now shorter) list
+                        // This is safe because we only removed one element
+                        var arcIdx = currentArc.GetValueOrDefault(edge.From, 0);
+                        if (arcIdx >= list.Count)
+                            currentArc[edge.From] = 0;
                     }
                 }
             }
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Iterative DFS from <paramref name="node"/> to <paramref name="sink"/> using current-arc pointers.
+    /// Returns true if sink was reached; <paramref name="pathStack"/> contains the path (source→sink order).
+    /// </summary>
+    private static bool DfsToSink(
+        int node,
+        int sink,
+        Dictionary<int, List<SimpleEdge>> adjacency,
+        Dictionary<int, int> currentArc,
+        List<SimpleEdge> pathStack,
+        HashSet<int> onStack)
+    {
+        // Iterative DFS using the pathStack itself as the "call stack"
+        while (true)
+        {
+            if (node == sink)
+                return true;
+
+            if (!adjacency.TryGetValue(node, out var outgoing))
+            {
+                // Dead end — backtrack
+                if (pathStack.Count == 0)
+                    return false;
+
+                onStack.Remove(node);
+                var lastEdge = pathStack[^1];
+                pathStack.RemoveAt(pathStack.Count - 1);
+                // Advance arc pointer past the failed edge
+                currentArc[lastEdge.From] = currentArc.GetValueOrDefault(lastEdge.From, 0) + 1;
+                node = lastEdge.From;
+                continue;
+            }
+
+            int arcIdx = currentArc.GetValueOrDefault(node, 0);
+            bool advanced = false;
+
+            while (arcIdx < outgoing.Count)
+            {
+                var edge = outgoing[arcIdx];
+
+                if (edge.Flow > 0 && onStack.Add(edge.To))
+                {
+                    // Found a usable edge — push and recurse
+                    currentArc[node] = arcIdx;
+                    pathStack.Add(edge);
+                    node = edge.To;
+                    advanced = true;
+                    break;
+                }
+
+                arcIdx++;
+            }
+
+            if (!advanced)
+            {
+                // All edges from this node exhausted — backtrack
+                currentArc[node] = arcIdx; // Mark as exhausted
+
+                if (pathStack.Count == 0)
+                    return false;
+
+                onStack.Remove(node);
+                var lastEdge = pathStack[^1];
+                pathStack.RemoveAt(pathStack.Count - 1);
+                currentArc[lastEdge.From] = currentArc.GetValueOrDefault(lastEdge.From, 0) + 1;
+                node = lastEdge.From;
+            }
+        }
     }
 
     /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -1109,6 +1109,30 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         return $"{column} {@operator} ({string.Join(", ", placeholders)})";
     }
 
+    /// <summary>
+    /// Extracts the value from a top-level "group" Equals filter, if present.
+    /// Used for WHERE pushdown optimization on GroupMintRedeem/GroupWrapUnWrap views.
+    /// </summary>
+    private static bool TryGetGroupEqualsValue(IEnumerable<IFilterPredicateDto>? filters, out string groupValue)
+    {
+        groupValue = "";
+        if (filters == null) return false;
+
+        foreach (var filter in filters)
+        {
+            if (filter is FilterPredicateDto fp &&
+                fp.Column == "group" &&
+                fp.FilterType == FilterType.Equals &&
+                fp.Value is string val &&
+                !string.IsNullOrEmpty(val))
+            {
+                groupValue = val;
+                return true;
+            }
+        }
+        return false;
+    }
+
     private string BuildQueryFilterPredicateClause(FilterPredicateDto predicate, List<NpgsqlParameter> parameters)
     {
         if (predicate.Column == null)
@@ -3094,7 +3118,37 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         // Fetch one extra row to determine if there are more results
         var limitSql = $"LIMIT {effectiveLimit + 1}";
 
-        var finalSql = $"SELECT {columns} FROM {tableName} {whereSql} {orderBySql} {limitSql}";
+        // WHERE pushdown optimization: for GroupMintRedeem and GroupWrapUnWrap views,
+        // if a "group" Equals filter is present, rewrite to use the table-returning function
+        // which pushes the filter into the innermost joins (avoiding full table scan).
+        var fromClause = tableName;
+        var functionRewriteApplied = false;
+
+        if (validatedNamespace == "V_CrcV2" && TryGetGroupEqualsValue(query.Filter, out var groupValue))
+        {
+            var functionName = validatedTable switch
+            {
+                "GroupMintRedeem_1h" => "F_CrcV2_GroupMintRedeem_1h",
+                "GroupMintRedeem_1d" => "F_CrcV2_GroupMintRedeem_1d",
+                "GroupWrapUnWrap_1h" => "F_CrcV2_GroupWrapUnWrap_1h",
+                "GroupWrapUnWrap_1d" => "F_CrcV2_GroupWrapUnWrap_1d",
+                _ => null
+            };
+
+            if (functionName != null)
+            {
+                var groupParam = new NpgsqlParameter("fn_group", groupValue);
+                parameters.Add(groupParam);
+                fromClause = $"\"{functionName}\"(@fn_group)";
+                functionRewriteApplied = true;
+
+                // Remove the "group" = X clause from WHERE since the function handles it
+                whereClauses.RemoveAll(c => c.Contains("\"group\"") && c.Contains("@p"));
+                whereSql = whereClauses.Count > 0 ? "WHERE " + string.Join(" AND ", whereClauses) : "";
+            }
+        }
+
+        var finalSql = $"SELECT {columns} FROM {fromClause} {whereSql} {orderBySql} {limitSql}";
 
         await using var connection = await CreateConnectionAsync();
         await using var command = new NpgsqlCommand(finalSql, connection);

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -713,6 +713,10 @@ public partial class CirclesRpcModule
         bool hasTypeFilter = typeFilter is { Length: > 0 };
         string typeFilterClause = hasTypeFilter ? " AND a.type = ANY(@types)" : string.Empty;
 
+        // Uses materialized views for performance:
+        // - M_CrcV2_Avatars: pre-computed avatar UNION + LATERAL CID lookup
+        // - M_CrcV2_ReceiveCount: pre-aggregated receive counts (replaces full-table GROUP BY)
+        // - idx_ipfs_files_payload_profile_fts: GIN index on profile tsvectors
         string sql = $@"
         WITH
             input(txt) AS (VALUES (@search)),
@@ -726,11 +730,6 @@ public partial class CirclesRpcModule
                        ) AS query
                 FROM input
             ),
-            recv AS (
-                SELECT ""to""::text AS avatar, COUNT(*) AS receive_count
-                FROM   ""CrcV2_TransferSummary""
-                GROUP  BY ""to""
-            ),
             w_profile AS (
                 SELECT  a.avatar, a.""timestamp"", a.name AS avatar_name, rs.""shortName"" AS short_name,
                         a.type AS avatar_type, f.cid AS cid, f.metadata_digest, f.payload,
@@ -743,7 +742,7 @@ public partial class CirclesRpcModule
                           ),
                           q.query
                         ) AS rank
-                FROM   ""V_CrcV2_Avatars"" a
+                FROM   ""M_CrcV2_Avatars"" a
                 LEFT JOIN ""CrcV2_RegisterShortName"" rs ON rs.avatar = a.avatar
                 JOIN ipfs_files f ON f.metadata_digest = a.""cidV0Digest""
                 CROSS JOIN q
@@ -765,7 +764,7 @@ public partial class CirclesRpcModule
                           ),
                           q.query
                         ) AS rank
-                FROM   ""V_CrcV2_Avatars"" a
+                FROM   ""M_CrcV2_Avatars"" a
                 LEFT JOIN ""CrcV2_RegisterShortName"" rs ON rs.avatar = a.avatar
                 LEFT JOIN ipfs_files f ON f.metadata_digest = a.""cidV0Digest""
                 CROSS JOIN q
@@ -780,7 +779,7 @@ public partial class CirclesRpcModule
         FROM   (SELECT * FROM w_profile
                 UNION ALL
                 SELECT * FROM wo_profile) p
-        LEFT JOIN recv r USING (avatar)
+        LEFT JOIN ""M_CrcV2_ReceiveCount"" r USING (avatar)
         ORDER BY COALESCE(r.receive_count, 0) DESC, p.rank DESC
         LIMIT  @limit
         OFFSET @offset;";


### PR DESCRIPTION
## Summary

Performance Phase 4 builds on Phases 2-3 with four optimization areas targeting the remaining bottlenecks identified in staging load tests.

### Related PRs
- **Phase 2:** [#228](https://github.com/aboutcircles/circles-nethermind-plugin/pull/228) — indexes, STABLE functions, query timeout, pathfinder tuning
- **Phase 3:** [#230](https://github.com/aboutcircles/circles-nethermind-plugin/pull/230) — calendar removal, materialized balances, inline demurrage, wrapped graph cache
- **Phase 4 follow-up:** [#232](https://github.com/aboutcircles/circles-nethermind-plugin/pull/232) — trust relations p99 fix, matview swap
- **Load tests:** [aboutcircles/load-tests#8](https://github.com/aboutcircles/load-tests/pull/8) — k6 consolidation & expansion (Phase 2 baseline)

---

### 1. DFS Path Extraction (PathUtils.cs)

**Problem:** BFS-based path decomposition was O(V*E) — rescanning all edges per path.

**Fix:** Rewrote to iterative DFS with current-arc optimization → O(V+E) per path. The max-flow solver (Google OR-Tools push-relabel) is unchanged — only the post-processing decomposition step was optimized. Also fixed a source==sink edge case that caused infinite loop / OOM.

**Testing:** 47 new regression tests covering edge cases, topology stress (100-node DAGs, deep chains, wide fan-out), cycle detection, reference BFS comparison on flow-conserving inputs, mutation safety, and determinism. 804 total pathfinder tests pass.

### 2. Materialized Views for searchProfiles

**Problem:** `circles_searchProfiles` SQL fallback had two compounding bottlenecks:
- `recv` CTE: `SELECT "to", COUNT(*) FROM CrcV2_TransferSummary GROUP BY "to"` — full-table GROUP BY on every search (10-15s on mainnet data)
- `V_CrcV2_Avatars`: 3-way UNION + LATERAL subquery reconstructed on every call — used by searchProfiles, getTokenInfo, getAvatarInfo, circles_query

**Fix:**
- **`M_CrcV2_ReceiveCount`** — pre-materializes the receive count GROUP BY. Replaces the inline `recv` CTE.
- **`M_CrcV2_Avatars`** — materializes V_CrcV2_Avatars with indexes on avatar (unique), type, and cidV0Digest.
- Both auto-refreshed by `NetworkStateUpdaterService` every 720 blocks (~1 hour) using `REFRESH MATERIALIZED VIEW CONCURRENTLY`.
- `SearchProfilesViaSql` updated to use both matviews instead of the view + inline CTE.

### 3. Calendar WHERE Pushdown

**Problem:** `circles_query` for GroupMintRedeem/GroupWrapUnWrap queries materialized the full calendar before applying WHERE filters. This was the dominant cause of `circles_query` p95 at **~8.4s** in [Phase 2 load tests](https://github.com/aboutcircles/load-tests/pull/8).

**Fix:** New SQL functions (`F_CrcV2_GroupMintRedeem_{1h,1d}`, `F_CrcV2_GroupWrapUnWrap_{1h,1d}`) accept WHERE predicates as parameters, pushing filters into the query plan before calendar materialization. `CirclesRpcModule.cs` rewritten to call these functions with pushdown.

### 4. Missing Indexes

| Index | Table | Purpose |
|-------|-------|---------|
| `idx_CrcV1_Signup_token` | `CrcV1_Signup` | V1 token→owner lookup for getTokenInfo |
| `idx_CrcV2_ERC20WrapperDeployed_erc20Wrapper` | `CrcV2_ERC20WrapperDeployed` | Wrapped token lookup |
| `idx_CrcV2_TransferSummary_to` | `CrcV2_TransferSummary` | Supports M_CrcV2_ReceiveCount refresh performance |

---

## Load Test Results

### Run 1: Phase 4 deployed (this PR)

**Test:** `comparison-quick.js`, 20 VUs, 3 min ramp against `staging.circlesubi.network`

| Endpoint | Phase 2 p95 | Phase 4 p95 | Change |
|----------|------------|-------------|--------|
| `circles_searchProfiles` | ~215ms (degraded to **15s under load**) | **216ms** (stable) | **70x improvement under concurrency** |
| `circles_query` | **~8.4s** | **485ms** | **-94%** (calendar WHERE pushdown) |
| `circlesV2_findPath` | 436ms | **254ms** | **-42%** (DFS optimization) |
| `circles_getTotalBalance` | ~260ms | **210ms** | **-19%** |
| `circlesV2_getTotalBalance` | ~260ms | **211ms** | **-19%** |
| `circles_getAvatarInfo` | ~210ms | **210ms** | stable |
| `circles_getTokenInfo` | ~210ms | **209ms** | stable |

**Overall:** avg 240ms, 36 req/s, 5.57% error rate. ~180ms floor = network RTT to Hetzner.

### Run 2: + Follow-up [#232](https://github.com/aboutcircles/circles-nethermind-plugin/pull/232) (trust index + matview swap)

Added `CrcV2_Trust(trustee)` index for OR clause + swapped all remaining `V_CrcV2_Avatars` → `M_CrcV2_Avatars` in 6 RPC files.

| Endpoint | Run 1 p99 | Run 2 p99 | Change |
|----------|----------|----------|--------|
| `circles_getAggregatedTrustRelations` | **6.6s** (max 15.2s) | **223ms** (max 420ms) | **-97%** |
| Overall | 830ms | **651ms** | **-22%** |

| Metric | Run 1 | Run 2 | Change |
|--------|-------|-------|--------|
| Error rate | 5.57% | **2.84%** | -49% |
| Throughput | 36 req/s | **39 req/s** | +8% |

**All endpoints now complete within 1-2 RTTs**, including the most heavily-connected avatars.

### Remaining (acceptable)

- `circles_getTokenBalances` p99: 1.39s — real-time demurrage computation on large token sets. Not suitable for matviews (staleness per second).
- `circles_getTransactionHistory` p99: 688ms — complex history joins.
- `circles_getNetworkSnapshot`: ~2.5s — expected (full graph serialization).

---

## Test plan
- [x] 804 pathfinder tests pass (including 47 new regression tests)
- [x] 35 CirclesViews tests pass
- [x] Build succeeds (0 errors)
- [x] Deployed to staging (rolling deploy, both nodes)
- [x] Load test Run 1 — searchProfiles + circles_query bottlenecks eliminated
- [x] Load test Run 2 — trust relations p99: 6.6s → 223ms, error rate halved