### PR TITLE
fix(pathfinder): disable broken wrapped snapshot + 56 test matrix tests

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -226,8 +226,9 @@ public class NetworkStateUpdaterService : BackgroundService
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
-        // Pre-build wrapped snapshot so withWrap=true requests hit the cache
-        BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
+        // NOTE: Pre-built wrapped snapshot disabled — IsWrapOnly() always returns false.
+        // The snapshot lacks source-specific wrapped supply edges, causing maxFlow=0.
+        // All withWrap=true requests now build ad-hoc graphs with proper source context.
 
         // Refresh materialized views periodically (non-fatal if DB unavailable)
         try { RefreshMaterializedViewsIfDue(lastBlock); }
@@ -453,8 +454,8 @@ public class NetworkStateUpdaterService : BackgroundService
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
-        // Pre-build wrapped snapshot so withWrap=true requests hit the cache
-        BuildAndPublishWrappedSnapshot(incLoadGraph, lastBlock, groupData);
+        // NOTE: Pre-built wrapped snapshot disabled — IsWrapOnly() always returns false.
+        // See CapacityGraphPool.IsWrapOnly() for details.
 
         // Refresh materialized views periodically (non-fatal if DB unavailable)
         try { RefreshMaterializedViewsIfDue(lastBlock); }
@@ -679,8 +680,9 @@ public class NetworkStateUpdaterService : BackgroundService
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
-        // Pre-build wrapped snapshot so withWrap=true requests hit the cache
-        BuildAndPublishWrappedSnapshot(loadGraph, lastBlock, groupData);
+        // NOTE: Pre-built wrapped snapshot disabled — IsWrapOnly() always returns false.
+        // The snapshot lacks source-specific wrapped supply edges, causing maxFlow=0.
+        // All withWrap=true requests now build ad-hoc graphs with proper source context.
 
         // Refresh materialized views periodically (non-fatal if DB unavailable)
         try { RefreshMaterializedViewsIfDue(lastBlock); }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
