### PR TITLE
fix(index): use block timestamp for TransferSummary demurrage

### DIFF
--- a/scripts/migrations/001-fix-wrapper-transfer-summary.sql
+++ b/scripts/migrations/001-fix-wrapper-transfer-summary.sql
@@ -37,7 +37,7 @@ END;
 $$ LANGUAGE plpgsql IMMUTABLE;
 
 -- Step 2: Compute the V2 day from a block timestamp
--- V2_INFLATION_DAY_ZERO_UNIX = 1602720000 (2023-02-01 00:00 UTC)
+-- V2_INFLATION_DAY_ZERO_UNIX = 1602720000 (2020-10-15 00:00 UTC)
 -- Uses the block timestamp (not NOW()) so the conversion matches what the
 -- indexer would have computed at the time the block was processed.
 CREATE OR REPLACE FUNCTION pg_temp.v2_day_from_timestamp(block_timestamp bigint)

--- a/scripts/migrations/002-fix-transfer-summary-demurrage.sql
+++ b/scripts/migrations/002-fix-transfer-summary-demurrage.sql
@@ -1,0 +1,141 @@
+-- Migration 002: Fix TransferSummary demurrage for inflationary ERC20 wrappers
+--
+-- Bug: TransferSummaryAggregator used AttoStaticCirclesToAttoCircles(val) which
+-- calls Today() (DateTimeOffset.UtcNow), not the block's timestamp. This means:
+--   1. The demurrage day index was wrong (based on indexing time, not block time)
+--   2. Re-indexing the same block on different days produced different amounts
+--
+-- Additionally, the epoch constant was wrong (1675209600 chiado vs 1602720000 gnosis)
+-- until PR #247 fixed it.
+--
+-- Fix: Recalculate amounts for TransferSummary rows that contain inflationary
+-- wrapper transfers, using the block's timestamp for the day index.
+--
+-- This migration is SAFE to run multiple times (idempotent — recalculates same result).
+-- Does NOT delete or insert rows — only UPDATEs existing amounts.
+--
+-- NOTE: Only affects NON-stream TransferSummary rows containing Erc20WrapperTransfer
+-- events from inflationary wrappers. Stream rows (from StreamCompleted) are already
+-- in demurraged CRC and unaffected.
+
+BEGIN;
+
+-- Step 1: Fixed64.Pow(GAMMA_64, day) — replicates C# Fixed64.Pow exactly
+CREATE OR REPLACE FUNCTION pg_temp.fixed64_gamma_pow(day integer)
+RETURNS numeric AS $$
+DECLARE
+    base numeric := 18443079296116538654;         -- GAMMA_64
+    result numeric := 18446744073709551616;        -- 2^64 (Q64.64 identity = 1.0)
+    two_64 numeric := 18446744073709551616;        -- 2^64
+    n integer := day;
+BEGIN
+    WHILE n > 0 LOOP
+        IF n % 2 = 1 THEN
+            result := trunc(result * base / two_64);
+        END IF;
+        base := trunc(base * base / two_64);
+        n := n / 2;
+    END LOOP;
+    RETURN result;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Step 2: V2 day index from block timestamp
+-- V2_INFLATION_DAY_ZERO_UNIX = 1602720000 (2020-10-15 00:00 UTC, gnosis mainnet)
+CREATE OR REPLACE FUNCTION pg_temp.v2_day_from_timestamp(block_timestamp bigint)
+RETURNS integer AS $$
+BEGIN
+    RETURN floor((block_timestamp - 1602720000) / 86400)::integer;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+-- Step 3: Identify and recalculate affected TransferSummary rows
+--
+-- Strategy: For each non-stream TransferSummary row that has Erc20WrapperTransfer
+-- events with inflationary tokens, recompute the amount by:
+--   1. Summing all individual transfer values from the events JSON
+--   2. For inflationary wrappers: apply InflationaryToDemurrage using block timestamp
+--   3. For demurraged wrappers + ERC1155: use raw value as-is
+--
+-- However, the events JSON doesn't reliably contain individual amounts for
+-- re-aggregation. Instead, we take a simpler approach:
+--
+-- For rows where ALL contributing transfers are from the SAME inflationary wrapper
+-- (the common case), we can reverse the old conversion and apply the correct one.
+-- For mixed rows, we flag them for manual review.
+
+-- Step 3a: Find TransferSummary rows that originated from inflationary wrapper transfers.
+-- These are non-stream rows (logIndex < 0) where the from/to pair exists in
+-- Erc20WrapperTransfer with an inflationary wrapper token.
+WITH affected_rows AS (
+    SELECT DISTINCT
+        ts."blockNumber",
+        ts."timestamp",
+        ts."transactionIndex",
+        ts."logIndex",
+        ts."transactionHash",
+        ts."from",
+        ts."to"
+    FROM "CrcV2_TransferSummary" ts
+    -- Match against actual Erc20WrapperTransfer events in the same transaction
+    INNER JOIN "CrcV2_Erc20WrapperTransfer" ewt
+        ON ewt."transactionHash" = ts."transactionHash"
+        AND ewt."from" = ts."from"
+        AND ewt."to" = ts."to"
+    -- Only inflationary wrappers (circlesType bit 0 set)
+    INNER JOIN "CrcV2_ERC20WrapperDeployed" wd
+        ON wd."erc20Wrapper" = ewt."tokenAddress"
+        AND (wd."circlesType" & 1) = 1
+    WHERE ts."logIndex" < 0  -- Synthetic rows from aggregator
+),
+
+-- Step 3b: Recompute the correct amount for each affected row.
+-- Sum all Erc20WrapperTransfer events matching (txHash, from, to),
+-- applying inflationary conversion with block timestamp.
+recomputed AS (
+    SELECT
+        ar."blockNumber",
+        ar."timestamp",
+        ar."transactionIndex",
+        ar."logIndex",
+        ar."transactionHash",
+        ar."from",
+        ar."to",
+        SUM(
+            CASE
+                WHEN wd."circlesType" IS NOT NULL AND (wd."circlesType" & 1) = 1
+                THEN trunc(
+                    pg_temp.fixed64_gamma_pow(pg_temp.v2_day_from_timestamp(ewt."timestamp"))
+                    * ewt."amount" / 18446744073709551616  -- 2^64
+                )
+                ELSE ewt."amount"
+            END
+        )::numeric AS correct_amount
+    FROM affected_rows ar
+    INNER JOIN "CrcV2_Erc20WrapperTransfer" ewt
+        ON ewt."transactionHash" = ar."transactionHash"
+        AND ewt."from" = ar."from"
+        AND ewt."to" = ar."to"
+    LEFT JOIN "CrcV2_ERC20WrapperDeployed" wd
+        ON wd."erc20Wrapper" = ewt."tokenAddress"
+    GROUP BY
+        ar."blockNumber",
+        ar."timestamp",
+        ar."transactionIndex",
+        ar."logIndex",
+        ar."transactionHash",
+        ar."from",
+        ar."to"
+)
+
+-- Step 3c: Update only rows where the amount actually changed
+UPDATE "CrcV2_TransferSummary" ts
+SET "amount" = r.correct_amount
+FROM recomputed r
+WHERE ts."blockNumber" = r."blockNumber"
+  AND ts."transactionIndex" = r."transactionIndex"
+  AND ts."logIndex" = r."logIndex"
+  AND ts."transactionHash" = r."transactionHash"
+  AND ts."amount" != r.correct_amount;
+
+COMMIT;

