### PR TITLE
docs: fix stale ports, versions, and private repo references

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -100,9 +100,14 @@ src/
 ├── Rpc/                             # JSON-RPC (2 projects)
 │   ├── Circles.Rpc.Host/           # RPC service
 │   └── Circles.Rpc.Host.Tests/     # Tests
-└── Cache/                           # Caching layer (2 projects)
-    ├── Circles.Cache.Service/       # Cache service
-    └── Circles.Cache.Service.Tests/ # Tests
+├── Cache/                           # Caching layer (2 projects)
+│   ├── Circles.Cache.Service/       # Cache service
+│   └── Circles.Cache.Service.Tests/ # Tests
+├── Common/                          # Shared utilities (1 project + tests)
+│   ├── Circles.Common/             # Demurrage math, numeric types
+│   └── Circles.Common.Tests/       # Common utility tests
+└── Metrics/                         # Observability (1 project)
+    └── Circles.Metrics.Exporter/   # Prometheus metrics exporter
 
 docker/
 ├── Index.Dockerfile                 # Nethermind plugin
@@ -504,7 +509,7 @@ ls -la nupkgs/
 ## Additional Resources
 
 - **Full Script Documentation**: [scripts/README.md](scripts/README.md)
-- **Circles Protocol**: https://docs.circles.garden/
+- **Circles Protocol**: https://docs.aboutcircles.com/
 - **Nethermind**: https://docs.nethermind.io/
 - **.NET 10**: https://docs.microsoft.com/en-us/dotnet/
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ If you're developing the plugin, building packages, or running services locally,
 - **[Indexer](src/Index/README.md)** - Indexer service
 - **[Pathfinder](src/Pathfinder/Circles.Pathfinder/README.md)** - Pathfinding service
 - **[Rpc](src/Rpc/Circles.Rpc.Host/README.md)** - Rpc service
+- **[Cache](src/Cache/README.md)** - Cache service
+- **[Metrics Exporter](src/Metrics/Circles.Metrics.Exporter/README.md)** - Prometheus metrics exporter
 
 Quick commands for developers:
 
@@ -187,6 +189,10 @@ at the same RPC endpoint.
 - `9000/tcp` (consensus p2p)
 - `9000/udp` (consensus p2p)
 - `5054/tcp` (consensus metrics)
+- `8080/tcp` (pathfinder REST API)
+- `8080/tcp` (rpc host — mapped to 8081 locally via `run-rpc.sh`)
+- `3001/tcp` (cache service)
+- `9100/tcp` (metrics exporter)
 
 ##### Volumes
 

--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -222,9 +222,8 @@ services:
       retries: 3
       start_period: 60s
 
-  # NOTE: profile-service removed - now deployed separately via Ansible
-  # See: aboutcircles-infrastructure/indexer_ansible/roles/profile_pinning_service
-  # Container name: profile-pinning, routes via /profiles/* in Caddy
+  # NOTE: profile-service removed - now deployed separately
+  # Profile pinning service (configured externally), routes via /profiles/* in Caddy
 
   postgres-gnosis:
     container_name: postgres-gnosis

--- a/docs/materialized-views.md
+++ b/docs/materialized-views.md
@@ -124,7 +124,7 @@ All matviews are populated on creation (no `WITH NO DATA`). This means migration
 
 #### Alertmanager Rules
 
-Defined in `aboutcircles-infrastructure/observability/prometheus/alerts/prometheus-alerts-matview.yml`:
+Alertmanager rules are defined in the infrastructure repository (not included in this repo):
 
 | Alert | Condition | Severity |
 |-------|-----------|----------|

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,9 +1,8 @@
 # Observability Stack
 