@@ -1,0 +1,655 @@
+using Circles.Common;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests crossing entity topologies (human, group, multi-hop) with filter combinations.
+/// Covers gap G1: entity-type × filter matrix.
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class EntityTypeFilterTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    private static void AssertMaxFlowPositive(string? maxFlowStr, string message = "MaxFlow should be positive")
+    {
+        Assert.That(maxFlowStr, Is.Not.Null.And.Not.Empty, "MaxFlow should not be null or empty");
+        var maxFlow = UInt256.Parse(maxFlowStr!);
+        Assert.That(maxFlow > UInt256.Zero, Is.True, message);
+    }
+
+    private static void AssertMaxFlowZero(string? maxFlowStr, string message = "MaxFlow should be zero")
+    {
+        if (string.IsNullOrEmpty(maxFlowStr)) return;
+        var maxFlow = UInt256.Parse(maxFlowStr);
+        Assert.That(maxFlow == UInt256.Zero, Is.True, message);
+    }
+
+    // ─────────────── GROUP-AS-SINK WITH FILTERS ───────────────
+
+    [Test]
+    public void ET01_GroupSink_ToTokens_GroupToken_FindsPath()
+    {
+        // Human→Group with toTokens=[groupToken]
+        // Source holds collateral token, group trusts it, sink (group) mints groupToken
+        var source = Node(1);
+        var group = Node(100);
+        var collateral = Node(10); // source's personal token used as collateral
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        // Sink (another human) trusts the group token
+        var sink = Node(2);
+        mock.AddTrust(sink, group); // sink trusts group token (groupId == groupToken)
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) } // Only group token accepted
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Group minting path should work with toTokens=[groupToken]");
+    }
+
+    [Test]
+    public void ET02_GroupSink_ExcludedToTokens_CollateralExcluded_NoDirectPath()
+    {
+        // Human→Human via group, excludedToTokens excludes the group token at sink
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group); // sink trusts group token
+        mock.AddTrust(sink, collateral); // sink also trusts collateral
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(group) } // Exclude group token at sink
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Should still find path via collateral (direct trust), but NOT via group token
+        AssertMaxFlowPositive(result.MaxFlow, "Should find direct path via collateral trust");
+    }
+
+    [Test]
+    public void ET03_GroupSink_FromTokens_SpecificCollateral_FindsPath()
+    {
+        // Human→Group, fromTokens restricts which collateral source can use
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateralA = Node(10);
+        var collateralB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateralA, 100_000_000);
+        mock.AddBalance(source, collateralB, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateralA);
+        mock.AddGroupTrust(group, collateralB);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            FromTokens = new List<string> { AddressIdPool.StringOf(collateralA) } // Only collateralA
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        // Max flow should be limited to collateralA's 100 CRC, not 300 CRC total
+        var maxFlowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(maxFlowWei <= UInt256.Parse("100000000000000000000"),
+            "FromTokens should restrict to collateralA only (100 CRC max)");
+    }
+
+    [Test]
+    public void ET04_GroupSink_FromTokens_WrongToken_NoPath()
+    {
+        // Human→Group, fromTokens=[token not trusted by group] → no path
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+        var wrongToken = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddBalance(source, wrongToken, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral); // Group trusts collateral, NOT wrongToken
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            FromTokens = new List<string> { AddressIdPool.StringOf(wrongToken) } // Group doesn't trust this
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowZero(result.MaxFlow, "Wrong fromToken should yield no path through group");
+    }
+
+    [Test]
+    public void ET05_GroupIntermediary_ToTokens_GroupTokenReachesSink()
+    {
+        // Human→Group→Human, toTokens=[groupToken] at final sink
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group); // Sink trusts group token
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) } // Only group token
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void ET06_GroupIntermediary_MaxTransfers_TruncatesAtGroupBoundary()
+    {
+        // Human→Group→Human with maxTransfers=2 (group minting needs collateral+mint = 2 steps)
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            MaxTransfers = 2 // Tight limit: collateral transfer + group mint
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // With maxTransfers=2, group minting should still work (it's 2 steps: collateral→router→group)
+        // But may be truncated if path is longer
+        Assert.That(result.Transfers == null || result.Transfers.Count <= 3,
+            "Transfer count should be within maxTransfers budget");
+    }
+
+    [Test]
+    public void ET07_GroupPlusHuman_ToTokens_And_MaxTransfers()
+    {
+        // Human→Group+Human chain with both toTokens and maxTransfers
+        var source = Node(1);
+        var intermediary = Node(2);
+        var sink = Node(3);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(intermediary, group); // intermediary trusts group token
+        mock.AddTrust(sink, intermediary); // sink trusts intermediary
+        mock.AddTrust(sink, group); // sink also trusts group token
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) },
+            MaxTransfers = 5
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        Assert.That(result.Transfers!.Count, Is.LessThanOrEqualTo(6));
+    }
+
+    [Test]
+    public void ET08_GroupSink_Quantized_With_ToTokens()
+    {
+        // Quantized mode with group minting and toTokens filter
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            QuantizedMode = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        // Quantized group minting with toTokens filter should produce valid quantized output
+        AssertMaxFlowPositive(result.MaxFlow);
+        // Flow should be a multiple of 96 CRC (quantization unit)
+        var truncated = CirclesConverter.TruncateToInt64(UInt256.Parse(result.MaxFlow!));
+        Assert.That(truncated % 96_000_000L, Is.EqualTo(0L),
+            "Quantized flow should be a multiple of 96 CRC");
+    }
+
+    [Test]
+    public void ET09_GroupSink_Quantized_ExcludedFromTokens()
+    {
+        // Quantized + excludedFromTokens: one collateral excluded, other available
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateralA = Node(10);
+        var collateralB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateralA, 200_000_000);
+        mock.AddBalance(source, collateralB, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateralA);
+        mock.AddGroupTrust(group, collateralB);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            QuantizedMode = true,
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(collateralA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        // Should use collateralB only (100 CRC → 96 quantized)
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("96000000000000000000"),
+            "Should only use collateralB (100 CRC → 96 CRC quantized)");
+    }
+
+    [Test]
+    public void ET10_GroupSink_Consent_GroupMinting()
+    {
+        // Consent at group boundary — source has consented flow
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Group minting with consented flow should work when both parties consent
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void ET11_GroupAsBalanceHolder_BasicTransfer()
+    {
+        // Group holds a token and transfers it (unusual but valid)
+        // Actually groups can't hold personal tokens in the normal flow model —
+        // they mint their OWN group token. Test that group-as-source is properly handled.
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, token, 100_000_000);
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink)
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void ET12_ThreeHopChain_ToTokens_FilterPropagates()
+    {
+        // 3-hop: Source→A→B→Sink, toTokens=[tokenX] — token filter at sink
+        var source = Node(1);
+        var nodeA = Node(2);
+        var nodeB = Node(3);
+        var sink = Node(4);
+        var tokenX = Node(10);
+        var tokenY = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenX, 100_000_000);
+        mock.AddBalance(source, tokenY, 100_000_000);
+        mock.AddTrust(nodeA, source);
+        mock.AddTrust(nodeA, tokenX);
+        mock.AddTrust(nodeA, tokenY);
+        mock.AddTrust(nodeB, nodeA);
+        mock.AddTrust(nodeB, tokenX);
+        mock.AddTrust(nodeB, tokenY);
+        mock.AddTrust(sink, nodeB);
+        mock.AddTrust(sink, tokenX);
+        mock.AddTrust(sink, tokenY);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenX) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "3-hop chain should work with toTokens filter");
+    }
+
+    [Test]
+    public void ET13_ThreeHopChain_ExcludedFromTokens()
+    {
+        // 3-hop chain with excludedFromTokens at source
+        var source = Node(1);
+        var nodeA = Node(2);
+        var sink = Node(3);
+        var tokenGood = Node(10);
+        var tokenBad = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenGood, 100_000_000);
+        mock.AddBalance(source, tokenBad, 200_000_000);
+        mock.AddTrust(nodeA, source);
+        mock.AddTrust(nodeA, tokenGood);
+        mock.AddTrust(nodeA, tokenBad);
+        mock.AddTrust(sink, nodeA);
+        mock.AddTrust(sink, tokenGood);
+        mock.AddTrust(sink, tokenBad);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(tokenBad) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("100000000000000000000"),
+            "Should use only tokenGood (100 CRC), not tokenBad (excluded)");
+    }
+
+    [Test]
+    public void ET14_GroupSink_TwoCollaterals_FromTokens_RestrictsToOne()
+    {
+        // Group trusts 2 collaterals, fromTokens restricts to one
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateralA = Node(10); // 100 CRC
+        var collateralB = Node(11); // 200 CRC
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateralA, 100_000_000);
+        mock.AddBalance(source, collateralB, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateralA);
+        mock.AddGroupTrust(group, collateralB);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            FromTokens = new List<string> { AddressIdPool.StringOf(collateralA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("100000000000000000000"),
+            "Only collateralA (100 CRC) should be used, not collateralB");
+    }
+
+    [Test]
+    public void ET15_GroupIntermediary_ExcludedToTokens_GroupTokenExcludedAtSink()
+    {
+        // Human→Group→Human, excludedToTokens=[groupToken] at final sink
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+        mock.AddTrust(sink, collateral); // Sink also trusts collateral directly
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(group) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Should find direct path via collateral trust, group token path blocked
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void ET16_GroupSink_Quantized_Consent_ToTokens_TripleCombo()
+    {
+        // Triple: quantized + consent + toTokens at group boundary
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            QuantizedMode = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) },
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
@@ -1,0 +1,423 @@
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// High-order flag combination tests (3-5 flags simultaneously).
+/// Covers gap G3: triple/quadruple flag combos.
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class KitchenSinkTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    private static void AssertMaxFlowPositive(string? maxFlowStr, string message = "MaxFlow should be positive")
+    {
+        Assert.That(maxFlowStr, Is.Not.Null.And.Not.Empty, "MaxFlow should not be null or empty");
+        var maxFlow = UInt256.Parse(maxFlowStr!);
+        Assert.That(maxFlow > UInt256.Zero, Is.True, message);
+    }
+
+    [Test]
+    public void KS01_Quantized_Wrapped_Consent_TripleCombo()
+    {
+        // Triple: quantized + wrapped + consent
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, avatar);
+        mock.AddTrust(sink, wrapper);
+        mock.AddTrust(source, sink); // Bidirectional: consent requires sender trusts receiver
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Quantized + wrapped + consent triple should work");
+    }
+
+    [Test]
+    public void KS02_Quantized_Wrapped_Consent_Groups_QuadCombo()
+    {
+        // Quad: quantized + wrapped + consent + group minting
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+        var group = Node(100);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, wrapper); // Group trusts wrapper as collateral
+        mock.AddTrust(sink, group); // Sink trusts group token
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        // Group minting with wrapped collateral, quantized, consented
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void KS03_Quantized_Wrapped_ToTokens_MaxTransfers_QuadCombo()
+    {
+        // Quad: quantized + wrapped + toTokens + maxTransfers
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, avatar);
+        mock.AddTrust(sink, wrapper);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(avatar) },
+            MaxTransfers = 2
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        Assert.That(result.Transfers == null || result.Transfers.Count <= 3);
+    }
+
+    [Test]
+    public void KS04_Consent_Groups_ExcludedFromTokens_TripleCombo()
+    {
+        // Triple: consent + groups + excludedFromTokens
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateralA = Node(10); // excluded
+        var collateralB = Node(11); // available
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateralA, 200_000_000);
+        mock.AddBalance(source, collateralB, 100_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateralA);
+        mock.AddGroupTrust(group, collateralB);
+        mock.AddTrust(sink, group);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(collateralA) },
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Should use only collateralB (100 CRC) via group minting with consent
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void KS05_Quantized_Groups_ToTokens_Consent_QuadCombo()
+    {
+        // Quad: quantized + groups + toTokens + consent
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+        var collateral = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, collateral, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, collateral);
+        mock.AddTrust(sink, group);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            QuantizedMode = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) },
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void KS06_AllParameters_NonConflicting_FullKitchenSink()
+    {
+        // All 14 parameters set (non-conflicting configuration)
+        var source = Node(1);
+        var sink = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+        var tokenC = Node(12);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenA, 200_000_000);
+        mock.AddBalance(source, wrapper, 100_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(tokenA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, tokenA);
+        mock.AddTrust(sink, wrapper);
+        mock.AddTrust(source, sink); // Bidirectional for consent
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            TargetFlow = "96000000000000000000",
+            WithWrap = true,
+            QuantizedMode = true,
+            MaxTransfers = 5,
+            FromTokens = new List<string> { AddressIdPool.StringOf(tokenA) },
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenA) },
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(tokenC) }, // Not held anyway
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(tokenB) }, // Not trusted anyway
+            DebugShowIntermediateSteps = true,
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            },
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(tokenA),
+                    Amount = "300000000000000000000",
+                    IsStatic = true
+                }
+            },
+            SimulatedTrusts = new List<SimulatedTrust>
+            {
+                new()
+                {
+                    Truster = AddressIdPool.StringOf(sink),
+                    Trustee = AddressIdPool.StringOf(tokenA)
+                }
+            }
+        };
+
+        // Should NOT crash with all parameters set
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        Assert.That(result.Debug, Is.Not.Null, "Debug output should be present");
+    }
+
+    [Test]
+    public void KS07_Debug_Quantized_Wrapped_Groups_DebugOutputComplete()
+    {
+        // Debug output for complex path: quantized + wrapped + groups
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+        var group = Node(100);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, wrapper);
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            DebugShowIntermediateSteps = true
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        Assert.That(result.Debug, Is.Not.Null, "Debug should be present for complex path");
+    }
+
+    [Test]
+    public void KS08_Simulated_Wrapped_Quantized_Consent_QuadSimulation()
+    {
+        // Quad: simulated + wrapped + quantized + consent
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        // No real balances — everything simulated
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(wrapper),
+                    Amount = "200000000000000000000",
+                    IsWrapped = true,
+                    IsStatic = true
+                }
+            },
+            SimulatedTrusts = new List<SimulatedTrust>
+            {
+                new()
+                {
+                    Truster = AddressIdPool.StringOf(sink),
+                    Trustee = AddressIdPool.StringOf(avatar)
+                },
+                new()
+                {
+                    Truster = AddressIdPool.StringOf(sink),
+                    Trustee = AddressIdPool.StringOf(wrapper)
+                },
+                new()
+                {
+                    Truster = AddressIdPool.StringOf(source),
+                    Trustee = AddressIdPool.StringOf(sink) // Bidirectional for consent
+                }
+            },
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Fully simulated + wrapped + quantized + consent should work");
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulatedBalanceTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulatedBalanceTests.cs
@@ -1,0 +1,382 @@
+using Circles.Common;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests for SimulatedBalance edge cases, especially IsStatic flag.
+/// Covers gap G4: zero existing IsStatic test coverage.
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class SimulatedBalanceTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    private static void AssertMaxFlowPositive(string? maxFlowStr, string message = "MaxFlow should be positive")
+    {
+        Assert.That(maxFlowStr, Is.Not.Null.And.Not.Empty, "MaxFlow should not be null or empty");
+        var maxFlow = UInt256.Parse(maxFlowStr!);
+        Assert.That(maxFlow > UInt256.Zero, Is.True, message);
+    }
+
+    [Test]
+    public void SB01_SimulatedBalance_IsStatic_NotDemurraged()
+    {
+        // IsStatic=true means balance should NOT be subject to demurrage
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "100000000000000000000", // 100 CRC
+                    IsStatic = true
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("100000000000000000000"));
+
+        // Static balance = 100 CRC, should be usable without demurrage reduction
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void SB02_SimulatedBalance_DefaultNotStatic_Demurraged()
+    {
+        // Default IsStatic=false means balance IS subject to demurrage
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "100000000000000000000" // 100 CRC
+                    // IsStatic defaults to false
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Non-static balance should still find a path (demurrage only slightly reduces)
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void SB03_SimulatedBalance_IsStatic_WithWrap()
+    {
+        // Static wrapped balance (ERC20 wrapper with fixed amount)
+        var source = Node(1);
+        var sink = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, avatar);
+        mock.AddTrust(sink, wrapper);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(wrapper),
+                    Amount = "100000000000000000000",
+                    IsStatic = true,
+                    IsWrapped = true
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Static wrapped simulated balance should work");
+    }
+
+    [Test]
+    public void SB04_SimulatedBalance_IsStatic_Quantized()
+    {
+        // Static balance + quantized mode
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            QuantizedMode = true,
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "200000000000000000000", // 200 CRC
+                    IsStatic = true
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("192000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        var truncated = CirclesConverter.TruncateToInt64(UInt256.Parse(result.MaxFlow!));
+        Assert.That(truncated % 96_000_000L, Is.EqualTo(0L),
+            "Static balance should quantize correctly");
+    }
+
+    [Test]
+    public void SB05_SimulatedBalance_OverridesExistingRealBalance()
+    {
+        // Simulated balance replaces/augments existing real balance
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, token, 50_000_000); // Real: 50 CRC
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "300000000000000000000" // Simulate 300 CRC (overrides 50 CRC)
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("200000000000000000000"));
+
+        // Flow should be based on simulated balance (up to 300 CRC), not real balance (50 CRC)
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei > UInt256.Parse("50000000000000000000"),
+            "Simulated balance should override real balance (>50 CRC)");
+    }
+
+    [Test]
+    public void SB06_SimulatedBalance_NewHolder_CreatesNode()
+    {
+        // Simulated balance for a holder that doesn't exist in real graph
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        // Source has NO real balance - only simulated
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, token);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "100000000000000000000"
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Simulated balance should create graph node for new holder");
+    }
+
+    [Test]
+    public void SB07_SimulatedBalance_And_SimulatedTrust_Combined()
+    {
+        // Both simulated balance and simulated trust needed for path
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        var mock = new MockLoadGraph();
+        // No real balances, no real trusts between source and sink
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(token),
+                    Amount = "100000000000000000000"
+                }
+            },
+            SimulatedTrusts = new List<SimulatedTrust>
+            {
+                new()
+                {
+                    Truster = AddressIdPool.StringOf(sink),
+                    Trustee = AddressIdPool.StringOf(token)
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Combined simulated balance + trust should create path");
+    }
+
+    [Test]
+    public void SB08_SimulatedBalance_IsStatic_WithToTokensFilter()
+    {
+        // Static simulated balance respects toTokens filter
+        var source = Node(1);
+        var sink = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, tokenA);
+        mock.AddTrust(sink, tokenB);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenA) }, // Only tokenA
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(tokenA),
+                    Amount = "50000000000000000000", // 50 CRC
+                    IsStatic = true
+                },
+                new()
+                {
+                    Holder = AddressIdPool.StringOf(source),
+                    Token = AddressIdPool.StringOf(tokenB),
+                    Amount = "200000000000000000000", // 200 CRC (filtered out)
+                    IsStatic = true
+                }
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("50000000000000000000"),
+            "ToTokens filter should limit to tokenA (50 CRC), excluding tokenB");
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SwapModeTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SwapModeTests.cs
@@ -1,0 +1,341 @@
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests for swap mode (source==sink) with various flag combinations.
+/// Covers gap G5: swap mode beyond the trivial case.
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class SwapModeTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    private static void AssertMaxFlowPositive(string? maxFlowStr, string message = "MaxFlow should be positive")
+    {
+        Assert.That(maxFlowStr, Is.Not.Null.And.Not.Empty, "MaxFlow should not be null or empty");
+        var maxFlow = UInt256.Parse(maxFlowStr!);
+        Assert.That(maxFlow > UInt256.Zero, Is.True, message);
+    }
+
+    private static void AssertMaxFlowZero(string? maxFlowStr, string message = "MaxFlow should be zero")
+    {
+        if (string.IsNullOrEmpty(maxFlowStr)) return;
+        var maxFlow = UInt256.Parse(maxFlowStr);
+        Assert.That(maxFlow == UInt256.Zero, Is.True, message);
+    }
+
+    [Test]
+    public void SW01_SwapMode_WithWrap_WrappedSelfConversion()
+    {
+        // source==sink, wrapped token self-conversion via intermediary
+        // Swap mode needs ToTokens to know what to receive
+        var source = Node(1);
+        var intermediary = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 100_000_000, isWrapped: true);
+        mock.AddBalance(intermediary, avatar, 100_000_000); // intermediary holds native
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddTrust(source, avatar);
+        mock.AddTrust(source, wrapper);
+        mock.AddTrust(intermediary, source);
+        mock.AddTrust(intermediary, avatar);
+        mock.AddTrust(intermediary, wrapper);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source), // Swap mode
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(avatar) } // Want native avatar token back
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null, "Swap mode should create virtual sink");
+    }
+
+    [Test]
+    public void SW02_SwapMode_WithWrap_ToTokens_FilterApplied()
+    {
+        // Swap mode + withWrap + toTokens: filter applied to swap output
+        var source = Node(1);
+        var bob = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+        var wrapperA = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapperA, 100_000_000, isWrapped: true);
+        mock.AddBalance(source, tokenB, 100_000_000);
+        mock.AddBalance(bob, tokenA, 100_000_000);
+        mock.AddBalance(bob, tokenB, 100_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapperA), AddressIdPool.StringOf(tokenA));
+        mock.AddTrust(source, tokenA);
+        mock.AddTrust(source, tokenB);
+        mock.AddTrust(source, wrapperA);
+        mock.AddTrust(bob, tokenA);
+        mock.AddTrust(bob, tokenB);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null);
+    }
+
+    [Test]
+    public void SW03_SwapMode_Consent_CheckedOnSwap()
+    {
+        // Swap mode with consented flow
+        var source = Node(1);
+        var intermediary = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenA, 100_000_000);
+        mock.AddBalance(intermediary, tokenB, 100_000_000);
+        mock.AddTrust(source, tokenA);
+        mock.AddTrust(source, tokenB);
+        mock.AddTrust(intermediary, source);
+        mock.AddTrust(intermediary, tokenA);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(intermediary);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source), // Swap
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(intermediary)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.ConsentedAvatars.Contains(source), Is.True);
+    }
+
+    [Test]
+    public void SW04_SwapMode_Groups_PersonalToGroupConversion()
+    {
+        // Swap mode: convert personal token → group token via quantized mode
+        // Non-quantized swap with groups requires the group minting edge to connect
+        // to the virtual sink, which is complex. Use quantized mode which always creates virtual sink.
+        var source = Node(1);
+        var bob = Node(2);
+        var group = Node(100);
+        var personalToken = Node(10);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, personalToken, 200_000_000);
+        mock.AddBalance(bob, personalToken, 200_000_000);
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, personalToken);
+        mock.AddTrust(source, group); // Source trusts group token (wants to receive it)
+        mock.AddTrust(source, personalToken);
+        mock.AddTrust(bob, personalToken);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source), // Swap: self-conversion
+            QuantizedMode = true // Quantized mode creates virtual sink for swap
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null, "Quantized swap should create virtual sink");
+        Assert.That(capacityGraph.IsGroup(group), Is.True);
+    }
+
+    [Test]
+    public void SW05_SwapMode_Quantized_WithWrap()
+    {
+        // Quantized swap with wrapped tokens
+        var source = Node(1);
+        var bob = Node(2);
+        var avatar = Node(10);
+        var wrapper = Node(50);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
+        mock.AddBalance(bob, avatar, 200_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
+        mock.AddTrust(source, avatar);
+        mock.AddTrust(source, wrapper);
+        mock.AddTrust(bob, source);
+        mock.AddTrust(bob, avatar);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            WithWrap = true,
+            QuantizedMode = true
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null);
+    }
+
+    [Test]
+    public void SW06_SwapMode_MaxTransfers_SingleStep()
+    {
+        // Swap mode with maxTransfers=1
+        var source = Node(1);
+        var bob = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenA, 100_000_000);
+        mock.AddBalance(bob, tokenB, 100_000_000);
+        mock.AddTrust(source, tokenA);
+        mock.AddTrust(source, tokenB);
+        mock.AddTrust(bob, source);
+        mock.AddTrust(bob, tokenA);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            MaxTransfers = 1,
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenB) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // MaxTransfers=1 in swap mode should still attempt path
+        Assert.That(result.Transfers == null || result.Transfers.Count <= 2);
+    }
+
+    [Test]
+    public void SW07_SwapMode_FromTokens_And_ExcludedToTokens_CrossFilter()
+    {
+        // Swap: send tokenA, receive tokenB (toTokens=[B], excludedToTokens=[A])
+        var source = Node(1);
+        var bob = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenA, 100_000_000);
+        mock.AddBalance(bob, tokenB, 100_000_000);
+        mock.AddTrust(source, tokenA);
+        mock.AddTrust(source, tokenB);
+        mock.AddTrust(bob, source);
+        mock.AddTrust(bob, tokenA);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            FromTokens = new List<string> { AddressIdPool.StringOf(tokenA) },
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenB) }, // Need ToTokens for swap
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(tokenA) } // Don't receive tokenA back
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null);
+    }
+
+    [Test]
+    public void SW08_SwapMode_AllFilters_KitchenSink()
+    {
+        // Swap mode with every filter set
+        var source = Node(1);
+        var bob = Node(2);
+        var tokenA = Node(10);
+        var tokenB = Node(11);
+        var tokenC = Node(12);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, tokenA, 100_000_000);
+        mock.AddBalance(source, tokenB, 100_000_000);
+        mock.AddBalance(source, tokenC, 100_000_000);
+        mock.AddBalance(bob, tokenA, 100_000_000);
+        mock.AddBalance(bob, tokenB, 100_000_000);
+        mock.AddBalance(bob, tokenC, 100_000_000);
+        mock.AddTrust(source, tokenA);
+        mock.AddTrust(source, tokenB);
+        mock.AddTrust(source, tokenC);
+        mock.AddTrust(bob, source);
+        mock.AddTrust(bob, tokenA);
+        mock.AddTrust(bob, tokenB);
+        mock.AddTrust(bob, tokenC);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            FromTokens = new List<string> { AddressIdPool.StringOf(tokenA), AddressIdPool.StringOf(tokenB) },
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenB), AddressIdPool.StringOf(tokenC) },
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(tokenB) }, // Exclude tokenB from sending
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(tokenC) }, // Exclude tokenC from receiving
+            MaxTransfers = 3,
+            DebugShowIntermediateSteps = true
+        };
+
+        // Should not crash with all filters active in swap mode
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrappedSnapshotRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrappedSnapshotRegressionTests.cs
@@ -71,11 +71,13 @@ public class WrappedSnapshotRegressionTests
     // ----------------------------------------------------------------
 
     [Test]
