### PR TITLE
fix: restore circles_events backwards compat, add circles_events_paginated

### DIFF
--- a/docs/rpc-reference.md
+++ b/docs/rpc-reference.md
@@ -40,6 +40,7 @@ Complete reference for all Circles JSON-RPC methods.
     - [circles\_getGroupMemberships](#circles_getgroupmemberships)
   - [Event \& Query Methods](#event--query-methods)
     - [circles\_events](#circles_events)
+    - [circles\_events\_paginated](#circles_events_paginated)
     - [circles\_query](#circles_query)
     - [circles\_tables](#circles_tables)
   - [Transaction History](#transaction-history)
@@ -1474,7 +1475,7 @@ curl -X POST http://localhost:8081 \
 
 ### circles_events
 
-Query all events that involve a specific address. Returns paginated results with cursor-based navigation.
+Query all events that involve a specific address. Returns a **flat array** of events for backwards compatibility. For paginated results with `hasMore`/`nextCursor`, use [`circles_events_paginated`](#circles_events_paginated).
 
 **Signature:** `circles_events(address, fromBlock, toBlock?, eventTypes?, filterPredicates?, sortAscending?, limit?, cursor?)`
 
@@ -1608,6 +1609,43 @@ curl -X POST http://localhost:8081 \
 - `Like`, `ILike`, `NotLike`
 - `In`, `NotIn`
 - `IsNull`, `IsNotNull`
+
+**Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": [
+    {
+      "event": "CrcV1_Trust",
+      "values": {
+        "blockNumber": 30282299,
+        "timestamp": 1715978910,
+        "transactionIndex": 0,
+        "logIndex": 2,
+        "transactionHash": "0x9d5e2ac..."
+      }
+    }
+  ],
+  "id": 1
+}
+```
+
+**Response Fields:**
+
+- `result`: Flat array of event objects (no pagination wrapper)
+
+> **Note:** For paginated results with `hasMore`/`nextCursor`, use `circles_events_paginated`.
+
+---
+
+### circles_events_paginated
+
+Same as `circles_events` but returns paginated results with cursor-based navigation.
+
+**Signature:** `circles_events_paginated(address, fromBlock, toBlock?, eventTypes?, filterPredicates?, sortAscending?, limit?, cursor?)`
+
+**Parameters:** Same as [`circles_events`](#circles_events).
 
 **Response:**
 
@@ -1922,7 +1960,7 @@ curl -X POST ... -d '{"params": ["0x...", 50, "MzY1MDAwMDA6MTA6Mw=="]}'
 **Cursor Formats:**
 
 - Most methods: Base64 encoded `blockNumber:transactionIndex:logIndex`
-- `circles_events`: Base64 encoded `blockNumber:transactionIndex:logIndex`
+- `circles_events` / `circles_events_paginated`: Base64 encoded `blockNumber:transactionIndex:logIndex`
 - `circles_getTransactionHistory`: Base64 encoded `blockNumber:transactionIndex:logIndex:batchIndex`
 - `circles_getTokenHolders`: Raw account address string
 

--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -925,6 +925,8 @@ run_test_json "query" "circles_paginated_query (CrcV2_TransferSingle)" '{
 
 run_test "events" "circles_events (basic)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"circles_events\",\"params\":[null,38000000,38001000,[\"CrcV1_Trust\"],null,false]}' -H \"Content-Type: application/json\" $RPC_URL"
 run_test "events" "circles_events (sort ascending)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"circles_events\",\"params\":[null,38000000,38001000,[\"CrcV1_Trust\"],null,true]}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "events" "circles_events_paginated (basic)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"circles_events_paginated\",\"params\":[null,38000000,38001000,[\"CrcV1_Trust\"],null,false]}' -H \"Content-Type: application/json\" $RPC_URL"
+run_test "events" "circles_events_paginated (with limit)" "curl -s -X POST --data '{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"circles_events_paginated\",\"params\":[null,38000000,38001000,[\"CrcV1_Trust\"],null,false,10]}' -H \"Content-Type: application/json\" $RPC_URL"
 
 if [[ ${#EVENT_TABLE_NAMES[@]} -gt 0 ]]; then
     if [[ "$OUTPUT_MODE" != "json" ]]; then

--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -287,6 +287,17 @@ public class RpcMethodSnapshotTests
         Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
     }
 
+    [Test]
+    public async Task GetEventsPaginated_WithAddressFilter_ReturnsPagedResponse()
+    {
+        var result = await CallRpc("circles_events_paginated", KnownV2Human, null, null, null, null, false);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Object));
+        Assert.That(result.TryGetProperty("events", out var events), Is.True);
+        Assert.That(events.ValueKind, Is.EqualTo(JsonValueKind.Array));
+        Assert.That(result.TryGetProperty("hasMore", out _), Is.True);
+        Assert.That(result.TryGetProperty("nextCursor", out _), Is.True);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // Profile queries
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -137,8 +137,12 @@ public static class OpenRpcGenerator
 
         // ── Events & Query ───────────────────────────────────────────────────
         ("circles_events", "GetEvents", "Events",
-            "Query indexed blockchain events with filters",
-            "Returns Circles protocol events (trust changes, transfers, registrations, group operations, etc.) with flexible filtering. Supports address filtering, block range, event type filtering, and advanced filter predicates for complex queries.\n\n**Common use case**: Real-time feed of protocol activity, or monitoring specific addresses for trust/transfer events.\n\n**Event types include**: CrcV1_Trust, CrcV1_Transfer, CrcV2_Trust, CrcV2_TransferSingle, CrcV2_TransferBatch, CrcV2_RegisterHuman, CrcV2_RegisterGroup, CrcV2_RegisterOrganization, and many more.\n\n**Params used together**:\n- `address` + `eventTypes`: Monitor specific events for an address\n- `fromBlock` + `toBlock`: Time-range queries\n- `filterPredicates`: Advanced SQL-like filtering (see FilterPredicateDto schema)\n- `sortAscending` + `limit` + `cursor`: Pagination control"),
+            "Query indexed blockchain events (flat array, backwards compatible)",
+            "Returns Circles protocol events as a **plain JSON array** for backwards compatibility with existing consumers. Same parameters and filtering as `circles_events_paginated` but without pagination metadata.\n\n**For paginated results**, use `circles_events_paginated` which returns `{events, hasMore, nextCursor}`.\n\n**Event types include**: CrcV1_Trust, CrcV1_Transfer, CrcV2_Trust, CrcV2_TransferSingle, CrcV2_TransferBatch, CrcV2_RegisterHuman, CrcV2_RegisterGroup, CrcV2_RegisterOrganization, and many more."),
+
+        ("circles_events_paginated", "GetEvents", "Events",
+            "Query indexed blockchain events with cursor pagination",
+            "Returns Circles protocol events with cursor-based pagination. Response includes `{events, hasMore, nextCursor}` for iterating through large result sets.\n\n**Parameters**: Same as `circles_events`.\n\n**Params used together**:\n- `address` + `eventTypes`: Monitor specific events for an address\n- `fromBlock` + `toBlock`: Time-range queries\n- `filterPredicates`: Advanced SQL-like filtering (see FilterPredicateDto schema)\n- `sortAscending` + `limit` + `cursor`: Pagination control"),
 
         ("circles_query", "Query", "Query",
             "Execute a structured database query (non-paginated)",
@@ -319,6 +323,26 @@ public static class OpenRpcGenerator
                 "Filter by protocol version: 1 = V1 only, 2 = V2 only, null/omit = both versions. V1 and V2 trust graphs are independent.")
         ],
         ["circles_events"] =
+        [
+            Param("address", false, "string",
+                "Filter events by this address (as sender, receiver, or involved party). Null = all addresses. Case-insensitive.",
+                pattern: AddrPattern),
+            Param("fromBlock", false, "integer",
+                "Starting block number (inclusive). Combine with toBlock for time-range queries. Gnosis Chain produces ~1 block per 5 seconds."),
+            Param("toBlock", false, "integer",
+                "Ending block number (inclusive). Null = up to the latest indexed block."),
+            ParamArray("eventTypes", false, "string",
+                "Filter by event types. Examples: ['CrcV2_TransferSingle','CrcV2_Trust'], ['CrcV1_Transfer'], ['CrcV2_RegisterHuman']. Null = all event types. Use circles_tables to discover all event types."),
+            ParamRef("filterPredicates", false, "FilterPredicateDto",
+                "Advanced filter predicates for SQL-like filtering. Supports AND/OR conjunctions, column-level filters with operators (equals, greaterThan, lessThan, like, in). See FilterPredicateDto schema."),
+            Param("sortAscending", false, "boolean",
+                "Sort order by block number. Default: false (newest first). Set true for chronological order."),
+            Param("limit", false, "integer",
+                "Maximum events to return per page. Default: 100, maximum: 1000."),
+            Param("cursor", false, "string",
+                "Opaque cursor from a previous response's nextCursor field for pagination. Do not construct manually.")
+        ],
+        ["circles_events_paginated"] =
         [
             Param("address", false, "string",
                 "Filter events by this address (as sender, receiver, or involved party). Null = all addresses. Case-insensitive.",
@@ -727,6 +751,33 @@ public static class OpenRpcGenerator
                     new() { Name = "fromBlock", Value = 35000000 },
                     new() { Name = "toBlock", Value = 35100000 },
                     new() { Name = "eventTypes", Value = new[] { "CrcV2_RegisterHuman" } },
+                ],
+            }
+        ],
+        ["circles_events_paginated"] =
+        [
+            new()
+            {
+                Name = "Recent transfers for an address (paginated)",
+                Description = "Get the 50 most recent V2 transfers involving an address with pagination metadata",
+                Params =
+                [
+                    new() { Name = "address", Value = ExampleAddr1 },
+                    new() { Name = "eventTypes", Value = new[] { "CrcV2_TransferSingle" } },
+                    new() { Name = "sortAscending", Value = false },
+                    new() { Name = "limit", Value = 50 },
+                ],
+            },
+            new()
+            {
+                Name = "Paginate through registrations",
+                Description = "Iterate through V2 human registrations with cursor-based pagination",
+                Params =
+                [
+                    new() { Name = "fromBlock", Value = 35000000 },
+                    new() { Name = "toBlock", Value = 35100000 },
+                    new() { Name = "eventTypes", Value = new[] { "CrcV2_RegisterHuman" } },
+                    new() { Name = "limit", Value = 100 },
                 ],
             }
         ],
@@ -1571,6 +1622,12 @@ public static class OpenRpcGenerator
 
     private static readonly Dictionary<string, JsonSchemaObject> ResultOverrides = new()
     {
+        ["circles_events"] = new JsonSchemaObject
+        {
+            Type = "array",
+            Description = "Flat array of event objects. Each element has blockNumber, transactionHash, logIndex, event (type name), and payload. For paginated results with hasMore/nextCursor, use circles_events_paginated.",
+            Items = new JsonSchemaObject { Type = "object" }
+        },
         ["circlesV2_findPath"] = new JsonSchemaObject
         {
             Ref = "#/components/schemas/MaxFlowResponse"

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -423,7 +423,10 @@ app.MapPost("/", async (
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
             // System & Query Methods
-            "circles_events" => await HandleEvents(request, rpcModule),
+            // Legacy non-paginated format (plain array) — kept for backwards compatibility
+            "circles_events" => await HandleEventsLegacy(request, rpcModule),
+            // Server-side cursor pagination ({events, hasMore, nextCursor})
+            "circles_events_paginated" => await HandleEventsPaginated(request, rpcModule),
             "circles_health" => await HandleHealth(request, rpcModule),
             "circles_tables" => await HandleTables(request, rpcModule),
             // Legacy non-paginated format ({columns, rows} only) — kept for non-paginating callers
@@ -1116,7 +1119,9 @@ static async Task<object> HandleV2FindPath(JsonRpcRequest request, CirclesRpcMod
     return await rpcModule.FindPathV2(flowRequest);
 }
 
-static async Task<object> HandleEvents(JsonRpcRequest request, CirclesRpcModule rpcModule)
+static (string? Address, long? FromBlock, long? ToBlock, string[]? EventTypes,
+    IFilterPredicateDto[]? FilterPredicates, bool? SortAscending, int? Limit, string? Cursor)
+    ParseEventParameters(JsonRpcRequest request)
 {
     var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
 
@@ -1130,7 +1135,7 @@ static async Task<object> HandleEvents(JsonRpcRequest request, CirclesRpcModule 
 
     if (parameters == null || parameters.Length == 0)
     {
-        return await rpcModule.GetEvents(null, null, null, null, null, false, null, null);
+        return (null, null, null, null, null, false, null, null);
     }
 
     if (parameters.Length > 0 && parameters[0].ValueKind != JsonValueKind.Null)
@@ -1161,7 +1166,6 @@ static async Task<object> HandleEvents(JsonRpcRequest request, CirclesRpcModule 
         sortAscending = parameters[5].GetBoolean();
     }
 
-    // New pagination parameters
     if (parameters.Length > 6 && parameters[6].ValueKind != JsonValueKind.Null)
     {
         limit = parameters[6].GetInt32();
@@ -1172,7 +1176,24 @@ static async Task<object> HandleEvents(JsonRpcRequest request, CirclesRpcModule 
         cursor = parameters[7].GetString();
     }
 
-    return await rpcModule.GetEvents(address, fromBlock, toBlock, eventTypes, filterPredicates, sortAscending, limit, cursor);
+    return (address, fromBlock, toBlock, eventTypes, filterPredicates, sortAscending, limit, cursor);
+}
+
+// Non-paginated events — returns plain array via EventsResponseJsonConverter for backwards compatibility.
+static async Task<object> HandleEventsLegacy(JsonRpcRequest request, CirclesRpcModule rpcModule)
+{
+    var p = ParseEventParameters(request);
+    var pagedResult = await rpcModule.GetEvents(p.Address, p.FromBlock, p.ToBlock,
+        p.EventTypes, p.FilterPredicates, p.SortAscending, p.Limit, p.Cursor);
+    return new EventsResponse(pagedResult.Events);
+}
+
+// Paginated events — returns {events, hasMore, nextCursor}.
+static async Task<object> HandleEventsPaginated(JsonRpcRequest request, CirclesRpcModule rpcModule)
+{
+    var p = ParseEventParameters(request);
+    return await rpcModule.GetEvents(p.Address, p.FromBlock, p.ToBlock,
+        p.EventTypes, p.FilterPredicates, p.SortAscending, p.Limit, p.Cursor);
 }
 
 static async Task<object> ReflectionHandler(JsonRpcRequest request, CirclesRpcModule rpcModule)

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -424,7 +424,7 @@ Query indexed blockchain events with advanced filtering.
 - `filterPredicates` (FilterPredicate[], optional) - Advanced filters
 - `sortAscending` (boolean, optional) - Sort order (default: false)
 
-**Returns:** `EventsResponse` - Array of events
+**Returns:** `EventsResponse` - Flat array of events (backwards compatible). For paginated results, use `circles_events_paginated`.
 
 **Filter Predicates:**
 Supports complex filters:
@@ -448,6 +448,14 @@ curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
   "id": 1
 }'
 ```
+
+#### `circles_events_paginated`
+
+Same as `circles_events` but returns `{events, hasMore, nextCursor}` for cursor-based pagination.
+
+**Parameters:** Same as `circles_events`.
+
+**Returns:** `PagedEventsResponse` - `{events: [...], hasMore: boolean, nextCursor: string | null}`
 
 #### `circles_query`
 
@@ -725,7 +733,8 @@ All 15 core methods are implemented and accessible via RPC:
 | `circles_getTransactionHistory`       | ✅ Working | ❌            | With circle amounts |
 | `circles_getTokenHolders`             | ✅ Working | ❌            | Token distribution  |
 | `circles_getCommonTrust`              | ✅ Working | ❌            | V1/V2 support       |
-| `circles_events`                      | ✅ Working | ❌            | Advanced filtering  |
+| `circles_events`                      | ✅ Working | ❌            | Flat array (compat) |
+| `circles_events_paginated`            | ✅ Working | ❌            | Cursor pagination   |
 | `circles_query`                       | ✅ Working | ❌            | Generic DB query    |
 | `circlesV2_findPath`                  | ✅ Working | ❌            | Pathfinder proxy    |
 


### PR DESCRIPTION
## Summary
- `circles_events` returns flat array again (backwards compatible)
- `circles_events_paginated` returns `{events, hasMore, nextCursor}` (new endpoint)
- Mirrors the existing `circles_query` / `circles_paginated_query` pattern
- SDK (`sdk-v2`) updated separately to call `circles_events_paginated`

## Changes
- **Program.cs**: Extracted `ParseEventParameters`, split into `HandleEventsLegacy` + `HandleEventsPaginated`
- **OpenRpcGenerator.cs**: Added `circles_events_paginated` to docs
- **RpcMethodSnapshotTests.cs**: Added paginated endpoint test
- **test-rpc.sh**: Added shell test cases
- **docs/rpc-reference.md**, **README.md**: Updated documentation

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] Code review agent — no issues
- [ ] `./scripts/test-rpc.sh` against staging after deploy
- [ ] Verify `circles_events` returns flat array
- [ ] Verify `circles_events_paginated` returns wrapped response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `circles_events_paginated` RPC method for cursor-based pagination support alongside the existing `circles_events` method.

* **Documentation**
  * Updated RPC method documentation to clarify event retrieval options and cursor-pagination mechanics.

* **Tests**
  * Added regression and smoke tests for the new paginated events functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->