-> **Note**: The observability stack configuration has been migrated to the
-> [aboutcircles-infrastructure](https://github.com/aboutcircles/aboutcircles-infrastructure)
-> repository. The canonical source for Prometheus configs, Grafana dashboards, and alert rules
-> is now in `aboutcircles-infrastructure/observability/`.
+> **Note**: The observability stack configuration has been migrated to a separate private
+> infrastructure repository. The canonical source for Prometheus configs, Grafana dashboards,
+> and alert rules is maintained there.
 >
 > The Metrics Exporter (`src/Metrics/Circles.Metrics.Exporter/`) remains in this repository
 > due to its tight coupling with the Circles database schema.

--- a/docs/rpc-pathfinder.md
+++ b/docs/rpc-pathfinder.md
@@ -39,7 +39,7 @@ Find the maximum possible transfer from source to sink.
 **Request:**
 
 ```bash
-curl -X POST http://localhost:5000/ \
+curl -X POST http://localhost:8081/ \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -96,7 +96,7 @@ Calculate a path that swaps one token for another. This creates a circular path 
 **Request:**
 
 ```bash
-curl -X POST http://localhost:5000/ \
+curl -X POST http://localhost:8081/ \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",
@@ -272,7 +272,7 @@ curl -i http://localhost:8080/snapshot -H 'If-None-Match: "31234567"'
 The snapshot is also accessible via the RPC host:
 
 ```bash
-curl -X POST http://localhost:5000/ \
+curl -X POST http://localhost:8081/ \
   -H "Content-Type: application/json" \
   -d '{
     "jsonrpc": "2.0",

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -523,8 +523,7 @@ The test environment is an independent repository ([circles-test-environment](ht
 # Run locally (from circles-test-environment repo)
 cd circles-test-environment/docker && docker compose up -d --build
 
-# Deploy via Ansible (from aboutcircles-infrastructure repo)
-make deploy HOST=indexer-staging2 -e deploy_test_environment=true
+# Deployment is managed via a separate infrastructure repository
 ```
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -638,7 +638,7 @@ Builds and runs Nethermind with the Circles Index plugin for local development.
 
 - Nethermind source code cloned to `src/nethermind/` or set `NETHERMIND_SOURCE`
 - PostgreSQL running (via Docker or locally)
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 
 **When to use:**
 
@@ -977,9 +977,9 @@ RegressionTestResults/     # Regression test results (created by rpc-regression.
 
 ## Additional Resources
 
-- [Circles Protocol Documentation](https://docs.circles.garden/)
+- [Circles Protocol Documentation](https://docs.aboutcircles.com/)
 - [Nethermind Documentation](https://docs.nethermind.io/)
-- [.NET 9 Documentation](https://docs.microsoft.com/en-us/dotnet/)
+- [.NET 10 Documentation](https://docs.microsoft.com/en-us/dotnet/)
 - [Docker Documentation](https://docs.docker.com/)
 - [NuGet Documentation](https://docs.microsoft.com/en-us/nuget/)
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -37,7 +37,7 @@ echo -e "${BLUE}Building all Docker images...${NC}\n"
 cd "$DOCKER_DIR"
 
 # Array of core images to build
-# Note: caddy Dockerfile moved to aboutcircles-infrastructure repo
+# Note: Caddy is built from a separate infrastructure repo
 # Note: test-environment image is built by circles-test-environment repo CI
 IMAGES=(
   "cache-service:cache-service.Dockerfile"
@@ -68,7 +68,7 @@ for arg in "$@"; do
       echo "  pathfinder        Build Pathfinder host (pathfinder-host.Dockerfile)"
       echo "  rpc               Build RPC host (rpc-host.Dockerfile)"
       echo ""
-      echo "Note: Caddy is built from aboutcircles-infrastructure repo"
+      echo "Note: Caddy is built from a separate infrastructure repo"
       echo "Note: Test environment image is built by circles-test-environment repo CI"
       echo ""
       echo "Platform detection:"

--- a/src/Cache/README.md
+++ b/src/Cache/README.md
@@ -123,10 +123,10 @@ cd src/Cache/Circles.Cache.Service
 dotnet run
 
 # Or use script (if available)
-./scripts/run-cache.sh
+./scripts/run-cache-service.sh
 ```
 
-Default URL: `http://localhost:5002`
+Default URL: `http://localhost:3001`
 
 ### Configuration
 
@@ -148,8 +148,8 @@ export ROLLBACK_CAPACITY=12
 # Optional - max lag before service is "not ready" (default: 10)
 export MAX_CATCHUP_LAG=10
 
-# Optional - HTTP port (default: 5002)
-export PORT=5002
+# Optional - HTTP port (default: 3001)
+export PORT=3001
 
 # Optional - max IPFS profile content cache entries (default: 50000)
 export IPFS_CACHE_MAX_ENTRIES=50000
@@ -167,7 +167,7 @@ Get all token balances for an address.
 GET /api/balances/{address}
 
 # Example
-curl http://localhost:5002/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7
+curl http://localhost:3001/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7
 ```
 
 **Response:**
@@ -191,7 +191,7 @@ curl http://localhost:5002/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912
 GET /api/balances/{address}/total/v1
 
 # Example
-curl http://localhost:5002/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total/v1
+curl http://localhost:3001/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total/v1
 ```
 
 **Response:**
@@ -216,7 +216,7 @@ GET /api/balances/{address}/total/v2
 GET /api/balances/{address}/total
 
 # Example
-curl http://localhost:5002/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total
+curl http://localhost:3001/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total
 ```
 
 ### Avatar Endpoints
@@ -229,7 +229,7 @@ Get avatar information for an address.
 GET /api/avatars/{address}
 
 # Example
-curl http://localhost:5002/api/avatars/0xde374ece6fa50e781e81aac78e811b33d16912c7
+curl http://localhost:3001/api/avatars/0xde374ece6fa50e781e81aac78e811b33d16912c7
 ```
 
 **Response:**
@@ -265,7 +265,7 @@ Content-Type: application/json
 }
 
 # Example
-curl -X POST http://localhost:5002/api/avatars/batch \
+curl -X POST http://localhost:3001/api/avatars/batch \
   -H 'Content-Type: application/json' \
   -d '{"addresses": ["0xde374ece6fa50e781e81aac78e811b33d16912c7"]}'
 ```
@@ -284,7 +284,7 @@ Get IPFS CID for an avatar's profile.
 GET /api/profiles/{address}/cid
 
 # Example
-curl http://localhost:5002/api/profiles/0xde374ece6fa50e781e81aac78e811b33d16912c7/cid
+curl http://localhost:3001/api/profiles/0xde374ece6fa50e781e81aac78e811b33d16912c7/cid
 ```
 
 **Response:**
@@ -320,7 +320,7 @@ Get IPFS profile content (JSON payload) by CID. The content is cached in an LRU 
 GET /api/profiles/content/{cid}
 
 # Example
-curl http://localhost:5002/api/profiles/content/QmX...
+curl http://localhost:3001/api/profiles/content/QmX...
 ```
 
 **Response:**
@@ -362,7 +362,7 @@ Content-Type: application/json
 GET /live
 
 # Example
-curl http://localhost:5002/live
+curl http://localhost:3001/live
 ```
 
 Returns `200 OK` if service is running.
@@ -373,7 +373,7 @@ Returns `200 OK` if service is running.
 GET /ready
 
 # Example
-curl http://localhost:5002/ready
+curl http://localhost:3001/ready
 ```
 
 Returns `200 OK` if service is ready to handle requests. Checks:
@@ -403,7 +403,7 @@ Returns `503 Service Unavailable` if not ready.
 GET /cache/stats
 
 # Example
-curl http://localhost:5002/cache/stats
+curl http://localhost:3001/cache/stats
 ```
 
 **Response:**
@@ -440,7 +440,7 @@ curl http://localhost:5002/cache/stats
 GET /metrics
 
 # Example
-curl http://localhost:5002/metrics
+curl http://localhost:3001/metrics
 ```
 
 Returns Prometheus-formatted metrics for monitoring.
@@ -451,7 +451,7 @@ Returns Prometheus-formatted metrics for monitoring.
 GET /
 
 # Example
-curl http://localhost:5002/
+curl http://localhost:3001/
 ```
 
 Returns service information and available endpoints.
@@ -714,7 +714,7 @@ export POSTGRES_READONLY_CONNECTION_STRING="Host=localhost;Port=5432;Database=po
 
 ### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - PostgreSQL 15+ (with indexed Circles data)
 - Running Circles Index plugin
 
@@ -732,10 +732,10 @@ dotnet build
 dotnet run
 
 # Test endpoints
-curl http://localhost:5002/live
-curl http://localhost:5002/ready
-curl http://localhost:5002/cache/stats
-curl http://localhost:5002/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total
+curl http://localhost:3001/live
+curl http://localhost:3001/ready
+curl http://localhost:3001/cache/stats
+curl http://localhost:3001/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912c7/total
 ```
 
 ### Project Structure
@@ -792,13 +792,13 @@ http_request_duration_seconds
 
 ```bash
 # Check if service is up
-curl http://localhost:5002/live
+curl http://localhost:3001/live
 
 # Check if service is ready to serve traffic
-curl http://localhost:5002/ready
+curl http://localhost:3001/ready
 
 # Get cache statistics
-curl http://localhost:5002/cache/stats
+curl http://localhost:3001/cache/stats
 ```
 
 ### Logs
@@ -828,7 +828,7 @@ The service logs important events:
 
 ```bash
 # Check if listener is connected
-curl http://localhost:5002/cache/stats | jq '.listenerConnected'
+curl http://localhost:3001/cache/stats | jq '.listenerConnected'
 
 # Check PostgreSQL notifications are being sent
 # (from Index plugin logs)
@@ -849,7 +849,7 @@ curl http://localhost:5002/cache/stats | jq '.listenerConnected'
 
 ```bash
 # Check cache sizes
-curl http://localhost:5002/cache/stats | jq '.total_entries'
+curl http://localhost:3001/cache/stats | jq '.total_entries'
 
 # Monitor memory
 docker stats circles-cache
@@ -869,7 +869,7 @@ docker stats circles-cache
 
 ```bash
 # Check warmup completed
-curl http://localhost:5002/cache/stats | jq '.warmupComplete'
+curl http://localhost:3001/cache/stats | jq '.warmupComplete'
 
 # Check for large number of tokens per address
 ```
@@ -888,7 +888,7 @@ curl http://localhost:5002/cache/stats | jq '.warmupComplete'
 
 ```bash
 # Check reorg metrics
-curl http://localhost:5002/metrics | grep reorgs_detected
+curl http://localhost:3001/metrics | grep reorgs_detected
 
 # Check logs for reorg warnings
 ```
@@ -903,10 +903,10 @@ curl http://localhost:5002/metrics | grep reorgs_detected
 
 ```bash
 # Use different port
-PORT=5003 dotnet run
+PORT=3002 dotnet run
 
 # Or set in environment
-export PORT=5003
+export PORT=3002
 ```
 
 ## Deployment
@@ -914,9 +914,9 @@ export PORT=5003
 ### Docker
 
 ```dockerfile
-FROM mcr.microsoft.com/dotnet/aspnet:9.0
+FROM mcr.microsoft.com/dotnet/aspnet:10.0
 WORKDIR /app
-COPY bin/Release/net9.0/publish/ .
+COPY bin/Release/net10.0/publish/ .
 ENTRYPOINT ["dotnet", "Circles.Cache.Service.dll"]
 ```
 
@@ -928,14 +928,14 @@ services:
   cache:
     build: ./src/Cache/Circles.Cache.Service
     ports:
-      - "5002:5002"
+      - "3001:3001"
     environment:
       - POSTGRES_CONNECTION_STRING=Host=postgres;Port=5432;Database=postgres;Username=postgres;Password=postgres
       - POSTGRES_READONLY_CONNECTION_STRING=${POSTGRES_CONNECTION_STRING}
       - CIRCLES_PG_NOTIFY_CHANNEL=circles_index_events
       - ROLLBACK_CAPACITY=12
       - MAX_CATCHUP_LAG=10
-      - PORT=5002
+      - PORT=3001
     depends_on:
       - postgres
     restart: unless-stopped
@@ -957,7 +957,7 @@ curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
 }'
 
 # Cache Service (in-memory - faster, near real-time)
-curl http://localhost:5002/api/balances/0xaddr.../total
+curl http://localhost:3001/api/balances/0xaddr.../total
 ```
 
 **Use Cases:**
@@ -971,7 +971,7 @@ The Cache Service can provide fast balance lookups for pathfinding:
 
 ```bash
 # 1. Get source address balances from cache
-curl http://localhost:5002/api/balances/0xsource.../
+curl http://localhost:3001/api/balances/0xsource.../
 
 # 2. Use pathfinder to find path
 curl -X POST http://localhost:8080/flow -d '{

--- a/src/Index/README.md
+++ b/src/Index/README.md
@@ -268,7 +268,7 @@ NETHERMIND_SOURCE=~/path/to/nethermind ./scripts/run-index.sh
 **Prerequisites:**
 - Nethermind source in `src/nethermind/` (git submodule)
 - PostgreSQL 15+ running
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - ~700GB+ disk space for blockchain data
 
 ## Configuration

--- a/src/Metrics/Circles.Metrics.Exporter/README.md
+++ b/src/Metrics/Circles.Metrics.Exporter/README.md
@@ -172,9 +172,9 @@ dotnet run
 ```
 
 Access:
-- http://localhost:5000/metrics - Prometheus metrics
-- http://localhost:5000/health - Health check
-- http://localhost:5000/ - Service info
+- http://localhost:9100/metrics - Prometheus metrics
+- http://localhost:9100/health - Health check
+- http://localhost:9100/ - Service info
 
 ### Docker
 

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -603,7 +603,7 @@ JSON-RPC 2.0 Response
 
 ### Prerequisites
 
-- .NET 9.0 SDK
+- .NET 10.0 SDK
 - PostgreSQL 15+ (with indexed Circles data)
 - Nethermind RPC endpoint (optional, for live mode)
 - Pathfinder service (optional, for pathfinding methods)


### PR DESCRIPTION
## Summary

Comprehensive documentation audit and cleanup verified against actual running services on staging1, staging2, and prod1.

- **Private repo refs removed**: All 7 `aboutcircles-infrastructure` references replaced with generic wording (security/UX: no internal repo names in public docs)
- **Cache service port**: 5002→3001 (~30 URLs in Cache/README.md — matched to Dockerfile, docker-compose, and run script)
- **Pathfinder/RPC port**: 5000→8081 in rpc-pathfinder.md curl examples
- **Metrics exporter port**: 5000→9100 (matched to Dockerfile `ASPNETCORE_URLS=http://+:9100`)
- **Script name**: `run-cache.sh`→`run-cache-service.sh` (actual script name)
- **.NET version**: 9→10 in 4 READMEs (6 refs + 1 Dockerfile example)
- **Stale URLs**: `docs.circles.garden`→`docs.aboutcircles.com`
- **Missing content**: Added `src/Common/` and `src/Metrics/` to DEVELOPMENT.md structure, added service ports and links to README.md

## Verification

All grep patterns return zero results:
- `aboutcircles-infrastructure` — 0 hits
- `localhost:5002` in *.md — 0 hits
- `localhost:5000` in *.md — 0 hits
- `.NET 9` / `net9.0` in *.md — 0 hits
- `docs.circles.garden` — 0 hits
- `run-cache.sh` (without `-service`) — 0 hits

## Test plan

- [ ] All internal doc links still resolve (pre-verified)
- [ ] No functional code changes — docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* **Updated Prerequisites** – .NET 10.0 SDK now required across development guides.
* **Updated Service Ports** – Cache Service port changed to 3001, Metrics Exporter to 9100, and RPC PathFinder to 8081.
* **Restructured Documentation** – Updated project structure references, links, and deployment guidance to reflect separation of infrastructure and application repositories.
* **Improved Developer Resources** – Added references to Cache Service and Prometheus Metrics Exporter documentation for developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->