-    public void IsWrapOnly_WithOnlyWrap_ReturnsTrue()
+    public void IsWrapOnly_AlwaysReturnsFalse_DueToMissingSourceContext()
     {
+        // IsWrapOnly is disabled because the pre-built wrapped snapshot lacks
+        // source-specific wrapped supply edges (line 733 of AddHolderToTokenEdges_Pooled).
         var request = new FlowRequest { WithWrap = true };
-        Assert.That(CapacityGraphPool.IsWrapOnly(request), Is.True,
-            "Request with only WithWrap=true should be classified as wrap-only.");
+        Assert.That(CapacityGraphPool.IsWrapOnly(request), Is.False,
+            "IsWrapOnly always returns false — pre-built snapshot can't have source-specific wrapped supply edges.");
     }
 
     [Test]
@@ -188,9 +190,9 @@ public class WrappedSnapshotRegressionTests
     }
 
     [Test]
-    public void IsWrapOnly_WithWrapAndEmptyLists_ReturnsTrue()
+    public void IsWrapOnly_WithWrapAndEmptyLists_ReturnsFalse()
     {
-        // Empty (non-null) lists should not prevent wrap-only classification
+        // IsWrapOnly is disabled — always returns false regardless of input
         var request = new FlowRequest
         {
             WithWrap = true,
@@ -203,7 +205,7 @@ public class WrappedSnapshotRegressionTests
             SimulatedConsentedAvatars = new List<string>(),
             QuantizedMode = false
         };
-        Assert.That(CapacityGraphPool.IsWrapOnly(request), Is.True);
+        Assert.That(CapacityGraphPool.IsWrapOnly(request), Is.False);
     }
 
     // ----------------------------------------------------------------
