### PR TITLE
docs: add undocumented endpoints, env vars, and fix compose snippet

### DIFF
--- a/src/Cache/README.md
+++ b/src/Cache/README.md
@@ -354,6 +354,122 @@ Content-Type: application/json
 
 **Limits:** Max 100 CIDs per request
 
+### Token Endpoints
+
+#### Get Token Info
+
+Get metadata for a token address (type, version, owner, flags).
+
+```bash
+GET /api/tokens/{tokenAddress}
+
+# Example
+curl http://localhost:3001/api/tokens/0x1234567890123456789012345678901234567890
+```
+
+**Response:**
+
+```json
+{
+  "tokenAddress": "0x1234...",
+  "tokenOwner": "0x5678...",
+  "tokenType": "CrcV2_RegisterHuman",
+  "version": 2,
+  "isErc20": false,
+  "isErc1155": true,
+  "isWrapped": false,
+  "isInflationary": false,
+  "isGroup": false,
+  "lastProcessedBlock": 31234567,
+  "timestamp": 1638360000
+}
+```
+
+Returns `404` if the token is not found.
+
+#### Get Token Info Batch
+
+```bash
+POST /api/tokens/batch
+Content-Type: application/json
+
+{
+  "tokenAddresses": ["0x1234...", "0x5678..."]
+}
+```
+
+**Limits:** Max 1000 token addresses per request
+
+### Trust Endpoints
+
+#### Get Trust Relations
+
+Get trust relationships for an address from cache.
+
+```bash
+GET /api/trust/{address}?version=2
+
+# Example (all versions)
+curl http://localhost:3001/api/trust/0xde374ece6fa50e781e81aac78e811b33d16912c7
+
+# Example (V2 only)
+curl http://localhost:3001/api/trust/0xde374ece6fa50e781e81aac78e811b33d16912c7?version=2
+```
+
+**Query Parameters:**
+- `version` (optional) — Filter by Circles version (1 or 2)
+
+### Group Membership Endpoints
+
+#### Get Group Members
+
+Get all non-expired members of a group.
+
+```bash
+GET /api/groups/{groupAddress}/members
+
+# Example
+curl http://localhost:3001/api/groups/0xGroupAddress.../members
+```
+
+#### Get Member Groups
+
+Get all groups a member belongs to (non-expired only).
+
+```bash
+GET /api/groups/memberships/{memberAddress}
+
+# Example
+curl http://localhost:3001/api/groups/memberships/0xMemberAddress...
+```
+
+### Pathfinder Graph Endpoint
+
+#### Get Graph Snapshot
+
+Returns the full trust graph and balance data for the pathfinder, served directly from cache (zero SQL queries). Supports ETag-based conditional requests.
+
+```bash
+GET /api/pathfinder/graph
+
+# Full graph
+curl http://localhost:3001/api/pathfinder/graph
+
+# Selective sections
+curl http://localhost:3001/api/pathfinder/graph?include=balances,trust
+
+# Conditional request (304 if unchanged)
+curl -H 'If-None-Match: "31234567"' http://localhost:3001/api/pathfinder/graph
+```
+
+**Query Parameters:**
+- `include` (optional) — Comma-separated sections to include. Default: all sections (`balances,trust,groups,groupTrusts,consentedFlow,avatars,wrapperMappings`)
+
+**Response Headers:**
+- `ETag: "{blockNumber}"` — Use with `If-None-Match` for efficient polling
+- Returns `304 Not Modified` when graph hasn't changed
+- Returns `503 Service Unavailable` if cache warmup is not complete
+
 ### System Endpoints
 
 #### Health Check
@@ -922,24 +1038,39 @@ ENTRYPOINT ["dotnet", "Circles.Cache.Service.dll"]
 
 ### Docker Compose
 
+The cache service is defined in `docker/docker-compose.gnosis.yml`:
+
 ```yaml
-version: "3.8"
-services:
-  cache:
-    build: ./src/Cache/Circles.Cache.Service
-    ports:
-      - "3001:3001"
-    environment:
-      - POSTGRES_CONNECTION_STRING=Host=postgres;Port=5432;Database=postgres;Username=postgres;Password=postgres
-      - POSTGRES_READONLY_CONNECTION_STRING=${POSTGRES_CONNECTION_STRING}
-      - CIRCLES_PG_NOTIFY_CHANNEL=circles_index_events
-      - ROLLBACK_CAPACITY=12
-      - MAX_CATCHUP_LAG=10
-      - PORT=3001
-    depends_on:
-      - postgres
-    restart: unless-stopped
+cache-service:
+  container_name: cache-service
+  build:
+    context: ..
+    dockerfile: docker/cache-service.Dockerfile
+  depends_on:
+    postgres-gnosis:
+      condition: service_healthy
+  restart: unless-stopped
+  expose:
+    - 3001
+  env_file:
+    - ../.env
+  environment:
+    - PORT=3001
+    - POSTGRES_CONNECTION_STRING=Server=postgres-gnosis;Port=5432;Database=postgres;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Application Name=cache-service;Tcp Keepalive=true;Keepalive=300;
+    - POSTGRES_READONLY_CONNECTION_STRING=Server=postgres-gnosis;Port=5432;Database=postgres;User Id=${POSTGRES_USER};Password=${POSTGRES_PASSWORD};Application Name=cache-service;Tcp Keepalive=true;Keepalive=300;
+    - PG_NOTIFY_CHANNEL=circles_index_events
+    - ROLLBACK_CAPACITY=12
+    - MAX_CATCHUP_LAG=100
+    - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
+  healthcheck:
+    test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/3001'"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+    start_period: 600s
 ```
