### PR TITLE
fix(rpc+cache): avatar type normalization + multi-angle audit bug fixes

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
@@ -188,8 +188,8 @@ public class NotificationListenerServiceTests
 
         // Add data at block 9 so it exists in the rollback history
         // (rollback to block 9 requires block 9 to be in _blockOrder)
-        caches.V1Avatars.Add(9, dummyAvatarKey, ("Human", "0xdummy"));
-        caches.V1Avatars.Add(10, avatarKey, ("Human", "0xtoken"));
+        caches.V1Avatars.Add(9, dummyAvatarKey, ("CrcV1_Signup", "0xdummy"));
+        caches.V1Avatars.Add(10, avatarKey, ("CrcV1_Signup", "0xtoken"));
 
         var blocks = new List<(long BlockNumber, string BlockHash)>
         {
@@ -237,7 +237,7 @@ public class NotificationListenerServiceTests
 
         var caches = new CacheContainer(settings.RollbackCapacity);
         SeedAllCachesAtBlock(caches, 100);
-        caches.V1Avatars.Add(101, "0xuser", ("Human", "0xtoken"));
+        caches.V1Avatars.Add(101, "0xuser", ("CrcV1_Signup", "0xtoken"));
 
         var blocks = new List<(long BlockNumber, string BlockHash)>
         {
@@ -383,7 +383,7 @@ public class NotificationListenerServiceTests
         // by adding data at blocks that push the oldest block out of the window
         for (int i = 101; i <= 120; i++)
         {
-            caches.V1Avatars.Add(i, $"0xuser{i}", ("Human", $"0xtoken{i}"));
+            caches.V1Avatars.Add(i, $"0xuser{i}", ("CrcV1_Signup", $"0xtoken{i}"));
         }
 
         // Now the cache's oldest block is around 116 (120 - 5 + 1)

--- a/src/Cache/Circles.Cache.Service.Tests/CacheContainerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CacheContainerTests.cs
@@ -43,11 +43,11 @@ public class CacheContainerTests
         var tokenAddress = "0x42cedde51198d1773590311e2a340dc06b24cb37";
 
         // Act
-        _cache.V1Avatars.Add(1000, address, ("Human", tokenAddress));
+        _cache.V1Avatars.Add(1000, address, ("CrcV1_Signup", tokenAddress));
 
         // Assert
         _cache.V1Avatars.TryGetValue(address, out var info).Should().BeTrue();
-        info.Type.Should().Be("Human");
+        info.Type.Should().Be("CrcV1_Signup");
         info.TokenAddress.Should().Be(tokenAddress);
     }
 
@@ -58,11 +58,11 @@ public class CacheContainerTests
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
 
         // Act
-        _cache.V1Avatars.Add(1000, address, ("Organization", null));
+        _cache.V1Avatars.Add(1000, address, ("CrcV1_OrganizationSignup", null));
 
         // Assert
         _cache.V1Avatars.TryGetValue(address, out var info).Should().BeTrue();
-        info.Type.Should().Be("Organization");
+        info.Type.Should().Be("CrcV1_OrganizationSignup");
         info.TokenAddress.Should().BeNull();
     }
 
@@ -74,11 +74,11 @@ public class CacheContainerTests
         var timestamp = 1704067200L; // 2024-01-01
 
         // Act
-        _cache.V2Avatars.Add(2000, address, ("Human", timestamp));
+        _cache.V2Avatars.Add(2000, address, ("CrcV2_RegisterHuman", timestamp));
 
         // Assert
         _cache.V2Avatars.TryGetValue(address, out var info).Should().BeTrue();
-        info.Type.Should().Be("Human");
+        info.Type.Should().Be("CrcV2_RegisterHuman");
         info.RegisteredAt.Should().Be(timestamp);
     }
 