@@ -250,8 +252,10 @@ public class WrappedSnapshotRegressionTests
     // ----------------------------------------------------------------
 
     [Test]
-    public async Task Rent_WrapOnly_ReturnsWrappedSnapshot()
+    public async Task Rent_WrapOnly_BuildsAdHocGraph()
     {
+        // After the IsWrapOnly fix, wrap-only requests build ad-hoc graphs
+        // (not the pre-built snapshot which lacks wrapped supply edges).
         var pool = CreatePool();
         var baseGraph = BuildMinimalGraph();
         var wrappedGraph = BuildMinimalGraph();
@@ -264,10 +268,10 @@ public class WrappedSnapshotRegressionTests
 
         using var handle = await pool.Rent(request, balances, trust);
 
-        Assert.That(handle.Graph, Is.SameAs(wrappedGraph),
-            "Wrap-only request should return the pre-built wrapped snapshot, not rebuild ad-hoc.");
+        Assert.That(handle.Graph, Is.Not.SameAs(wrappedGraph),
+            "Wrap-only request should NOT use pre-built snapshot (lacks source-specific wrapped edges).");
         Assert.That(handle.Graph, Is.Not.SameAs(baseGraph),
-            "Should return wrapped graph, not base graph.");
+            "Should build ad-hoc graph, not return base graph.");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
@@ -1,0 +1,647 @@
+using Circles.Common;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Systematic wrapper×filter×mode crossing tests.
+/// Covers gaps G2 (wrapper × all 4 filters × quantized) and G7 (wrapper + group minting).
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class WrapperFilterMatrixTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+
+    // Wrapper addresses are distinct from avatar addresses
+    private static readonly int AvatarA = Node(10);
+    private static readonly int WrapperDemurraged = Node(50); // Demurraged wrapper for AvatarA
+    private static readonly int WrapperStatic = Node(51);     // Static wrapper for AvatarA
+
+    private static void AssertMaxFlowPositive(string? maxFlowStr, string message = "MaxFlow should be positive")
+    {
+        Assert.That(maxFlowStr, Is.Not.Null.And.Not.Empty, "MaxFlow should not be null or empty");
+        var maxFlow = UInt256.Parse(maxFlowStr!);
+        Assert.That(maxFlow > UInt256.Zero, Is.True, message);
+    }
+
+    private static void AssertMaxFlowZero(string? maxFlowStr, string message = "MaxFlow should be zero")
+    {
+        if (string.IsNullOrEmpty(maxFlowStr)) return;
+        var maxFlow = UInt256.Parse(maxFlowStr);
+        Assert.That(maxFlow == UInt256.Zero, Is.True, message);
+    }
+
+    // ─────────────── QUANTIZED + WRAPPER + FILTERS ───────────────
+
+    [Test]
+    public void WF01_Quantized_WithWrap_ToTokens_WrapperExpanded()
+    {
+        // quantized + withWrap + toTokens=[avatarA] → wrapper expanded in toTokensFilter
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Quantized wrapped flow with toTokens should work");
+        var truncated = CirclesConverter.TruncateToInt64(UInt256.Parse(result.MaxFlow!));
+        Assert.That(truncated % 96_000_000L, Is.EqualTo(0L),
+            "Flow should be quantized to 96 CRC multiples");
+    }
+
+    [Test]
+    public void WF02_Quantized_WithWrap_FromTokens_WrapperExpanded()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddBalance(source, Node(11), 200_000_000); // Another token (not wrapped)
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(sink, Node(11));
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            FromTokens = new List<string> { AddressIdPool.StringOf(AvatarA) } // Only AvatarA → expands to include wrapper
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Quantized wrapped flow with fromTokens should work");
+    }
+
+    [Test]
+    public void WF03_Quantized_WithWrap_ExcludedFromTokens_WrapperExcluded()
+    {
+        // excludedFromTokens=[avatarA] → wrapper also excluded, falls to other token
+        var source = Node(1);
+        var sink = Node(2);
+        var otherToken = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddBalance(source, otherToken, 100_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(sink, otherToken);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(AvatarA) } // Excludes wrapper too
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("96000000000000000000"),
+            "Should only use otherToken (100 CRC → 96), wrapper excluded");
+    }
+
+    [Test]
+    public void WF04_Quantized_WithWrap_ExcludedToTokens_WrapperExcludedAtSink()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+        var otherToken = Node(11);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddBalance(source, otherToken, 100_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(sink, otherToken);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) } // Exclude at sink → wrapper also excluded
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    // ─────────────── STATIC VS DEMURRAGED WRAPPERS ───────────────
+
+    [Test]
+    public void WF05_StaticWrapper_ToTokens_Expanded()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperStatic, 100_000_000, isWrapped: true, isStatic: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperStatic);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Static wrapper should be expanded in toTokens filter");
+    }
+
+    [Test]
+    public void WF06_StaticWrapper_FromTokens_Expanded()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperStatic, 100_000_000, isWrapped: true, isStatic: true);
+        mock.AddBalance(source, Node(12), 200_000_000); // Another token
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperStatic);
+        mock.AddTrust(sink, Node(12));
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            FromTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Static wrapper should be expanded in fromTokens filter");
+    }
+
+    [Test]
+    public void WF07_BothWrappers_ToTokens_AllExpanded()
+    {
+        // Avatar has BOTH static and demurraged wrappers → both expanded
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddBalance(source, WrapperStatic, 50_000_000, isWrapped: true, isStatic: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(sink, WrapperStatic);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Both static and demurraged wrappers should reach sink");
+    }
+
+    [Test]
+    public void WF08_BothWrappers_ExcludedFromTokens_AllExcluded()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+        var otherToken = Node(12);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddBalance(source, WrapperStatic, 50_000_000, isWrapped: true, isStatic: true);
+        mock.AddBalance(source, otherToken, 30_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(sink, WrapperStatic);
+        mock.AddTrust(sink, otherToken);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            ExcludedFromTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Should use only otherToken (30 CRC), both wrappers excluded
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("30000000000000000000"),
+            "Both wrappers excluded, only otherToken (30 CRC) available");
+    }
+
+    // ─────────────── WRAPPER + GROUP MINTING ───────────────
+
+    [Test]
+    public void WF09_WrappedCollateral_GroupSink_ToTokens()
+    {
+        // Wrapped token used as collateral for group minting with toTokens
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, WrapperDemurraged); // Group trusts wrapper as collateral
+        mock.AddTrust(sink, group);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(group) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Wrapped collateral → group minting with toTokens should work");
+    }
+
+    [Test]
+    public void WF10_WrappedCollateral_GroupSink_Consent_Triple()
+    {
+        // Triple: withWrap + group minting + consent
+        var source = Node(1);
+        var sink = Node(2);
+        var group = Node(100);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddGroup(group);
+        mock.AddGroupTrust(group, WrapperDemurraged);
+        mock.AddTrust(sink, group);
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Wrapped collateral + group mint + consent should work");
+    }
+
+    // ─────────────── SWAP MODE + WRAPPER ───────────────
+
+    [Test]
+    public void WF11_SwapMode_WithWrap_SelfConversion()
+    {
+        // source==sink, swap wrapped → native. Needs ToTokens and second holder.
+        var source = Node(1);
+        var bob = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddBalance(bob, AvatarA, 50_000_000); // Bob holds native
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(source, AvatarA);
+        mock.AddTrust(source, WrapperDemurraged);
+        mock.AddTrust(bob, source);
+        mock.AddTrust(bob, AvatarA);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source), // Swap mode
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) } // Want native back
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null, "Swap mode should create virtual sink");
+    }
+
+    [Test]
+    public void WF12_SwapMode_WithWrap_ExcludedToTokens()
+    {
+        // Swap mode + withWrap + excludedToTokens: receive tokenB, exclude wrapper from output
+        var source = Node(1);
+        var tokenB = Node(12);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddBalance(source, tokenB, 50_000_000);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(source, AvatarA);
+        mock.AddTrust(source, WrapperDemurraged);
+        mock.AddTrust(source, tokenB);
+
+        // Second holder so pool nodes exist in swap mode
+        var bob = Node(3);
+        mock.AddBalance(bob, AvatarA, 50_000_000);
+        mock.AddBalance(bob, tokenB, 50_000_000);
+        mock.AddTrust(bob, AvatarA);
+        mock.AddTrust(bob, tokenB);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(source),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(tokenB) }, // Want tokenB back
+            ExcludedToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) } // Exclude wrapper
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        Assert.That(capacityGraph.VirtualSinkAddress, Is.Not.Null);
+    }
+
+    // ─────────────── GUARD TESTS ───────────────
+
+    [Test]
+    public void WF13_WithWrapFalse_ToTokens_WrapperNotExpanded()
+    {
+        // WithWrap=false: wrapper should NOT be expanded in filter
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddBalance(source, AvatarA, 100_000_000); // Native balance
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = false, // Explicitly false
+            ToTokens = new List<string> { AddressIdPool.StringOf(AvatarA) }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        // Should only use native AvatarA token (100 CRC), NOT wrapped (200 CRC)
+        AssertMaxFlowPositive(result.MaxFlow);
+        var flowWei = UInt256.Parse(result.MaxFlow!);
+        Assert.That(flowWei <= UInt256.Parse("100000000000000000000"),
+            "WithWrap=false should not expand wrapper in toTokens filter");
+    }
+
+    [Test]
+    public void WF14_ExplicitWrapperAddress_InFilter_Works()
+    {
+        // User passes wrapper address directly in toTokens (not avatar address)
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, WrapperDemurraged);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            ToTokens = new List<string> { AddressIdPool.StringOf(WrapperDemurraged) } // Wrapper directly
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Explicit wrapper address in toTokens should work");
+    }
+
+    [Test]
+    public void WF15_Quantized_WithWrap_MaxTransfers_SingleStep()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            MaxTransfers = 1
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder();
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        // Should find single-step quantized wrapped transfer
+        AssertMaxFlowPositive(result.MaxFlow);
+    }
+
+    [Test]
+    public void WF16_Quantized_WithWrap_Consent_TripleCombo()
+    {
+        var source = Node(1);
+        var sink = Node(2);
+
+        var mock = new MockLoadGraph();
+        mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
+        mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
+        mock.AddTrust(sink, source);
+        mock.AddTrust(sink, AvatarA);
+        mock.AddTrust(sink, WrapperDemurraged);
+        mock.AddTrust(source, sink); // Bidirectional trust required for consent
+        mock.AddConsentedAvatar(source);
+        mock.AddConsentedAvatar(sink);
+
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustGraph = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
+
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+            WithWrap = true,
+            QuantizedMode = true,
+            SimulatedConsentedAvatars = new List<string>
+            {
+                AddressIdPool.StringOf(source),
+                AddressIdPool.StringOf(sink)
+            }
+        };
+
+        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
+        var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
+
+        AssertMaxFlowPositive(result.MaxFlow, "Quantized + wrapped + consent triple should work");
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -136,25 +136,14 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
 
     /// <summary>
     /// Returns true when the ONLY reason a request needs filtering is WithWrap=true.
