### PR TITLE
fix: revert rate limit exemption, checked overflow cast, Connection: close

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -177,7 +177,7 @@ services:
     healthcheck:
       # /ready returns 503 until graph loaded + trusts loaded + capacity pool initialized + DB connected.
       # Prevents depends_on chain from starting RPC before pathfinder can serve requests.
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
       interval: 15s
       timeout: 10s
       retries: 5
@@ -220,7 +220,7 @@ services:
     healthcheck:
       # /ready returns 503 until Nethermind synced + pathfinder connected + DB connected + indexer caught up.
       # Prevents Caddy from routing traffic before RPC can serve all endpoints.
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.0\\r\\nHost: localhost\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/8080; echo -e \"GET /ready HTTP/1.1\\r\\nHost: localhost\\r\\nConnection: close\\r\\n\\r\\n\" >&3; head -1 <&3 | grep -q \"200 OK\"'"]
       interval: 15s
       timeout: 10s
       retries: 5

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -920,10 +920,23 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                     values.TryGetValue("transactionIndex", out var ti) &&
                     values.TryGetValue("logIndex", out var li))
                 {
-                    // Parse hex values back to numbers for the cursor
-                    lastBlockNumber = Convert.ToInt64(bn?.ToString()?.Replace("0x", ""), 16);
-                    lastTransactionIndex = Convert.ToInt32(ti?.ToString()?.Replace("0x", ""), 16);
-                    lastLogIndex = Convert.ToInt32(li?.ToString()?.Replace("0x", ""), 16);
+                    // Parse hex values back to numbers for the cursor.
+                    // Use Int64 intermediate to handle unsigned 32-bit hex (0x80000000+),
+                    // then checked narrowing to Int32 (throws on truly out-of-range values).
+                    try
+                    {
+                        lastBlockNumber = Convert.ToInt64(bn?.ToString()?.Replace("0x", ""), 16);
+                        lastTransactionIndex = checked((int)Convert.ToInt64(ti?.ToString()?.Replace("0x", ""), 16));
+                        lastLogIndex = checked((int)Convert.ToInt64(li?.ToString()?.Replace("0x", ""), 16));
+                    }
+                    catch (OverflowException)
+                    {
+                        _logger?.LogError(
+                            "Cursor hex overflow: bn={Bn} ti={Ti} li={Li} (raw types: bn={BnType} ti={TiType} li={LiType})",
+                            bn?.ToString(), ti?.ToString(), li?.ToString(),
+                            bn?.GetType().Name, ti?.GetType().Name, li?.GetType().Name);
+                        throw;
+                    }
                 }
             }
         }

--- a/src/Rpc/Circles.Rpc.Host/RpcRateLimiter.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcRateLimiter.cs
@@ -1,6 +1,5 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Net;
 using System.Threading.RateLimiting;
 
 namespace Circles.Rpc.Host;
@@ -50,12 +49,10 @@ public sealed class RpcRateLimiter : IDisposable
     /// <summary>
     /// Try to acquire <paramref name="permits"/> tokens for the given IP.
     /// Returns true if allowed, false if rate-limited (caller should return 429).
-    /// Internal Docker/private network callers (group-tms, cache-service, etc.) are exempt.
     /// </summary>
     public bool TryAcquire(string remoteIp, int permits = 1)
     {
         if (!IsEnabled || permits <= 0) return true;
-        if (IsPrivateNetwork(remoteIp)) return true;
 
         var (limiter, _) = _limiters.GetOrAdd(remoteIp, _ => (CreateLimiter(), Stopwatch.GetTimestamp()));
 
@@ -90,34 +87,6 @@ public sealed class RpcRateLimiter : IDisposable
                     removed.Limiter.Dispose();
             }
         }
-    }
-
-    /// <summary>
-    /// Returns true for private/reserved IP ranges (RFC 1918, link-local, loopback).
-    /// These are internal Docker network callers that should bypass rate limiting.
-    /// Handles both raw IPs and IPv4-mapped IPv6 (::ffff:172.18.x.x).
-    /// </summary>
-    private static bool IsPrivateNetwork(string ipString)
-    {
-        // Strip ::ffff: prefix (IPv4-mapped IPv6, common in Kestrel)
-        if (ipString.StartsWith("::ffff:", StringComparison.OrdinalIgnoreCase))
-            ipString = ipString[7..];
-
-        if (!IPAddress.TryParse(ipString, out var ip))
-            return false;
-
-        var bytes = ip.GetAddressBytes();
-        if (bytes.Length != 4) return false; // Only handle IPv4
-
-        return bytes[0] switch
-        {
-            10 => true,                                          // 10.0.0.0/8
-            172 => bytes[1] >= 16 && bytes[1] <= 31,             // 172.16.0.0/12 (Docker default)
-            192 => bytes[1] == 168,                               // 192.168.0.0/16
-            127 => true,                                          // 127.0.0.0/8 (loopback)
-            169 => bytes[1] == 254,                               // 169.254.0.0/16 (link-local)
-            _ => false
-        };
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- **Revert** private network IP exemption from rate limiter (was incorrectly merged in PR #279). Internal callers that exceed rate limits need to fix their pagination, not bypass the limiter.
- **Checked cast** for cursor hex parsing — `checked((int)Convert.ToInt64(...))` handles unsigned 32-bit hex without silent truncation
- **Diagnostic logging** on overflow — logs actual hex values and types to identify root cause
- **Connection: close** header in Docker healthcheck HTTP requests

## Test plan
- [x] Builds clean
- [x] Code review agent verified
- [ ] Deploy to staging, verify rate limiter applies to all IPs