### PR TITLE
fix(pathfinder): performance fixes for wrapper token support

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -560,6 +560,80 @@ public class InMemoryAvatarStateTests
         Assert.That(snapshot.Count, Is.EqualTo(1));
         Assert.That(snapshot.Contains(Bob), Is.False);
     }
+
+    // ── GetActiveAvatarSet cache invalidation ──────────────────────────
+
+    [Test]
+    public void GetActiveAvatarSet_AddAvatar_InvalidatesCache()
+    {
+        var state = new InMemoryAvatarState();
+        state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
+
+        var set1 = state.GetActiveAvatarSet();
+        Assert.That(set1, Has.Count.EqualTo(1));
+
+        state.AddAvatar(Bob, "CrcV2_RegisterHuman");
+
+        var set2 = state.GetActiveAvatarSet();
+        Assert.That(set2, Has.Count.EqualTo(2));
+        Assert.That(set2.Contains(Bob), Is.True);
+    }
+
+    [Test]
+    public void GetActiveAvatarSet_MarkStopped_InvalidatesCache()
+    {
+        var state = new InMemoryAvatarState();
+        state.InitializeFromFullLoad(new[]
+        {
+            (Alice, "CrcV2_RegisterHuman"),
+            (Bob, "CrcV2_RegisterHuman"),
+        });
+
+        var set1 = state.GetActiveAvatarSet();
+        Assert.That(set1, Has.Count.EqualTo(2));
+
+        state.MarkStopped(Alice);
+
+        var set2 = state.GetActiveAvatarSet();
+        Assert.That(set2, Has.Count.EqualTo(1));
+        Assert.That(set2.Contains(Alice), Is.False);
+    }
+
+    [Test]
+    public void GetActiveAvatarSet_InitializeFromFullLoad_InvalidatesCache()
+    {
+        var state = new InMemoryAvatarState();
+        state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
+
+        var set1 = state.GetActiveAvatarSet();
+        Assert.That(set1.Contains(Alice), Is.True);
+
+        state.InitializeFromFullLoad(new[] { (Bob, "CrcV2_RegisterHuman") });
+
+        var set2 = state.GetActiveAvatarSet();
+        Assert.That(set2.Contains(Alice), Is.False);
+        Assert.That(set2.Contains(Bob), Is.True);
+    }
+
+    [Test]
+    public void GetActiveAvatarSet_InitializeStoppedAvatars_InvalidatesCache()
+    {
+        var state = new InMemoryAvatarState();
+        state.InitializeFromFullLoad(new[]
+        {
+            (Alice, "CrcV2_RegisterHuman"),
+            (Bob, "CrcV2_RegisterHuman"),
+        });
+
+        var set1 = state.GetActiveAvatarSet();
+        Assert.That(set1, Has.Count.EqualTo(2));
+
+        state.InitializeStoppedAvatars(new[] { Bob });
+
+        var set2 = state.GetActiveAvatarSet();
+        Assert.That(set2, Has.Count.EqualTo(1));
+        Assert.That(set2.Contains(Bob), Is.False);
+    }
 }
 
 [TestFixture, Parallelizable]

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
@@ -10,6 +10,7 @@ public class InMemoryAvatarState
     private readonly HashSet<string> _avatars = new();
     private readonly HashSet<string> _groups = new();
     private readonly HashSet<string> _stopped = new();
+    private HashSet<string>? _cachedActiveSet;
 
     /// <summary>Total number of registered avatars (including stopped).</summary>
     public int Count => _avatars.Count;
@@ -24,10 +25,10 @@ public class InMemoryAvatarState
     /// <summary>Only registered groups (subset of avatars).</summary>
     public HashSet<string> GetGroupSet() => _groups;
 
-    /// <summary>All registered avatars excluding stopped avatars.</summary>
-    public HashSet<string> GetActiveAvatarSet()
+    /// <summary>All registered avatars excluding stopped avatars. Cached until mutation.</summary>
+    public IReadOnlySet<string> GetActiveAvatarSet()
     {
-        return _avatars.Where(a => !_stopped.Contains(a)).ToHashSet();
+        return _cachedActiveSet ??= _avatars.Where(a => !_stopped.Contains(a)).ToHashSet();
     }
 
     /// <summary>Returns true if address is a registered, non-stopped avatar.</summary>
