### PR TITLE
fix(rpc): use address endpoint for profile proxy address searches

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Circles.Common;
 using Microsoft.Extensions.Caching.Memory;
 using Npgsql;
@@ -628,11 +629,19 @@ public partial class CirclesRpcModule
     private async Task<ProfileSearchResult?> SearchProfilesViaProxy(
         string qText, int limit, int offset, string[]? typeFilter)
     {
-        var url = $"{_settings.ProfilePinningServiceUrl!.TrimEnd('/')}/search/text?q={Uri.EscapeDataString(qText)}&limit={limit}&offset={offset}";
+        var baseUrl = _settings.ProfilePinningServiceUrl!.TrimEnd('/');
+
+        // Use /search?address= for address-like queries (FTS doesn't index addresses)
+        bool isAddressQuery = qText.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+                              && qText.Length >= 10
+                              && Regex.IsMatch(qText, @"^0x[0-9a-fA-F]+$");
+
+        var url = isAddressQuery
+            ? $"{baseUrl}/search?address={Uri.EscapeDataString(qText)}&limit={limit}&offset={offset}"
+            : $"{baseUrl}/search/text?q={Uri.EscapeDataString(qText)}&limit={limit}&offset={offset}";
 
         if (typeFilter is { Length: > 0 })
         {
-            // Profile pinning service currently supports single type filter
             url += $"&type={Uri.EscapeDataString(typeFilter[0])}";
         }
 
@@ -650,7 +659,8 @@ public partial class CirclesRpcModule
 
         if (proxyResults == null || proxyResults.Length == 0)
         {
-            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            // Return null to fall through to SQL fallback
+            return null;
         }
 
         // Safety net: server handles offset, but cap to requested limit


### PR DESCRIPTION
## Summary
- `SearchProfilesViaProxy` always routed through `/search/text` (FTS), but addresses are not in the FTS vector — so searching by `0xef63...` returned empty
- Now detects address-like queries (`0x` + hex, ≥10 chars) and routes to `/search?address=` which does prefix matching (`WHERE address LIKE 'addr%'`)
- Empty proxy results now return `null` to fall through to SQL fallback instead of short-circuiting with empty `ProfileSearchResult`

## Test plan
- [x] Build passes (0 errors)
- [x] RPC host tests pass (35 passed, 0 failed)
- [ ] Deploy to staging and test `circles_searchProfiles` with address prefix `0xef63`
- [ ] Verify text-based searches still work through `/search/text`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile search now intelligently detects and processes address-based queries, routing them through a dedicated service for improved lookup accuracy

* **Bug Fixes**
  * Enhanced fallback behaviour when the proxy search service returns empty results, ensuring seamless redirection to alternative search methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->