--- a/src/Common/Circles.Common/CirclesConverter.cs
+++ b/src/Common/Circles.Common/CirclesConverter.cs
@@ -145,6 +145,16 @@ public static class CirclesConverter
     public static BigInteger AttoStaticCirclesToAttoCircles(BigInteger attoStaticCircles) =>
         InflationaryToDemurrage(attoStaticCircles, Today());
 
+    /// <summary>V2 Static (inflationary) Circles → V2 demurraged Circles, at a specific block timestamp.</summary>
+    /// <remarks>
+    /// Use this overload when the conversion must be deterministic (e.g., indexing).
+    /// The <paramref name=”blockTimestampUnix”/> should be the block's timestamp, not <c>Now()</c>,
+    /// so that re-indexing the same block always produces the same result.
+    /// </remarks>
+    public static BigInteger AttoStaticCirclesToAttoCircles(BigInteger attoStaticCircles, long blockTimestampUnix) =>
+        InflationaryToDemurrage(attoStaticCircles,
+            DayFromTimestamp(DateTimeOffset.FromUnixTimeSeconds(blockTimestampUnix), V2_INFLATION_DAY_ZERO_UNIX));
+
     private static ulong Today() =>
         DayFromTimestamp(DateTimeOffset.UtcNow, V2_INFLATION_DAY_ZERO_UNIX);
 

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferSummaryAggregatorTests.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Circles.Common;
 using Nethermind.Int256;
 