@@ -46,6 +47,7 @@ public class InMemoryAvatarState
     /// </summary>
     public void InitializeFromFullLoad(IEnumerable<(string Avatar, string Type)> rows)
     {
+        _cachedActiveSet = null;
         _avatars.Clear();
         _groups.Clear();
         foreach (var row in rows)
@@ -61,6 +63,7 @@ public class InMemoryAvatarState
     /// </summary>
     public void InitializeStoppedAvatars(IEnumerable<string> stoppedAvatars)
     {
+        _cachedActiveSet = null;
         _stopped.Clear();
         foreach (var avatar in stoppedAvatars)
             _stopped.Add(avatar.ToLowerInvariant());
@@ -69,12 +72,14 @@ public class InMemoryAvatarState
     /// <summary>Mark an avatar as stopped (incremental delta).</summary>
     public void MarkStopped(string avatar)
     {
+        _cachedActiveSet = null;
         _stopped.Add(avatar.ToLowerInvariant());
     }
 
     /// <summary>Register a new avatar (incremental delta). Groups added to both sets.</summary>
     public void AddAvatar(string avatar, string type)
     {
+        _cachedActiveSet = null;
         avatar = avatar.ToLowerInvariant();
         _avatars.Add(avatar);
         if (type == "CrcV2_RegisterGroup")

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
@@ -65,7 +65,7 @@ public class InMemoryTrustState
     /// Filters: expiry > maxBlockTimestamp, both parties are avatars, truster is not a group.
     /// </summary>
     public IEnumerable<(string Truster, string Trustee, int Limit)> GetActiveTrusts(
-        long maxBlockTimestamp, HashSet<string> avatarSet, HashSet<string> groupSet)
+        long maxBlockTimestamp, IReadOnlySet<string> avatarSet, HashSet<string> groupSet)
     {
         foreach (var kv in _state)
         {

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -21,6 +21,7 @@ public class IncrementalLoadGraph : ILoadGraph
     private readonly Settings _settings;
     private readonly long _maxBlockTimestamp;
     private readonly ILogger _logger;
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)>? _cachedWrapperMappings;
 
     public IncrementalLoadGraph(
         InMemoryBalanceState balanceState,
@@ -95,7 +96,7 @@ public class IncrementalLoadGraph : ILoadGraph
             yield return trust;
         }
 
-        var wrapperMappingsByAvatar = _inner.LoadWrapperMappings()
+        var wrapperMappingsByAvatar = GetCachedWrapperMappings()
             .GroupBy(x => x.UnderlyingAvatar.ToLowerInvariant())
             .ToDictionary(
                 g => g.Key,
@@ -148,8 +149,12 @@ public class IncrementalLoadGraph : ILoadGraph
     }
 
     /// <summary>
-    /// Delegates to inner LoadGraph — wrapper deployment table is append-only, fast query.
+    /// Returns cached wrapper mappings — loaded once per graph build from inner LoadGraph.
+    /// Wrapper deployments are append-only, so caching within a single build is safe.
     /// </summary>
     public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-        => _inner.LoadWrapperMappings();
+        => GetCachedWrapperMappings();
+
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> GetCachedWrapperMappings()
+        => _cachedWrapperMappings ??= _inner.LoadWrapperMappings().ToList();
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
@@ -63,41 +63,16 @@ demurraged_sum as (
     ) as t
     group by account, "tokenAddress"
 ),
-native_tx as (
-    select "timestamp", "from" as account, "tokenAddress", -value as delta
-    from "CrcV2_TransferSingle"
-    where "from" <> '0x0000000000000000000000000000000000000000'
-    union all
-    select "timestamp", "to" as account, "tokenAddress", value as delta
-    from "CrcV2_TransferSingle"
-    where "to" <> '0x0000000000000000000000000000000000000000'
-    union all
-    select "timestamp", "from" as account, "tokenAddress", -value as delta
-    from "CrcV2_TransferBatch"
-    where "from" <> '0x0000000000000000000000000000000000000000'
-    union all
-    select "timestamp", "to" as account, "tokenAddress", value as delta
-    from "CrcV2_TransferBatch"
-    where "to" <> '0x0000000000000000000000000000000000000000'
-),
-native_agg as (
-    select account
-         , "tokenAddress"
-         , sum(delta) as balance
-         , max("timestamp") as "lastActivity"
-    from native_tx
-    group by account, "tokenAddress"
-    having sum(delta) > 0
-),
 native_sum as (
-    select balance
-         , n.account
-         , n."tokenAddress"
-         , n."lastActivity"
+    select b."totalBalance" as balance
+         , b."account"
+         , b."tokenAddress"
+         , b."lastActivity"
          , false as "isWrapped"
          , false as "isStatic"
-    from native_agg n
-    join registered_avatars ra on ra.avatar = n.account
+    from "V_CrcV2_BalancesByAccountAndToken" b
+    join registered_avatars ra on ra.avatar = b."account"
+    where b."totalBalance" > 0
 )
 select balance::text
      , account


### PR DESCRIPTION
## Summary

Performance and correctness fixes for PRs #267-#269 (wrapper token support):

- **H1**: `balanceFullStateQuery.sql` replaced raw transfer aggregation (full table scan of all `CrcV2_TransferSingle` + `CrcV2_TransferBatch`) with `V_CrcV2_BalancesByAccountAndToken` — the materialized-view-backed path that only scans delta since last refresh
- **H2**: Cached `LoadWrapperMappings()` per graph build via lazy `??=` — prevents redundant DB queries when both `LoadV2Trust()` and `LoadWrapperMappings()` are called in the same build cycle
- **M1**: Cached `GetActiveAvatarSet()` with dirty-flag invalidation on all mutation methods (`InitializeFromFullLoad`, `InitializeStoppedAvatars`, `MarkStopped`, `AddAvatar`)
- **Safety**: Changed `GetActiveAvatarSet()` return type to `IReadOnlySet<string>` to prevent callers from mutating the cached set
- **Tests**: Fixed invalid hex addresses in `PathfinderGraphControllerTests`, added 4 cache invalidation tests

## Test plan

- [x] `./scripts/test.sh pathfinder` — all pass
- [x] `./scripts/test.sh cache` — all pass
- [x] `./scripts/test.sh common` — all pass (86 tests)
- [x] `./scripts/test.sh` — full suite, 5/5 projects pass
- [ ] Manual: verify pathfinder startup time improvement against staging DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests validating caching behaviour for state mutations and data integrity.

* **Refactor**
  * Implemented caching optimisation for active avatar set retrieval and wrapper mappings to improve performance and reduce redundant computations.
  * Enhanced type consistency by updating parameter types across related components.
  * Optimised balance query to use database view for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->