### PR TITLE
fix: filter limit=0 untrust entries in V1 trust DB fallback

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -51,10 +51,8 @@ public partial class CirclesRpcModule
         _logger?.LogDebug("Using database for trust relations query for {Address}", address);
 
         await using var connection = await CreateConnectionAsync();
-        // NOTE: This query intentionally includes limit=0 entries (untrusts) to match production behavior.
-        // Semantically, limit=0 means "untrusted" and arguably shouldn't be returned as a trust relation.
-        // Both this fallback and the cache warmup (CacheWarmupService.LoadTrustRelationsAsync) now include
-        // limit=0 entries for production parity. TODO: Consider filtering limit=0 in both places in future.
+        // Filter out limit=0 entries (untrusts) to match cache warmup behavior
+        // (CacheWarmupService.LoadTrustRelationsAsync also uses AND "limit" > 0)
         const string sql = @"
             select ""user"",
                    ""canSendTo"",
@@ -70,6 +68,7 @@ public partial class CirclesRpcModule
                      from ""CrcV1_Trust""
                  ) t
             where rn = 1
+              and ""limit"" > 0
               and (""user"" = @address
                or ""canSendTo"" = @address)
         ";


### PR DESCRIPTION
## Summary
- The cache warmup path (`CacheWarmupService.cs:1370`) correctly excludes `limit=0` entries (revoked V1 trusts) via `AND "limit" > 0`
- The DB fallback path in `GetTrustRelations` had no such filter, causing revoked trusts to appear as active trust relations
- Found during prod regression test (`rpc.prod.circlesubi.network` vs `rpc.aboutcircles.com`): trust values `100 vs 0` for addr3

## Test plan
- [x] Builds clean (0 errors)
- [x] Regression test confirmed cache path (new prod) returns correct results
- [x] DB fallback now aligned with cache warmup filter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected database query filtering to properly exclude zero-limit entries from trust relations retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->