@@ -23,6 +24,8 @@ public class TransferSummaryAggregatorTests
     private const string WrapperInflationary = "0x4444444444444444444444444444444444444444";
     private const string ZeroAddress = "0x0000000000000000000000000000000000000000";
     private const string HubAddress = "0x5555555555555555555555555555555555555555";
+    // Fixed block timestamp for deterministic tests: 2023-11-14 22:13:20 UTC
+    private const long BlockTimestamp = 1_700_000_000;
 
     [SetUp]
     public void SetUp()
@@ -305,10 +308,106 @@ public class TransferSummaryAggregatorTests
             CreateErc20WrapperTransfer(Alice, Bob, 1_000_000_000_000_000_000UL, WrapperInflationary)
         };
 
-        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
 
         var total = result.NonStreamTransfers.Totals.First();
         Assert.That(total.Value.ToString(), Is.Not.EqualTo("1000000000000000000"));
+    }
+
+    [Test]
+    public void AggregateAll_Erc20InflationaryTransfer_DeterministicWithBlockTimestamp()
+    {
+        // The same block timestamp must always produce the same conversion result.
+        // This guards against the old Now()-based bug where re-indexing changed values.
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, 1_000_000_000_000_000_000UL, WrapperInflationary)
+        };
+
+        var result1 = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
+        var result2 = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
+
+        var total1 = result1.NonStreamTransfers.Totals.First();
+        var total2 = result2.NonStreamTransfers.Totals.First();
+        Assert.That(total1.Value, Is.EqualTo(total2.Value),
+            "Same block timestamp must produce identical conversion — no Now() dependency");
+    }
+
+    [Test]
+    public void AggregateAll_Erc20InflationaryTransfer_DifferentTimestamps_DifferentValues()
+    {
+        // Different block timestamps should produce different demurraged values
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, 1_000_000_000_000_000_000UL, WrapperInflationary)
+        };
+
+        var resultEarly = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
+        // 365 days later
+        var resultLater = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp + 365 * 86400);
+
+        var totalEarly = resultEarly.NonStreamTransfers.Totals.First();
+        var totalLater = resultLater.NonStreamTransfers.Totals.First();
+        Assert.That(totalLater.Value, Is.LessThan(totalEarly.Value),
+            "Later timestamp should apply more demurrage (smaller value)");
+    }
+
+    [Test]
+    public void AggregateAll_Erc20InflationaryTransfer_BitIdenticalToCirclesConverter()
+    {
+        // The aggregator's result must be bit-identical to calling CirclesConverter directly
+        // with the same timestamp. This prevents formula drift between the two code paths.
+        const ulong rawValue = 1_000_000_000_000_000_000UL;
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, rawValue, WrapperInflationary)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
+        var aggregatorValue = result.NonStreamTransfers.Totals.First().Value;
+
+        // Compute expected value directly via CirclesConverter
+        var expected = CirclesConverter.AttoStaticCirclesToAttoCircles(
+            new System.Numerics.BigInteger(rawValue), BlockTimestamp);
+
+        Assert.That(aggregatorValue, Is.EqualTo(expected),
+            "Aggregator must produce bit-identical result to CirclesConverter.AttoStaticCirclesToAttoCircles(val, timestamp)");
+    }
+
+    [Test]
+    public void AggregateAll_Erc20InflationaryTransfer_ZeroTimestamp_FallsBackToNow()
+    {
+        // When blockTimestamp=0 (default), falls back to Now()-based conversion.
+        // This preserves backward compatibility for callers that don't pass a timestamp.
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, 1_000_000_000_000_000_000UL, WrapperInflationary)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, 0);
+
+        var total = result.NonStreamTransfers.Totals.First();
+        // Should still convert (not crash, not return raw value)
+        Assert.That(total.Value.ToString(), Is.Not.EqualTo("1000000000000000000"),
+            "Zero timestamp fallback should still apply conversion via Now()");
+    }
+
+    [Test]
+    public void AggregateAll_Erc20DemurragedTransfer_UnaffectedByTimestamp()
+    {
+        // Demurraged wrapper transfers must NOT be affected by the timestamp parameter.
+        // Only inflationary wrappers get converted.
+        const ulong rawValue = 1_000_000_000_000_000_000UL;
+        var events = new IIndexedEventV2[]
+        {
+            CreateErc20WrapperTransfer(Alice, Bob, rawValue, WrapperDemurraged)
+        };
+
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
+
+        var total = result.NonStreamTransfers.Totals.First();
+        Assert.That(total.Value.ToString(), Is.EqualTo("1000000000000000000"),
+            "Demurraged wrapper value must pass through unchanged regardless of timestamp");
     }
 
     [Test]
