### PR TITLE
fix(pathfinder): wrapper token filter expansion + 3 additional correctness fixes

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1184,6 +1184,61 @@ public class GraphFactoryTests
             "Wrapped token should also be excluded when excludedFromTokens is expanded");
     }
 
+    /// <summary>
+    /// B7: excludedToTokens must also be applied to the virtual sink in swap mode.
+    /// Without this fix, excludedToTokens had no effect on what the virtual sink accepted.
+    /// </summary>
+    [Test]
+    public void SwapMode_ExcludedToTokens_AppliedToVirtualSink()
+    {
+        var mock = new HelperMock();
+        // Alice holds some other token (not in toTokens) to generate outbound supply
+        // Bob holds TokenA and TokenB so pool nodes get created (Alice's are excluded in swap mode)
+        mock.AddBalance(
+            AddressIdPool.IdOf(Bob.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            500_000_000);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Bob.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenB.ToLowerInvariant()),
+            300_000_000);
+        // Alice trusts both (needed for swap/virtual sink to accept)
+        mock.AddTrust(Alice, TokenA);
+        mock.AddTrust(Alice, TokenB);
+        // Bob trusts Alice's tokens too (needed for pool outbound edges)
+        mock.AddTrust(Bob, TokenA);
+        mock.AddTrust(Bob, TokenB);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Alice,
+            ToTokens = new List<string> { TokenA, TokenB },
+            ExcludedToTokens = new List<string> { TokenB } // exclude TokenB from receiving
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        Assert.That(cg.VirtualSinkAddress, Is.Not.Null, "Virtual sink should be created for swap mode");
+
+        int virtualSinkId = cg.VirtualSinkAddress!.Value;
+        int tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        int tokenBId = AddressIdPool.IdOf(TokenB.ToLowerInvariant());
+        int poolA = AddressIdPool.TokenPoolIdOf(tokenAId);
+        int poolB = AddressIdPool.TokenPoolIdOf(tokenBId);
+
+        // Virtual sink should accept TokenA but NOT TokenB
+        Assert.That(cg.Edges.Any(e => e.From == poolA && e.To == virtualSinkId), Is.True,
+            "TokenA pool→virtualSink edge should exist");
+        Assert.That(cg.Edges.Any(e => e.From == poolB && e.To == virtualSinkId), Is.False,
+            "TokenB pool→virtualSink should be excluded by excludedToTokens");
+    }
+
     #endregion
 
     #region Mock

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -23,6 +23,9 @@ public class GraphFactoryTests
     private static readonly string TokenB = "0xf10b000000000000000000000000000000000006";
     private static readonly string GroupG = "0xf199000000000000000000000000000000000007";
     private static readonly string GroupH = "0xf198000000000000000000000000000000000008";
+    // Wrapper contract addresses for testing wrapper filter expansion
+    private static readonly string WrapperA = "0xf1ea000000000000000000000000000000000011";
+    private static readonly string WrapperB = "0xf1eb000000000000000000000000000000000012";
 
     /// <summary>Creates a factory with a mock ILoadGraph (no groups, no consent by default).</summary>
     private static GraphFactory MakeFactory(MockLoadGraph? mock = null)
@@ -922,6 +925,263 @@ public class GraphFactoryTests
         // No outbound edges from router to token pools
         Assert.That(cg.Edges.Any(e => e.From == routerId), Is.False,
             "Router should have no outbound token pool edges");
