### PR TITLE
fix: consistent tokenId hex format and V_CrcV1_Avatars column rename

### DIFF
--- a/src/Cache/API_REFERENCE.md
+++ b/src/Cache/API_REFERENCE.md
@@ -260,7 +260,7 @@ curl http://localhost:3001/api/balances/0xde374ece6fa50e781e81aac78e811b33d16912
 
 - Balances are returned in Circles (not attoCircles)
 - V1 tokens include `tokenOwner` field (the avatar that minted the token)
-- V2 tokens use numeric `tokenId` instead of address
+- V2 ERC1155 tokens use the token's lowercase hex address as `tokenId`
 - Empty array `[]` returned if address has no balances
 
 ---

--- a/src/Index/Circles.Index.CirclesViews/queries/V_CrcV1_Avatars.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_CrcV1_Avatars.sql
@@ -5,13 +5,13 @@
 -- logIndex:ValueTypes.Int:true
 -- transactionHash:ValueTypes.String:true
 -- type:ValueTypes.String:true
--- user:ValueTypes.Address:true
+-- avatar:ValueTypes.Address:true
 -- token:ValueTypes.Address:true
 -- cidV0Digest:ValueTypes.Bytes:false
 
 create or replace view "V_CrcV1_Avatars" 
     ("blockNumber", timestamp, "transactionIndex", "logIndex", 
-    "transactionHash", type, "user", token, "cidV0Digest") as
+    "transactionHash", type, avatar, token, "cidV0Digest") as
 with signup as (               -- your signup / organisation append
     select  s."blockNumber",
             s."timestamp",
@@ -19,7 +19,7 @@ with signup as (               -- your signup / organisation append
             s."logIndex",
             s."transactionHash",
             s.type,
-            s."user",
+            s.avatar,
             s.token
     from   (
                select 'CrcV1_Signup'               as type,
@@ -28,7 +28,7 @@ with signup as (               -- your signup / organisation append
                       "transactionIndex",
                       "logIndex",
                       "transactionHash",
-                      "user",
+                      "user" as avatar,
                       token
                from   "CrcV1_Signup"
                union all
@@ -38,7 +38,7 @@ with signup as (               -- your signup / organisation append
                       "transactionIndex",
                       "logIndex",
                       "transactionHash",
-                      organization,
+                      organization as avatar,
                       null
                from   "CrcV1_OrganizationSignup"
            ) s
@@ -49,7 +49,7 @@ from    signup           as s
             left join lateral (
     select  "metadataDigest" as "cidV0Digest"
     from    "CrcV1_UpdateMetadataDigest" m
-    where   m.avatar = s."user"
+    where   m.avatar = s.avatar
     order   by m."blockNumber"        desc,
                m."transactionIndex"    desc,
                m."logIndex"            desc

--- a/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Avatars.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Avatars.sql
@@ -38,7 +38,7 @@ SELECT "V_CrcV1_Avatars"."blockNumber",
        1                        AS version,
        "V_CrcV1_Avatars".type,
        NULL::text               AS "invitedBy",
-       "V_CrcV1_Avatars"."user" AS avatar,
+       "V_CrcV1_Avatars".avatar,
        "V_CrcV1_Avatars".token  AS "tokenId",
        NULL::text               AS name,
        "cidV0Digest"            AS "cidV0Digest"

--- a/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Stats.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Stats.sql
@@ -3,14 +3,14 @@
 -- value:ValueTypes.Int:false
 
 create or replace view "V_Crc_Stats"("measure", "value") as
-select 'avatar_count_v1' as measure, count("user") as value
+select 'avatar_count_v1' as measure, count(avatar) as value
 from "V_CrcV1_Avatars"
 union all
-select 'organization_count_v1' as measure, count("user") as value
+select 'organization_count_v1' as measure, count(avatar) as value
 from "V_CrcV1_Avatars"
 where token is null
 union all
-select 'human_count_v1' as measure, count("user") as value
+select 'human_count_v1' as measure, count(avatar) as value
 from "V_CrcV1_Avatars"
 where token is not null
 union all

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
@@ -428,7 +428,7 @@ public partial class CirclesRpcModule
             }
 
             var tokenId = token.IsErc1155
-                ? AddressToTokenIdBigInt(token.TokenAddress).ToString(CultureInfo.InvariantCulture)
+                ? token.TokenAddress.ToLowerInvariant()
                 : token.TokenAddress;
 
             tokenBalances.Add(new CirclesTokenBalance(
@@ -552,7 +552,7 @@ public partial class CirclesRpcModule
             }
 
             var tokenId = token.IsErc1155
-                ? AddressToTokenIdBigInt(token.TokenAddress).ToString(CultureInfo.InvariantCulture)
+                ? token.TokenAddress.ToLowerInvariant()
                 : token.TokenAddress;
 
             return new CirclesTokenBalance(


### PR DESCRIPTION
## Summary

Regression test (`rpc.prod.circlesubi.network` vs `rpc.aboutcircles.com`) revealed two inconsistencies in the new architecture:

- **TokenId format**: DB fallback path returned decimal BigInteger (`"205720575866..."`) while cache path returned hex address (`"0x2408d464..."`) for ERC1155 tokens. Unified to always return lowercase hex address, matching what the cache already does.
- **V_CrcV1_Avatars column**: Column was named `"user"` while V_CrcV2_Avatars uses `avatar`. Renamed for consistency. Updated dependent views `V_Crc_Avatars` and `V_Crc_Stats`.

### Breaking changes

1. **`tokenId` field** in `circles_getTokenBalances` responses for ERC1155 tokens changes from decimal string to hex address. SDK clients parsing decimal tokenIds need updating.
2. **`V_CrcV1_Avatars`** column `"user"` renamed to `avatar`. Any `circles_query` using the old column name needs updating.

### Files changed

| File | Change |
|---|---|
| `CirclesRpcModule.Balances.cs` | Lines 430, 554: `AddressToTokenIdBigInt().ToString()` → `token.TokenAddress.ToLowerInvariant()` |
| `V_CrcV1_Avatars.sql` | Column `"user"` → `avatar` (aliased at source from base tables) |
| `V_Crc_Avatars.sql` | Updated reference from `"user" AS avatar` → `.avatar` |
| `V_Crc_Stats.sql` | 3x `count("user")` → `count(avatar)` |
| `API_REFERENCE.md` | Updated stale documentation about numeric tokenId |

### Full regression report

See `.claude/investigations/regression-new-arch-vs-prod-2026-03-23.md` for the full 233-test comparison.

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 1,072 passed, 0 failed
- [x] Code reviewer agent — caught `V_Crc_Stats.sql` dependency (fixed)
- [x] Silent failure hunter agent — confirmed no silent error paths
- [ ] Deploy to staging and re-run `make test-rpc-regression` to confirm tokenId consistency
- [ ] Verify `circles_query` against `V_CrcV1_Avatars` with `avatar` column works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API documentation to correctly specify that Circles V2 ERC1155 token identifiers are represented as lowercase hexadecimal addresses.

* **Refactoring**
  * Improved internal consistency by standardising token identifier handling across database views and RPC services to align with V2 token format specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->