@@ -511,10 +610,10 @@ public class TransferSummaryAggregatorTests
             CreateStreamCompleted(Alice, Bob, 1_000_000_000_000_000_000UL)
         };
 
-        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache);
+        var result = TransferSummaryAggregator.AggregateAll(events, _erc20WrapperCache, BlockTimestamp);
 
         var total = result.NonStreamTransfers.Totals.First();
-        // Inflationary → AttoStaticCircles conversion should change the value
+        // Inflationary → demurraged conversion should change the value
         Assert.That(total.Value.ToString(), Is.Not.EqualTo("1000000000000000000"));
     }
 
@@ -914,5 +1013,79 @@ public class TransferSummaryAggregatorTests
             Trustee: trustee,
             ExpiryTime: UInt256.MaxValue
         );
+    }
+}
+
+/// <summary>
+/// Tests for <see cref="CirclesConverter.AttoStaticCirclesToAttoCircles(BigInteger, long)"/>
+/// — the timestamp-based overload added to fix the Now()-dependent demurrage bug.
+/// </summary>
+[TestFixture]
+public class CirclesConverterTimestampOverloadTests
+{
+    // V2 epoch: 2020-10-15 00:00 UTC
+    private const long V2Epoch = 1_602_720_000;
+
+    [Test]
+    public void TimestampOverload_MatchesManualDayComputation()
+    {
+        // Manually compute day index, then verify the overload produces the same result
+        const long timestamp = 1_700_000_000; // 2023-11-14
+        var expectedDay = (ulong)((timestamp - V2Epoch) / 86_400);
+        var value = BigInteger.Parse("1000000000000000000");
+
+        var viaOverload = CirclesConverter.AttoStaticCirclesToAttoCircles(value, timestamp);
+        var viaManual = CirclesConverter.InflationaryToDemurrage(value, expectedDay);
+
+        Assert.That(viaOverload, Is.EqualTo(viaManual),
+            "Timestamp overload must produce identical result to manual day computation");
+    }
+
+    [Test]
+    public void TimestampOverload_AtEpoch_NoDecay()
+    {
+        // At the epoch itself (day 0), no demurrage should be applied
+        var value = BigInteger.Parse("1000000000000000000");
+
+        var result = CirclesConverter.AttoStaticCirclesToAttoCircles(value, V2Epoch);
+
+        Assert.That(result, Is.EqualTo(value),
+            "Day 0 should produce no decay");
+    }
+
+    [Test]
+    public void TimestampOverload_OneYearLater_About7PercentDecay()
+    {
+        var value = BigInteger.Parse("1000000000000000000"); // 1 CRC
+        long oneYearLater = V2Epoch + 365 * 86_400;
+
+        var result = CirclesConverter.AttoStaticCirclesToAttoCircles(value, oneYearLater);
+
+        double ratio = (double)result / (double)value;
+        Assert.That(ratio, Is.InRange(0.925, 0.935),
+            "1 year of demurrage should be approximately 7% decay");
+    }
+
+    [TestCase(1_602_720_000L, 1_602_720_000L)]   // Same timestamp = same result
+    [TestCase(1_700_000_000L, 1_700_000_000L)]   // Same timestamp = same result
+    public void TimestampOverload_SameInput_SameOutput(long ts1, long ts2)
+    {
+        var value = BigInteger.Parse("5000000000000000000");
+        var r1 = CirclesConverter.AttoStaticCirclesToAttoCircles(value, ts1);
+        var r2 = CirclesConverter.AttoStaticCirclesToAttoCircles(value, ts2);
+        Assert.That(r1, Is.EqualTo(r2));
+    }
+
+    [Test]
+    public void TimestampOverload_LaterTimestamp_SmallerResult()
+    {
+        var value = BigInteger.Parse("1000000000000000000");
+        long t1 = V2Epoch + 100 * 86_400;
+        long t2 = V2Epoch + 200 * 86_400;
+
+        var r1 = CirclesConverter.AttoStaticCirclesToAttoCircles(value, t1);
+        var r2 = CirclesConverter.AttoStaticCirclesToAttoCircles(value, t2);
+
+        Assert.That(r2, Is.LessThan(r1), "More days = more decay");
     }
 }

