### PR TITLE
perf(index): speed up indexer pipeline for initial sync

### DIFF
--- a/src/Common/Circles.Common/ILogParser.cs
+++ b/src/Common/Circles.Common/ILogParser.cs
@@ -1,4 +1,6 @@
+using System.Collections.Immutable;
 using Nethermind.Core;
+using Nethermind.Core.Crypto;
 using Nethermind.Logging;
 
 namespace Circles.Common;
@@ -8,6 +10,14 @@ public interface ILogParser
     Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings);
 
     IRollbackCache[] Caches { get; }
+
+    /// <summary>
+    /// Topic hashes of events that write to caches during ParseLog/ParseTransaction.
+    /// Used by the pipeline to partition receipts: receipts with only non-cache-writing
+    /// topics can be parsed in parallel, while cache-writing receipts must be sequential.
+    /// Return empty to indicate no cache writes (safe for parallel parsing).
+    /// </summary>
+    IReadOnlySet<Hash256> CacheWritingTopics => ImmutableHashSet<Hash256>.Empty;
 
     /// <summary>
     /// Parses a log entry into a list of index events.

--- a/src/Common/Circles.Common/InsertBuffer.cs
+++ b/src/Common/Circles.Common/InsertBuffer.cs
@@ -10,5 +10,11 @@ public class InsertBuffer<T>
 
     public void Add(T item) => _currentSegment.Enqueue(item);
 
+    public void AddRange(IReadOnlyList<T> items)
+    {
+        for (int i = 0; i < items.Count; i++)
+            _currentSegment.Enqueue(items[i]);
+    }
+
     public ConcurrentQueue<T> TakeSnapshot() => Interlocked.Exchange(ref _currentSegment, new ConcurrentQueue<T>());
 }

--- a/src/Common/Circles.Common/RollbackCache.cs
+++ b/src/Common/Circles.Common/RollbackCache.cs
@@ -10,6 +10,13 @@ public interface IRollbackCache
     int Count { get; }
 
     string Name { get; }
+
+    /// <summary>
+    /// When true, skips locking and diff tracking for maximum throughput during initial sync.
+    /// Rollback capability is lost — <see cref="DeleteAllGreaterOrEqualBlock"/> becomes a no-op.
+    /// Must call <see cref="RollbackCache{TKey,TValue}.Seed"/> to rebuild state before disabling.
+    /// </summary>
+    bool BulkMode { get; set; }
 }
 
 public readonly struct RollbackStats
@@ -49,10 +56,16 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     private readonly Dictionary<long, Dictionary<TKey, Change>> _blockDiffs = new();
     private readonly LinkedList<long> _blockOrder = new();
 