-    /// These requests can use the pre-built wrapped snapshot instead of rebuilding.
+    /// DISABLED: The pre-built wrapped snapshot lacks source-specific wrapped supply edges.
+    /// Line 733 of AddHolderToTokenEdges_Pooled skips all wrapped balances when sourceId
+    /// is null (pre-build mode), because only the source can supply wrapped tokens (the
+    /// caller initiates the ERC20 unwrap). This means the pre-built snapshot has zero
+    /// wrapped supply edges, causing maxFlow=0 for users whose balance is in wrappers.
+    /// Always return false to force ad-hoc graph building with proper source context.
     /// </summary>
-    public static bool IsWrapOnly(FlowRequest r)
-    {
-        if (r.WithWrap != true)
-            return false;
-
-        bool hasOtherFilters =
-            (r.FromTokens?.Any() ?? false) ||
-            (r.ToTokens?.Any() ?? false) ||
-            (r.ExcludedFromTokens?.Any() ?? false) ||
-            (r.ExcludedToTokens?.Any() ?? false) ||
-            (r.SimulatedBalances?.Any() ?? false) ||
-            (r.SimulatedTrusts?.Any() ?? false) ||
-            (r.SimulatedConsentedAvatars?.Any() ?? false) ||
-            (r.QuantizedMode == true);
-
-        return !hasOtherFilters;
-    }
+    public static bool IsWrapOnly(FlowRequest r) => false;
 }
 
 public sealed class CapacityGraphSnapshot(long block, CapacityGraph @base)