+    }
+
+    #endregion
+
+    #region Wrapper Filter Expansion (withWrap + toTokens/fromTokens/excluded)
+
+    /// <summary>
+    /// Main bug: withWrap=true + toTokens=[avatarAddr] should expand toTokensFilter
+    /// to include wrapper IDs, allowing wrapped token flow to reach the sink.
+    /// Without expansion, TokenPool(wrapper)→Sink edge is blocked.
+    /// </summary>
+    [Test]
+    public void WithWrap_ToTokens_ExpandsFilterWithWrapperIds()
+    {
+        var mock = new HelperMock();
+        // WrapperA wraps TokenA's underlying avatar
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        // Alice holds wrapped balance (token = wrapper contract addr)
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            500_000_000, isWrapped: true);
+        // Bob trusts both TokenA (native) and WrapperA (via trust query UNION 2)
+        mock.AddTrust(Bob, TokenA);
+        mock.AddTrust(Bob, WrapperA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = true,
+            ToTokens = new List<string> { TokenA } // avatar address, not wrapper
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int bobId = AddressIdPool.IdOf(Bob.ToLowerInvariant());
+        int wrapperId = AddressIdPool.IdOf(WrapperA.ToLowerInvariant());
+        int wrapperPool = AddressIdPool.TokenPoolIdOf(wrapperId);
+
+        // TokenPool(wrapper)→Bob edge should exist because toTokensFilter was expanded
+        Assert.That(cg.Edges.Any(e => e.From == wrapperPool && e.To == bobId && e.Token == wrapperId), Is.True,
+            "Wrapper token pool→sink edge should exist when toTokensFilter is expanded with wrapper IDs");
+    }
+
+    /// <summary>
+    /// withWrap=false should NOT expand filters — wrapped balances are excluded entirely.
+    /// </summary>
+    [Test]
+    public void WithWrapFalse_ToTokens_NoExpansion()
+    {
+        var mock = new HelperMock();
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            500_000_000, isWrapped: true);
+        mock.AddTrust(Bob, TokenA);
+        mock.AddTrust(Bob, WrapperA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = false,
+            ToTokens = new List<string> { TokenA }
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        int wrapperId = AddressIdPool.IdOf(WrapperA.ToLowerInvariant());
+        int wrapperPool = AddressIdPool.TokenPoolIdOf(wrapperId);
+
+        // No wrapper edges at all — wrapped balances skipped
+        Assert.That(cg.Edges.Any(e => e.From == aliceId && e.To == wrapperPool), Is.False,
+            "Wrapped balance should not produce source edge when withWrap=false");
+    }
+
+    /// <summary>
+    /// Multiple wrappers for different avatars should all be expanded.
+    /// </summary>
+    [Test]
+    public void WithWrap_ToTokens_MultipleWrappers_AllExpanded()
+    {
+        var mock = new HelperMock();
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        mock.AddWrapperMapping(WrapperB, TokenB);
+        // Alice holds both wrapped tokens
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            300_000_000, isWrapped: true);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperB.ToLowerInvariant()),
+            400_000_000, isWrapped: true);
+        // Bob trusts everything
+        mock.AddTrust(Bob, TokenA);
+        mock.AddTrust(Bob, TokenB);
+        mock.AddTrust(Bob, WrapperA);
+        mock.AddTrust(Bob, WrapperB);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = true,
+            ToTokens = new List<string> { TokenA, TokenB }
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int bobId = AddressIdPool.IdOf(Bob.ToLowerInvariant());
+        int wrapperAId = AddressIdPool.IdOf(WrapperA.ToLowerInvariant());
+        int wrapperBId = AddressIdPool.IdOf(WrapperB.ToLowerInvariant());
+        int poolA = AddressIdPool.TokenPoolIdOf(wrapperAId);
+        int poolB = AddressIdPool.TokenPoolIdOf(wrapperBId);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolA && e.To == bobId), Is.True,
+            "WrapperA pool→sink should exist");
+        Assert.That(cg.Edges.Any(e => e.From == poolB && e.To == bobId), Is.True,
+            "WrapperB pool→sink should exist");
+    }
+
+    /// <summary>
+    /// withWrap=true but empty toTokens → no expansion needed, no crash.
+    /// </summary>
+    [Test]
+    public void WithWrap_EmptyToTokens_NoExpansion_NoCrash()
+    {
+        var mock = new HelperMock();
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            500_000_000, isWrapped: true);
+        mock.AddTrust(Bob, WrapperA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = true
+            // No ToTokens — no whitelist active
+        };
+
+        Assert.DoesNotThrow(() => factory.CreateCapacityGraph(bg, trustLookup, request));
+    }
+
+    /// <summary>
+    /// fromTokens=[avatarAddr] with withWrap=true should also allow the wrapper balance.
+    /// Without expansion, the wrapper is blocked at source because fromTokensFilter
+    /// doesn't contain the wrapper ID.
+    /// </summary>
+    [Test]
+    public void WithWrap_FromTokens_ExpandsFilterWithWrapperIds()
+    {
+        var mock = new HelperMock();
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            500_000_000, isWrapped: true);
+        mock.AddTrust(Bob, WrapperA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = true,
+            FromTokens = new List<string> { TokenA } // avatar address
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        int wrapperId = AddressIdPool.IdOf(WrapperA.ToLowerInvariant());
+        int wrapperPool = AddressIdPool.TokenPoolIdOf(wrapperId);
+
+        // Source→TokenPool(wrapper) edge should exist
+        Assert.That(cg.Edges.Any(e => e.From == aliceId && e.To == wrapperPool), Is.True,
+            "Wrapped source balance should be allowed when fromTokensFilter is expanded");
+    }
+
+    /// <summary>
+    /// excludedFromTokens=[avatarAddr] with withWrap=true should also exclude the wrapper.
+    /// Without expansion, the wrapper leaks through as a source edge.
+    /// </summary>
+    [Test]
+    public void WithWrap_ExcludedFromTokens_ExpandsFilterWithWrapperIds()
+    {
+        var mock = new HelperMock();
+        mock.AddWrapperMapping(WrapperA, TokenA);
+        // Alice holds both native AND wrapped token
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            300_000_000, isWrapped: false);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(WrapperA.ToLowerInvariant()),
+            500_000_000, isWrapped: true);
+        mock.AddTrust(Bob, TokenA);
+        mock.AddTrust(Bob, WrapperA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            WithWrap = true,
+            ExcludedFromTokens = new List<string> { TokenA } // exclude avatar → should also exclude wrapper
+        };
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        int tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        int wrapperId = AddressIdPool.IdOf(WrapperA.ToLowerInvariant());
+        int poolNative = AddressIdPool.TokenPoolIdOf(tokenAId);
+        int poolWrapper = AddressIdPool.TokenPoolIdOf(wrapperId);
+
+        // Both native and wrapped should be excluded from source
+        Assert.That(cg.Edges.Any(e => e.From == aliceId && e.To == poolNative), Is.False,
+            "Native token should be excluded by excludedFromTokens");
+        Assert.That(cg.Edges.Any(e => e.From == aliceId && e.To == poolWrapper), Is.False,
+            "Wrapped token should also be excluded when excludedFromTokens is expanded");
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
@@ -538,5 +538,65 @@ public class PipelineMethodTests
         Assert.That(edges[3].Flow, Is.EqualTo(192), "D→Sink unchanged");
     }
 