+    /// <inheritdoc />
+    public bool BulkMode { get; set; }
+
     public IReadOnlyDictionary<TKey, TValue> ReadOnlyDictionary
     {
         get
         {
+            if (BulkMode)
+                return new Dictionary<TKey, TValue>(_current);
+
             _lock.EnterReadLock();
             try
             {
@@ -92,6 +105,16 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     {
         if (seedData is null) throw new ArgumentNullException(nameof(seedData));
 
+        if (BulkMode)
+        {
+            _current.Clear();
+            foreach (var (k, v) in seedData) _current[k] = v;
+            _blockDiffs.Clear();
+            _blockOrder.Clear();
+            _lastBlockNo = atBlockNo;
+            return;
+        }
+
         _lock.EnterWriteLock();
         try
         {
@@ -120,6 +143,13 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     {
         if (key is null) throw new ArgumentNullException(nameof(key));
 
+        if (BulkMode)
+        {
+            var isNew = !_current.ContainsKey(key);
+            _current[key] = value;
+            return isNew;
+        }
+
         _lock.EnterWriteLock();
         try
         {
@@ -144,6 +174,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     public bool Remove(long blockNo, TKey key)
     {
         if (key is null) throw new ArgumentNullException(nameof(key));
+
+        if (BulkMode)
+            return _current.Remove(key);
 
         _lock.EnterWriteLock();
         try
@@ -182,6 +215,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     /// </summary>
     public RollbackStats DeleteAllGreaterOrEqualBlock(long toBlockNo)
     {
+        if (BulkMode)
+            return new RollbackStats(0, 0);
+
         _lock.EnterWriteLock();
         try
         {
@@ -233,6 +269,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
     {
         get
         {
+            if (BulkMode)
+                return _current.Count;
+
             _lock.EnterReadLock();
             try
             {
@@ -247,6 +286,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
 
     internal bool RemoveWithoutHistory(TKey key)
     {
+        if (BulkMode)
+            return _current.Remove(key);
+
         _lock.EnterWriteLock();
         try
         {
@@ -296,6 +338,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
 
     public bool ContainsKey(TKey key)
     {
+        if (BulkMode)
+            return _current.ContainsKey(key);
+
         _lock.EnterReadLock();
         try
         {
@@ -309,6 +354,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
 
     public TValue Get(TKey key)
     {
+        if (BulkMode)
+            return _current[key];
+
         _lock.EnterReadLock();
         try
         {
@@ -322,6 +370,9 @@ public sealed class RollbackCache<TKey, TValue> : IRollbackCache where TKey : no
 
     public bool TryGetValue(TKey key, out TValue value)
     {
+        if (BulkMode)
+            return _current.TryGetValue(key, out value!);
+
         _lock.EnterReadLock();
         try
         {

--- a/src/Common/Circles.Common/Sink.cs
+++ b/src/Common/Circles.Common/Sink.cs
@@ -98,6 +98,16 @@ public class Sink(
         }
     }
 
+    public async Task AddEvents(IReadOnlyList<object> indexEvents)
+    {
+        _insertBuffer.AddRange(indexEvents);
+
+        if (_insertBuffer.Length >= batchSize)
+        {
+            await Flush();
+        }
+    }
+
     public async Task Flush()
     {
         var snapshot = _insertBuffer.TakeSnapshot();

--- a/src/Index/Circles.Index.CirclesV1.NameRegistry/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV1.NameRegistry/LogParser.cs
@@ -17,6 +17,11 @@ public class LogParser(Address v1NameRegistryAddress) : ILogParser
 
     public IRollbackCache[] Caches { get; } = [V1AvatarToCidMap];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.UpdateMetadataDigest.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         var selectSignups = new Select(

--- a/src/Index/Circles.Index.CirclesV1/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV1/LogParser.cs
@@ -34,6 +34,12 @@ public class LogParser(Address v1HubAddress) : ILogParser
         CirclesV1TokenOwnersByToken, CirclesV1TokensByTokenOwner, V1Avatars
     ];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.Signup.Topic),
+        new(DatabaseSchema.OrganizationSignup.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         InitV1TokenAddresses(logger, database);

--- a/src/Index/Circles.Index.CirclesV2.BaseGroupDeployer/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.BaseGroupDeployer/LogParser.cs
@@ -17,6 +17,11 @@ public class LogParser(Address deployerAddress) : ILogParser
     public static readonly RollbackCache<Address, object?> BaseGroupsCreated = new("BaseGroupsCreated");
     public IRollbackCache[] Caches { get; } = [BaseGroupsCreated];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.BaseGroupCreated.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         if (settings.BaseGroupDeployer != null)

--- a/src/Index/Circles.Index.CirclesV2.InvitationsAtScale/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.InvitationsAtScale/LogParser.cs
@@ -50,6 +50,12 @@ public class LogParser(
 
     public IRollbackCache[] Caches { get; } = [Farms, InvitationModules, ReferralsModules, QuotaGrantModules];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.AdminSet.Topic),
+        new(DatabaseSchema.InvitationModuleUpdated.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         // Farm emitters

--- a/src/Index/Circles.Index.CirclesV2.NameRegistry/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.NameRegistry/LogParser.cs
@@ -29,6 +29,12 @@ public class LogParser(Address nameRegistryAddress) : ILogParser
 
     public IRollbackCache[] Caches { get; } = [V2AvatarToCidMap, V2AvatarToShortNameMap, V2AShortNameToAvatarMap];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.RegisterShortName.Topic),
+        new(DatabaseSchema.UpdateMetadataDigest.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         var selectSignups = new Select(

--- a/src/Index/Circles.Index.CirclesV2.PaymentGateway/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.PaymentGateway/LogParser.cs
@@ -23,6 +23,11 @@ public class LogParser(ImmutableHashSet<Address> factoryAddresses) : ILogParser
 
     public IRollbackCache[] Caches { get; } = [Gateways];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.GatewayCreated.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         var seeds = new Dictionary<Address, object?>();

--- a/src/Index/Circles.Index.CirclesV2.TokenOffers/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.TokenOffers/LogParser.cs
@@ -38,6 +38,15 @@ public class LogParser(ImmutableHashSet<Address> factoryAddresses) : ILogParser
 
     public IRollbackCache[] Caches { get; } = [OfferCycles, TokenOffers, AccountWeightProviders];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.ERC20TokenOfferCycleCreated.Topic),
+        new(DatabaseSchema.ERC20TokenOfferCreated.Topic),
+        new(DatabaseSchema.NextOfferCreated.Topic),
+        new(DatabaseSchema.AccountWeightProviderCreated.Topic),
+        new(DatabaseSchema.CycleConfiguration.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         // Seed from previously indexed tables

--- a/src/Index/Circles.Index.CirclesV2/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2/LogParser.cs
@@ -58,6 +58,14 @@ public class LogParser(Address v2HubAddress, Address erc20LiftAddress) : ILogPar
         V2Avatars
     ];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.RegisterHuman.Topic),
+        new(DatabaseSchema.RegisterGroup.Topic),
+        new(DatabaseSchema.RegisterOrganization.Topic),
+        new(DatabaseSchema.ERC20WrapperDeployed.Topic)
+    };
+
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
         InitErc20WrapperCache(logger, database);

--- a/src/Index/Circles.Index.Safe/LogParser.cs
+++ b/src/Index/Circles.Index.Safe/LogParser.cs
@@ -50,6 +50,11 @@ public class LogParser(ImmutableHashSet<Address> factoryAddresses) : ILogParser
 
     public IRollbackCache[] Caches { get; } = [KnownSafeProxies];
 
+    public IReadOnlySet<Hash256> CacheWritingTopics { get; } = new HashSet<Hash256>
+    {
+        new(DatabaseSchema.ProxyCreation.Topic)
+    };
+
     private readonly Hash256 _proxyCreationTopic = new(DatabaseSchema.ProxyCreation.Topic);
     private readonly byte[] _legacyCrcProxyCreationTopic = KeccakHelper.ComputeHash("ProxyCreation(address)");
     private readonly Hash256 _safeSetupTopic = new(DatabaseSchema.SafeSetup.Topic);

--- a/src/Index/Circles.Index/BlockIndexer.cs
+++ b/src/Index/Circles.Index/BlockIndexer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Threading.Tasks.Dataflow;
 using Circles.Common;
 using Nethermind.Blockchain;
@@ -63,6 +64,124 @@ public class ImportFlow(
     private long _totalBlocksWithMissingReceipts = 0;
     private long _totalBlocksWithReceipts = 0;
 
+    // Combined set of all cache-writing topics from all parsers (built once, reused per block)
+    private HashSet<Hash256>? _cacheWritingTopics;
+
+    private HashSet<Hash256> GetCacheWritingTopics()
+    {
+        if (_cacheWritingTopics != null) return _cacheWritingTopics;
+        _cacheWritingTopics = new HashSet<Hash256>();
+        foreach (var parser in context.LogParsers)
+        {
+            // Safety check: parsers with caches MUST declare their cache-writing topics,
+            // otherwise their cache-mutating receipts will be processed in parallel (data race).
+            if (parser.Caches.Length > 0 && parser.CacheWritingTopics.Count == 0)
+            {
+                context.Logger.Warn(
+                    $"{parser.GetType().Name} has {parser.Caches.Length} cache(s) but declares no CacheWritingTopics " +
+                    $"— cache writes may race with parallel parsing!");
+            }
+
+            foreach (var topic in parser.CacheWritingTopics)
+                _cacheWritingTopics.Add(topic);
+        }
+        return _cacheWritingTopics;
+    }
+
+    /// <summary>
+    /// Checks if a receipt contains any log that could trigger a cache write.
+    /// </summary>
+    private bool ReceiptHasCacheWritingLogs(TxReceipt receipt, HashSet<Hash256> cacheTopics)
+    {
+        if (receipt.Logs == null || cacheTopics.Count == 0) return false;
+        for (int i = 0; i < receipt.Logs.Length; i++)
+        {
+            var log = receipt.Logs[i];
+            if (log.Topics.Length > 0 && cacheTopics.Contains(log.Topics[0]))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Parse all logs and transactions for a single receipt, returning the collected events.
+    /// </summary>
+    private List<IIndexEvent> ParseReceipt(
+        BlockWithReceipts blockWithReceipts,
+        TxReceipt receipt,
+        Transaction transaction,
+        int transactionIndex)
+    {
+        var blockNum = blockWithReceipts.Block.Number;
+        var parserToEvents = new Dictionary<ILogParser, List<IIndexEvent>>(context.LogParsers.Length);
+        foreach (var parser in context.LogParsers)
+            parserToEvents[parser] = new List<IIndexEvent>();
+
+        // 1) Parse logs
+        if (receipt.Logs != null)
+        {
+            for (int logIndex = 0; logIndex < receipt.Logs.Length; logIndex++)
+            {
+                var logEntry = receipt.Logs[logIndex];
+                foreach (var parser in context.LogParsers)
+                {
+                    try
+                    {
+                        var parsedLogEvents = parser.ParseLog(
+                            blockWithReceipts.Block, transaction, receipt, logEntry, logIndex);
+                        parserToEvents[parser].AddRange(parsedLogEvents);
+                    }
+                    catch (Exception e)
+                    {
+                        context.Logger.Error($"Error parsing log at block {blockNum:N0}, tx {receipt.TxHash}, log {logIndex}: {e.Message}");
+                        throw;
+                    }
+                }
+            }
+        }
+
+        // 2) ParseTransaction for each parser
+        foreach (var parser in context.LogParsers)
+        {
+            try
+            {
+                var parserName = parser.GetType().Name;
+                var eventCount = parserToEvents[parser].Count;
+                var sw = System.Diagnostics.Stopwatch.StartNew();
+                using var watchdog = new Timer(_ =>
+                {
+                    context.Logger.Warn(
+                        $"SLOW: {parserName}.ParseTransaction running for {sw.Elapsed.TotalSeconds:F1}s " +
+                        $"on block {blockNum:N0}, tx {receipt.TxHash}, {eventCount} events");
+                }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
+
+                var txEvents = parser.ParseTransaction(
+                    blockWithReceipts.Block, transactionIndex, transaction, receipt, parserToEvents[parser]);
+
+                sw.Stop();
+                if (sw.Elapsed.TotalSeconds > 1)
+                {
+                    context.Logger.Warn(
+                        $"{parserName}.ParseTransaction took {sw.Elapsed.TotalSeconds:F2}s " +
+                        $"on block {blockNum:N0}, tx {receipt.TxHash}, {eventCount} events");
+                }
+
+                parserToEvents[parser].AddRange(txEvents);
+            }
+            catch (Exception e)
+            {
+                context.Logger.Error($"Error in {parser.GetType().Name}.ParseTransaction at block {blockNum:N0}, tx {receipt.TxHash}: {e.Message}");
+                throw;
+            }
+        }
+
+        // 3) Combine events from all parsers
+        var events = new List<IIndexEvent>();
+        foreach (var kvp in parserToEvents)
+            events.AddRange(kvp.Value);
+        return events;
+    }
+
     private ExecutionDataflowBlockOptions CreateOptions(
         CancellationToken cancellationToken
         , int boundedCapacity = -1
@@ -79,15 +198,20 @@ public class ImportFlow(
     private async Task Sink((BlockWithReceipts, IEnumerable<IIndexEvent>) data)
     {
         Dictionary<string, int> eventCounts = new();
-        var allEvents = data.Item2.ToList();
+        var allEvents = data.Item2 as IReadOnlyList<IIndexEvent> ?? data.Item2.ToList();
 
+        // Build event counts and collect boxed events for bulk enqueue
+        var boxedEvents = new List<object>(allEvents.Count);
         foreach (var indexEvent in allEvents)
         {
-            await context.Sink.AddEvent(indexEvent);
+            boxedEvents.Add(indexEvent);
             var tableName = context.Database.Schema.EventDtoTableMap.Map[indexEvent.GetType()];
             var tableNameString = $"{tableName.Namespace}_{tableName.Table}";
             eventCounts[tableNameString] = eventCounts.GetValueOrDefault(tableNameString) + 1;
         }
+
+        // Bulk enqueue — single buffer-length check instead of N
+        await context.Sink.AddEvents(boxedEvents);
 
         var block = data.Item1.Block;
         await AddBlock(new BlockWithEventCounts(
@@ -110,7 +234,7 @@ public class ImportFlow(
                 }
                 return block;
             },
-            CreateOptions(cancellationToken, 3, 3));
+            CreateOptions(cancellationToken, Environment.ProcessorCount, Environment.ProcessorCount));
 
         TransformBlock<Block, BlockWithReceipts> receiptsSourceBlock =
             new(block =>
@@ -169,7 +293,6 @@ public class ImportFlow(
         TransformBlock<BlockWithReceipts, (BlockWithReceipts, IEnumerable<IIndexEvent>)> parserBlock = new(
             blockWithReceipts =>
             {
-                var blockNum = blockWithReceipts.Block.Number;
                 Dictionary<Hash256, Transaction> transactionsByHash = new();
                 Dictionary<Hash256, int> transactionIndexByHash = new();
 
@@ -183,104 +306,71 @@ public class ImportFlow(
                     transactionIndexByHash[tx.Hash] = i;
                 }
 
-                // We'll collect final events for the entire block in 'allEvents'
-                List<IIndexEvent> allEvents = new();
+                // Build receipt work items with their original indices for ordered merging
+                var cacheTopics = GetCacheWritingTopics();
+                var unsafeReceipts = new List<(int Index, TxReceipt Receipt, Transaction Tx, int TxIndex)>();
+                var safeReceipts = new List<(int Index, TxReceipt Receipt, Transaction Tx, int TxIndex)>();
 
-                // Go through every receipt (which belongs to a transaction).
+                int receiptIdx = 0;
                 foreach (var receipt in blockWithReceipts.Receipts)
                 {
                     var txHash = receipt.TxHash;
                     if (txHash == null || !transactionsByHash.TryGetValue(txHash, out var transaction))
+                    {
+                        receiptIdx++;
                         continue;
-
-                    var transactionIndex = transactionIndexByHash[txHash];
-
-                    // A dictionary mapping each parser -> the events it produced from logs
-                    var parserToEvents = new Dictionary<ILogParser, List<IIndexEvent>>(context.LogParsers.Length);
-                    foreach (var parser in context.LogParsers)
-                    {
-                        parserToEvents[parser] = new List<IIndexEvent>();
                     }
 
-                    // 1) Parse logs with each parser; each parser only stores in its own list
-                    if (receipt.Logs != null)
-                    {
-                        for (int logIndex = 0; logIndex < receipt.Logs.Length; logIndex++)
-                        {
-                            var logEntry = receipt.Logs[logIndex];
-                            foreach (var parser in context.LogParsers)
-                            {
-                                try
-                                {
-                                    var parsedLogEvents = parser.ParseLog(
-                                        blockWithReceipts.Block,
-                                        transaction,
-                                        receipt,
-                                        logEntry,
-                                        logIndex);
+                    var txIndex = transactionIndexByHash[txHash];
+                    var item = (receiptIdx, receipt, transaction, txIndex);
 
-                                    parserToEvents[parser].AddRange(parsedLogEvents);
-                                }
-                                catch (Exception e)
-                                {
-                                    context.Logger.Error($"Error parsing log at block {blockNum:N0}, tx {receipt.TxHash}, log {logIndex}: {e.Message}");
-                                    throw;
-                                }
-                            }
-                        }
-                    }
+                    if (ReceiptHasCacheWritingLogs(receipt, cacheTopics))
+                        unsafeReceipts.Add(item);
+                    else
+                        safeReceipts.Add(item);
 
-                    // 2) For each parser, call ParseTransaction with the events from that parser only
-                    foreach (var parser in context.LogParsers)
-                    {
-                        try
-                        {
-                            // Watchdog: log warning if ParseTransaction takes too long
-                            var parserName = parser.GetType().Name;
-                            var eventCount = parserToEvents[parser].Count;
-                            var sw = System.Diagnostics.Stopwatch.StartNew();
-                            using var watchdog = new Timer(_ =>
-                            {
-                                context.Logger.Warn(
-                                    $"SLOW: {parserName}.ParseTransaction running for {sw.Elapsed.TotalSeconds:F1}s " +
-                                    $"on block {blockNum:N0}, tx {receipt.TxHash}, {eventCount} events");
-                            }, null, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10));
-
-                            var txEvents = parser.ParseTransaction(
-                                blockWithReceipts.Block,
-                                transactionIndex,
-                                transaction,
-                                receipt,
-                                parserToEvents[parser]);
-
-                            sw.Stop();
-                            if (sw.Elapsed.TotalSeconds > 1)
-                            {
-                                context.Logger.Warn(
-                                    $"{parserName}.ParseTransaction took {sw.Elapsed.TotalSeconds:F2}s " +
-                                    $"on block {blockNum:N0}, tx {receipt.TxHash}, {eventCount} events");
-                            }
-
-                            // Add these newly derived events to that parser's list
-                            parserToEvents[parser].AddRange(txEvents);
-                        }
-                        catch (Exception e)
-                        {
-                            context.Logger.Error($"Error in {parser.GetType().Name}.ParseTransaction at block {blockNum:N0}, tx {receipt.TxHash}: {e.Message}");
-                            throw;
-                        }
-                    }
-
-                    // 3) Combine everything from parserToEvents into our final block-level list
-                    foreach (var kvp in parserToEvents)
-                    {
-                        allEvents.AddRange(kvp.Value);
-                    }
+                    receiptIdx++;
                 }
 
-                return (blockWithReceipts, allEvents);
+                // Allocate result slots indexed by receipt position for ordered merging
+                var totalReceipts = receiptIdx;
+                var eventsByReceipt = new List<IIndexEvent>[totalReceipts];
+
+                // 1) Process unsafe receipts sequentially (cache writes must be ordered)
+                foreach (var (idx, receipt, tx, txIdx) in unsafeReceipts)
+                {
+                    eventsByReceipt[idx] = ParseReceipt(blockWithReceipts, receipt, tx, txIdx);
+                }
+
+                // Ensure cache writes from sequential phase are visible to parallel threads.
+                // Required because BulkMode bypasses locks — Dictionary writes on the calling
+                // thread need a memory barrier before pool threads read from the same Dictionary.
+                if (unsafeReceipts.Count > 0 && safeReceipts.Count > 0)
+                    Thread.MemoryBarrier();
+
+                // 2) Process safe receipts in parallel (no cache mutations)
+                if (safeReceipts.Count > 0)
+                {
+                    Parallel.ForEach(safeReceipts,
+                        new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+                        item =>
+                        {
+                            var events = ParseReceipt(blockWithReceipts, item.Receipt, item.Tx, item.TxIndex);
+                            eventsByReceipt[item.Index] = events;
+                        });
+                }
+
+                // 3) Merge events in original receipt order
+                var allEvents = new List<IIndexEvent>();
+                for (int i = 0; i < totalReceipts; i++)
+                {
+                    if (eventsByReceipt[i] != null)
+                        allEvents.AddRange(eventsByReceipt[i]);
+                }
+
+                return (blockWithReceipts, (IEnumerable<IIndexEvent>)allEvents);
             },
-            CreateOptions(cancellationToken, 1, 1));
+            CreateOptions(cancellationToken, Environment.ProcessorCount * 2, 1));
 
 
         receiptsSourceBlock.LinkTo(parserBlock, new DataflowLinkOptions { PropagateCompletion = true });

--- a/src/Index/Circles.Index/StateMachine.cs
+++ b/src/Index/Circles.Index/StateMachine.cs
@@ -65,6 +65,13 @@ public class StateMachine(
     // so subscribers know sync is complete and they can start warming up.
     private bool _hasSentLiveNotification;
 
+    // Bulk sync mode: when the gap between chain head and indexer head is large (>10K blocks),
+    // caches operate in BulkMode (no locks, no diff tracking) for maximum throughput.
+    // On transition to live mode, caches are re-seeded from DB and BulkMode is disabled.
+    private bool _inBulkSyncMode;
+    private const long BulkSyncThreshold = 10_000;
+    private const long BulkSyncExitThreshold = 1_000;
+
     public async Task HandleEvent(IEvent e)
     {
         try
@@ -162,34 +169,48 @@ public class StateMachine(
                             await context.Database.DeleteAllGreaterOrEqualBlock(enterState.Arg);
 
 
-                            context.Logger.Info(
-                                $"Reorg at {enterState.Arg}. Removing objects from caches...");
-
-                            try
+                            // In BulkMode, caches have no diff history — rollback is impossible.
+                            // Re-seed from DB instead (DB was already cleaned above).
+                            if (_inBulkSyncMode)
                             {
-                                var allCaches = context.LogParsers.SelectMany(o => o.Caches).ToArray();
-                                foreach (var cache in allCaches)
-                                {
-                                    var countBefore = cache.Count;
-                                    var stats = cache.DeleteAllGreaterOrEqualBlock(enterState.Arg);
-                                    var removed = stats.Removed;
-                                    var restored = stats.Restored;
-                                    var deleted = countBefore - cache.Count;
-                                    context.Logger.Info(
-                                        $"Cache '{cache.Name}' maintenance: removed {removed}, restored {restored}, count delta {deleted}.");
-                                }
-
-                                context.Logger.Info("Reorg cleanup complete. Ready to process new blocks.");
+                                context.Logger.Warn(
+                                    $"Reorg during bulk sync at {enterState.Arg}. " +
+                                    $"Re-seeding all caches from DB (rollback not available in BulkMode)...");
+                                await InitializeCaches(context.Database.LatestBlock() ?? 0);
+                                context.Logger.Info("Reorg cleanup complete (bulk re-seed). Ready to process new blocks.");
                                 await TransitionTo(State.WaitForNewBlock);
                             }
-                            catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot roll back beyond stored history"))
+                            else
                             {
-                                // Cache rollback capacity exceeded - we can't roll back this far.
-                                // Need to reinitialize caches from database.
-                                context.Logger.Warn(
-                                    $"Cache rollback capacity exceeded at block {enterState.Arg}. " +
-                                    $"Reinitializing caches from database...");
-                                await TransitionTo(State.Initial);
+                                context.Logger.Info(
+                                    $"Reorg at {enterState.Arg}. Removing objects from caches...");
+
+                                try
+                                {
+                                    var allCaches = context.LogParsers.SelectMany(o => o.Caches).ToArray();
+                                    foreach (var cache in allCaches)
+                                    {
+                                        var countBefore = cache.Count;
+                                        var stats = cache.DeleteAllGreaterOrEqualBlock(enterState.Arg);
+                                        var removed = stats.Removed;
+                                        var restored = stats.Restored;
+                                        var deleted = countBefore - cache.Count;
+                                        context.Logger.Info(
+                                            $"Cache '{cache.Name}' maintenance: removed {removed}, restored {restored}, count delta {deleted}.");
+                                    }
+
+                                    context.Logger.Info("Reorg cleanup complete. Ready to process new blocks.");
+                                    await TransitionTo(State.WaitForNewBlock);
+                                }
+                                catch (InvalidOperationException ex) when (ex.Message.Contains("Cannot roll back beyond stored history"))
+                                {
+                                    // Cache rollback capacity exceeded - we can't roll back this far.
+                                    // Need to reinitialize caches from database.
+                                    context.Logger.Warn(
+                                        $"Cache rollback capacity exceeded at block {enterState.Arg}. " +
+                                        $"Reinitializing caches from database...");
+                                    await TransitionTo(State.Initial);
+                                }
                             }
                             return;
                     }
@@ -222,6 +243,13 @@ public class StateMachine(
                                 return;
                             }
 
+                            // Enable bulk sync mode when the gap is large
+                            var gap = newHead.Head - (latestBlock ?? 0);
+                            if (!_inBulkSyncMode && gap > BulkSyncThreshold)
+                            {
+                                SetBulkMode(true);
+                            }
+
                             await TransitionTo(State.Syncing, newHead.Head);
                             return;
                     }
@@ -233,6 +261,17 @@ public class StateMachine(
                     {
                         case EnterState<long> enterSyncing:
                             var importedBlockRange = await Sync(enterSyncing.Arg);
+
+                            // Check if bulk sync mode should be exited
+                            if (_inBulkSyncMode)
+                            {
+                                var latestIndexed = context.Database.LatestBlock() ?? 0;
+                                var remainingGap = enterSyncing.Arg - latestIndexed;
+                                if (remainingGap <= BulkSyncExitThreshold)
+                                {
+                                    await TransitionToLiveMode();
+                                }
+                            }
 
                             // Track blocks processed for status logging
                             if (importedBlockRange.Min.HasValue && importedBlockRange.Max.HasValue)
@@ -447,6 +486,41 @@ public class StateMachine(
                 context.Logger,
                 context.Database,
                 context.Settings)));
+    }
+
+    private void SetBulkMode(bool enabled)
+    {
+        var allCaches = context.LogParsers.SelectMany(o => o.Caches).ToArray();
+        foreach (var cache in allCaches)
+        {
+            cache.BulkMode = enabled;
+        }
+
+        _inBulkSyncMode = enabled;
+        context.Logger.Info(enabled
+            ? $"Bulk sync mode ENABLED — cache locks and diff tracking disabled for {allCaches.Length} caches"
+            : $"Bulk sync mode DISABLED — cache rollback capability restored for {allCaches.Length} caches");
+    }
+
+    private async Task TransitionToLiveMode()
+    {
+        context.Logger.Info("Transitioning from bulk sync to live mode — re-seeding caches from DB...");
+
+        // Disable BulkMode first so Seed() uses proper locking
+        SetBulkMode(false);
+
+        try
+        {
+            // Re-seed all caches from DB to get clean state with rollback capability
+            await InitializeCaches(context.Database.LatestBlock() ?? 0);
+        }
+        catch (Exception ex)
+        {
+            // Restore BulkMode to maintain consistent state — let error handler retry
+            context.Logger.Error($"Failed to re-seed caches during live mode transition: {ex.Message}");
+            SetBulkMode(true);
+            throw;
+        }
     }
 
     private async IAsyncEnumerable<long> GetBlocksToSync(long toBlock)


### PR DESCRIPTION
## Summary

- Three-phase optimization targeting the V2-heavy zone (blocks 30M–45M) where initial sync throughput drops from ~13K to ~600–800 blocks/sec
- **Phase 1**: Pipeline tuning — increase dataflow block capacities, batch event enqueue (zero risk)
- **Phase 2**: BulkMode on RollbackCache — skip locks + diff tracking during bulk sync, auto-detect gap >10K blocks (low risk)
- **Phase 3**: Parallel per-receipt parsing — partition receipts by cache-writing topics, process 90%+ transfer-only receipts via `Parallel.ForEach` (medium risk, highest impact)

### Phase 1 details
- `parserBlock` capacity: 1 → `ProcessorCount * 2` (receipts stage can queue ahead)
- `sourceBlock` capacity: (3,3) → (`ProcessorCount`, `ProcessorCount`)
- `Sink.AddEvents` + `InsertBuffer.AddRange` — single buffer-length check per block instead of N

### Phase 2 details
- `IRollbackCache.BulkMode` flag bypasses `ReaderWriterLockSlim` and per-block diff tracking
- StateMachine enables at gap >10K, disables at <1K via `TransitionToLiveMode` (re-seeds caches from DB)
- Reorg during BulkMode re-seeds from DB (not a no-op)
- `TransitionToLiveMode` restores BulkMode on failure for consistency

### Phase 3 details
- `ILogParser.CacheWritingTopics` — each parser declares which event topics mutate caches
- Pre-scan `Topics[0]` to partition receipts into unsafe (sequential) and safe (parallel)
- `Thread.MemoryBarrier()` between sequential writes and parallel reads
- `Parallel.ForEach` with `MaxDegreeOfParallelism = ProcessorCount`
- Events merged in original receipt order via indexed array
- Startup warning if a parser has caches but declares no topics

### Review findings addressed
- Missing `OrganizationSignup.Topic` in V1 `CacheWritingTopics` (would cause concurrent Dictionary writes)
- Default `CacheWritingTopics` changed to `ImmutableHashSet.Empty` (no allocation per access)
- Reorg during BulkMode now re-seeds caches from DB instead of silent no-op
- `TransitionToLiveMode` failure restores BulkMode before re-throwing
- Memory barrier + bounded parallelism on `Parallel.ForEach`

### Expected impact
- Phase 1 alone: ~800–1000 blk/s in V2 zone
- Phase 1+2: ~900–1200 blk/s
- Phase 1+2+3: ~2500–3500 blk/s (3–5x improvement)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — all 5 test projects pass (0 failures)
- [ ] Deploy to staging, index blocks 30M–31M, compare event counts with production
- [ ] Verify BulkMode → live transition by watching logs during catch-up
- [ ] Trigger a reorg during bulk sync to verify cache re-seeding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced initial synchronisation performance with optimised bulk processing mode for large synchronisation gaps, enabling faster chain catch-up
- Improved parallel event processing capabilities for non-critical transactions

**Performance Improvements**
- Optimised block processing with intelligent sequential and parallel handling of different receipt types
- Increased throughput during chain synchronisation with improved cache management strategies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->