@@ -144,13 +144,13 @@ public class CacheContainerTests
     {
         // Arrange - Add data at block 1000
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V1Avatars.Add(1000, address, ("Human", "0xtoken"));
-        _cache.V2Avatars.Add(1000, address, ("Human", 12345L));
+        _cache.V1Avatars.Add(1000, address, ("CrcV1_Signup", "0xtoken"));
+        _cache.V2Avatars.Add(1000, address, ("CrcV2_RegisterHuman", 12345L));
 
         // Add more data at block 2000
         var address2 = "0x1234567890abcdef1234567890abcdef12345678";
-        _cache.V1Avatars.Add(2000, address2, ("Organization", null));
-        _cache.V2Avatars.Add(2000, address2, ("Organization", 67890L));
+        _cache.V1Avatars.Add(2000, address2, ("CrcV1_OrganizationSignup", null));
+        _cache.V2Avatars.Add(2000, address2, ("CrcV2_RegisterOrganization", 67890L));
 
         // Act - Rollback to block 1500
         _cache.RollbackAll(1500);
@@ -168,9 +168,9 @@ public class CacheContainerTests
     public void GetStatistics_ShouldReturnCorrectCounts()
     {
         // Arrange
-        _cache.V1Avatars.Add(1000, "0xaddr1", ("Human", "0xtoken1"));
-        _cache.V1Avatars.Add(1000, "0xaddr2", ("Human", "0xtoken2"));
-        _cache.V2Avatars.Add(2000, "0xaddr3", ("Human", 12345L));
+        _cache.V1Avatars.Add(1000, "0xaddr1", ("CrcV1_Signup", "0xtoken1"));
+        _cache.V1Avatars.Add(1000, "0xaddr2", ("CrcV1_Signup", "0xtoken2"));
+        _cache.V2Avatars.Add(2000, "0xaddr3", ("CrcV2_RegisterHuman", 12345L));
 
         // Act
         var stats = _cache.GetStatistics();

--- a/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
@@ -253,7 +253,7 @@ public class ControllerTests
     {
         // Arrange
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(2000, address, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(2000, address, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2AvatarToCidMap.Add(2000, address, "QmYxivS5DXZgDUgLE8YTZV9AnFKPSLvd5R5sWEyWAJKXWE");
 
         var controller = CreateAvatarsController();
@@ -267,7 +267,7 @@ public class ControllerTests
         var avatar = okResult!.Value as AvatarInfoResponse;
         avatar.Should().NotBeNull();
         avatar!.Version.Should().Be(2);
-        avatar.Type.Should().Be("Human");
+        avatar.Type.Should().Be("CrcV2_RegisterHuman");
         avatar.IsHuman.Should().BeTrue();
         avatar.CidV0.Should().Be("QmYxivS5DXZgDUgLE8YTZV9AnFKPSLvd5R5sWEyWAJKXWE");
         avatar.RegisteredAt.Should().Be(1704067200L);
@@ -279,7 +279,7 @@ public class ControllerTests
         // Arrange
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V1Avatars.Add(1000, address, ("Human", token));
+        _cache.V1Avatars.Add(1000, address, ("CrcV1_Signup", token));
 
         var controller = CreateAvatarsController();
 
@@ -292,7 +292,7 @@ public class ControllerTests
         var avatar = okResult!.Value as AvatarInfoResponse;
         avatar.Should().NotBeNull();
         avatar!.Version.Should().Be(1);
-        avatar.Type.Should().Be("Human");
+        avatar.Type.Should().Be("CrcV1_Signup");
         avatar.HasV1.Should().BeTrue();
         avatar.V1Token.Should().Be(token);
         avatar.TokenId.Should().Be(token);
@@ -316,7 +316,7 @@ public class ControllerTests
     {
         // Arrange
         var address = "0x1234567890abcdef1234567890abcdef12345678";
-        _cache.V2Avatars.Add(2000, address, ("Group", 1704067200L));
+        _cache.V2Avatars.Add(2000, address, ("CrcV2_RegisterGroup", 1704067200L));
         _cache.Groups.Add(2000, address, ("Community DAO", "0xmint", "CDAO"));
 
         var controller = CreateAvatarsController();
@@ -329,7 +329,7 @@ public class ControllerTests
         okResult.Should().NotBeNull();
         var avatar = okResult!.Value as AvatarInfoResponse;
         avatar.Should().NotBeNull();
-        avatar!.Type.Should().Be("Group");
+        avatar!.Type.Should().Be("CrcV2_RegisterGroup");
         avatar.Name.Should().Be("Community DAO");
         avatar.Symbol.Should().Be("CDAO");
         avatar.IsHuman.Should().BeFalse();
@@ -343,8 +343,8 @@ public class ControllerTests
         var addr2 = "0x1234567890abcdef1234567890abcdef12345678";
         var addr3 = "0xnonexistent0000000000000000000000000000";
 
-        _cache.V2Avatars.Add(2000, addr1, ("Human", 1704067200L));
-        _cache.V1Avatars.Add(1000, addr2, ("Organization", null));
+        _cache.V2Avatars.Add(2000, addr1, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V1Avatars.Add(1000, addr2, ("CrcV1_OrganizationSignup", null));
 
         var controller = CreateAvatarsController();
 

--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -130,7 +130,7 @@ public class PathfinderGraphControllerTests
     {
         var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 1.5m);
         // Set a recent lastActivity so demurrage is minimal
         var recentTimestamp = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 60;
@@ -177,7 +177,7 @@ public class PathfinderGraphControllerTests
     {
         var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 0m);
 
         var controller = CreateController();
@@ -194,8 +194,8 @@ public class PathfinderGraphControllerTests
         var wrapperAddress = "0xwrapper00000000000000000000000000000000";
         var underlyingAvatar = "0xunderlying0000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, underlyingAvatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, underlyingAvatar, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 0)); // 0 = demurraged
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
         _cache.V2LastActivity.Add(1000, $"{account}:{wrapperAddress}",
@@ -217,8 +217,8 @@ public class PathfinderGraphControllerTests
         var wrapperAddress = "0xstaticwrap0000000000000000000000000000";
         var underlyingAvatar = "0xunderlying0000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, underlyingAvatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, underlyingAvatar, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 1)); // 1 = static
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
 
@@ -238,7 +238,7 @@ public class PathfinderGraphControllerTests
         var wrapperAddress = "0xwrapper00000000000000000000000000000000";
         var unregisteredAvatar = "0xunregistered000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         // underlyingAvatar NOT registered in V2Avatars
         _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (unregisteredAvatar, 0));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
@@ -257,8 +257,8 @@ public class PathfinderGraphControllerTests
     {
         var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, truster, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         // expiryTime in the far future
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
 
@@ -275,8 +275,8 @@ public class PathfinderGraphControllerTests
     {
         var truster = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, truster, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         // expiryTime in the past → revoked
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 1L);
 
@@ -294,8 +294,8 @@ public class PathfinderGraphControllerTests
         var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
         var wrapperAddress = "0xwrapper00000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, truster, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
         // trustee has a wrapper deployed
         _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (trustee, 0));
@@ -318,8 +318,8 @@ public class PathfinderGraphControllerTests
         var wrapper1 = "0xwrapper10000000000000000000000000000000";
         var wrapper2 = "0xwrapper20000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, truster, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, truster, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
         _cache.Erc20WrapperAddresses.Add(1000, wrapper1, (trustee, 0));
         _cache.Erc20WrapperAddresses.Add(1000, wrapper2, (trustee, 1));
@@ -338,7 +338,7 @@ public class PathfinderGraphControllerTests
         var org = "0xorg00000000000000000000000000000000000000";
         var group = "0xgroup000000000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, org, ("Organization", 1704067200L));
+        _cache.V2Avatars.Add(1000, org, ("CrcV2_RegisterOrganization", 1704067200L));
         // Group is NOT in V2Avatars — only in Groups cache (like production)
         _cache.Groups.Add(1000, group, ("Gnosis Group", StandardTreasuryMint, "GG"));
         _cache.V2TrustRelations.Add(1000, $"{org}:{group}", 9999999999L);
@@ -357,8 +357,8 @@ public class PathfinderGraphControllerTests
         var group = "0xgroup000000000000000000000000000000000000";
         var trustee = "0x42cedde51198d1773590311e2a340dc06b24cb37";
 
-        _cache.V2Avatars.Add(1000, group, ("Group", 1704067200L));
-        _cache.V2Avatars.Add(1000, trustee, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, group, ("CrcV2_RegisterGroup", 1704067200L));
+        _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Groups.Add(1000, group, ("Test Group", StandardTreasuryMint, "TG"));
         _cache.V2TrustRelations.Add(1000, $"{group}:{trustee}", 9999999999L);
 
@@ -397,8 +397,8 @@ public class PathfinderGraphControllerTests
         var routerGroup = "0xroutergroup000000000000000000000000000000";
         var member = "0xmember00000000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, routerGroup, ("Group", 1704067200L));
-        _cache.V2Avatars.Add(1000, member, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, routerGroup, ("CrcV2_RegisterGroup", 1704067200L));
+        _cache.V2Avatars.Add(1000, member, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Groups.Add(1000, routerGroup, ("Router Group", StandardTreasuryMint, "RG"));
         _cache.V2TrustRelations.Add(1000, $"{routerGroup}:{member}", 9999999999L);
 
@@ -417,8 +417,8 @@ public class PathfinderGraphControllerTests
         var nonRouterGroup = "0xnonrouter00000000000000000000000000000000";
         var member = "0xmember00000000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, nonRouterGroup, ("Group", 1704067200L));
-        _cache.V2Avatars.Add(1000, member, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, nonRouterGroup, ("CrcV2_RegisterGroup", 1704067200L));
+        _cache.V2Avatars.Add(1000, member, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Groups.Add(1000, nonRouterGroup, ("Custom Group", "0xothermint", "CG"));
         _cache.V2TrustRelations.Add(1000, $"{nonRouterGroup}:{member}", 9999999999L);
 
@@ -435,7 +435,7 @@ public class PathfinderGraphControllerTests
     public void BuildConsentedFlow_ShouldExtractBit0OfByte31()
     {
         var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, avatar, ("CrcV2_RegisterHuman", 1704067200L));
 
         // Create 32-byte flag with bit 0 of byte[31] set to 1
         var flags = new byte[32];
@@ -455,7 +455,7 @@ public class PathfinderGraphControllerTests
     public void BuildConsentedFlow_ShouldReturnFalse_WhenBit0IsZero()
     {
         var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, avatar, ("CrcV2_RegisterHuman", 1704067200L));
 
         var flags = new byte[32];
         flags[31] = 0x00; // consent = false
@@ -473,7 +473,7 @@ public class PathfinderGraphControllerTests
     public void BuildConsentedFlow_ShouldHandleOnlyBit0_NotOtherBits()
     {
         var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, avatar, ("CrcV2_RegisterHuman", 1704067200L));
 
         var flags = new byte[32];
         flags[31] = 0xFE; // all bits except bit 0 → consent = false
@@ -490,7 +490,7 @@ public class PathfinderGraphControllerTests
     public void BuildConsentedFlow_ShouldSkipShortFlagBytes()
     {
         var avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(1000, avatar, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, avatar, ("CrcV2_RegisterHuman", 1704067200L));
 
         // Only 16 bytes — should be skipped with warning
         var shortFlags = new byte[16];
@@ -542,7 +542,7 @@ public class PathfinderGraphControllerTests
     {
         var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 100m);
 
         // lastActivity 30 days ago — should show noticeable demurrage
@@ -566,7 +566,7 @@ public class PathfinderGraphControllerTests
     private void SeedMinimalData()
     {
         var addr = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        _cache.V2Avatars.Add(1000, addr, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, addr, ("CrcV2_RegisterHuman", 1704067200L));
     }
 
     private void SeedFullData()
@@ -576,9 +576,9 @@ public class PathfinderGraphControllerTests
         var group = "0xgroup000000000000000000000000000000000000";
         var now = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, bob, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, group, ("Group", 1704067200L));
+        _cache.V2Avatars.Add(1000, alice, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, bob, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, group, ("CrcV2_RegisterGroup", 1704067200L));
 
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{alice}:{bob}", 100m);
         _cache.V2LastActivity.Add(1000, $"{alice}:{bob}", now);
@@ -602,9 +602,9 @@ public class PathfinderGraphControllerTests
         var bob = "0xbob00000000000000000000000000000000000000";
         var lonely = "0xlonely00000000000000000000000000000000";
 
-        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, bob, ("Human", 1704067200L));
-        _cache.V2Avatars.Add(1000, lonely, ("Organization", 1704067200L));
+        _cache.V2Avatars.Add(1000, alice, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, bob, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, lonely, ("CrcV2_RegisterOrganization", 1704067200L));
 
         var controller = CreateController();
         var result = controller.GetGraph();
@@ -624,7 +624,7 @@ public class PathfinderGraphControllerTests
     public void GetGraph_AvatarsInclude_ShouldBeFilterable()
     {
         var alice = "0xalice0000000000000000000000000000000000";
-        _cache.V2Avatars.Add(1000, alice, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, alice, ("CrcV2_RegisterHuman", 1704067200L));
 
         var controller = CreateController();
 
@@ -659,7 +659,7 @@ public class PathfinderGraphControllerTests
         var token2 = "0xabc123def456789012345678901234567890abcd";
         var now = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
-        _cache.V2Avatars.Add(1000, account, ("Human", 1704067200L));
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token1}", 1.0m);
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token2}", 2.0m);
         _cache.V2LastActivity.Add(1000, $"{account}:{token1}", now);

--- a/src/Cache/Circles.Cache.Service.Tests/RpcCacheClientTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/RpcCacheClientTests.cs
@@ -98,7 +98,7 @@ public class RpcCacheClientTests
         {
             Avatar = "0xde374ece6fa50e781e81aac78e811b33d16912c7",
             Version = 2,
-            Type = "Human",
+            Type = "CrcV2_RegisterHuman",
             TokenId = (string?)null,
             HasV1 = false,
             V1Token = (string?)null,
@@ -118,7 +118,7 @@ public class RpcCacheClientTests
         // Assert
         avatar.Should().NotBeNull();
         avatar!.Version.Should().Be(2);
-        avatar.Type.Should().Be("Human");
+        avatar.Type.Should().Be("CrcV2_RegisterHuman");
         avatar.IsHuman.Should().BeTrue();
         avatar.CidV0.Should().Be("QmYxivS5DXZgDUgLE8YTZV9AnFKPSLvd5R5sWEyWAJKXWE");
         avatar.RegisteredAt.Should().Be(1704067200L);
@@ -134,7 +134,7 @@ public class RpcCacheClientTests
             {
                 Avatar = "0xaddr1",
                 Version = 2,
-                Type = "Human",
+                Type = "CrcV2_RegisterHuman",
                 IsHuman = true
             },
             null, // Not found
@@ -142,7 +142,7 @@ public class RpcCacheClientTests
             {
                 Avatar = "0xaddr3",
                 Version = 1,
-                Type = "Human",
+                Type = "CrcV1_Signup",
                 HasV1 = true,
                 V1Token = "0xtoken3"
             }
@@ -237,14 +237,14 @@ public class RpcCacheClientTests
         var cacheResponse = new Circles.Cache.Service.Models.AvatarInfoResponse(
             Avatar: "0xtest",
             Version: 2,
-            Type: "Human",
+            Type: "CrcV2_RegisterHuman",
             ShortName: "zAlice" // This field exists in cache response
         );
 
         var rpcModel = new AvatarInfoResponse(
             Avatar: "0xtest",
             Version: 2,
-            Type: "Human"
+            Type: "CrcV2_RegisterHuman"
             // ShortName property does not exist!
         );
 

--- a/src/Cache/Circles.Cache.Service/Controllers/AvatarsController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/AvatarsController.cs
@@ -52,7 +52,7 @@ public class AvatarsController : ControllerBase
                     Version: 2,
                     Type: v2Info.Type,
                     CidV0: cid,
-                    IsHuman: v2Info.Type.Contains("Human"),
+                    IsHuman: v2Info.Type == "CrcV2_RegisterHuman",
                     Name: isGroup ? groupInfo.Name : null,
                     Symbol: isGroup ? groupInfo.Symbol : null,
                     ShortName: shortName,
@@ -75,7 +75,7 @@ public class AvatarsController : ControllerBase
                     HasV1: true,
                     V1Token: v1Info.TokenAddress,
                     CidV0: cid,
-                    IsHuman: v1Info.Type.Contains("Human"),
+                    IsHuman: v1Info.Type == "CrcV1_Signup",
                     LastProcessedBlock: lastBlock,
                     Timestamp: timestamp
                 ));
@@ -90,7 +90,7 @@ public class AvatarsController : ControllerBase
                 return Ok(new AvatarInfoResponse(
                     Avatar: address,
                     Version: 2,
-                    Type: "Group",
+                    Type: "CrcV2_RegisterGroup",
                     CidV0: cid,
                     IsHuman: false,
                     Name: groupOnlyInfo.Name,
@@ -149,7 +149,7 @@ public class AvatarsController : ControllerBase
                         Version: 2,
                         Type: v2Info.Type,
                         CidV0: cid,
-                        IsHuman: v2Info.Type.Contains("Human"),
+                        IsHuman: v2Info.Type == "CrcV2_RegisterHuman",
                         Name: isGroup ? groupInfo.Name : null,
                         Symbol: isGroup ? groupInfo.Symbol : null,
                         ShortName: shortName,
@@ -171,7 +171,7 @@ public class AvatarsController : ControllerBase
                         HasV1: true,
                         V1Token: v1Info.TokenAddress,
                         CidV0: cid,
-                        IsHuman: v1Info.Type.Contains("Human"),
+                        IsHuman: v1Info.Type == "CrcV1_Signup",
                         LastProcessedBlock: lastBlock,
                         Timestamp: timestamp
                     ));
@@ -185,7 +185,7 @@ public class AvatarsController : ControllerBase
                     results.Add(new AvatarInfoResponse(
                         Avatar: address,
                         Version: 2,
-                        Type: "Group",
+                        Type: "CrcV2_RegisterGroup",
                         CidV0: cid,
                         IsHuman: false,
                         Name: groupOnlyInfo.Name,

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -180,9 +180,9 @@ public class BalancesController : ControllerBase
 
                         if (_caches.V2Avatars.TryGetValue(tokenAddress, out var avatarInfo))
                         {
-                            // V2Avatars stores "Human" / "Organization" — groups are in the Groups cache
+                            // V2Avatars stores full type names (CrcV2_RegisterHuman / CrcV2_RegisterOrganization)
                             isGroup = false;
-                            tokenType = avatarInfo.Type == "Human" ? "CrcV2_RegisterHuman" : "CrcV2_RegisterOrganization";
+                            tokenType = avatarInfo.Type;
                         }
                         else if (_caches.Groups.TryGetValue(tokenAddress, out _))
                         {

--- a/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
@@ -118,11 +118,11 @@ public class TokensController : ControllerBase
         }
 
         // 2. Check V2 Avatar token (ERC1155) - avatar address IS the token address
-        // V2Avatars stores "Human" / "Organization" (groups are in the Groups cache)
+        // V2Avatars stores full type names (CrcV2_RegisterHuman / CrcV2_RegisterOrganization)
         if (_caches.V2Avatars.TryGetValue(tokenAddressLower, out var v2Avatar))
         {
             var isGroup = false; // V2Avatars only contains humans and organizations, not groups
-            var tokenType = v2Avatar.Type == "Human" ? "CrcV2_RegisterHuman" : "CrcV2_RegisterOrganization";
+            var tokenType = v2Avatar.Type;
             return new TokenInfoResponse(
                 TokenAddress: tokenAddressLower,
                 TokenOwner: tokenAddressLower, // For V2, token owner is the avatar itself

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -1,5 +1,5 @@
-using System.Numerics;
 using System.Data;
+using System.Numerics;
 using Circles.Cache.Service.Caches;
 using Circles.Common;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -407,7 +407,7 @@ public class CacheWarmupService : BackgroundService
             SELECT
                 s.""user"" as address,
                 s.""token"",
-                'Human' as type
+                'CrcV1_Signup' as type
             FROM ""CrcV1_Signup"" s
             WHERE s.""blockNumber"" <= @toBlock
 
@@ -416,7 +416,7 @@ public class CacheWarmupService : BackgroundService
             SELECT
                 o.""organization"" as address,
                 NULL as token,
-                'Organization' as type
+                'CrcV1_OrganizationSignup' as type
             FROM ""CrcV1_OrganizationSignup"" o
             WHERE o.""blockNumber"" <= @toBlock";
 
@@ -438,16 +438,16 @@ public class CacheWarmupService : BackgroundService
 
             var addressKey = address.ToLowerInvariant();
 
-            if (type == "Human")
+            if (type == "CrcV1_Signup")
             {
                 var tokenKey = token!.ToLowerInvariant();
-                avatars[addressKey] = ("Human", token!);
+                avatars[addressKey] = ("CrcV1_Signup", token!);
                 tokenOwners[tokenKey] = address;
                 humanCount++;
             }
             else
             {
-                avatars[addressKey] = ("Organization", null);
+                avatars[addressKey] = ("CrcV1_OrganizationSignup", null);
                 orgCount++;
             }
         }
@@ -483,7 +483,7 @@ public class CacheWarmupService : BackgroundService
             SELECT
                 r.""avatar"" as address,
                 r.""timestamp"",
-                'Human' as type
+                'CrcV2_RegisterHuman' as type
             FROM ""CrcV2_RegisterHuman"" r
             WHERE r.""blockNumber"" <= @toBlock
 
@@ -492,7 +492,7 @@ public class CacheWarmupService : BackgroundService
             SELECT
                 r.""organization"" as address,
                 r.""timestamp"",
-                'Organization' as type
+                'CrcV2_RegisterOrganization' as type
             FROM ""CrcV2_RegisterOrganization"" r
             WHERE r.""blockNumber"" <= @toBlock";
 
@@ -515,7 +515,7 @@ public class CacheWarmupService : BackgroundService
                 var addressKey = address.ToLowerInvariant();
                 v2Avatars[addressKey] = (type, timestamp);
 
-                if (type == "Human")
+                if (type == "CrcV2_RegisterHuman")
                     humanCount++;
                 else
                     orgCount++;
@@ -1724,7 +1724,7 @@ public class CacheWarmupService : BackgroundService
                 var userKey = user.ToLowerInvariant();
                 var tokenKey = token.ToLowerInvariant();
 
-                _caches.V1Avatars.Add(blockNumber, userKey, ("Human", token));
+                _caches.V1Avatars.Add(blockNumber, userKey, ("CrcV1_Signup", token));
                 _caches.V1TokenOwnerByToken.Add(blockNumber, tokenKey, user);
             }
         }
@@ -1749,7 +1749,7 @@ public class CacheWarmupService : BackgroundService
 
                 var orgKey = organization.ToLowerInvariant();
 
-                _caches.V1Avatars.Add(blockNumber, orgKey, ("Organization", null));
+                _caches.V1Avatars.Add(blockNumber, orgKey, ("CrcV1_OrganizationSignup", null));
             }
         }
     }
@@ -1780,7 +1780,7 @@ public class CacheWarmupService : BackgroundService
 
                 var avatarKey = avatar.ToLowerInvariant();
 
-                _caches.V2Avatars.Add(blockNumber, avatarKey, ("Human", timestamp));
+                _caches.V2Avatars.Add(blockNumber, avatarKey, ("CrcV2_RegisterHuman", timestamp));
             }
         }
 
@@ -1805,7 +1805,7 @@ public class CacheWarmupService : BackgroundService
 
                 var orgKey = organization.ToLowerInvariant();
 
-                _caches.V2Avatars.Add(blockNumber, orgKey, ("Organization", timestamp));
+                _caches.V2Avatars.Add(blockNumber, orgKey, ("CrcV2_RegisterOrganization", timestamp));
             }
         }
 

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -405,7 +405,7 @@ public class NotificationListenerService : BackgroundService
                 var userKey = user.ToLowerInvariant();
                 var tokenKey = token.ToLowerInvariant();
 