+    /// <summary>
+    /// Regression: when an intermediary vertex handles two tokens and quantization reduces
+    /// them by different amounts, backward propagation must scale per-token independently.
+    /// The old code summed all tokens and scaled proportionally, which redistributed flow
+    /// between token types — violating Hub.sol's per-token NettedFlowMismatch check.
+    /// </summary>
+    [Test]
+    public void PropagateBackwards_MultiToken_ScalesPerTokenIndependently()
+    {
+        int source = 1, intermediary = 2, sink = 3;
+        int tokenA = 10, tokenB = 20;
+
+        var edges = new List<FlowEdge>
+        {
+            // Source → Intermediary (two tokens)
+            new(source, intermediary, tokenA, 200) { Flow = 200 },
+            new(source, intermediary, tokenB, 50) { Flow = 50 },
+            // Intermediary → Sink (after quantization: TokenA reduced, TokenB zeroed)
+            new(intermediary, sink, tokenA, 192) { Flow = 192 },
+            // TokenB→Sink was 50, quantized to 0 (below 96 CRC quantum) — edge removed
+        };
+
+        V2Pathfinder.PropagateQuantizationBackwards(edges, sink, source);
+
+        // Per-token conservation at intermediary:
+        // TokenA: in should match out (192)
+        Assert.That(edges[0].Flow, Is.EqualTo(192),
+            "TokenA inflow at intermediary should match TokenA outflow (192)");
+        // TokenB: out is 0 (no edge to sink), so in should be scaled to 0
+        Assert.That(edges[1].Flow, Is.EqualTo(0),
+            "TokenB inflow should be 0 because TokenB outflow was zeroed by quantization");
+
+        // Sink-bound edges unchanged
+        Assert.That(edges[2].Flow, Is.EqualTo(192), "TokenA→Sink unchanged");
+    }
+
+    /// <summary>
+    /// When both tokens are reduced proportionally (same percentage), per-token scaling
+    /// should produce the same result as the old total-based scaling.
+    /// </summary>
+    [Test]
+    public void PropagateBackwards_MultiToken_EqualReduction_PreservesRatio()
+    {
+        int source = 1, mid = 2, sink = 3;
+        int tokenA = 10, tokenB = 20;
+
+        var edges = new List<FlowEdge>
+        {
+            new(source, mid, tokenA, 200) { Flow = 200 },
+            new(source, mid, tokenB, 100) { Flow = 100 },
+            new(mid, sink, tokenA, 192) { Flow = 192 },
+            new(mid, sink, tokenB, 96) { Flow = 96 },
+        };
+
+        V2Pathfinder.PropagateQuantizationBackwards(edges, sink, source);
+
+        Assert.That(edges[0].Flow, Is.EqualTo(192), "TokenA: 200 → 192");
+        Assert.That(edges[1].Flow, Is.EqualTo(96), "TokenB: 100 → 96");
+    }
+
     #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -271,6 +271,23 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                                          .ToHashSet()
                                      ?? new HashSet<int>();
 
