### PR TITLE
Wire up RPC concurrency limit semaphore

### DIFF
--- a/src/Common/Circles.Common/Settings.cs
+++ b/src/Common/Circles.Common/Settings.cs
@@ -108,6 +108,11 @@ public class Settings
             ? maxRequests
             : Environment.ProcessorCount;
 
+    public readonly int RpcMaxConcurrentRequests =
+        int.TryParse(Environment.GetEnvironmentVariable("RPC_MAX_CONCURRENT_REQUESTS"), out var rpcMaxRequests)
+            ? rpcMaxRequests
+            : Math.Max(Environment.ProcessorCount * 4, 32);
+
     #endregion
 
     #region Indexed contract addresses

--- a/src/Rpc/Circles.Rpc.Host/BuilderSetup.cs
+++ b/src/Rpc/Circles.Rpc.Host/BuilderSetup.cs
@@ -33,7 +33,7 @@ public static class BuilderSetup
         var settings = new Settings();
 
         Console.WriteLine("Starting Circles.Rpc service...");
-        Console.WriteLine($"* Max concurrent requests: {settings.MaxConcurrentRequests}");
+        Console.WriteLine($"* RPC max concurrent requests: {settings.RpcMaxConcurrentRequests}");
 
         var csb = new NpgsqlConnectionStringBuilder(settings.IndexReadonlyDbConnectionString);
         Console.WriteLine($"* DB Host: {csb.Host}");
@@ -45,7 +45,7 @@ public static class BuilderSetup
         Console.WriteLine($"* Cache Service URL: {settings.CacheServiceUrl ?? "Not configured"}");
         Console.WriteLine($"* Use Cache Service: {settings.UseCacheService}");
 
-        var semaphore = new SemaphoreSlim(settings.MaxConcurrentRequests, settings.MaxConcurrentRequests);
+        var semaphore = new SemaphoreSlim(settings.RpcMaxConcurrentRequests, settings.RpcMaxConcurrentRequests);
 
         var builder = WebApplication.CreateSlimBuilder(args);
         builder.Services.AddSingleton(settings);

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -246,6 +246,11 @@ async Task HandleSubscriptionWebSocket(HttpContext context, CirclesSubscriptionS
 app.Map("/ws/subscribe", HandleSubscriptionWebSocket).DisableAntiforgery();
 app.Map("/ws", HandleSubscriptionWebSocket).DisableAntiforgery();
 
+// ─── Concurrency guard ───────────────────────────────────────────────────────
+// Limits concurrent RPC requests to prevent DB pool exhaustion under load.
+// Returns 503 immediately when at capacity (same pattern as pathfinder).
+var rpcSemaphore = app.Services.GetRequiredService<SemaphoreSlim>();
+
 // ─── Batch JSON-RPC middleware ────────────────────────────────────────────────
 // JSON-RPC batch requests (body is a JSON array) are forwarded entirely to Nethermind.
 // Nethermind has the Circles module loaded, so it can handle both circles_* and eth_* methods.
@@ -359,6 +364,13 @@ app.MapPost("/", async (
             Id = JsonRpcId.CoerceId(request.Id),
             Error = new JsonRpcError { Code = -32600, Message = "Invalid Request" }
         });
+    }
+
+    // Concurrency guard — reject immediately when at capacity
+    if (!rpcSemaphore.Wait(0))
+    {
+        RpcMetrics.RejectedTotal.Inc();
+        return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
     }
 
     var remoteIp = context.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -573,6 +585,10 @@ app.MapPost("/", async (
             Id = JsonRpcId.CoerceId(request.Id),
             Error = new JsonRpcError { Code = -32603, Message = $"Internal server error: {ex.Message}" }
         });
+    }
+    finally
+    {
+        rpcSemaphore.Release();
     }
 
 }).DisableAntiforgery();

--- a/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
@@ -51,6 +51,13 @@ public static class RpcMetrics
         "Number of active WebSocket subscriptions");
 
     /// <summary>
+    /// Total RPC requests rejected due to concurrency limit.
+    /// </summary>
+    public static readonly Counter RejectedTotal = Metrics.CreateCounter(
+        "circles_rpc_rejected_total",
+        "Total number of RPC requests rejected due to concurrency limit");
+
+    /// <summary>
     /// Total proxied RPC requests forwarded to Nethermind by method.
     /// </summary>
     public static readonly Counter ProxiedTotal = Metrics.CreateCounter(


### PR DESCRIPTION
## Summary
- The `SemaphoreSlim` was registered in DI but never injected into the RPC handler — the only service without concurrency protection
- Adds `RPC_MAX_CONCURRENT_REQUESTS` env var (default: `max(cpus*4, 32)` = 48 on 12-core prod)
- Wires semaphore into `MapPost("/")` with non-blocking `Wait(0)` → immediate 503 when at capacity
- Adds `circles_rpc_rejected_total` Prometheus counter for monitoring
- Follows exact same pattern as pathfinder's `FindPathHandler.ExecuteWithGuard()`

## Context
Backend rate limit audit revealed the RPC endpoint was the only service with zero concurrency protection. The pathfinder has `MaxConcurrentRequests=16` with 503 rejection, but the RPC handler's semaphore was dead code (registered but never consumed).

## Test plan
- [x] Build passes (0 errors)
- [x] Pathfinder tests pass (804/804)
- [x] CirclesViews tests pass (35/35)
- [ ] Deploy to staging, verify 503 under load via stress test
- [ ] Monitor `circles_rpc_rejected_total` in Grafana

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced configurable RPC request concurrency limits, separate from general application limits. RPC requests exceeding capacity now return HTTP 503 status responses.

* **Chores**
  * Added monitoring metrics to track total rejected RPC requests due to concurrency constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->