--- a/src/Index/Circles.Index.CirclesV2/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2/LogParser.cs
@@ -207,7 +207,7 @@ public class LogParser(Address v2HubAddress, Address erc20LiftAddress) : ILogPar
             yield break;
         }
 
-        var result = TransferSummaryAggregator.AggregateAll(eventsv2, Erc20WrapperAddresses);
+        var result = TransferSummaryAggregator.AggregateAll(eventsv2, Erc20WrapperAddresses, (long)block.Timestamp);
         int syntheticLogIndex = -(result.StreamTransfers.Totals.Count() + result.NonStreamTransfers.Totals.Count());
 
         if (result.StreamTransfers.Totals.Any())

--- a/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
+++ b/src/Index/Circles.Index.CirclesV2/TransferSummaryAggregator.cs
@@ -33,7 +33,8 @@ public record AggregationResult(
 public static class TransferSummaryAggregator
 {
     public static AggregationResult AggregateAll(IEnumerable<IIndexedEventV2> events,
-        RollbackCache<string, (string, TokenValueRepresentation)> erc20WrapperAddresses)
+        RollbackCache<string, (string, TokenValueRepresentation)> erc20WrapperAddresses,
+        long blockTimestamp = 0)
     {
         var streamSums = new Dictionary<TransferKey, TransferTotal>();
         var nonStreamSums = new Dictionary<TransferKey, TransferTotal>();
@@ -72,14 +73,14 @@ public static class TransferSummaryAggregator
                 // Aggregate them separately so they appear in TransferSummary.
                 if (e is Erc20WrapperTransfer)
                 {
-                    AddNonStreamTransfers(nonStreamSums, e, erc20WrapperAddresses);
+                    AddNonStreamTransfers(nonStreamSums, e, erc20WrapperAddresses, blockTimestamp);
                     nonStreamEvents.Add(e);
                 }
             }
             else
             {
                 nonStreamEvents.Add(e);
-                AddNonStreamTransfers(nonStreamSums, e, erc20WrapperAddresses);
+                AddNonStreamTransfers(nonStreamSums, e, erc20WrapperAddresses, blockTimestamp);
             }
         }
 