+        // STEP 1h: Expand filters with wrapper IDs when withWrap is enabled.
+        // User-provided filters contain avatar addresses, but wrapped balances use wrapper
+        // contract addresses as token IDs. Without expansion, inclusion filters (toTokens,
+        // fromTokens) block wrapped tokens, and exclusion filters (excludedFromTokens,
+        // excludedToTokens) fail to exclude them.
+        if (request?.WithWrap ?? false)
+        {
+            var wrapperMap = capacityGraph.WrapperToAvatar;
+            if (wrapperMap.Count > 0)
+            {
+                ExpandFilterWithWrapperIds(toTokensFilter, wrapperMap, "toTokensFilter");
+                ExpandFilterWithWrapperIds(fromTokensFilter, wrapperMap, "fromTokensFilter");
+                ExpandFilterWithWrapperIds(excludedFromTokensFilter, wrapperMap, "excludedFromTokensFilter");
+                ExpandFilterWithWrapperIds(excludedToTokensFilter, wrapperMap, "excludedToTokensFilter");
+            }
+        }
+
         // STEP 2: Validate source and sink are not groups or router
         int? sourceId = !string.IsNullOrWhiteSpace(request?.Source) ? AddressIdPool.IdOf(request.Source) : null;
         int? sinkId = !string.IsNullOrWhiteSpace(request?.Sink) ? AddressIdPool.IdOf(request.Sink) : null;
