### PR TITLE
fix: reduce log noise for transient sync errors

### DIFF
--- a/src/Index/Circles.Index/BlockIndexer.cs
+++ b/src/Index/Circles.Index/BlockIndexer.cs
@@ -365,22 +365,49 @@ public class ImportFlow(
         }
         catch (AggregateException ae)
         {
-            // Log and rethrow - the actual exception from the pipeline
-            foreach (var ex in ae.Flatten().InnerExceptions)
+            // Transient sync errors (missing blocks/receipts) are expected during
+            // Nethermind sync and handled by StateMachine with unlimited retries + backoff.
+            // Log them at Info to avoid alarming operators; genuine errors stay at Error.
+            var inners = ae.Flatten().InnerExceptions;
+            bool allTransient = inners.Count > 0 && inners.All(ex =>
+                ex is BlockNotAvailableException || ex is ReceiptsNotAvailableException);
+
+            if (allTransient)
             {
-                context.Logger.Error($"Pipeline error: {ex.Message}");
+                foreach (var ex in inners)
+                {
+                    context.Logger.Info($"Pipeline: {ex.Message}");
+                }
             }
+            else
+            {
+                foreach (var ex in inners)
+                {
+                    context.Logger.Error($"Pipeline error: {ex.Message}", ex);
+                }
+            }
+
             throw;
         }
 
-        // Also check if source block faulted (might not propagate to sink)
+        // Source block faults may not propagate to the sink (TPL Dataflow quirk).
+        // Same transient-vs-error classification: BlockNotAvailableException /
+        // ReceiptsNotAvailableException are logged at Info, everything else at Error.
         if (sourceBlock.Completion.IsFaulted)
         {
             var sourceEx = sourceBlock.Completion.Exception;
             if (sourceEx != null)
             {
-                context.Logger.Error($"Source block faulted: {sourceEx.Flatten().Message}");
-                throw sourceEx.Flatten();
+                var flat = sourceEx.Flatten();
+                bool allTransient = flat.InnerExceptions.Count > 0 && flat.InnerExceptions.All(ex =>
+                    ex is BlockNotAvailableException || ex is ReceiptsNotAvailableException);
+
+                if (allTransient)
+                    context.Logger.Info($"Source block waiting for sync: {flat.Message}");
+                else
+                    context.Logger.Error($"Source block faulted: {flat.Message}", flat);
+
+                throw flat;
             }
         }
 

--- a/src/Index/Circles.Index/StateMachine.cs
+++ b/src/Index/Circles.Index/StateMachine.cs
@@ -65,6 +65,12 @@ public class StateMachine(
     // so subscribers know sync is complete and they can start warming up.
     private bool _hasSentLiveNotification;
 
+    // pg_notify failure tracking — escalate logging if notifications are persistently broken
+    // (cache service would serve stale data without them).
+    private int _consecutiveNotifyFailures;
+    private const int NotifyFailureWarnThreshold = 3;
+    private const int NotifyFailureErrorThreshold = 10;
+
     public async Task HandleEvent(IEvent e)
     {
         try
@@ -486,7 +492,7 @@ public class StateMachine(
             await context.Sink.Flush();
             await flow.FlushBlocks();
         }
-        catch (TaskCanceledException)
+        catch (OperationCanceledException)
         {
             context.Logger.Info("Cancelled indexing blocks.");
         }
@@ -519,10 +525,36 @@ public class StateMachine(
 
             await command.ExecuteNonQueryAsync(cancellationToken);
             context.Logger.Debug($"Sent {context.Settings.PgNotifyChannel} notification for blocks {range.Min}-{range.Max}.");
+
+            if (_consecutiveNotifyFailures > 0)
+            {
+                context.Logger.Info($"pg_notify recovered after {_consecutiveNotifyFailures} consecutive failure(s).");
+                _consecutiveNotifyFailures = 0;
+            }
         }
         catch (Exception ex)
         {
-            context.Logger.Error($"Failed to send {context.Settings.PgNotifyChannel} notification for blocks {range.Min}-{range.Max}: {ex.Message}");
+            _consecutiveNotifyFailures++;
+
+            if (_consecutiveNotifyFailures >= NotifyFailureErrorThreshold)
+            {
+                // Persistent failure — cache service is likely serving stale data
+                context.Logger.Error(
+                    $"pg_notify has failed {_consecutiveNotifyFailures} consecutive times! " +
+                    $"Cache subscribers may be stale. Latest: {ex.Message}");
+            }
+            else if (_consecutiveNotifyFailures >= NotifyFailureWarnThreshold)
+            {
+                context.Logger.Warn(
+                    $"pg_notify failed {_consecutiveNotifyFailures} consecutive times for blocks " +
+                    $"{range.Min}-{range.Max}: {ex.Message}");
+            }
+            else
+            {
+                context.Logger.Error(
+                    $"Failed to send {context.Settings.PgNotifyChannel} notification for blocks " +
+                    $"{range.Min}-{range.Max}: {ex.Message}");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- During initial Nethermind sync, `ReceiptsNotAvailableException` and `BlockNotAvailableException` are expected and auto-retried by the StateMachine — but `BlockIndexer` was logging them at **Error** level ("Pipeline error:"), making sync look like it was crashing
- Downgraded to **Info** for transient errors; genuine pipeline errors remain at Error with full stack traces
- Fixed three pre-existing issues found during review

## Changes

### BlockIndexer.cs
- Pipeline `AggregateException` catch: classify transient vs genuine, log at Info vs Error accordingly
- Source block fault check: same classification + `Count > 0` guard against empty `InnerExceptions`
- Pass exception objects to `Error()` calls for stack traces (#2)

### StateMachine.cs
- `catch (TaskCanceledException)` → `catch (OperationCanceledException)` — catches parent type so `OperationCanceledException` from CancellationToken doesn't leak as permanent error (#5)
- `NotifyViaPostgres`: track consecutive failures with escalating log levels (Error → Warn → Error with "cache stale" warning), log recovery (#6)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 5/5 projects pass
- [ ] Manual: start with Nethermind still syncing → confirm Info-level "Pipeline:" messages instead of Error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved block indexing error classification to distinguish transient synchronisation delays from genuine failures; temporary issues now logged at lower severity.
  * Added progressive tracking of notification delivery failures with escalated alerting severity thresholds.
  * Refined cancellation handling in synchronisation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->