+
+**Note:** The `Tcp Keepalive=true;Keepalive=300;` parameters (5 min) prevent PostgreSQL's `idle_session_timeout` (10 min) from killing the long-lived LISTEN/NOTIFY connection.
 
 ## Integration
 
@@ -967,19 +1098,9 @@ curl http://localhost:3001/api/balances/0xaddr.../total
 
 ### Using with Pathfinder
 
-The Cache Service can provide fast balance lookups for pathfinding:
+The Pathfinder can load its entire trust graph from the Cache Service instead of SQL (zero-query mode). Set `USE_CACHE_GRAPH_SOURCE=true` and `CACHE_SERVICE_URL=http://cache-service:3001` in the Pathfinder environment.
 
-```bash
-# 1. Get source address balances from cache
-curl http://localhost:3001/api/balances/0xsource.../
-
-# 2. Use pathfinder to find path
-curl -X POST http://localhost:8080/flow -d '{
-  "source": "0xsource...",
-  "sink": "0xsink...",
-  "targetFlow": "1000000000000000000"
-}'
-```
+The graph endpoint (`/api/pathfinder/graph`) serves the complete trust graph with ETag caching — the Pathfinder polls this and only re-downloads when the block number changes.
 
 ## Related Documentation
 
@@ -1008,3 +1129,9 @@ curl -X POST http://localhost:8080/flow -d '{
 | `/api/profiles/cid/batch`          | POST   | Get profile CIDs (batch)         |
 | `/api/profiles/content/{cid}`      | GET    | Get profile content by CID       |
 | `/api/profiles/content/batch`      | POST   | Get profile content (batch)      |
+| `/api/tokens/{tokenAddress}`       | GET    | Get token metadata               |
+| `/api/tokens/batch`                | POST   | Get token metadata (batch)       |
+| `/api/trust/{address}`             | GET    | Get trust relations              |
+| `/api/groups/{group}/members`      | GET    | Get group members                |
+| `/api/groups/memberships/{member}` | GET    | Get member's groups              |
+| `/api/pathfinder/graph`            | GET    | Full graph snapshot (ETag-aware) |

--- a/src/Metrics/Circles.Metrics.Exporter/README.md
+++ b/src/Metrics/Circles.Metrics.Exporter/README.md
@@ -94,6 +94,25 @@ Data source: `CrcV2_Erc20WrapperTransfer` table
 | Variable | Description | Required |
 |----------|-------------|----------|
 | `ConnectionStrings__CirclesDb` | PostgreSQL connection string for Circles indexer | Yes |
+| `CoinGecko__ApiKey` | CoinGecko API key for CRC price data | No |
+| `Pricing__FallbackCrcPriceUsd` | Fallback CRC price when CoinGecko unavailable (default: `0.01`) | No |
+| `Pricing__CacheExpiryMinutes` | Price cache TTL in minutes (default: `5`) | No |
+
+In `docker-compose.gnosis.yml`, the metrics exporter supports a separate database connection via `METRICS_DB_HOST`, `METRICS_DB_USER`, and `METRICS_DB_PASSWORD` variables (falls back to the main `POSTGRES_*` vars if unset).
+
+### Docker Compose Profile
+
+The metrics exporter is **opt-in** via the `metrics` compose profile:
+
+```bash
+# Start with metrics exporter enabled
+docker compose -f docker/docker-compose.gnosis.yml --profile metrics up -d
+
+# Without metrics exporter (default)
+docker compose -f docker/docker-compose.gnosis.yml up -d
+```
+
+Resource limits: 1 CPU, 512 MB RAM.
 
 ### appsettings.json
 
@@ -174,6 +193,7 @@ dotnet run
 Access:
 - http://localhost:9100/metrics - Prometheus metrics
 - http://localhost:9100/health - Health check
+- http://localhost:9100/ready - Readiness check (used by Docker healthcheck)
 - http://localhost:9100/ - Service info
 
 ### Docker

--- a/src/Pathfinder/Circles.Pathfinder/README.md
+++ b/src/Pathfinder/Circles.Pathfinder/README.md
@@ -187,3 +187,46 @@ The pathfinder enforces correct ordering via two methods in `V2Pathfinder.cs`:
 The production router is: `0xdc287474114cc0551a81ddc2eb51783fbf34802f`
 
 Configure via environment variable: `V2_BASE_GROUP_ROUTER`