-                _caches.V1Avatars.Add(blockNumber, userKey, ("Human", token));
+                _caches.V1Avatars.Add(blockNumber, userKey, ("CrcV1_Signup", token));
                 _caches.V1TokenOwnerByToken.Add(blockNumber, tokenKey, user);
                 count++;
             }
@@ -438,7 +438,7 @@ public class NotificationListenerService : BackgroundService
 
                 var orgKey = organization.ToLowerInvariant();
 
-                _caches.V1Avatars.Add(blockNumber, orgKey, ("Organization", null));
+                _caches.V1Avatars.Add(blockNumber, orgKey, ("CrcV1_OrganizationSignup", null));
                 orgCount++;
             }
         }
@@ -514,7 +514,7 @@ public class NotificationListenerService : BackgroundService
 
                 var avatarKey = avatar.ToLowerInvariant();
 
-                _caches.V2Avatars.Add(blockNumber, avatarKey, ("Human", timestamp));
+                _caches.V2Avatars.Add(blockNumber, avatarKey, ("CrcV2_RegisterHuman", timestamp));
                 count++;
             }
         }
@@ -548,7 +548,7 @@ public class NotificationListenerService : BackgroundService
 
                 var orgKey = organization.ToLowerInvariant();
 
-                _caches.V2Avatars.Add(blockNumber, orgKey, ("Organization", timestamp));
+                _caches.V2Avatars.Add(blockNumber, orgKey, ("CrcV2_RegisterOrganization", timestamp));
                 count++;
             }
         }

--- a/src/Rpc/Circles.Rpc.Host.Tests/AbiEncoderTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/AbiEncoderTests.cs
@@ -97,6 +97,101 @@ public class AbiEncoderTests
         Assert.That(result[1], Is.EqualTo(new BigInteger(2)));
     }
 