@@ -337,6 +354,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             {
                 // Only consider source's balances
                 if (balanceNode.Holder != sourceId.Value)
+                    continue;
+
+                // Skip wrapped balances unless WithWrap is enabled — their supply edges
+                // won't be created (line 708), so adding them to toTokensFilter would
+                // produce silent zero-flow
+                if (balanceNode.IsWrapped && !(request?.WithWrap ?? false))
                     continue;
 
                 // Check if sink trusts this token AND balance is sufficient
@@ -989,6 +1012,32 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
 
         return (virtualSinkAddressId, virtualSinkTrustedTokens);
+    }
+
+    /// <summary>
+    /// Expands a token filter to include wrapper IDs for any avatar IDs already in the filter.
+    /// This bridges the avatar-address / wrapper-contract-address namespace gap so that
+    /// user-provided filters (which use avatar addresses) also match wrapped token flows
+    /// (which use wrapper contract addresses as token IDs in the graph).
+    /// </summary>
+    private void ExpandFilterWithWrapperIds(
+        HashSet<int> filter,
+        Dictionary<int, int> wrapperToAvatar,
+        string filterName)
+    {
+        if (filter.Count == 0)
+            return;
+
+        int added = 0;
+        foreach (var (wrapperId, avatarId) in wrapperToAvatar)
+        {
+            if (filter.Contains(avatarId) && filter.Add(wrapperId))
+                added++;
+        }
+
+        if (added > 0)
+            _logger.LogDebug("Expanded {FilterName} with {Count} wrapper ID(s) for withWrap=true",
+                filterName, added);
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -414,6 +414,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 capacityGraph,
                 sourceId!.Value,
                 effectiveToTokensFilter,
+                excludedToTokensFilter,
                 balanceGraph,
                 wrappedTokensInSim,
                 mergedTrust,
@@ -959,6 +960,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         CapacityGraph capacityGraph,
         int sourceAddress,
         HashSet<int> toTokensFilter,
+        HashSet<int> excludedToTokensFilter,
         BalanceGraph balanceGraph,
         HashSet<int> wrappedTokensInSim,
         IReadOnlyDictionary<int, HashSet<int>> mergedTrust,
@@ -991,6 +993,10 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         var virtualSinkTrustedTokens = new HashSet<int>();
         foreach (var token in toTokensFilter)
         {
+            // Apply excludedToTokensFilter — previously only applied at real sink (AddTokenPoolOutEdges)
+            if (excludedToTokensFilter.Count > 0 && excludedToTokensFilter.Contains(token))
+                continue;
+
             // In quantizedMode: accept all specified tokens (trust validation happens post-path)
             // In regular mode: require source trust
             if (!quantizedMode && !sourceTrustedTokens.Contains(token))

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -380,10 +380,25 @@ public class V2Pathfinder
             int resolvedToken = ctx.Graph.WrapperToAvatar.TryGetValue(e.Token, out int avatarId)
                 ? avatarId : e.Token;
 
+            // Also resolve From/To — wrapper addresses can leak into the graph as avatar
+            // nodes via trust query UNION 2 and appear as flow intermediaries
+            int resolvedFrom = ctx.Graph.WrapperToAvatar.TryGetValue(e.From, out int fromAvatarId)
+                ? fromAvatarId : e.From;
+            int resolvedTo = ctx.Graph.WrapperToAvatar.TryGetValue(e.To, out int toAvatarId)
+                ? toAvatarId : e.To;
+
+            if (resolvedFrom != e.From || resolvedTo != e.To)
+            {
+                _logger?.LogWarning(
+                    "Resolved wrapper address in flow vertex: From={OrigFrom}→{ResFrom}, To={OrigTo}→{ResTo}",
+                    AddressIdPool.StringOf(e.From), AddressIdPool.StringOf(resolvedFrom),
+                    AddressIdPool.StringOf(e.To), AddressIdPool.StringOf(resolvedTo));
+            }
+
             ctx.Transfers.Add(new TransferPathStep
             {
-                From = AddressIdPool.StringOf(e.From),
-                To = AddressIdPool.StringOf(e.To),
+                From = AddressIdPool.StringOf(resolvedFrom),
+                To = AddressIdPool.StringOf(resolvedTo),
                 TokenOwner = AddressIdPool.StringOf(resolvedToken),
                 Value = CirclesConverter
                     .BlowUpToUInt256(e.Flow)
@@ -1401,49 +1416,118 @@ public class V2Pathfinder
             if (!visited.Add(vertex)) continue;
             if (vertex == sourceId) continue; // Source net flow is allowed to change
 
-            // Compute current total outflow
+            if (!incomingEdges.TryGetValue(vertex, out var inIndices) || inIndices.Count == 0)
+                continue; // No incoming edges — this is a source vertex
+
+            // Determine if this is a token-converting vertex (e.g., group minting).
+            // At groups: collateral tokens come in, group tokens go out — different types.
+            // At normal intermediaries: same token types flow through.
+            var inTokenTypes = new HashSet<int>();
+            foreach (int idx in inIndices)
+                inTokenTypes.Add(edges[idx].Token);
+
+            var outTokenTypes = new HashSet<int>();
             long totalOut = 0;
             if (outgoingEdges.TryGetValue(vertex, out var outIndices))
             {
                 foreach (int idx in outIndices)
+                {
+                    outTokenTypes.Add(edges[idx].Token);
                     totalOut += edges[idx].Flow;
+                }
             }
 
-            // Compute current total inflow
             long totalIn = 0;
-            if (!incomingEdges.TryGetValue(vertex, out var inIndices) || inIndices.Count == 0)
-                continue; // No incoming edges — this is a source vertex
-
             foreach (int idx in inIndices)
                 totalIn += edges[idx].Flow;
 
-            if (totalIn <= totalOut) continue; // Already balanced or underflow (shouldn't happen)
+            if (totalIn <= totalOut) continue; // Already balanced
 
-            // Scale incoming edges to match outflow
-            long allocated = 0;
-            for (int j = 0; j < inIndices.Count; j++)
+            // Token conversion: outflow contains token types not present in inflow.
+            // This happens at group minting vertices (collateral in → group token out).
+            // When quantization zeroes a token, in={A,B} out={A} — out IS a subset of in,
+            // so per-token scaling correctly handles it (token B gets scaled to 0).
+            bool isTokenConverting = !outTokenTypes.IsSubsetOf(inTokenTypes);
+
+            if (isTokenConverting)
             {
-                int idx = inIndices[j];
-                var e = edges[idx];
-                long newFlow;
-
-                if (j == inIndices.Count - 1)
+                // Token-converting vertex (group minting): use total-based scaling.
+                // Per-token conservation doesn't apply here — token types change.
+                long allocated = 0;
+                for (int j = 0; j < inIndices.Count; j++)
                 {
-                    // Last edge gets remainder for exact conservation
-                    newFlow = totalOut - allocated;
+                    int idx = inIndices[j];
+                    var e = edges[idx];
+                    long newFlow;
+
+                    if (j == inIndices.Count - 1)
+                        newFlow = totalOut - allocated;
+                    else
+                        newFlow = totalIn > 0 ? (e.Flow * totalOut) / totalIn : 0;
+
+                    if (newFlow < 0) newFlow = 0;
+                    e.Flow = newFlow;
+                    allocated += newFlow;
+                    queue.Enqueue(e.From);
                 }
-                else
+            }
+            else
+            {
+                // Same token types in/out: scale per-token independently.
+                // This preserves per-token flow conservation — total-based scaling
+                // would redistribute flow between token types, violating Hub.sol's
+                // per-token NettedFlowMismatch check.
+                var outflowByToken = new Dictionary<int, long>();
+                if (outIndices != null)
                 {
-                    // Proportional scaling
-                    newFlow = (e.Flow * totalOut) / totalIn;
+                    foreach (int idx in outIndices)
+                    {
+                        var e = edges[idx];
+                        outflowByToken.TryGetValue(e.Token, out long current);
+                        outflowByToken[e.Token] = current + e.Flow;
+                    }
                 }
 
-                if (newFlow < 0) newFlow = 0;
-                e.Flow = newFlow;
-                allocated += newFlow;
+                var inByToken = new Dictionary<int, List<int>>();
+                foreach (int idx in inIndices)
+                {
+                    int token = edges[idx].Token;
+                    if (!inByToken.TryGetValue(token, out var list))
+                    {
+                        list = new List<int>();
+                        inByToken[token] = list;
+                    }
+                    list.Add(idx);
+                }
 
-                // Enqueue the predecessor vertex
-                queue.Enqueue(e.From);
+                foreach (var (token, tokenInIndices) in inByToken)
+                {
+                    outflowByToken.TryGetValue(token, out long tokenOut);
+
+                    long tokenIn = 0;
+                    foreach (int idx in tokenInIndices)
+                        tokenIn += edges[idx].Flow;
+
+                    if (tokenIn <= tokenOut) continue;
+
+                    long allocated = 0;
+                    for (int j = 0; j < tokenInIndices.Count; j++)
+                    {
+                        int idx = tokenInIndices[j];
+                        var e = edges[idx];
+                        long newFlow;
+
+                        if (j == tokenInIndices.Count - 1)
+                            newFlow = tokenOut - allocated;
+                        else
+                            newFlow = tokenIn > 0 ? (e.Flow * tokenOut) / tokenIn : 0;
+
+                        if (newFlow < 0) newFlow = 0;
+                        e.Flow = newFlow;
+                        allocated += newFlow;
+                        queue.Enqueue(e.From);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes wrapper/avatar ID namespace mismatch in all 4 token filters, plus 3 additional correctness issues found during comprehensive audit (5 independent research agents).

### Bugs Fixed

- **B1-B4**: All 4 token filters (`toTokens`, `fromTokens`, `excludedFromTokens`, `excludedToTokens`) now expand with wrapper IDs when `withWrap=true`. Previously, user-provided avatar addresses didn't match wrapper contract addresses used internally, causing wrapped tokens to be blocked (inclusion filters) or leak through (exclusion filters).
- **B5**: Quantized mode auto-discovery (STEP 2a2) now skips wrapped balances when `WithWrap=false`, preventing silent zero-flow when a wrapper token enters `toTokensFilter` but its supply edge is blocked.
- **B7**: `excludedToTokensFilter` now applied to virtual sink in swap mode (was previously ignored).
- **Wrapper flow vertices**: `From`/`To` in transfer DTOs now resolved through `WrapperToAvatar` mapping, preventing `CirclesAvatarMustBeRegistered` reverts from Hub.sol.
- **PropagateQuantizationBackwards**: Now uses per-token scaling for normal intermediaries (preserves per-token flow conservation) and total-based scaling for token-converting vertices (groups). Previously used total-based scaling everywhere, which redistributed flow between token types when quantization reduced them by different amounts.

### Files Changed

- `GraphFactory.cs` — STEP 1h filter expansion, STEP 2a2 IsWrapped guard, CreateVirtualSink excludedToTokens
- `V2Pathfinder.cs` — From/To wrapper resolution, per-token backward propagation
- `GraphFactoryTests.cs` — 8 new tests (wrapper filter expansion + swap mode exclusion)
- `PipelineMethodTests.cs` — 2 new tests (per-token backward propagation)

## Test plan

- [x] All 946 unit tests pass (5 projects, 0 failures)
- [x] Pre-push hooks pass (format + build)
- [ ] Deploy to staging, verify user's original curl command returns direct unwrap+transfer path
- [ ] Run `make test-rpc-regression` against staging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced wrapper token filtering and validation across graph construction
  * Added address resolution for wrapper addresses with informational logging during transfer building
  * Improved backward quantization propagation to handle token-specific flows independently

* **Tests**
  * Extended test coverage for wrapper token expansion and filtering scenarios
  * Added regression tests for multi-token quantization in backward propagation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->