### PR TITLE
perf(sql): filter non-group addresses from V_CrcV2_Groups affected CTE

### DIFF
--- a/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_Groups.sql
@@ -27,11 +27,14 @@ WITH watermark AS (
 affected AS (
     SELECT "group" FROM "CrcV2_RegisterGroup" WHERE "blockNumber" > (SELECT wm FROM watermark)
     UNION SELECT truster FROM "CrcV2_Trust" WHERE "blockNumber" > (SELECT wm FROM watermark)
+        AND truster IN (SELECT "group" FROM "CrcV2_RegisterGroup")
     UNION SELECT emitter FROM "CrcV2_BaseGroupOwnerUpdated" WHERE "blockNumber" > (SELECT wm FROM watermark)
     UNION SELECT emitter FROM "CrcV2_BaseGroupServiceUpdated" WHERE "blockNumber" > (SELECT wm FROM watermark)
     UNION SELECT emitter FROM "CrcV2_BaseGroupFeeCollectionUpdated" WHERE "blockNumber" > (SELECT wm FROM watermark)
     UNION SELECT avatar FROM "CrcV2_UpdateMetadataDigest" WHERE "blockNumber" > (SELECT wm FROM watermark)
+        AND avatar IN (SELECT "group" FROM "CrcV2_RegisterGroup")
     UNION SELECT avatar FROM "CrcV2_ERC20WrapperDeployed" WHERE "blockNumber" > (SELECT wm FROM watermark)
+        AND avatar IN (SELECT "group" FROM "CrcV2_RegisterGroup")
 ),
 -- Live re-computation for affected groups only
 live_groups AS (


### PR DESCRIPTION
## Summary
- The `affected` CTE in `V_CrcV2_Groups` included human-to-human trust events and non-group metadata/wrapper updates, inflating the `NOT IN` hash table with irrelevant addresses
- Added `AND truster/avatar IN (SELECT "group" FROM "CrcV2_RegisterGroup")` to 3 UNION branches: `CrcV2_Trust`, `CrcV2_UpdateMetadataDigest`, `CrcV2_ERC20WrapperDeployed`
- No correctness change — these addresses were already filtered out by the `CrcV2_RegisterGroup` join in `live_groups`

## Test plan
- [x] Build passes
- [ ] Deploy and verify V_CrcV2_Groups returns same results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Restricted trust relationship modifications to registered groups only.
  * Restricted avatar metadata updates to registered groups only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->