+
+## Configuration
+
+All configuration is via environment variables. See `Settings.cs` for the full list.
+
+### Graph Source
+
+The pathfinder can load its trust graph from the **Cache Service** (recommended) or directly from PostgreSQL.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `USE_CACHE_GRAPH_SOURCE` | auto (true if `CACHE_SERVICE_URL` set) | Load graph from Cache Service instead of DB |
+| `CACHE_SERVICE_URL` | (unset) | Cache Service URL (e.g. `http://cache-service:3001`) |
+| `CACHE_GRAPH_FALLBACK_TO_DB` | `true` | Fall back to DB if cache is unavailable |
+| `CACHE_GRAPH_REQUEST_TIMEOUT_SECONDS` | `60` | Timeout for cache graph fetch |
+
+### Solver
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MAX_CONCURRENT_REQUESTS` | `max(CPUCount × 2, 8)` | Max concurrent pathfinder requests |
+| `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | `10` | MaxFlow solver timeout per request |
+| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `0.9995` | 0.05% haircut on demurraged balances to avoid rounding reverts |
+| `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | `true` | Exclude consented avatars from intermediary positions in paths |
+
+### Materialized View Refresh
+
+The pathfinder refreshes materialized views in-process as a primary mechanism (the Docker cron `matview-refresh` container is the backup).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MATVIEW_REFRESH_ENABLED` | `true` | Enable in-process matview refreshes |
+| `MATVIEW_REFRESH_FAST_BLOCKS` | `60` | Blocks between fast-tier refreshes (~5 min on Gnosis) |
+| `MATVIEW_REFRESH_SLOW_BLOCKS` | `180` | Blocks between slow-tier refreshes (~15 min on Gnosis) |
+| `MATVIEW_REFRESH_INTERVAL_BLOCKS` | (unset) | Legacy: overrides both tiers if set |
+| `MATVIEW_DB_CONNECTION_STRING` | falls back to `POSTGRES_CONNECTION_STRING` | Separate write connection for matview refreshes |
+
+### Incremental Updates
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PATHFINDER_INCREMENTAL_ENABLED` | `true` | Use incremental graph updates vs full refresh each block |
+| `PATHFINDER_FULL_REFRESH_INTERVAL_BLOCKS` | `200` | Blocks between full DB refreshes (drift correction) |

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -42,6 +42,16 @@ export BALANCE_MODE="live"  # "live" (eth_call) or "database" (fast but stale)
 export DATABASE_QUERY_TIMEOUT_SECONDS=30
 export PROFILE_SEARCH_TIMEOUT_SECONDS=30
 export EXTERNAL_PATHFINDER_URL="http://localhost:8080"
+
+# Cache Service (optional — enables fast balance/avatar/profile queries)
+export USE_CACHE_SERVICE=true
+export CACHE_SERVICE_URL="http://cache-service:3001"
+
+# Profile Pinning Service (optional — fast profile search proxy, falls back to SQL)
+export PROFILE_PINNING_SERVICE_URL="http://profile-pinning:3000"
+
+# CORS
+export CORS_ALLOWED_ORIGINS="*"
 ```
 
 See `.env.example` for full configuration options.


### PR DESCRIPTION
## Summary

Follow-up to #258. Fixes the fake Docker Compose snippet in Cache README and documents previously undocumented implementation.

### Cache Service (4 new endpoint groups documented)
- **Tokens**: `GET /api/tokens/{addr}`, `POST /api/tokens/batch` (max 1000)
- **Trust**: `GET /api/trust/{addr}?version=2`
- **Group Memberships**: `GET /api/groups/{group}/members`, `GET /api/groups/memberships/{member}`
- **Pathfinder Graph**: `GET /api/pathfinder/graph?include=balances,trust,...` (ETag-aware, zero SQL)
- Docker Compose snippet replaced with real `docker-compose.gnosis.yml` config
- Pathfinder integration rewritten to explain cache graph source mode

### Pathfinder (new Configuration section)
- Graph source config (`USE_CACHE_GRAPH_SOURCE`, `CACHE_SERVICE_URL`, fallback)
- Solver settings (`MAX_CONCURRENT_REQUESTS`, `SOLVER_TIMEOUT`, `DEMURRAGE_SAFETY_MARGIN`)
- Matview refresh env vars (`MATVIEW_REFRESH_ENABLED`, fast/slow blocks)
- Incremental update settings

### RPC Host
- Added `USE_CACHE_SERVICE`, `CACHE_SERVICE_URL`, `PROFILE_PINNING_SERVICE_URL`, `CORS_ALLOWED_ORIGINS`

### Metrics Exporter
- CoinGecko pricing config (`CoinGecko__ApiKey`, `Pricing__*`)
- Compose profile activation (`--profile metrics`)
- Added `/ready` endpoint to docs

## Test plan

- [ ] No functional code changes — docs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Added REST API documentation for new endpoints: token metadata, trust relations, group membership, and pathfinder graph with ETag-based caching.
* Documented new configuration options for Cache Service, CoinGecko-based pricing, metrics database connection, and CORS settings.
* Updated Docker Compose guidance with metrics profile support and enhanced service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->