### PR DESCRIPTION
## Summary

- **Bugfix**: `IsWrapOnly()` pre-built wrapped snapshot caused `maxFlow=0` for `{withWrap:true}` requests without `toTokens`. The snapshot was built without source/sink context, so `AddHolderToTokenEdges_Pooled` line 733 (`if bn.IsWrapped && !isSource`) skipped ALL wrapped supply edges. Users with ERC20 wrapper balances got zero flow unless they also specified `toTokens`.
- **Tests**: 56 new unit tests across 5 files covering flag interaction gaps (entity types × filters, wrapper × mode crossings, triple/quad flag combos, IsStatic simulated balances, swap mode).

### Root cause trace
1. `CapacityGraphPool.IsWrapOnly()` returned `true` for `{withWrap:true}` without other filters
2. Routed to pre-built snapshot built with `new FlowRequest { WithWrap = true }` — no source/sink
3. `sourceId = null` → `isSource = false` for all holders → line 733 skipped all wrapped supply edges
4. Solver found zero augmenting paths → `maxFlow=0`

### Fix
- `IsWrapOnly()` always returns `false` → forces ad-hoc graph building with proper source context
- Pre-build calls in `NetworkStateUpdaterService` disabled (saves ~250ms/block)
- 3 wrapped snapshot regression tests updated to match new behavior

## Test plan
- [x] 868 tests pass, 1 pre-existing flaky (E004), 273 skipped (staging/Anvil-dependent)
- [ ] Deploy to staging, verify `{withWrap:true}` WITHOUT `toTokens` returns flow > 0
- [ ] Verify `{withWrap:true, toTokens:[...]}` still works (regression check)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for entity type filtering with 16 new test cases across multiple filter configurations.
  * Added comprehensive test suites for kitchen sink scenarios, simulated balances, swap mode, and wrapper/filter interactions (56+ new tests).
  * Updated regression tests to reflect current wrapped snapshot behaviour.

* **Refactor**
  * Optimised graph construction to consistently use ad-hoc building instead of cached wrapped snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->