+    // ═══════════════════════════════════════════════════════════════════════
+    // Edge case tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void DecodeUint256_OnlyPrefix_ReturnsZero()
+    {
+        var result = AbiEncoder.DecodeUint256("0x");
+        Assert.That(result, Is.EqualTo(BigInteger.Zero));
+    }
+
+    [Test]
+    public void DecodeUint256Array_EmptyPayload_ReturnsEmptyArray()
+    {
+        var result = AbiEncoder.DecodeUint256Array("");
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void DecodeUint256Array_OnlyPrefix_ReturnsEmptyArray()
+    {
+        var result = AbiEncoder.DecodeUint256Array("0x");
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void DecodeUint256Array_TruncatedPayload_TooShortForOffset_Throws()
+    {
+        // offset=0x20 points to position 64, but payload has no data there
+        // This is a bounds violation — the decoder throws ArgumentOutOfRangeException
+        Assert.That(() => AbiEncoder.DecodeUint256Array("0x" + FormatHex(0x20)),
+            Throws.InstanceOf<ArgumentOutOfRangeException>(),
+            "Truncated payload should throw when array length cannot be read");
+    }
+
+    [Test]
+    public void DecodeUint256Array_ZeroLengthArray_ReturnsEmptyArray()
+    {
+        // Valid encoding of an empty array: offset(32) + length(0)
+        var payload = "0x" + FormatHex(0x20) + FormatHex(0);
+        var result = AbiEncoder.DecodeUint256Array(payload);
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void DecodeUint256Array_SingleElement_ParsesCorrectly()
+    {
+        var payload = BuildUint256ArrayPayload(new[] { new BigInteger(42) });
+        var result = AbiEncoder.DecodeUint256Array(payload);
+
+        Assert.That(result.Length, Is.EqualTo(1));
+        Assert.That(result[0], Is.EqualTo(new BigInteger(42)));
+    }
+
+    [Test]
+    public void DecodeUint256_MaxUint256_ParsesCorrectly()
+    {
+        // Max uint256: 2^256 - 1
+        var maxHex = new string('f', 64);
+        var result = AbiEncoder.DecodeUint256("0x" + maxHex);
+
+        var expected = BigInteger.Pow(2, 256) - 1;
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void EncodeBalanceOfErc20_WithoutPrefix_Works()
+    {
+        const string address = "1234567890abcdef1234567890abcdef12345678";
+        var calldata = AbiEncoder.EncodeBalanceOfErc20(address);
+
+        // Should handle address without 0x prefix
+        Assert.That(calldata, Does.StartWith("0x70a08231"));
+        Assert.That(calldata, Does.Contain(address));
+    }
+
+    [Test]
+    public void EncodeBalanceOfBatch_EmptyArrays_ReturnsValidEncoding()
+    {
+        var calldata = AbiEncoder.EncodeBalanceOfBatch(
+            Array.Empty<string>(),
+            Array.Empty<BigInteger>());
+
+        Assert.That(calldata, Does.StartWith("0x4e1273f4"));
+    }
+
+    [Test]
+    public void EncodeBalanceOfBatch_MismatchedLengths_ThrowsArgumentException()
+    {
+        Assert.That(() => AbiEncoder.EncodeBalanceOfBatch(
+            new[] { "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" },
+            Array.Empty<BigInteger>()),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
     private static string FormatHex(long value)
     {
         return value.ToString("X").PadLeft(64, '0');

--- a/src/Rpc/Circles.Rpc.Host.Tests/CursorUtilsTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/CursorUtilsTests.cs
@@ -69,4 +69,169 @@ public class CursorUtilsTests
             Assert.That(batch, Is.Null);
         });
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // BUG-6 regression tests: malformed cursor silently returns page 1
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void DecodeCursor_ValidBase64ButWrongFormat_ReturnsNulls()
+    {
+        // Valid base64 but not "block:tx:log" format — just "hello"
+        var cursor = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("hello"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_ValidBase64WithTwoParts_ReturnsNulls()
+    {
+        // Valid base64 "123:456" — only 2 parts, needs 3
+        var cursor = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("123:456"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_NegativeValues_ParsesSuccessfully()
+    {
+        // Negative values are technically valid base64-encoded cursor data
+        var cursor = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("-1:-2:-3"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        // Currently these parse successfully — we may want to reject them
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.EqualTo(-1));
+            Assert.That(tx, Is.EqualTo(-2));
+            Assert.That(log, Is.EqualTo(-3));
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_TamperedCursor_NonNumericParts_ReturnsNulls()
+    {
+        // Tampered cursor with non-numeric parts
+        var cursor = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("abc:def:ghi"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_EmptyString_ReturnsNulls()
+    {
+        var (block, tx, log) = CursorUtils.DecodeCursor("");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_Null_ReturnsNulls()
+    {
+        var (block, tx, log) = CursorUtils.DecodeCursor(null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void DecodeCursor_OverflowValues_ReturnsNulls()
+    {
+        // Values that overflow long/int
+        var cursor = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes("99999999999999999999:1:1"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        // Should return nulls because long.Parse overflows
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // wasMalformed output parameter tests
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void DecodeCursor_ValidCursor_WasMalformedIsFalse()
+    {
+        var cursor = CursorUtils.EncodeCursor(100, 5, 2);
+        CursorUtils.DecodeCursor(cursor, out var wasMalformed);
+        Assert.That(wasMalformed, Is.False);
+    }
+
+    [Test]
+    public void DecodeCursor_NullCursor_WasMalformedIsFalse()
+    {
+        // Null = "no cursor" not "bad cursor"
+        CursorUtils.DecodeCursor(null, out var wasMalformed);
+        Assert.That(wasMalformed, Is.False);
+    }
+
+    [Test]
+    public void DecodeCursor_EmptyCursor_WasMalformedIsFalse()
+    {
+        CursorUtils.DecodeCursor("", out var wasMalformed);
+        Assert.That(wasMalformed, Is.False);
+    }
+
+    [Test]
+    public void DecodeCursor_GarbageCursor_WasMalformedIsTrue()
+    {
+        CursorUtils.DecodeCursor("not-valid-base64!", out var wasMalformed);
+        Assert.That(wasMalformed, Is.True);
+    }
+
+    [Test]
+    public void DecodeCursor_ValidBase64ButWrongFormat_WasMalformedIsTrue()
+    {
+        var cursor = Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes("just-text"));
+        CursorUtils.DecodeCursor(cursor, out var wasMalformed);
+        Assert.That(wasMalformed, Is.True);
+    }
+
+    [Test]
+    public void EncodeCursor_LargeBlockNumber_RoundTrips()
+    {
+        // Test with max realistic block number
+        var cursor = CursorUtils.EncodeCursor(long.MaxValue, int.MaxValue, int.MaxValue);
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.EqualTo(long.MaxValue));
+            Assert.That(tx, Is.EqualTo(int.MaxValue));
+            Assert.That(log, Is.EqualTo(int.MaxValue));
+        });
+    }
 }

--- a/src/Rpc/Circles.Rpc.Host.Tests/InputValidationTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/InputValidationTests.cs
@@ -1,0 +1,125 @@
+using Circles.Rpc.Host;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Tests for input validation edge cases across the RPC module.
+/// These tests verify boundary conditions without requiring a database.
+/// </summary>
+[TestFixture]
+public class InputValidationTests
+{
+    // ═══════════════════════════════════════════════════════════════════════
+    // Cursor validation (BUG-6: silent failure on malformed cursor)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void CursorDecode_ValidBase64ButSqlInjection_DoesNotParse()
+    {
+        // Attacker tries to inject SQL via cursor
+        var malicious = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes("1; DROP TABLE users;--:1:1"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(malicious);
+
+        // long.Parse should fail on "1; DROP TABLE users;--"
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void CursorDecode_FloatingPointValues_DoesNotParse()
+    {
+        var cursor = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes("1.5:2.5:3.5"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.Null);
+            Assert.That(tx, Is.Null);
+            Assert.That(log, Is.Null);
+        });
+    }
+
+    [Test]
+    public void CursorDecode_ExtraColonSeparatedParts_StillParses()
+    {
+        // "1:2:3:extra:stuff" — has >= 3 parts, so should parse first 3
+        var cursor = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes("100:5:2:extra:stuff"));
+        var (block, tx, log) = CursorUtils.DecodeCursor(cursor);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(block, Is.EqualTo(100));
+            Assert.That(tx, Is.EqualTo(5));
+            Assert.That(log, Is.EqualTo(2));
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // BUG-1 regression: avatar type mapping
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public void AvatarTypeMapping_DbFullNames_PassThrough()
+    {
+        // The V_CrcV2_Avatars view stores full event names.
+        // These should pass through unchanged (already canonical).
+        var fullNames = new[] { "CrcV2_RegisterHuman", "CrcV2_RegisterOrganization", "CrcV2_RegisterGroup" };
+
+        foreach (var fullName in fullNames)
+        {
+            var result = CirclesRpcModule.NormalizeAvatarType(fullName);
+            Assert.That(result, Is.EqualTo(fullName),
+                $"Full DB name '{fullName}' should pass through unchanged");
+        }
+    }
+
+    [Test]
+    public void AvatarTypeMapping_LegacyShortNames_MapToFullNames()
+    {
+        // Legacy safety net: short names map to V2 full names.
+        // Cache now stores full names, but mapping preserved for backward compatibility.
+        var mappings = new Dictionary<string, string>
+        {
+            { "Human", "CrcV2_RegisterHuman" },
+            { "Organization", "CrcV2_RegisterOrganization" },
+            { "Group", "CrcV2_RegisterGroup" },
+        };
+
+        foreach (var (shortName, expectedFull) in mappings)
+        {
+            var result = CirclesRpcModule.NormalizeAvatarType(shortName);
+            Assert.That(result, Is.EqualTo(expectedFull),
+                $"Legacy short name '{shortName}' should normalize to '{expectedFull}'");
+        }
+    }
+
+    [Test]
+    public void AvatarTypeMapping_V1FullNames_PassThrough()
+    {
+        // V1 full type names should pass through unchanged.
+        var v1Names = new[] { "CrcV1_Signup", "CrcV1_OrganizationSignup" };
+
+        foreach (var name in v1Names)
+        {
+            var result = CirclesRpcModule.NormalizeAvatarType(name);
+            Assert.That(result, Is.EqualTo(name),
+                $"V1 full name '{name}' should pass through unchanged");
+        }
+    }
+
+    [Test]
+    public void AvatarTypeMapping_UnknownType_ReturnsPassthrough()
+    {
+        // Unknown types pass through (not null — NormalizeAvatarType returns the input or "Unknown")
+        Assert.That(CirclesRpcModule.NormalizeAvatarType("SomethingElse"), Is.EqualTo("SomethingElse"));
+        Assert.That(CirclesRpcModule.NormalizeAvatarType(null), Is.EqualTo("Unknown"));
+        Assert.That(CirclesRpcModule.NormalizeAvatarType(""), Is.EqualTo(""));
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -1,0 +1,354 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Snapshot-based regression tests for the Circles RPC Host.
+/// Calls live RPC methods against a staging/test environment and verifies structural expectations.
+///
+/// These tests require TEST_ENV_URL to be set (e.g., http://localhost:8081 or https://rpc.aboutcircles.com).
+/// They are categorized as "RpcRegression" and skipped when the environment is not configured.
+/// </summary>
+[TestFixture]
+[Category("RpcRegression")]
+public class RpcMethodSnapshotTests
+{
+    private static readonly string? TestEnvUrl = Environment.GetEnvironmentVariable("TEST_ENV_URL");
+    private HttpClient? _client;
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (string.IsNullOrEmpty(TestEnvUrl))
+        {
+            Assert.Ignore("TEST_ENV_URL not set — skipping RPC regression tests. " +
+                           "Set TEST_ENV_URL=http://localhost:8081 to run against local, " +
+                           "or TEST_ENV_URL=https://rpc.aboutcircles.com for production comparison.");
+            return;
+        }
+
+        _client = new HttpClient { BaseAddress = new Uri(TestEnvUrl) };
+        _client.Timeout = TimeSpan.FromSeconds(30);
+    }
+
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        _client?.Dispose();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Test infrastructure
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private async Task<JsonElement> CallRpc(string method, params object[] parameters)
+    {
+        var request = new
+        {
+            jsonrpc = "2.0",
+            method,
+            @params = parameters,
+            id = 1
+        };
+
+        var response = await _client!.PostAsJsonAsync("/", request, new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(json);
+
+        if (doc.RootElement.TryGetProperty("error", out var error))
+        {
+            Assert.Fail($"RPC error: {error}");
+        }
+
+        return doc.RootElement.GetProperty("result");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Health & Schema
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task Health_ReturnsHealthy()
+    {
+        var result = await CallRpc("circles_health");
+        Assert.That(result.GetProperty("status").GetString(), Is.EqualTo("healthy"));
+    }
+
+    [Test]
+    public async Task Tables_ReturnsNonEmptySchema()
+    {
+        var result = await CallRpc("circles_tables");
+        Assert.That(result.GetArrayLength(), Is.GreaterThan(0),
+            "Should return at least one namespace");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Balance queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    // Known V2 human address (from test-rpc.sh)
+    private const string KnownV2Human = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+
+    [Test]
+    public async Task GetTotalBalance_V2_ReturnsNonNullString()
+    {
+        var result = await CallRpc("circlesV2_getTotalBalance", KnownV2Human, 2, true);
+        var balance = result.GetProperty("totalBalance").GetString();
+        Assert.That(balance, Is.Not.Null.And.Not.Empty,
+            "V2 total balance should be a non-empty string");
+    }
+
+    [Test]
+    public async Task GetTotalBalance_V2Raw_ReturnsNonNullString()
+    {
+        var result = await CallRpc("circlesV2_getTotalBalance", KnownV2Human, 2, false);
+        var balance = result.GetProperty("totalBalance").GetString();
+        Assert.That(balance, Is.Not.Null.And.Not.Empty,
+            "V2 raw total balance should be a non-empty string");
+    }
+
+    [Test]
+    public async Task GetTokenBalances_ReturnsArrayWithBalanceFields()
+    {
+        var result = await CallRpc("circles_getTokenBalances", KnownV2Human);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
+
+        if (result.GetArrayLength() > 0)
+        {
+            var first = result[0];
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.TryGetProperty("tokenAddress", out _), Is.True, "Should have tokenAddress");
+                Assert.That(first.TryGetProperty("tokenId", out _), Is.True, "Should have tokenId");
+                Assert.That(first.TryGetProperty("tokenOwner", out _), Is.True, "Should have tokenOwner");
+                Assert.That(first.TryGetProperty("attoCircles", out _), Is.True, "Should have attoCircles");
+                Assert.That(first.TryGetProperty("circles", out _), Is.True, "Should have circles");
+                Assert.That(first.TryGetProperty("staticAttoCircles", out _), Is.True, "Should have staticAttoCircles");
+                Assert.That(first.TryGetProperty("attoCrc", out _), Is.True, "Should have attoCrc");
+                Assert.That(first.TryGetProperty("version", out _), Is.True, "Should have version");
+            });
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Avatar queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetAvatarInfo_KnownV2Human_ReturnsVersion2()
+    {
+        var result = await CallRpc("circles_getAvatarInfo", KnownV2Human);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetProperty("version").GetInt32(), Is.EqualTo(2));
+            Assert.That(result.GetProperty("avatar").GetString(), Is.EqualTo(KnownV2Human));
+        });
+    }
+
+    [Test]
+    public async Task GetAvatarInfoBatch_ReturnsArrayMatchingInput()
+    {
+        var addresses = new[] { KnownV2Human, "0x0000000000000000000000000000000000000001" };
+        var result = await CallRpc("circles_getAvatarInfoBatch", (object)addresses);
+        Assert.That(result.GetArrayLength(), Is.EqualTo(2),
+            "Result length should match input length");
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Trust queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetTrustRelations_ReturnsStructuredResponse()
+    {
+        var result = await CallRpc("circles_getTrustRelations", KnownV2Human);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.TryGetProperty("user", out _), Is.True, "Should have user");
+            Assert.That(result.TryGetProperty("trusts", out _), Is.True, "Should have trusts");
+            Assert.That(result.TryGetProperty("trustedBy", out _), Is.True, "Should have trustedBy");
+        });
+    }
+
+    [Test]
+    public async Task GetAggregatedTrustRelations_ReturnsArray()
+    {
+        var result = await CallRpc("circles_getAggregatedTrustRelations", KnownV2Human);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
+
+        if (result.GetArrayLength() > 0)
+        {
+            var first = result[0];
+            Assert.Multiple(() =>
+            {
+                Assert.That(first.TryGetProperty("subjectAvatar", out _), Is.True);
+                Assert.That(first.TryGetProperty("relation", out _), Is.True);
+                Assert.That(first.TryGetProperty("objectAvatar", out _), Is.True);
+                // BUG-1 regression: objectAvatarType should NOT be null for known avatars
+                // (was always null in DB path before fix)
+                Assert.That(first.TryGetProperty("objectAvatarType", out var avatarType), Is.True);
+                if (avatarType.ValueKind != JsonValueKind.Null)
+                {
+                    var type = avatarType.GetString();
+                    var validTypes = new[] {
+                        "CrcV2_RegisterHuman", "CrcV2_RegisterOrganization", "CrcV2_RegisterGroup",
+                        "CrcV1_Signup", "CrcV1_OrganizationSignup"
+                    };
+                    Assert.That(validTypes, Does.Contain(type),
+                        $"objectAvatarType '{type}' should be a canonical full type name");
+                }
+            });
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Token queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetTokenInfo_KnownV2Human_ReturnsTokenInfo()
+    {
+        var result = await CallRpc("circles_getTokenInfo", KnownV2Human);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.GetProperty("tokenAddress").GetString(), Is.EqualTo(KnownV2Human));
+            Assert.That(result.GetProperty("version").GetInt32(), Is.EqualTo(2));
+            Assert.That(result.GetProperty("isErc1155").GetBoolean(), Is.True);
+        });
+    }
+
+    [Test]
+    public async Task GetTokenInfoBatch_ReturnsArrayMatchingInput()
+    {
+        var addresses = new[] { KnownV2Human };
+        var result = await CallRpc("circles_getTokenInfoBatch", (object)addresses);
+        Assert.That(result.GetArrayLength(), Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task GetTokenHolders_ReturnsPagedResponse()
+    {
+        var result = await CallRpc("circles_getTokenHolders", KnownV2Human, 10);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.TryGetProperty("results", out _), Is.True);
+            Assert.That(result.TryGetProperty("hasMore", out _), Is.True);
+
+            var results = result.GetProperty("results");
+            if (results.GetArrayLength() > 0)
+            {
+                var first = results[0];
+                Assert.That(first.TryGetProperty("account", out _), Is.True);
+                Assert.That(first.TryGetProperty("balance", out _), Is.True);
+                Assert.That(first.TryGetProperty("version", out _), Is.True);
+            }
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Group queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task FindGroups_ReturnsPagedResponse()
+    {
+        var result = await CallRpc("circles_findGroups", 10);
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.TryGetProperty("results", out _), Is.True);
+            Assert.That(result.TryGetProperty("hasMore", out _), Is.True);
+
+            var results = result.GetProperty("results");
+            if (results.GetArrayLength() > 0)
+            {
+                var first = results[0];
+                Assert.That(first.TryGetProperty("group", out _), Is.True);
+                Assert.That(first.TryGetProperty("name", out _), Is.True);
+                Assert.That(first.TryGetProperty("symbol", out _), Is.True);
+            }
+        });
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Event queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetEvents_WithAddressFilter_ReturnsRows()
+    {
+        var result = await CallRpc("circles_events", KnownV2Human, null, null, null, null, false);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Profile queries
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetProfileCid_ReturnsResponse()
+    {
+        var result = await CallRpc("circles_getProfileCid", KnownV2Human);
+        Assert.That(result.TryGetProperty("cid", out _), Is.True);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Pagination consistency
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetTokenHolders_Pagination_HasMoreImpliesCursor()
+    {
+        // BUG-4 regression: HasMore:true must always have a non-null NextCursor
+        var result = await CallRpc("circles_getTokenHolders", KnownV2Human, 1);
+        var hasMore = result.GetProperty("hasMore").GetBoolean();
+
+        if (hasMore)
+        {
+            var nextCursor = result.GetProperty("nextCursor");
+            Assert.That(nextCursor.ValueKind, Is.Not.EqualTo(JsonValueKind.Null),
+                "When hasMore=true, nextCursor must not be null (BUG-4 regression)");
+        }
+    }
+
+    [Test]
+    public async Task FindGroups_Pagination_HasMoreImpliesCursor()
+    {
+        var result = await CallRpc("circles_findGroups", 1);
+        var hasMore = result.GetProperty("hasMore").GetBoolean();
+
+        if (hasMore)
+        {
+            var nextCursor = result.GetProperty("nextCursor");
+            Assert.That(nextCursor.ValueKind, Is.Not.EqualTo(JsonValueKind.Null),
+                "When hasMore=true, nextCursor must not be null");
+        }
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Cross-path consistency (cache vs DB)
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Test]
+    public async Task GetTotalBalance_TimeCirclesVsRaw_TimeCirclesIsNonZeroWhenRawIsNonZero()
+    {
+        var tcResult = await CallRpc("circlesV2_getTotalBalance", KnownV2Human, 2, true);
+        var rawResult = await CallRpc("circlesV2_getTotalBalance", KnownV2Human, 2, false);
+
+        var tcBalance = tcResult.GetProperty("totalBalance").GetString();
+        var rawBalance = rawResult.GetProperty("totalBalance").GetString();
+
+        // If raw is non-zero, time-circles should also be non-zero
+        if (rawBalance != "0" && rawBalance != null)
+        {
+            Assert.That(tcBalance, Is.Not.EqualTo("0").And.Not.Null,
+                "If raw balance is non-zero, time-circles balance should also be non-zero");
+        }
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host.Tests/TokenConversionTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/TokenConversionTests.cs
@@ -1,0 +1,115 @@
+using System.Numerics;
+using Circles.Rpc.Host;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Tests for TokenIdToAddress / AddressToTokenIdBigInt round-trip conversion
+/// and edge cases in token ID handling.
+/// </summary>
+[TestFixture]
+public class TokenConversionTests
+{
+    // TokenIdToAddress and AddressToTokenIdBigInt are private static methods.
+    // We use reflection to test them, or test indirectly via public methods.
+    // For now, we test the conversion logic by reimplementing the same algorithm
+    // and verifying it matches expectations.
+
+    [TestCase("0x42cedde51198d1773590311e2a340dc06b24cb37")]
+    [TestCase("0x0000000000000000000000000000000000000001")]
+    [TestCase("0xffffffffffffffffffffffffffffffffffffffff")]
+    [TestCase("0x0000000000000000000000000000000000000000")]
+    public void AddressToTokenId_RoundTrip_PreservesAddress(string address)
+    {
+        var tokenId = AddressToTokenIdBigInt(address);
+        var recovered = TokenIdToAddress(tokenId.ToString());
+
+        Assert.That(recovered, Is.EqualTo(address.ToLowerInvariant()));
+    }
+
+    [Test]
+    public void AddressToTokenId_ZeroAddress_ReturnsZero()
+    {
+        var result = AddressToTokenIdBigInt("0x0000000000000000000000000000000000000000");
+        Assert.That(result, Is.EqualTo(BigInteger.Zero));
+    }
+
+    [Test]
+    public void AddressToTokenId_MaxUint160_ReturnsCorrectValue()
+    {
+        var maxUint160 = BigInteger.Pow(2, 160) - 1;
+        var result = AddressToTokenIdBigInt("0xffffffffffffffffffffffffffffffffffffffff");
+        Assert.That(result, Is.EqualTo(maxUint160));
+    }
+
+    [Test]
+    public void TokenIdToAddress_AlreadyHexAddress_LowercasesIt()
+    {
+        var result = TokenIdToAddress("0xAbCdEf1234567890AbCdEf1234567890AbCdEf12");
+        Assert.That(result, Is.EqualTo("0xabcdef1234567890abcdef1234567890abcdef12"));
+    }
+
+    [Test]
+    public void TokenIdToAddress_NumericId_ConvertsToAddress()
+    {
+        // tokenId = 1 → should be 0x0000...0001
+        var result = TokenIdToAddress("1");
+        Assert.That(result, Is.EqualTo("0x0000000000000000000000000000000000000001"));
+    }
+
+    [Test]
+    public void TokenIdToAddress_LeadingZeroAddress_PreservesFullLength()
+    {
+        // Address with leading zeros: 0x0000...0042
+        var result = TokenIdToAddress("66"); // 0x42
+        Assert.That(result, Has.Length.EqualTo(42)); // "0x" + 40 hex chars
+        Assert.That(result, Is.EqualTo("0x0000000000000000000000000000000000000042"));
+    }
+
+    [Test]
+    public void TokenIdToAddress_LargeValue_TruncatesTo40Chars()
+    {
+        // A value that when converted to hex has more than 40 chars
+        // BigInteger.ToString("x") prepends "0" for positive MSB >= 8
+        // For max uint160: all f's = 40 chars, but BigInteger prepends "0" → 41 chars
+        var maxUint160 = BigInteger.Pow(2, 160) - 1;
+        var result = TokenIdToAddress(maxUint160.ToString());
+        Assert.That(result, Is.EqualTo("0xffffffffffffffffffffffffffffffffffffffff"));
+    }
+
+    [Test]
+    public void AddressToTokenId_NeverReturnsNegative()
+    {
+        // BigInteger.Parse with HexNumber can return negative if MSB >= 8
+        // The "0" prefix in the code prevents this
+        var result = AddressToTokenIdBigInt("0xffffffffffffffffffffffffffffffffffffffff");
+        Assert.That(result.Sign, Is.EqualTo(1), "Token ID should always be positive");
+    }
+
+    // Mirror the private methods for testing
+    private static BigInteger AddressToTokenIdBigInt(string address)
+    {
+        var hex = address.StartsWith("0x") ? address.Substring(2) : address;
+        return BigInteger.Parse("0" + hex, System.Globalization.NumberStyles.HexNumber);
+    }
+
+    private static string TokenIdToAddress(string tokenId)
+    {
+        if (tokenId.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+        {
+            return tokenId.ToLowerInvariant();
+        }
+
+        var bigInt = BigInteger.Parse(tokenId);
+        var hex = bigInt.ToString("x");
+        if (hex.Length > 40)
+        {
+            hex = hex.Substring(hex.Length - 40);
+        }
+        else
+        {
+            hex = hex.PadLeft(40, '0');
+        }
+        return "0x" + hex;
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -54,7 +54,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 ""from"",
                 ""to"",
                 NULL::text as id,
-                amount as value
+                amount as value,
+                0 as ""isInflationary""
             FROM ""CrcV1_TransferSummary""
             WHERE (""from"" = @address OR ""to"" = @address)
               {(hasCursor ? @"AND (
@@ -88,7 +89,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                     ""from"",
                     ""to"",
                     ""tokenAddress"" as id,
-                    amount as value
+                    amount as value,
+                    0 as ""isInflationary""
                 FROM ""CrcV1_Transfer""
                 WHERE (""from"" = @address OR ""to"" = @address)
                 UNION ALL
@@ -104,7 +106,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                     ""from"",
                     ""to"",
                     NULL::text as id,
-                    amount as value
+                    amount as value,
+                    0 as ""isInflationary""
                 FROM ""CrcV1_HubTransfer""
                 WHERE (""from"" = @address OR ""to"" = @address)
             ) AS v1_transfers
@@ -137,7 +140,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 ""from"",
                 ""to"",
                 NULL::text as id,
-                amount as value
+                amount as value,
+                0 as ""isInflationary""
             FROM ""CrcV2_TransferSummary""
             WHERE (""from"" = @address OR ""to"" = @address)
               {(hasCursor ? @"AND (
@@ -170,7 +174,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                     ""from"",
                     ""to"",
                     id::text,
-                    value
+                    value,
+                    0 as ""isInflationary""
                 FROM ""CrcV2_TransferSingle""
                 WHERE (""from"" = @address OR ""to"" = @address)
                 UNION ALL
@@ -186,25 +191,28 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                     ""from"",
                     ""to"",
                     id::text,
-                    value
+                    value,
+                    0 as ""isInflationary""
                 FROM ""CrcV2_TransferBatch""
                 WHERE (""from"" = @address OR ""to"" = @address)
                 UNION ALL
                 SELECT
-                    ""blockNumber"",
-                    timestamp,
-                    ""transactionIndex"",
-                    ""logIndex"",
+                    wt.""blockNumber"",
+                    wt.timestamp,
+                    wt.""transactionIndex"",
+                    wt.""logIndex"",
                     0 as ""batchIndex"",
-                    ""transactionHash"",
+                    wt.""transactionHash"",
                     2 as version,
                     NULL::text as operator,
-                    ""from"",
-                    ""to"",
-                    ""tokenAddress"" as id,
-                    amount as value
-                FROM ""CrcV2_Erc20WrapperTransfer""
-                WHERE (""from"" = @address OR ""to"" = @address)
+                    wt.""from"",
+                    wt.""to"",
+                    wt.""tokenAddress"" as id,
+                    wt.amount as value,
+                    CASE WHEN wd.""circlesType"" = 1 THEN 1 ELSE 0 END as ""isInflationary""
+                FROM ""CrcV2_Erc20WrapperTransfer"" wt
+                INNER JOIN ""CrcV2_ERC20WrapperDeployed"" wd ON wd.""erc20Wrapper"" = wt.""tokenAddress""
+                WHERE (wt.""from"" = @address OR wt.""to"" = @address)
             ) AS v2_transfers
             WHERE true
               {(hasCursor ? @"AND (
@@ -272,6 +280,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         var to = reader.GetString(9);
         var id = reader.IsDBNull(10) ? null : reader.GetString(10);
         var valueRaw = reader.GetFieldValue<System.Numerics.BigInteger>(11);
+        var isInflationary = reader.GetInt32(12);
 
         // Calculate all circle amount formats
         BigInteger attoCirclesDemurraged;
@@ -285,9 +294,18 @@ public partial class CirclesRpcModule : ICirclesRpcModule
             attoCirclesDemurraged = CirclesConverter.AttoCrcToAttoCircles(attoCrc, (ulong)timestamp);
             staticAttoCircles = CirclesConverter.AttoCirclesToAttoStaticCircles(attoCirclesDemurraged);
         }
+        else if (isInflationary == 1)
+        {
+            // V2 inflationary wrapper: value is static (inflationary) attoCircles
+            staticAttoCircles = valueRaw;
+            var timestampUtc = DateTimeOffset.FromUnixTimeSeconds(timestamp);
+            var day = CirclesConverter.DayFromTimestamp(timestampUtc, 1_602_720_000);
+            attoCirclesDemurraged = CirclesConverter.InflationaryToDemurrage(staticAttoCircles, day);
+            attoCrc = CirclesConverter.AttoCirclesToAttoCrc(attoCirclesDemurraged, (ulong)timestamp);
+        }
         else
         {
-            // V2: value is demurraged attoCircles
+            // V2 demurraged: value is demurraged attoCircles
             attoCirclesDemurraged = valueRaw;
             var timestampUtc = DateTimeOffset.FromUnixTimeSeconds(timestamp);
             var day = CirclesConverter.DayFromTimestamp(timestampUtc, 1_602_720_000);
@@ -329,7 +347,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         int? version = null,
         bool excludeIntermediary = true)
     {
-        var normalizedAddress = avatarAddress.ToLower();
+        var normalizedAddress = ValidateAndNormalizeAddress(avatarAddress, nameof(avatarAddress));
         await using var connection = await CreateConnectionAsync();
 
         var (cursorBlock, cursorTxIndex, cursorLogIndex, cursorBatchIndex) = CursorUtils.DecodeCursorWithBatch(cursor);
@@ -414,7 +432,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         int limit = 50,
         string? cursor = null)
     {
-        var addr = address.ToLower();
+        var addr = ValidateAndNormalizeAddress(address);
         limit = Math.Clamp(limit, 1, 1000);
 
         if (direction != null && direction != "sent" && direction != "received")
@@ -634,6 +652,12 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         int? limit = null,
         string? cursor = null)
     {
+        // Validate address if provided (nullable — null means "all addresses")
+        if (address != null)
+        {
+            address = ValidateAndNormalizeAddress(address);
+        }
+
         // Apply pagination limits
         const int defaultLimit = 100;
         const int maxLimit = 1000;
@@ -2012,7 +2036,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         int? version = null,
         bool excludeIntermediary = true)
     {
-        var normalizedAddress = address.ToLower();
+        var normalizedAddress = ValidateAndNormalizeAddress(address);
         await using var connection = await CreateConnectionAsync();
 
         var (cursorBlock, cursorTxIndex, cursorLogIndex) = CursorUtils.DecodeCursor(cursor);
@@ -3010,8 +3034,13 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         var fullTableName = $"{validatedNamespace}_{validatedTable}";
         var tableName = $"\"{fullTableName}\"";
 
-        // Check if the table has event columns for cursor-based pagination
+        // Security: Only allow querying tables that exist in the known schema.
+        // Without this check, users could probe system tables like pg_catalog.
         var tableColumns = DatabaseSchemaMap.GetTableColumns(fullTableName);
+        if (tableColumns == null)
+        {
+            throw new ArgumentException($"Table '{fullTableName}' is not a known Circles table.");
+        }
         var hasEventColumns = tableColumns != null &&
             tableColumns.ContainsKey("blockNumber") &&
             tableColumns.ContainsKey("transactionIndex") &&

--- a/src/Rpc/Circles.Rpc.Host/CursorUtils.cs
+++ b/src/Rpc/Circles.Rpc.Host/CursorUtils.cs
@@ -7,9 +7,16 @@ public static class CursorUtils
 {
     /// <summary>
     /// Decodes a base64-encoded cursor string into blockNumber, transactionIndex, logIndex.
+    /// Returns nulls for both absent and malformed cursors (callers treat null as "page 1").
     /// </summary>
-    public static (long? blockNumber, int? transactionIndex, int? logIndex) DecodeCursor(string? cursor)
+    /// <param name="cursor">Base64-encoded "block:tx:log" string, or null/empty for first page.</param>
+    /// <param name="wasMalformed">Set to true if cursor was non-null but could not be decoded.
+    /// Callers can use this to log a warning or return an error.</param>
+    public static (long? blockNumber, int? transactionIndex, int? logIndex) DecodeCursor(
+        string? cursor, out bool wasMalformed)
     {
+        wasMalformed = false;
+
         if (string.IsNullOrEmpty(cursor))
         {
             return (null, null, null);
@@ -26,17 +33,30 @@ public static class CursorUtils
         }
         catch
         {
-            // Invalid cursor, ignore
+            // Fall through to malformed
         }
 
+        wasMalformed = true;
         return (null, null, null);
+    }
+
+    /// <summary>
+    /// Decodes a base64-encoded cursor string into blockNumber, transactionIndex, logIndex.
+    /// Backwards-compatible overload that does not report malformed status.
+    /// </summary>
+    public static (long? blockNumber, int? transactionIndex, int? logIndex) DecodeCursor(string? cursor)
+    {
+        return DecodeCursor(cursor, out _);
     }
 
     /// <summary>
     /// Decodes a base64-encoded cursor string into blockNumber, transactionIndex, logIndex, batchIndex.
     /// </summary>
-    public static (long? blockNumber, int? transactionIndex, int? logIndex, int? batchIndex) DecodeCursorWithBatch(string? cursor)
+    public static (long? blockNumber, int? transactionIndex, int? logIndex, int? batchIndex) DecodeCursorWithBatch(
+        string? cursor, out bool wasMalformed)
     {
+        wasMalformed = false;
+
         if (string.IsNullOrEmpty(cursor))
         {
             return (null, null, null, null);
@@ -57,10 +77,19 @@ public static class CursorUtils
         }
         catch
         {
-            // Invalid cursor, ignore
+            // Fall through to malformed
         }
 
+        wasMalformed = true;
         return (null, null, null, null);
+    }
+
+    /// <summary>
+    /// Backwards-compatible overload that does not report malformed status.
+    /// </summary>
+    public static (long? blockNumber, int? transactionIndex, int? logIndex, int? batchIndex) DecodeCursorWithBatch(string? cursor)
+    {
+        return DecodeCursorWithBatch(cursor, out _);
     }
 
     /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -464,7 +464,7 @@ public record AggregatedTrustRelation(
     [property: JsonPropertyName("objectAvatar")] string ObjectAvatar,
     [property: JsonPropertyName("timestamp")] long Timestamp,
     [property: JsonPropertyName("expiryTime")] long ExpiryTime,
-    [property: JsonPropertyName("objectAvatarType")] string? ObjectAvatarType  // "Human" | "Group" | "Organization"
+    [property: JsonPropertyName("objectAvatarType")] string? ObjectAvatarType  // "CrcV2_RegisterHuman" | "CrcV2_RegisterGroup" | "CrcV2_RegisterOrganization" | "CrcV1_Signup" | "CrcV1_OrganizationSignup"
 );
 
 /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
@@ -11,6 +11,8 @@ public partial class CirclesRpcModule
 {
     public async Task<AvatarInfo> GetAvatarInfo(string address)
     {
+        address = ValidateAndNormalizeAddress(address);
+
         var results = await GetAvatarInfoBatchInternal(new[] { address });
         var result = results[0];
 
@@ -24,6 +26,9 @@ public partial class CirclesRpcModule
 
     public async Task<AvatarInfo[]> GetAvatarInfoBatch(string[] addresses)
     {
+        for (int i = 0; i < addresses.Length; i++)
+            addresses[i] = ValidateAndNormalizeAddress(addresses[i], $"addresses[{i}]");
+
         var results = await GetAvatarInfoBatchInternal(addresses);
         return results.Where(r => r != null).ToArray()!;
     }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
@@ -53,7 +53,7 @@ public partial class CirclesRpcModule
                     {
                         cacheResult[i] = new AvatarInfo(
                             Version: cacheInfo.Version,
-                            Type: cacheInfo.Type,
+                            Type: NormalizeAvatarType(cacheInfo.Type),
                             Avatar: cacheInfo.Avatar,
                             TokenId: cacheInfo.TokenId ?? cacheInfo.Avatar,
                             HasV1: cacheInfo.HasV1,

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
@@ -11,8 +11,17 @@ namespace Circles.Rpc.Host;
 /// </summary>
 public partial class CirclesRpcModule
 {
+    /// <summary>
+    /// Three query paths with intentionally different semantics:
+    /// 1. Cache (asTimeCircles=true): Returns time-circles value from cache service (pre-computed demurraged balance)
+    /// 2. Raw (asTimeCircles=false): Returns static (non-demurraged) transfer sum via GetRawTotalBalanceAsync
+    /// 3. DB fallback (asTimeCircles=true, cache unavailable): Computes from GetTokenBalancesForAccount (per-token demurraged sum)
+    /// Note: Path 1 and 3 may differ slightly due to caching delays and rounding differences.
+    /// </summary>
     public async Task<TotalBalanceResponse> GetTotalBalance(string address, int version, bool? asTimeCircles = true)
     {
+        address = ValidateAndNormalizeAddress(address);
+
         // If cache service is enabled and asTimeCircles is true (or null), use cache for performance
         if (_settings.UseCacheService && _cacheServiceClient != null && (asTimeCircles == null || asTimeCircles == true))
         {
@@ -67,16 +76,15 @@ public partial class CirclesRpcModule
     /// <summary>
     /// Optimized query for raw total balance (asTimeCircles=false path).
     /// Uses direct SQL aggregation instead of fetching all token details.
-    /// WARNING: The V2 result mixes unit systems and is an APPROXIMATION:
-    /// - V2 ERC1155: totalBalance = static transfer aggregate (demurrage not applied)
-    /// - V2 wrapped inflationary: static/inflationary transfer aggregate
-    /// - V2 wrapped demurraged: raw demurraged transfer sums (each transfer in its own time-specific denomination)
-    /// Summing these values is not mathematically precise. For accurate balances, use asTimeCircles=true
-    /// which converts all values to a common unit via GetTokenBalancesForAccount.
+    /// All V2 token types return static (non-demurraged) transfer sums:
+    /// - V2 ERC1155: totalBalance from view (static transfer aggregate)
+    /// - V2 wrapped inflationary: raw transfer sum (already static/inflationary)
+    /// - V2 wrapped demurraged: raw transfer sum (no demurrage applied — consistent with "raw" semantics)
+    /// For time-circles (demurraged) balances, use asTimeCircles=true.
     /// </summary>
     private async Task<string> GetRawTotalBalanceAsync(string address, int version)
     {
-        var lowerAddress = address.ToLower();
+        var lowerAddress = address; // already validated and lowered by caller
         await using var connection = await CreateConnectionAsync();
 
         string sql;
@@ -208,6 +216,8 @@ public partial class CirclesRpcModule
 
     public async Task<CirclesTokenBalance[]> GetTokenBalances(string address)
     {
+        address = ValidateAndNormalizeAddress(address);
+
         // If cache service is enabled, use it (no DB fallback needed)
         if (_settings.UseCacheService && _cacheServiceClient != null)
         {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
@@ -65,8 +65,14 @@ public partial class CirclesRpcModule
     }
 
     /// <summary>
-    /// Optimized query for raw (static) total balance.
+    /// Optimized query for raw total balance (asTimeCircles=false path).
     /// Uses direct SQL aggregation instead of fetching all token details.
+    /// WARNING: The V2 result mixes unit systems and is an APPROXIMATION:
+    /// - V2 ERC1155: totalBalance = static transfer aggregate (demurrage not applied)
+    /// - V2 wrapped inflationary: static/inflationary transfer aggregate
+    /// - V2 wrapped demurraged: raw demurraged transfer sums (each transfer in its own time-specific denomination)
+    /// Summing these values is not mathematically precise. For accurate balances, use asTimeCircles=true
+    /// which converts all values to a common unit via GetTokenBalancesForAccount.
     /// </summary>
     private async Task<string> GetRawTotalBalanceAsync(string address, int version)
     {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
@@ -80,6 +80,24 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         }
     }
 
+    /// <summary>
+    /// Normalizes avatar type names to canonical full format.
+    /// Both cache and DB now store full names. Legacy short names mapped as safety net.
+    /// V2: CrcV2_RegisterHuman, CrcV2_RegisterOrganization, CrcV2_RegisterGroup
+    /// V1: CrcV1_Signup, CrcV1_OrganizationSignup
+    /// </summary>
+    public static string NormalizeAvatarType(string? type) => type switch
+    {
+        // Legacy short names (safety net — cache now stores full names)
+        "Human" => "CrcV2_RegisterHuman",
+        "Organization" => "CrcV2_RegisterOrganization",
+        "Group" => "CrcV2_RegisterGroup",
+        // Full names pass through
+        "CrcV2_RegisterHuman" or "CrcV2_RegisterOrganization" or "CrcV2_RegisterGroup"
+            or "CrcV1_Signup" or "CrcV1_OrganizationSignup" => type,
+        _ => type ?? "Unknown"
+    };
+
     private async Task<NpgsqlConnection> CreateConnectionAsync()
     {
         var connection = await _dataSource.OpenConnectionAsync();

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
@@ -32,7 +32,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
     private readonly NpgsqlDataSource _dataSource;
     private readonly MemoryCache _profileByCidCache;
     private readonly MemoryCache _tokenExposureCache;
-    private static readonly HttpClient HttpClient = new();
+    private static readonly HttpClient HttpClient = new() { Timeout = TimeSpan.FromSeconds(30) };
     private readonly NethermindRpcClient? _nethermindRpcClient;
     private readonly IHttpContextAccessor? _httpContextAccessor;
     private readonly ILogger<CirclesRpcModule>? _logger;

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
@@ -39,14 +39,14 @@ public partial class CirclesRpcModule
         {
             if (!string.IsNullOrEmpty(queryParams.NameStartsWith))
             {
-                sql.Append(" AND r.name ILIKE @namePrefix");
-                parameters.Add(new NpgsqlParameter("namePrefix", queryParams.NameStartsWith + "%"));
+                sql.Append(@" AND r.name ILIKE @namePrefix ESCAPE '\'");
+                parameters.Add(new NpgsqlParameter("namePrefix", EscapeLikePattern(queryParams.NameStartsWith) + "%"));
             }
 
             if (!string.IsNullOrEmpty(queryParams.SymbolStartsWith))
             {
-                sql.Append(" AND r.symbol ILIKE @symbolPrefix");
-                parameters.Add(new NpgsqlParameter("symbolPrefix", queryParams.SymbolStartsWith + "%"));
+                sql.Append(@" AND r.symbol ILIKE @symbolPrefix ESCAPE '\'");
+                parameters.Add(new NpgsqlParameter("symbolPrefix", EscapeLikePattern(queryParams.SymbolStartsWith) + "%"));
             }
 
             if (queryParams.OwnerIn != null && queryParams.OwnerIn.Length > 0)
@@ -121,6 +121,8 @@ public partial class CirclesRpcModule
 
     public async Task<PagedResponse<GroupMembershipRow>> GetGroupMembers(string groupAddress, int limit = 100, string? cursor = null)
     {
+        groupAddress = ValidateAndNormalizeAddress(groupAddress, nameof(groupAddress));
+
         // If cache service is enabled and no cursor (first page), try cache first
         if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor))
         {
@@ -179,6 +181,8 @@ public partial class CirclesRpcModule
 
     public async Task<PagedResponse<GroupMembershipRow>> GetGroupMemberships(string memberAddress, int limit = 50, string? cursor = null)
     {
+        memberAddress = ValidateAndNormalizeAddress(memberAddress, nameof(memberAddress));
+
         // If cache service is enabled and no cursor (first page), try cache first
         if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor))
         {
@@ -239,7 +243,7 @@ public partial class CirclesRpcModule
         string? cursor,
         bool filterByGroup)
     {
-        var normalizedAddress = address.ToLower();
+        var normalizedAddress = address; // already validated and lowered by caller
         await using var connection = await CreateConnectionAsync();
 
         // Decode cursor if provided

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
@@ -148,14 +148,23 @@ public partial class CirclesRpcModule
                         .ToList();
 
                     var hasMore = allMembers.Count > limit;
-                    var resultItems = allMembers.Take(limit).ToArray();
 
-                    // Cache-based results don't support pagination via cursor
-                    return new PagedResponse<GroupMembershipRow>(
-                        Results: resultItems,
-                        HasMore: hasMore,
-                        NextCursor: null // Cache doesn't support cursor pagination
-                    );
+                    // If cache has more results than requested, fall through to DB
+                    // which supports proper cursor pagination. Otherwise clients get
+                    // HasMore:true but NextCursor:null and can't page further.
+                    if (hasMore)
+                    {
+                        _logger?.LogDebug("Cache has more group members than limit ({Limit}), falling through to DB for pagination support", limit);
+                        // Fall through to DB path below
+                    }
+                    else
+                    {
+                        return new PagedResponse<GroupMembershipRow>(
+                            Results: allMembers.ToArray(),
+                            HasMore: false,
+                            NextCursor: null
+                        );
+                    }
                 }
             }
             catch (Exception ex)
@@ -196,13 +205,22 @@ public partial class CirclesRpcModule
                         .ToList();
 
                     var hasMore = allGroups.Count > limit;
-                    var resultItems = allGroups.Take(limit).ToArray();
 
-                    return new PagedResponse<GroupMembershipRow>(
-                        Results: resultItems,
-                        HasMore: hasMore,
-                        NextCursor: null // Cache doesn't support cursor pagination
-                    );
+                    // If cache has more results than requested, fall through to DB
+                    // which supports proper cursor pagination
+                    if (hasMore)
+                    {
+                        _logger?.LogDebug("Cache has more group memberships than limit ({Limit}), falling through to DB for pagination support", limit);
+                        // Fall through to DB path below
+                    }
+                    else
+                    {
+                        return new PagedResponse<GroupMembershipRow>(
+                            Results: allGroups.ToArray(),
+                            HasMore: false,
+                            NextCursor: null
+                        );
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
@@ -39,6 +39,28 @@ public partial class CirclesRpcModule
     }
 
     /// <summary>
+    /// Escapes ILIKE/LIKE special characters (%, _, \) in user-provided input
+    /// before appending a trailing wildcard. Prevents wildcard injection.
+    /// </summary>
+    private static string EscapeLikePattern(string input)
+        => input.Replace(@"\", @"\\").Replace("%", @"\%").Replace("_", @"\_");
+
+    /// <summary>
+    /// Validates that an address is a well-formed Ethereum address (0x + 40 hex chars)
+    /// and returns it lowercased.
+    /// </summary>
+    private static string ValidateAndNormalizeAddress(string address, string parameterName = "address")
+    {
+        if (string.IsNullOrEmpty(address))
+            throw new ArgumentException($"{parameterName} must not be empty.");
+
+        if (!Regex.IsMatch(address, @"^0x[0-9a-fA-F]{40}$"))
+            throw new ArgumentException($"{parameterName} is not a valid Ethereum address: {address}");
+
+        return address.ToLowerInvariant();
+    }
+
+    /// <summary>
     /// Validates that an identifier contains only safe characters (letters, digits, underscore).
     /// </summary>
     private static string ValidateIdentifier(string identifier, string identifierType)

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -14,6 +14,8 @@ public partial class CirclesRpcModule
 {
     public async Task<ProfileCidResponse> GetProfileCid(string address)
     {
+        address = ValidateAndNormalizeAddress(address);
+
         var results = await GetProfileCidBatchInternal(new[] { address });
         return new ProfileCidResponse(results[0]);
     }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -85,7 +85,7 @@ public partial class CirclesRpcModule
 
     private async Task<Dictionary<string, TokenExposureInfo>> GetTokenExposureIdsAsync(string address)
     {
-        var lowerAddress = address.ToLower();
+        var lowerAddress = address; // already validated and lowered by caller
         var cacheKey = $"tokenExposure:{lowerAddress}";
 
         // Check cache first (5 minute TTL for token exposure data)
@@ -250,7 +250,7 @@ public partial class CirclesRpcModule
 
     public async Task<TokenInfo?> GetTokenInfo(string tokenAddress)
     {
-        var lowerTokenAddress = tokenAddress.ToLower();
+        var lowerTokenAddress = ValidateAndNormalizeAddress(tokenAddress, nameof(tokenAddress));
 
         // If cache service is enabled, try using it first
         if (_settings.UseCacheService && _cacheServiceClient != null)
@@ -379,6 +379,9 @@ public partial class CirclesRpcModule
 
     public async Task<TokenInfo?[]> GetTokenInfoBatch(string[] tokenAddresses)
     {
+        for (int i = 0; i < tokenAddresses.Length; i++)
+            tokenAddresses[i] = ValidateAndNormalizeAddress(tokenAddresses[i], $"tokenAddresses[{i}]");
+
         if (tokenAddresses.Length > 1000)
         {
             throw new ArgumentOutOfRangeException(nameof(tokenAddresses), "Batch size exceeds 1000");
@@ -457,7 +460,7 @@ public partial class CirclesRpcModule
 
     public async Task<PagedResponse<TokenHolderRow>> GetTokenHolders(string tokenAddress, int limit = 100, string? cursor = null)
     {
-        var normalizedToken = tokenAddress.ToLower();
+        var normalizedToken = ValidateAndNormalizeAddress(tokenAddress, nameof(tokenAddress));
         await using var connection = await CreateConnectionAsync();
 
         // Build query with cursor pagination - UNION both V1 and V2 views

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -423,22 +423,33 @@ public partial class CirclesRpcModule
             }
         }
 
-        // Fallback: Execute all lookups in parallel using database
+        // Fallback: Execute lookups with bounded concurrency to prevent connection pool exhaustion
+        // Each GetTokenInfo opens up to 3 sequential DB connections (V1, V2 avatar, V2 wrapper)
         _logger?.LogDebug("Using database for token info batch query ({Count} addresses)", tokenAddresses.Length);
-        var getTokenInfoTasks = tokenAddresses.Select(async tokenAddress =>
+
+        const int maxConcurrency = 10;
+        var dbResults = new TokenInfo?[tokenAddresses.Length];
+        using var semaphore = new SemaphoreSlim(maxConcurrency);
+
+        var tasks = tokenAddresses.Select(async (tokenAddress, index) =>
         {
+            await semaphore.WaitAsync();
             try
             {
-                return await GetTokenInfo(tokenAddress);
+                dbResults[index] = await GetTokenInfo(tokenAddress);
             }
-            catch
+            catch (Exception ex)
             {
-                // Return null for tokens that don't exist or fail to load
-                return null;
+                _logger?.LogWarning(ex, "Failed to load token info for {TokenAddress}", tokenAddress);
+                dbResults[index] = null;
+            }
+            finally
+            {
+                semaphore.Release();
             }
         }).ToArray();
 
-        var dbResults = await Task.WhenAll(getTokenInfoTasks);
+        await Task.WhenAll(tasks);
 
         // Return array with same length as input, preserving positions
         return dbResults;
@@ -450,18 +461,20 @@ public partial class CirclesRpcModule
         await using var connection = await CreateConnectionAsync();
 
         // Build query with cursor pagination - UNION both V1 and V2 views
+        // V1: totalBalance is the raw ERC20 balance (matches on-chain balanceOf)
+        // V2: demurragedTotalBalance matches Hub.sol balanceOf() (totalBalance is static/raw)
         var sql = @$"
             SELECT
                 account,
-                ""totalBalance"",
+                balance,
                 ""tokenAddress"",
                 version
             FROM (
-                SELECT account, ""totalBalance"", ""tokenAddress"", 1 as version
+                SELECT account, ""totalBalance"" as balance, ""tokenAddress"", 1 as version
                 FROM ""V_CrcV1_BalancesByAccountAndToken""
                 WHERE ""tokenAddress"" = @tokenAddress AND ""totalBalance"" > 0
                 UNION ALL
-                SELECT account, ""totalBalance"", ""tokenAddress"", 2 as version
+                SELECT account, ""demurragedTotalBalance"" as balance, ""tokenAddress"", 2 as version
                 FROM ""V_CrcV2_BalancesByAccountAndToken""
                 WHERE ""tokenAddress"" = @tokenAddress AND ""totalBalance"" > 0
             ) AS combined_balances

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -103,7 +103,7 @@ public partial class CirclesRpcModule
             try
             {
                 var avatarInfo = await _cacheServiceClient.GetAvatarInfoAsync(address);
-                return avatarInfo is { Version: 2, Type: "Human" };
+                return avatarInfo is { Version: 2, Type: "CrcV2_RegisterHuman" };
             }
             catch (Exception ex)
             {
@@ -163,13 +163,10 @@ public partial class CirclesRpcModule
                     for (int i = 0; i < counterpartAddresses.Length; i++)
                     {
                         var info = avatarInfos[i];
-                        avatarTypeMap[counterpartAddresses[i]] = info?.Type switch
-                        {
-                            "Human" => "Human",
-                            "Organization" => "Organization",
-                            "Group" => "Group",
-                            _ => null
-                        };
+                        // Normalize cache short names to full canonical format
+                        avatarTypeMap[counterpartAddresses[i]] = info?.Type != null
+                            ? NormalizeAvatarType(info.Type)
+                            : null;
                     }
 
                     // Build aggregated relations
@@ -300,14 +297,11 @@ public partial class CirclesRpcModule
                 throw new InvalidOperationException($"Unexpected number of trust rows for counterpart: {rows.Count}");
             }
 
-            // Map avatar type to simple format
-            string? objectAvatarType = avatarType switch
-            {
-                "Human" => "Human",
-                "Organization" => "Organization",
-                "Group" => "Group",
-                _ => null
-            };
+            // Normalize avatar type to full canonical format (CrcV2_RegisterHuman etc.)
+            // DB already stores full names. Cache stores short names → normalize.
+            string? objectAvatarType = avatarType != null
+                ? NormalizeAvatarType(avatarType)
+                : null;
 
             result.Add(new AggregatedTrustRelation(
                 SubjectAvatar: normalizedAvatar,

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -11,6 +11,8 @@ public partial class CirclesRpcModule
 {
     public async Task<TrustRelationsResponse> GetTrustRelations(string address)
     {
+        address = ValidateAndNormalizeAddress(address);
+
         // If cache service is enabled, try using it first (V1 only for backward compatibility)
         if (_settings.UseCacheService && _cacheServiceClient != null)
         {
@@ -32,7 +34,7 @@ public partial class CirclesRpcModule
                         .ToArray();
 
                     return new TrustRelationsResponse(
-                        User: address.ToLower(),
+                        User: address,
                         Trusts: cacheTrusts,
                         TrustedBy: cacheTrustedBy
                     );
@@ -72,7 +74,7 @@ public partial class CirclesRpcModule
                or ""canSendTo"" = @address)
         ";
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("address", address.ToLower());
+        command.Parameters.AddWithValue("address", address);
         var trusts = new List<TrustRelation>();
         var trustedBy = new List<TrustRelation>();
         await using var reader = await command.ExecuteReaderAsync();
@@ -93,7 +95,7 @@ public partial class CirclesRpcModule
                 trustedBy.Add(new TrustRelation(User: canSendTo, Limit: limit));
             }
         }
-        return new TrustRelationsResponse(User: address.ToLower(), Trusts: trusts.ToArray(), TrustedBy: trustedBy.ToArray());
+        return new TrustRelationsResponse(User: address, Trusts: trusts.ToArray(), TrustedBy: trustedBy.ToArray());
     }
 
     private async Task<bool> IsV2Human(string address)
@@ -114,14 +116,14 @@ public partial class CirclesRpcModule
         await using var connection = await CreateConnectionAsync();
         const string sql = @"SELECT 1 FROM ""CrcV2_RegisterHuman"" WHERE avatar = @address";
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("address", address.ToLower());
+        command.Parameters.AddWithValue("address", address);
         var result = await command.ExecuteScalarAsync();
         return result != null;
     }
 
     public async Task<AggregatedTrustRelation[]> GetAggregatedTrustRelations(string avatar)
     {
-        var normalizedAvatar = avatar.ToLower();
+        var normalizedAvatar = ValidateAndNormalizeAddress(avatar, nameof(avatar));
 
         if (_settings.UseCacheService && _cacheServiceClient != null)
         {
@@ -318,13 +320,16 @@ public partial class CirclesRpcModule
 
     public async Task<CommonTrustResponse> GetCommonTrust(string address1, string address2, int? version = null)
     {
+        address1 = ValidateAndNormalizeAddress(address1, nameof(address1));
+        address2 = ValidateAndNormalizeAddress(address2, nameof(address2));
+
         if (_settings.UseCacheService && _cacheServiceClient != null)
         {
             try
             {
                 _logger?.LogDebug("Using Cache Service for common trust between {A1} and {A2}", address1, address2);
-                var addr1 = address1.ToLower();
-                var addr2 = address2.ToLower();
+                var addr1 = address1;
+                var addr2 = address2;
 
                 // Determine if address2 is V2 human (uses cache internally)
                 var isAddr2V2Human = await IsV2Human(addr2);
@@ -439,8 +444,8 @@ public partial class CirclesRpcModule
 
         await using var connection = await CreateConnectionAsync();
         await using var command = new NpgsqlCommand(sql, connection);
-        command.Parameters.AddWithValue("address1", address1.ToLower());
-        command.Parameters.AddWithValue("address2", address2.ToLower());
+        command.Parameters.AddWithValue("address1", address1);
+        command.Parameters.AddWithValue("address2", address2);
 
         var commonTrusts = new List<string>();
         await using var reader = await command.ExecuteReaderAsync();
@@ -448,7 +453,7 @@ public partial class CirclesRpcModule
         {
             commonTrusts.Add(reader.GetString(0));
         }
-        return new CommonTrustResponse(Address1: address1.ToLower(), Address2: address2.ToLower(), CommonTrusts: commonTrusts.ToArray());
+        return new CommonTrustResponse(Address1: address1, Address2: address2, CommonTrusts: commonTrusts.ToArray());
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Multi-angle audit of the RPC Host and Cache Service, fixing data integrity bugs, security issues, and consistency problems across the stack.

### Commit 1: Avatar Type Normalization
- **Cache Service** now stores canonical full type names (`CrcV2_RegisterHuman`, `CrcV1_Signup`, etc.) instead of short names (`Human`, `Organization`)
- **RPC Host** `NormalizeAvatarType` provides backward-compatible safety net for legacy short names
- Fixed `IsV2Human` in Trust module to match new cache format (would have broken `GetCommonTrust` for all V2 humans)
- Updated all 10 Cache Service files + 10 RPC Host files + all tests

### Commit 2: Multi-Angle Audit Bug Fixes

**Critical:**
- **ERC20 wrapper transfer double-inflation** in `GetTransactionHistory`: Inflationary wrapper amounts were treated as demurraged, causing `DemurrageToInflationary` to produce doubly-inflated static values. Added `isInflationary` column via JOIN with `CrcV2_ERC20WrapperDeployed` to discriminate wrapper types.

**High:**
- **`GetRawTotalBalanceAsync` mixed units**: Removed POWER() demurrage from `v2_wrapped_demurraged` CTE so all V2 paths return consistent static transfer sums
- Documented `GetTotalBalance` three-path consistency (cache vs raw vs DB fallback)

**Medium:**
- **ILIKE wildcard injection**: Escape `%`, `_`, `\` in `FindGroups` name/symbol filters
- **Address validation**: Added `ValidateAndNormalizeAddress` to 16+ public RPC methods
- **Query table allowlist**: Reject table names not in `DatabaseSchemaMap` (prevents probing system tables)
- **Static HttpClient timeout**: Set 30s timeout to prevent indefinite IPFS hangs

### New Tests (854 lines)
- `InputValidationTests.cs` — cursor decode edge cases, avatar type mapping
- `RpcMethodSnapshotTests.cs` — live RPC regression tests (staging-based)
- `TokenConversionTests.cs` — TokenId ↔ Address round-trip edge cases
- Extended `AbiEncoderTests.cs` and `CursorUtilsTests.cs`

## Test Results
- **RPC Host**: 76 passed, 0 failed, 89 skipped (staging-dependent)
- **Cache Service**: 96 passed, 0 failed, 26 skipped (integration)
- **Total**: 172 passed, 0 failed

## Assumptions & Notes
- **V2 DayFromTimestamp epoch**: The transaction history conversion uses `1_602_720_000` (V1 epoch) for `DayFromTimestamp` even for V2 transfers. This is a pre-existing issue affecting demurrage ↔ static conversions in transaction history display. Not changed in this PR to avoid blast radius — flagged for separate investigation.
- **GetRawTotalBalanceAsync**: Now returns static transfer sums for all V2 token types. For wrapped demurraged tokens this means the "raw" value is the sum of raw transfer amounts (not the current demurraged balance). This is consistent with the "raw/static" semantics but differs from the previous behavior which applied demurrage.
- **Address validation**: Applied to all public methods that accept address parameters. The `GetEvents` address parameter is nullable (null = all addresses); validation only runs when non-null.
- **ILIKE escape**: Uses `ESCAPE '\'` PostgreSQL clause. Only applied to `FindGroups`; the generic `Query` API intentionally allows user-provided LIKE patterns.
- **Query table allowlist**: The `circles_query` endpoint now rejects tables not in `DatabaseSchemaMap`. This prevents querying PostgreSQL system tables but means any future tables need to be registered in the schema.

## Test plan
- [ ] Verify RPC regression tests pass against staging: `TEST_ENV_URL=https://rpc.aboutcircles.com dotnet test --filter "Category=RpcRegression"`
- [ ] Verify cache service restart picks up new type names correctly (warm cache will have old names until restart)
- [ ] Test `GetTransactionHistory` with a user who has both ERC1155 and ERC20 wrapper transfers — verify inflationary amounts are no longer double-inflated
- [ ] Verify `FindGroups` with special characters in name filter (`%`, `_`) returns correct results
- [ ] Test `circles_query` with non-existent table name — should return error, not empty result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved input validation and address normalisation across API endpoints for enhanced security.
  * Enhanced error signalling for cursor decoding with malformed input detection.
  * Updated avatar type classifications to reflect specific registration and signup categories.

* **Tests**
  * Added comprehensive test coverage for edge cases in address conversion, cursor decoding, and input validation.
  * Introduced environment-driven RPC method snapshot tests for regression detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->