@@ -112,7 +113,8 @@ public static class TransferSummaryAggregator
     }
 
     static void AddNonStreamTransfers(Dictionary<TransferKey, TransferTotal> sums, IIndexedEventV2 e,
-        RollbackCache<string, (string, TokenValueRepresentation)> erc20WrapperAddresses)
+        RollbackCache<string, (string, TokenValueRepresentation)> erc20WrapperAddresses,
+        long blockTimestamp)
     {
         if (e is TransferSingle ts)
         {
@@ -128,7 +130,11 @@ public static class TransferSummaryAggregator
             if (erc20WrapperAddresses.TryGetValue(ewt.TokenAddress, out var wrapperType) &&
                 wrapperType.Item2 == TokenValueRepresentation.Inflationary)
             {
-                val = CirclesConverter.AttoStaticCirclesToAttoCircles(val);
+                // Use block timestamp for deterministic conversion — not Now().
+                // This ensures re-indexing the same block always produces identical results.
+                val = blockTimestamp > 0
+                    ? CirclesConverter.AttoStaticCirclesToAttoCircles(val, blockTimestamp)
+                    : CirclesConverter.AttoStaticCirclesToAttoCircles(val);
             }
 
             AddSum(sums, ewt.From, ewt.To, val, ewt.TokenAddress);


### PR DESCRIPTION
## Summary

- **Bug**: `TransferSummaryAggregator` used `AttoStaticCirclesToAttoCircles(val)` which calls `Today()` (`DateTimeOffset.UtcNow`) — making the stored `amount` non-deterministic. Re-indexing the same block on different days produced different values. Pre-existing since `2e80189e` (Feb 2025, daniel), not introduced by the pathfinder refactor.
- **Fix**: New `CirclesConverter.AttoStaticCirclesToAttoCircles(val, blockTimestamp)` overload. `AggregateAll` now accepts `blockTimestamp` and passes it through to the conversion. LogParser passes `block.Timestamp`.
- **Data fix**: SQL migration `002-fix-transfer-summary-demurrage.sql` recalculates affected rows in-place using the block's timestamp — no `REINDEX_FROM_BLOCK` required. Only updates `CrcV2_TransferSummary` rows that originated from inflationary ERC20 wrapper transfers.

### Files changed (6)

| File | Change |
|------|--------|
| `CirclesConverter.cs` | New timestamp-based overload |
| `TransferSummaryAggregator.cs` | Accept + forward `blockTimestamp` |
| `LogParser.cs` | Pass `block.Timestamp` to aggregator |
| `TransferSummaryAggregatorTests.cs` | 9 new tests (determinism, bit-identity, backward compat, converter overload) |
| `001-fix-wrapper-transfer-summary.sql` | Fix stale comment (chiado date → gnosis date) |
| `002-fix-transfer-summary-demurrage.sql` | New: in-place data fix for existing rows |

## Test plan

- [x] 96 unit tests pass (9 new)
- [x] Full suite: 5/5 projects pass
- [x] `BitIdenticalToCirclesConverter` — aggregator matches `CirclesConverter` exactly
- [x] `DeterministicWithBlockTimestamp` — same timestamp always produces same result
- [x] `DemurragedTransfer_UnaffectedByTimestamp` — only inflationary wrappers converted
- [ ] Run `002-fix-transfer-summary-demurrage.sql` on staging after deploy
- [ ] Verify affected TransferSummary rows have correct amounts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected demurrage calculations for inflationary wrapper transfers by aligning day indexing to block timestamps rather than current time.

* **Improvements**
  * Enhanced deterministic conversion handling for re-indexing scenarios to ensure consistent results across operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->