### PR TITLE
feat: make metrics-exporter opt-in via compose profiles

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -358,6 +358,8 @@ services:
       retries: 3
 
   metrics-exporter:
+    profiles:
+      - metrics
     container_name: metrics-exporter
     dns:
       - 8.8.8.8


### PR DESCRIPTION
## Summary

- Adds `profiles: ["metrics"]` to the metrics-exporter service in `docker-compose.gnosis.yml`
- With this change, `docker compose up -d` no longer starts metrics-exporter by default
- To include it: `docker compose --profile metrics up -d`

## Why

Since Grafana/Prometheus/Alertmanager all live on staging, and both staging and prod index the same Gnosis chain, there's no need to run the 214-metric exporter on prod. The Deployment collector (7 metrics) already probes prod RPC remotely from staging.

## Companion PR

- aboutcircles/aboutcircles-infrastructure — ansible changes to conditionally pass `--profile metrics` and strip the Prometheus scrape config on non-metrics hosts

## Test plan

- [ ] Staging: deploy with `deploy_metrics_exporter: true` → metrics-exporter starts, Prometheus scrapes OK
- [ ] Prod: deploy with default (`false`) → metrics-exporter not started, no ServiceDown alert
- [ ] Manual override: can re-enable on prod by setting `deploy_metrics_exporter: true` in host_vars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined service configuration to enable selective metrics collection, providing improved operational flexibility for deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->