### PR TITLE
fix(docker): use /ready endpoint for pathfinder and RPC healthchecks

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -175,11 +175,13 @@ services:
       - CACHE_SERVICE_URL=http://cache-service:3001
       - CACHE_GRAPH_FALLBACK_TO_DB=${CACHE_GRAPH_FALLBACK_TO_DB:-true}
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8080'"]
-      interval: 30s
+      # /ready returns 503 until graph loaded + trusts loaded + capacity pool initialized + DB connected.
+      # Prevents depends_on chain from starting RPC before pathfinder can serve requests.
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
+      interval: 15s
       timeout: 10s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 120s
 
   rpc:
     container_name: rpc
@@ -216,11 +218,13 @@ services:
       - PROFILE_PINNING_SERVICE_URL=http://profile-pinning:3000
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-*}
     healthcheck:
-      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8080'"]
-      interval: 30s
+      # /ready returns 503 until Nethermind synced + pathfinder connected + DB connected + indexer caught up.
+      # Prevents Caddy from routing traffic before RPC can serve all endpoints.
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
+      interval: 15s
       timeout: 10s
-      retries: 3
-      start_period: 60s
+      retries: 5
+      start_period: 120s
 
   # NOTE: profile-service removed - now deployed separately
   # Profile pinning service (configured externally), routes via /profiles/* in Caddy

--- a/src/Rpc/Circles.Rpc.Host/RpcRateLimiter.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcRateLimiter.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Net;
 using System.Threading.RateLimiting;
 
 namespace Circles.Rpc.Host;
@@ -49,10 +50,12 @@ public sealed class RpcRateLimiter : IDisposable
     /// <summary>
     /// Try to acquire <paramref name="permits"/> tokens for the given IP.
     /// Returns true if allowed, false if rate-limited (caller should return 429).
+    /// Internal Docker/private network callers (group-tms, cache-service, etc.) are exempt.
     /// </summary>
     public bool TryAcquire(string remoteIp, int permits = 1)
     {
         if (!IsEnabled || permits <= 0) return true;
+        if (IsPrivateNetwork(remoteIp)) return true;
 
         var (limiter, _) = _limiters.GetOrAdd(remoteIp, _ => (CreateLimiter(), Stopwatch.GetTimestamp()));
 
@@ -87,6 +90,34 @@ public sealed class RpcRateLimiter : IDisposable
                     removed.Limiter.Dispose();
             }
         }
+    }
+
+    /// <summary>
+    /// Returns true for private/reserved IP ranges (RFC 1918, link-local, loopback).
+    /// These are internal Docker network callers that should bypass rate limiting.
+    /// Handles both raw IPs and IPv4-mapped IPv6 (::ffff:172.18.x.x).
+    /// </summary>
+    private static bool IsPrivateNetwork(string ipString)
+    {
+        // Strip ::ffff: prefix (IPv4-mapped IPv6, common in Kestrel)
+        if (ipString.StartsWith("::ffff:", StringComparison.OrdinalIgnoreCase))
+            ipString = ipString[7..];
+
+        if (!IPAddress.TryParse(ipString, out var ip))
+            return false;
+
+        var bytes = ip.GetAddressBytes();
+        if (bytes.Length != 4) return false; // Only handle IPv4
+
+        return bytes[0] switch
+        {
+            10 => true,                                          // 10.0.0.0/8
+            172 => bytes[1] >= 16 && bytes[1] <= 31,             // 172.16.0.0/12 (Docker default)
+            192 => bytes[1] == 168,                               // 192.168.0.0/16
+            127 => true,                                          // 127.0.0.0/8 (loopback)
+            169 => bytes[1] == 254,                               // 169.254.0.0/16 (link-local)
+            _ => false
+        };
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
Replace TCP port checks (`</dev/tcp/localhost/8080>`) with HTTP `/ready` endpoint checks for pathfinder and RPC Docker healthchecks.

**Problem:** Docker reported containers as "healthy" immediately when the port started listening, before the service was actually ready. This caused transient pathfinder errors during startup — the RPC container started accepting requests before the pathfinder graph was loaded.

**Fix:** Use raw bash HTTP request to `/ready` which returns:
- Pathfinder: 503 until graph + trusts + capacity pool + DB all loaded
- RPC: 503 until Nethermind synced + pathfinder connected + DB + indexer caught up

Also adjusted intervals (30s → 15s) and start_period (60s → 120s) to match actual startup behavior.

## Test plan
- [ ] Deploy to staging, verify `docker ps` shows pathfinder as "starting" during graph load, then transitions to "healthy"
- [ ] Verify RPC stays "starting" until pathfinder is ready (depends_on chain)
- [ ] Run smoke tests after containers report healthy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced service healthchecks to use HTTP-based readiness verification, replacing basic port checks.
  * Adjusted healthcheck timing to improve startup detection and monitoring resilience.

* **New Features**
  * Internal/private network callers are now exempt from per-IP rate limiting, improving local service reliability.

* **Documentation**
  * Updated docs to note private/internal network exemption and readiness probe behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->