### PR TITLE
fix(tests): resolve 3 pre-existing test failures

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -229,8 +229,9 @@ public class NetworkStateUpdaterService : BackgroundService
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
 
-        // Refresh materialized views periodically
-        RefreshMaterializedViewsIfDue(lastBlock);
+        // Refresh materialized views periodically (non-fatal if DB unavailable)
+        try { RefreshMaterializedViewsIfDue(lastBlock); }
+        catch (Exception ex) { _log.LogWarning(ex, "Materialized view refresh failed"); }
 
         GraphUpdateMetrics.UpdateDuration.WithLabels("trust").Observe(swTrust.Elapsed.TotalSeconds);
         GraphUpdateMetrics.UpdateDuration.WithLabels("balance").Observe(swBalance.Elapsed.TotalSeconds);
@@ -455,8 +456,9 @@ public class NetworkStateUpdaterService : BackgroundService
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(incLoadGraph, lastBlock, groupData);
 
-        // Refresh materialized views periodically
-        RefreshMaterializedViewsIfDue(lastBlock);
+        // Refresh materialized views periodically (non-fatal if DB unavailable)
+        try { RefreshMaterializedViewsIfDue(lastBlock); }
+        catch (Exception ex) { _log.LogWarning(ex, "Materialized view refresh failed"); }
     }
 
     /// <summary>
@@ -680,8 +682,9 @@ public class NetworkStateUpdaterService : BackgroundService
         // Pre-build wrapped snapshot so withWrap=true requests hit the cache
         BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
 
-        // Refresh materialized views periodically
-        RefreshMaterializedViewsIfDue(lastBlock);
+        // Refresh materialized views periodically (non-fatal if DB unavailable)
+        try { RefreshMaterializedViewsIfDue(lastBlock); }
+        catch (Exception ex) { _log.LogWarning(ex, "Materialized view refresh failed"); }
     }
 
     /// <summary>

--- a/src/Rpc/Circles.Rpc.Host.Tests/QueryCommandTimeoutTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/QueryCommandTimeoutTests.cs
@@ -41,8 +41,8 @@ public class QueryCommandTimeoutTests
         var source = File.ReadAllText(sourceFile);
 
         // The Query method creates NpgsqlCommand with finalSql. Verify CommandTimeout is set.
-        // Look for the pattern: new NpgsqlCommand(finalSql, ...) followed by CommandTimeout
-        var queryMethodIndex = source.IndexOf("var finalSql = $\"SELECT {columns} FROM {tableName}",
+        // Look for the pattern: var finalSql = $"SELECT {columns} FROM {fromClause} ..."
+        var queryMethodIndex = source.IndexOf("var finalSql = $\"SELECT {columns} FROM {fromClause}",
             StringComparison.Ordinal);
         Assert.That(queryMethodIndex, Is.GreaterThan(0),
             "Could not find the Query method's finalSql construction");


### PR DESCRIPTION
## Summary
- **NetworkStateUpdaterService**: wrap `RefreshMaterializedViewsIfDue` in try-catch at all 3 call sites — matview refresh is non-fatal and should not crash graph builds when DB is unavailable (unit tests)
- **QueryCommandTimeoutTests**: update search pattern from `{tableName}` to `{fromClause}` to match refactored `circles_query` SQL construction

## Test plan
- [x] All 3 previously-failing tests now pass
- [x] Full suite: **5/5 projects pass, 0 failures**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced system resilience to handle database unavailability without interruption; warnings are logged for visibility.

* **Tests**
  * Updated test verification pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->