### PR TITLE
perf: optimize trust relations p99 tail and swap to materialized avatars

### DIFF
--- a/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesViews/DatabaseSchema.cs
@@ -181,6 +181,12 @@ public class DatabaseSchema : IDatabaseSchema
                 "idx_CrcV2_CreateVault_group",
                 "CREATE INDEX IF NOT EXISTS \"idx_CrcV2_CreateVault_group\" ON public.\"CrcV2_CreateVault\" (\"group\");"
             },
+            // Trust query optimization: standalone trustee index for OR clause in getAggregatedTrustRelations.
+            // The covering index (truster, trustee, ...) serves truster= lookups but trustee= needs its own index.
+            {
+                "idx_crcv2_trust_trustee",
+                "CREATE INDEX IF NOT EXISTS idx_crcv2_trust_trustee ON public.\"CrcV2_Trust\" (\"trustee\");"
+            },
             // Phase 4: V1 token→owner lookup for getTokenInfo
             {
                 "idx_CrcV1_Signup_token",

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -2885,7 +2885,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                           ),
                           q.query
                         ) AS rank
-                FROM   ""V_CrcV2_Avatars"" a
+                FROM   ""M_CrcV2_Avatars"" a
                 LEFT JOIN ""CrcV2_RegisterShortName"" rs ON rs.avatar = a.avatar
                 JOIN ipfs_files f ON f.metadata_digest = a.""cidV0Digest""
                 CROSS JOIN q
@@ -2907,7 +2907,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                           ),
                           q.query
                         ) AS rank
-                FROM   ""V_CrcV2_Avatars"" a
+                FROM   ""M_CrcV2_Avatars"" a
                 LEFT JOIN ""CrcV2_RegisterShortName"" rs ON rs.avatar = a.avatar
                 LEFT JOIN ipfs_files f ON f.metadata_digest = a.""cidV0Digest""
                 CROSS JOIN q

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
@@ -138,7 +138,7 @@ public partial class CirclesRpcModule
         var v2AvatarMap = new Dictionary<string, AvatarInfo>();
         const string v2Sql = @"
             SELECT a.avatar, a.""timestamp"", a.name, a.type, rn.""metadataDigest"", rsn.""shortName"", a.""cidV0Digest""
-            FROM ""V_CrcV2_Avatars"" a
+            FROM ""M_CrcV2_Avatars"" a
             LEFT JOIN ""CrcV2_UpdateMetadataDigest"" rn ON rn.avatar = a.avatar
             LEFT JOIN ""CrcV2_RegisterShortName"" rsn ON rsn.avatar = a.avatar
             WHERE a.avatar = ANY(@addresses)";

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -324,7 +324,7 @@ public partial class CirclesRpcModule
         }
 
         // Get avatar types from V2
-        const string v2TypeSql = @"SELECT avatar, type FROM ""V_CrcV2_Avatars"" WHERE avatar = ANY(@addresses)";
+        const string v2TypeSql = @"SELECT avatar, type FROM ""M_CrcV2_Avatars"" WHERE avatar = ANY(@addresses)";
         await using (var cmd = new NpgsqlCommand(v2TypeSql, connection))
         {
             cmd.Parameters.AddWithValue("addresses", lowerAddresses);

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -313,7 +313,7 @@ public partial class CirclesRpcModule
         }
 
         // 2. Check for V2 Avatar/Group token
-        const string v2AvatarSql = @"SELECT avatar, type FROM ""V_CrcV2_Avatars"" WHERE avatar = @tokenAddress LIMIT 1";
+        const string v2AvatarSql = @"SELECT avatar, type FROM ""M_CrcV2_Avatars"" WHERE avatar = @tokenAddress LIMIT 1";
         await using (var cmd = new NpgsqlCommand(v2AvatarSql, connection))
         {
             cmd.Parameters.AddWithValue("tokenAddress", lowerTokenAddress);

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -214,7 +214,7 @@ public partial class CirclesRpcModule
                 t.timestamp,
                 a.type as avatar_type
             FROM ""V_CrcV2_TrustRelations"" t
-            LEFT JOIN ""V_CrcV2_Avatars"" a
+            LEFT JOIN ""M_CrcV2_Avatars"" a
                 ON a.avatar = CASE
                     WHEN t.truster = @avatar THEN t.trustee
                     ELSE t.truster


### PR DESCRIPTION
## Summary

Targets the p99 long tail on `circles_getAggregatedTrustRelations` (6.6s p99, 15.2s max) — affects heavily-connected avatars (investors, groups, organizations with many trust relations).

### Changes

1. **Add `CrcV2_Trust(trustee)` index** — the query uses `WHERE truster = @avatar OR trustee = @avatar`. The covering index `(truster, trustee, blockNumber DESC, ...)` serves `truster=` lookups efficiently, but `trustee=` falls back to seq scan on 585K+ rows. The new standalone index enables BitmapOr with two index scans.

2. **Swap all `V_CrcV2_Avatars` → `M_CrcV2_Avatars`** in RPC queries — 6 files had remaining references to the non-materialized view (3-way UNION + LATERAL subquery). Now all RPC endpoints use the pre-materialized version:
   - `CirclesRpcModule.Trust.cs` — getAggregatedTrustRelations JOIN
   - `CirclesRpcModule.Tokens.cs` — getTokenInfo avatar lookup
   - `CirclesRpcModule.Avatars.cs` — FetchV2Avatars batch lookup
   - `CirclesRpcModule.Profiles.cs` — avatar type lookup in enriched profiles
   - `CirclesRpcModule.cs` — searchProfiles with/without profile CTEs

### Expected Impact

| Endpoint | Before p99 | Expected p99 |
|----------|-----------|-------------|
| `circles_getAggregatedTrustRelations` | 6.6s (max 15.2s) | <500ms |
| `circles_getAvatarInfo` | 210ms | <200ms (matview hit) |
| `circles_getTokenInfo` | 209ms | <200ms (matview hit) |

## Test plan
- [x] Build passes (0 errors)
- [ ] Deploy to staging, run k6 load test
- [ ] Verify p99 trust relations improvement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimised database queries and indexing to enhance performance of trust relationship and avatar data retrieval operations across pathfinding, profile lookups, token information and trust queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->