### PR TITLE
fix: remove WITH NO DATA + matview observability docs

### DIFF
--- a/docs/materialized-views.md
+++ b/docs/materialized-views.md
@@ -109,11 +109,40 @@ SELECT 'M_CrcV2_Avatars', count(*) FROM "M_CrcV2_Avatars";
 
 ### Initial Population
 
-Matviews are created with `WITH NO DATA` (except `V_TrustScores_Current` and `M_CrcV2_BalancesByAccountAndToken`). On first refresh, `REFRESH CONCURRENTLY` will fail with error `55000` — both the Pathfinder and Docker cron automatically fall back to a blocking `REFRESH` for initial population.
+All matviews are populated on creation (no `WITH NO DATA`). This means migrations block briefly while the initial query runs, but eliminates the `55000` error fallback dance on first refresh. The `55000` catch in `NetworkStateUpdaterService` and the Docker cron is retained as a safety net for manual matview recreation.
 
 ### Monitoring
 
-Watch for:
+#### Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `circles_matview_refresh_duration_seconds` | Histogram | `view` | Time taken per matview refresh |
+| `circles_matview_refresh_total` | Counter | `view` | Total successful refreshes |
+| `circles_matview_refresh_errors_total` | Counter | `view` | Total refresh failures |
+| `circles_matview_last_refresh_block` | Gauge | `tier` | Block number of last refresh (fast/slow) |
+
+#### Alertmanager Rules
+
+Defined in `aboutcircles-infrastructure/observability/prometheus/alerts/prometheus-alerts-matview.yml`:
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| `MatviewRefreshFailing` | Error rate > 0 for 15min | warning |
+| `MatviewRefreshStale` | No fast-tier refresh for 30min | critical |
+| `MatviewTrustScoresStale` | No slow-tier refresh for 3h | warning |
+| `MatviewRefreshSlow` | p95 refresh > 120s | warning |
+
+#### Grafana Dashboard
+
+Panel "45 Materialized Views" at `/grafana/d/circles-matviews` in the pathfinder dashboard group. Shows:
+- Refresh duration per view (time series)
+- Refresh errors per view (stat)
+- Last refresh block per tier (stat with thresholds)
+- Refresh success rate (gauge)
+
+#### What to Watch
+
 - `circles_matview_refresh_errors_total` increasing → check Postgres logs
 - `circles_matview_last_refresh_block{tier="fast"}` not advancing → Pathfinder may be stuck
 - `ispopulated = false` in `pg_matviews` → matview never populated, needs manual refresh

--- a/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_Groups.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/M_CrcV2_Groups.sql
@@ -100,8 +100,7 @@ CREATE MATERIALIZED VIEW IF NOT EXISTS "M_CrcV2_Groups" AS
     LEFT JOIN  erc20_demurraged         ed ON ed.avatar  = c."group"
     LEFT JOIN  erc20_static             es ON es.avatar  = c."group"
     LEFT JOIN  "CrcV2_CMGroupCreated"   cm ON cm.proxy   = c."group"
-    LEFT JOIN  "CrcV2_BaseGroupCreated" bg ON bg."group" = c."group"
-WITH NO DATA;
+    LEFT JOIN  "CrcV2_BaseGroupCreated" bg ON bg."group" = c."group";
 
 -- Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_M_CrcV2_Groups_pk"

--- a/src/Index/Circles.Index.CirclesViews/queries/V_TrustScores_Current.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_TrustScores_Current.sql
@@ -116,8 +116,7 @@ SELECT
     out_degree,
     mutual_count,
     age_days
-FROM scores
-WITH NO DATA;
+FROM scores;
 
 -- Create indexes for efficient querying (only if they don't exist)
 CREATE UNIQUE INDEX IF NOT EXISTS idx_trust_current_avatar ON "V_TrustScores_Current"(avatar);


### PR DESCRIPTION
## Summary

- Remove `WITH NO DATA` from `M_CrcV2_Groups.sql` and `V_TrustScores_Current.sql` — matviews populated on creation during migration, eliminating `55000` fallback
- Update `docs/materialized-views.md` with monitoring section (Prometheus metrics, alert rules, Grafana dashboard)

Companion infrastructure PR adds the actual alert rules and Grafana dashboard in aboutcircles-infrastructure.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [ ] Staging: matviews created and populated on deploy (no `55000` errors in pathfinder logs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for materialised view refresh monitoring, including duration, error rates, and staleness indicators
  * Introduced Alertmanager rules for proactive notifications on refresh failures, performance degradation, and data staleness

* **Improvements**
  * Materialised views now populate data immediately on creation, improving initialisation speed

* **Documentation**
  * Updated documentation to reflect revised materialised view population behaviour and new observability configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->