### PR TITLE
feat(pathfinder): include registered group wrappers in balances and m…

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -251,6 +251,28 @@ public class PathfinderGraphControllerTests
         response!.Balances.Should().BeEmpty();
     }
 
+    [Fact]
+    public void BuildBalances_ShouldIncludeWrappersOfRegisteredGroups()
+    {
+        var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var wrapperAddress = "0xgroupwrapper0000000000000000000000000000";
+        var groupAvatar = "0xgroup000000000000000000000000000000000000";
+
+        _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.Groups.Add(1000, groupAvatar, ("Group", StandardTreasuryMint, "G"));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, 1)); // static wrapper
+        _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.Balances.Should().HaveCount(1);
+        response.Balances![0].TokenAddress.Should().Be(wrapperAddress);
+        response.Balances[0].IsWrapped.Should().BeTrue();
+        response.Balances[0].CirclesType.Should().Be("static");
+    }
+
     // ── BuildTrust ─────────────────────────────────────────────────────
 
     [Fact]
@@ -641,6 +663,23 @@ public class PathfinderGraphControllerTests
         var response2 = ok2!.Value as PathfinderGraphResponse;
         response2!.Avatars.Should().NotBeNull();
         response2.Avatars!.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public void BuildWrapperMappings_ShouldIncludeWrappersOfRegisteredGroups()
+    {
+        var wrapperAddress = "0xgroupwrapper0000000000000000000000000000";
+        var groupAvatar = "0xgroup000000000000000000000000000000000000";
+
+        _cache.Groups.Add(1000, groupAvatar, ("Group", StandardTreasuryMint, "G"));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, 0));
+
+        var controller = CreateController();
+        var result = controller.GetGraph(include: "wrapperMappings");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.WrapperMappings.Should().ContainSingle(x =>
+            x.WrapperAddress == wrapperAddress && x.UnderlyingAvatar == groupAvatar);
     }
 
     // ── Regression: Cache Key Format Consistency (PR #188 / NotificationListener fix) ──

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -158,7 +158,10 @@ public class PathfinderGraphController : ControllerBase
             if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var wrapperInfo))
             {
                 isWrapped = true;
-                if (!_caches.V2Avatars.ContainsKey(wrapperInfo.Avatar))
+                // Wrapper underlying can be any registered avatar type, including groups.
+                // In cache state, groups are tracked in Groups cache and may be absent from V2Avatars.
+                if (!_caches.V2Avatars.ContainsKey(wrapperInfo.Avatar)
+                    && !_caches.Groups.ContainsKey(wrapperInfo.Avatar))
                     continue;
                 isStatic = wrapperInfo.CirclesType == 1;
             }
@@ -332,7 +335,9 @@ public class PathfinderGraphController : ControllerBase
         var mappings = new List<PathfinderWrapperMappingRow>();
         foreach (var kvp in _caches.Erc20WrapperAddresses.ReadOnlyDictionary)
         {
-            if (!_caches.V2Avatars.ContainsKey(kvp.Value.Avatar))
+            // Keep mappings for wrappers of humans/orgs and groups alike.
+            if (!_caches.V2Avatars.ContainsKey(kvp.Value.Avatar)
+                && !_caches.Groups.ContainsKey(kvp.Value.Avatar))
                 continue;
 
             mappings.Add(new PathfinderWrapperMappingRow(


### PR DESCRIPTION
…appings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected wrapper-related graph queries to include group avatars in addition to standard avatars when retrieving balance and mapping information.

* **Tests**
  * Added test coverage for wrapper functionality with group avatar registrations, including balance and mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->