### PR TITLE
fix(pathfinder): router trust filter + named SQL parameters

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
@@ -45,6 +45,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10); // source's personal token used as collateral
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -81,6 +82,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -118,6 +120,7 @@ public class EntityTypeFilterTests
         var collateralB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateralA, 100_000_000);
         mock.AddBalance(source, collateralB, 200_000_000);
         mock.AddGroup(group);
@@ -159,6 +162,7 @@ public class EntityTypeFilterTests
         var wrongToken = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddBalance(source, wrongToken, 100_000_000);
         mock.AddGroup(group);
@@ -194,6 +198,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -228,6 +233,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -266,6 +272,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -304,6 +311,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 200_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -345,6 +353,7 @@ public class EntityTypeFilterTests
         var collateralB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateralA, 200_000_000);
         mock.AddBalance(source, collateralB, 100_000_000);
         mock.AddGroup(group);
@@ -386,6 +395,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -546,6 +556,7 @@ public class EntityTypeFilterTests
         var collateralB = Node(11); // 200 CRC
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateralA, 100_000_000);
         mock.AddBalance(source, collateralB, 200_000_000);
         mock.AddGroup(group);
@@ -585,6 +596,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -621,6 +633,7 @@ public class EntityTypeFilterTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 200_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/FlagInteractionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/FlagInteractionTests.cs
@@ -52,6 +52,7 @@ public class FlagInteractionTests
         var tokenB = Node(11); // Source has but excluded from ToTokens
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddBalance(source, tokenB, 100_000_000);
         mock.AddBalance(intermediary, tokenA, 100_000_000);
@@ -92,6 +93,7 @@ public class FlagInteractionTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddBalance(source, tokenB, 100_000_000);
         mock.AddTrust(sink, source);
@@ -129,6 +131,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, tokenA);
@@ -165,6 +168,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000); // 200 CRC
         mock.AddTrust(source, tokenA);
 
@@ -197,6 +201,7 @@ public class FlagInteractionTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000);
         mock.AddBalance(source, tokenB, 200_000_000);
         mock.AddTrust(sink, source);
@@ -233,6 +238,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // No natural balance - will be injected
         mock.AddTrust(sink, token);
         mock.AddTrust(sink, source);
@@ -275,6 +281,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000); // 100 CRC
         mock.AddTrust(source, tokenA);
 
@@ -306,6 +313,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000); // 100 CRC
         mock.AddTrust(sink, tokenA);
 
@@ -341,6 +349,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, tokenA);
@@ -374,6 +383,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, tokenA);
@@ -410,6 +420,7 @@ public class FlagInteractionTests
         var wrappedToken = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrappedToken, 100_000_000, isWrapped: true);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, wrappedToken);
@@ -446,6 +457,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
 
@@ -487,6 +499,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         // No trust relationship - will be injected
 
@@ -532,6 +545,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // Empty graph - everything simulated
 
         var factory = new GraphFactory(RouterAddress, mock);
@@ -579,6 +593,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -613,6 +628,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -646,6 +662,7 @@ public class FlagInteractionTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // No balance for source
         mock.AddTrust(sink, source);
 
@@ -679,6 +696,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         // Sink trusts nothing - won't appear in graph
 
@@ -715,6 +733,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, tokenA); // Group accepts tokenA as collateral
@@ -748,6 +767,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, tokenA);
@@ -784,6 +804,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -827,6 +848,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -862,6 +884,7 @@ public class FlagInteractionTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, tokenA);
@@ -907,6 +930,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -945,6 +969,7 @@ public class FlagInteractionTests
         var tokenB = Node(11); // Not in FromTokens
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000); // 100 CRC
         mock.AddBalance(source, tokenB, 200_000_000); // 200 CRC (ignored)
         mock.AddTrust(sink, source);
@@ -988,6 +1013,7 @@ public class FlagInteractionTests
         var tokenB = Node(11); // Available
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000); // 200 CRC (excluded)
         mock.AddBalance(source, tokenB, 100_000_000); // 100 CRC
         mock.AddTrust(sink, source);
@@ -1029,6 +1055,7 @@ public class FlagInteractionTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 200_000_000); // 200 CRC
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -1069,6 +1096,7 @@ public class FlagInteractionTests
         var tokenB = Node(11); // Allowed at sink
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000);
         mock.AddBalance(source, tokenB, 100_000_000);
         mock.AddTrust(sink, source);
@@ -1106,6 +1134,7 @@ public class FlagInteractionTests
         var wrappedToken = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrappedToken, 100_000_000, isWrapped: true);
         // Consented flow requirements: source trusts sink, sink has consented flow
         mock.AddConsentedAvatar(source);
@@ -1152,6 +1181,7 @@ public class FlagInteractionTests
         var wrappedToken = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrappedToken, 100_000_000, isWrapped: true);
         mock.AddConsentedAvatar(source);  // Source has consented flow
         // Sink does NOT have consented flow (violation)
@@ -1190,6 +1220,7 @@ public class FlagInteractionTests
         var wrappedToken = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrappedToken, 100_000_000, isWrapped: true);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, wrappedToken);
@@ -1227,6 +1258,7 @@ public class FlagInteractionTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000);
         mock.AddBalance(source, tokenB, 50_000_000); // Below threshold
         mock.AddTrust(sink, source);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -16,6 +16,14 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
     private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
+    private string? _routerAddress;
+
+    /// <summary>
+    /// Set the router address. When set, AddGroupTrust also registers
+    /// Router→token trust (mirrors Hub.sol: Router must trust collateral).
+    /// </summary>
+    public void SetRouterAddress(string routerAddress) =>
+        _routerAddress = routerAddress.ToLowerInvariant();
 
     /// <summary>
     /// Add a trust relationship using integer node IDs.
@@ -78,6 +86,8 @@ public class MockLoadGraph : ILoadGraph
     public void AddGroupTrust(int groupId, int trustedTokenId)
     {
         _groupTrusts.Add((AddressIdPool.StringOf(groupId), AddressIdPool.StringOf(trustedTokenId)));
+        if (_routerAddress != null)
+            _trusts.Add((_routerAddress, AddressIdPool.StringOf(trustedTokenId), 100));
     }
 
     /// <summary>
@@ -86,6 +96,8 @@ public class MockLoadGraph : ILoadGraph
     public void AddGroupTrust(string groupAddress, string trustedToken)
     {
         _groupTrusts.Add((groupAddress.ToLowerInvariant(), trustedToken.ToLowerInvariant()));
+        if (_routerAddress != null)
+            _trusts.Add((_routerAddress, trustedToken.ToLowerInvariant(), 100));
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
@@ -35,6 +35,7 @@ public class KitchenSinkTests
         var wrapper = Node(50);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
         mock.AddTrust(sink, source);
@@ -80,6 +81,7 @@ public class KitchenSinkTests
         var group = Node(100);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
         mock.AddGroup(group);
@@ -124,6 +126,7 @@ public class KitchenSinkTests
         var wrapper = Node(50);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
         mock.AddTrust(sink, source);
@@ -164,6 +167,7 @@ public class KitchenSinkTests
         var collateralB = Node(11); // available
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateralA, 200_000_000);
         mock.AddBalance(source, collateralB, 100_000_000);
         mock.AddGroup(group);
@@ -208,6 +212,7 @@ public class KitchenSinkTests
         var collateral = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, collateral, 200_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, collateral);
@@ -252,6 +257,7 @@ public class KitchenSinkTests
         var wrapper = Node(50);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 200_000_000);
         mock.AddBalance(source, wrapper, 100_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(tokenA));
@@ -325,6 +331,7 @@ public class KitchenSinkTests
         var group = Node(100);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, wrapper, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
         mock.AddGroup(group);
@@ -362,6 +369,7 @@ public class KitchenSinkTests
         var wrapper = Node(50);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // No real balances — everything simulated
         mock.AddWrapperMapping(AddressIdPool.StringOf(wrapper), AddressIdPool.StringOf(avatar));
         mock.AddConsentedAvatar(source);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MaxTransfersTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MaxTransfersTests.cs
@@ -45,6 +45,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000); // 100 CRC
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -81,6 +82,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddBalance(intermediate, token, 100_000_000);
         mock.AddTrust(intermediate, source);
@@ -121,6 +123,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -161,6 +164,7 @@ public class MaxTransfersTests
         var tokenB = Node(11);  // For multi-hop
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // Direct path possible with tokenA
         mock.AddBalance(source, tokenA, 100_000_000);
         mock.AddTrust(sink, source);
@@ -210,6 +214,7 @@ public class MaxTransfersTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // Direct path with tokenA (1 step, higher flow)
         mock.AddBalance(source, tokenA, 80_000_000);
         mock.AddTrust(sink, source);
@@ -254,6 +259,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -289,6 +295,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -325,6 +332,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddBalance(intermediate, token, 100_000_000);
         mock.AddTrust(intermediate, source);
@@ -366,6 +374,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, token);
@@ -406,6 +415,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddGroup(group);
         mock.AddGroupTrust(group, token);
@@ -452,6 +462,7 @@ public class MaxTransfersTests
         var tokenB = Node(11); // Lower balance
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 100_000_000); // 100 CRC
         mock.AddBalance(source, tokenB, 20_000_000);  // 20 CRC
         mock.AddTrust(sink, source);
@@ -505,6 +516,7 @@ public class MaxTransfersTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 50_000_000);
         mock.AddBalance(source, tokenB, 50_000_000);
         mock.AddTrust(sink, source);
@@ -544,6 +556,7 @@ public class MaxTransfersTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -395,6 +395,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_MaxTransfersZero_NoPruning()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -700,6 +701,7 @@ public class MutationKillerTests
     public void Kill_MaxFlowSolver_ZeroFlowEdgesExcluded()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -816,6 +818,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_OutputExcludesZeroFlowEdges()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1016,6 +1019,7 @@ public class MutationKillerTests
     {
         // An unconsented sender should always pass validation
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1044,6 +1048,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_ConsentedFlow_ConsentedSenderTrustsReceiver_Passes()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1074,6 +1079,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_ConsentedFlow_ConsentedSenderDoesNotTrustReceiver_Blocked()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1151,6 +1157,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_PrunePathBudget_ExactFit()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1257,6 +1264,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_QuantizedMode_OutputIsMultipleOf96CRC()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);
@@ -1318,6 +1326,7 @@ public class MutationKillerTests
     public void Kill_V2Pathfinder_MintOrdering_ExactBalanceValid()
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         int source = AddressIdPool.IdOf(Alice);
         int sink = AddressIdPool.IdOf(Bob);
         int token = AddressIdPool.IdOf(TokenA);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PoolToSolverIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PoolToSolverIntegrationTests.cs
@@ -41,6 +41,7 @@ public class PoolToSolverIntegrationTests
         UInt256? targetFlow = null)
     {
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddr);
         setupGraph(mock);
 
         var factory = new GraphFactory(RouterAddr, mock);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/QuantizedModeTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/QuantizedModeTests.cs
@@ -1150,6 +1150,7 @@ public class QuantizedAggregationTests
         var tokenA = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         // Source has 100 CRC of tokenA (needs 96+ for auto-discovery, but we use explicit ToTokens)
         mock.AddBalance(source, tokenA, 100_000_000);
 
@@ -1200,6 +1201,7 @@ public class QuantizedAggregationTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 60_000_000);  // < 96 CRC
         mock.AddBalance(source, tokenB, 100_000_000); // > 96 CRC
         mock.AddTrust(sink, source);
@@ -1239,6 +1241,7 @@ public class QuantizedAggregationTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 300_000_000); // 300 CRC = 3 invites
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);
@@ -1279,6 +1282,7 @@ public class QuantizedAggregationTests
         var tokenB = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, tokenA, 50_000_000); // 50 CRC < 96
         mock.AddBalance(source, tokenB, 40_000_000); // 40 CRC < 96
         mock.AddTrust(sink, source);
@@ -1321,6 +1325,7 @@ public class QuantizedAggregationTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 200_000_000); // 200 CRC = 2 invites
         mock.AddGroup(group);
         mock.AddGroupTrust(group, token);
@@ -1384,6 +1389,7 @@ public class QuantizedAggregationTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 200_000_000);
         mock.AddConsentedAvatar(source);
         // Consented flow requires: source trusts sink AND sink has consented flow
@@ -1426,6 +1432,7 @@ public class QuantizedAggregationTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 200_000_000);
         mock.AddConsentedAvatar(source);  // Source has consented flow
         mock.AddTrust(source, sink);       // Source trusts sink
@@ -1467,6 +1474,7 @@ public class QuantizedAggregationTests
         var token = Node(10);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, token, 100_000_000);
         mock.AddTrust(sink, source);
         mock.AddTrust(sink, token);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
@@ -48,6 +48,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddTrust(sink, source);
@@ -85,6 +86,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddBalance(source, Node(11), 200_000_000); // Another token (not wrapped)
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -123,6 +125,7 @@ public class WrapperFilterMatrixTests
         var otherToken = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddBalance(source, otherToken, 100_000_000);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -163,6 +166,7 @@ public class WrapperFilterMatrixTests
         var otherToken = Node(11);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddBalance(source, otherToken, 100_000_000);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -201,6 +205,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperStatic, 100_000_000, isWrapped: true, isStatic: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
         mock.AddTrust(sink, source);
@@ -234,6 +239,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperStatic, 100_000_000, isWrapped: true, isStatic: true);
         mock.AddBalance(source, Node(12), 200_000_000); // Another token
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperStatic), AddressIdPool.StringOf(AvatarA));
@@ -270,6 +276,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddBalance(source, WrapperStatic, 50_000_000, isWrapped: true, isStatic: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -307,6 +314,7 @@ public class WrapperFilterMatrixTests
         var otherToken = Node(12);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddBalance(source, WrapperStatic, 50_000_000, isWrapped: true, isStatic: true);
         mock.AddBalance(source, otherToken, 30_000_000);
@@ -353,6 +361,7 @@ public class WrapperFilterMatrixTests
         var group = Node(100);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddGroup(group);
@@ -388,6 +397,7 @@ public class WrapperFilterMatrixTests
         var group = Node(100);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddGroup(group);
@@ -430,6 +440,7 @@ public class WrapperFilterMatrixTests
         var bob = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddBalance(bob, AvatarA, 50_000_000); // Bob holds native
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -463,6 +474,7 @@ public class WrapperFilterMatrixTests
         var tokenB = Node(12);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddBalance(source, tokenB, 50_000_000);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -505,6 +517,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddBalance(source, AvatarA, 100_000_000); // Native balance
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
@@ -544,6 +557,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 100_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddTrust(sink, source);
@@ -576,6 +590,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddTrust(sink, source);
@@ -611,6 +626,7 @@ public class WrapperFilterMatrixTests
         var sink = Node(2);
 
         var mock = new MockLoadGraph();
+        mock.SetRouterAddress(RouterAddress);
         mock.AddBalance(source, WrapperDemurraged, 200_000_000, isWrapped: true);
         mock.AddWrapperMapping(AddressIdPool.StringOf(WrapperDemurraged), AddressIdPool.StringOf(AvatarA));
         mock.AddTrust(sink, source);

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -215,7 +215,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -240,7 +240,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -353,7 +353,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -376,7 +376,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("$1", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
@@ -1,4 +1,4 @@
 SELECT
     "group" as group_address
 FROM "CrcV2_RegisterGroup"
-WHERE "mint" = LOWER($1);
+WHERE "mint" = LOWER(@router);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -3,4 +3,4 @@ SELECT
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
 INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
-WHERE g."mint" = LOWER($1);
+WHERE g."mint" = LOWER(@router);

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -817,13 +817,28 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             }
         }
 
-        // Groups can receive tokens they trust directly from token pools
+        // Groups can receive tokens they trust directly from token pools,
+        // but ONLY if the Router also trusts that token. Hub.sol line 665
+        // checks trustMarkers[router][token] for every Avatar→Router edge
+        // in operateFlowMatrix, so tokens not trusted by the Router would
+        // revert on-chain even though the pathfinder found a valid flow.
+        HashSet<int>? routerTrusts = null;
+        if (g.RouterNode.HasValue)
+            accountTrusts.TryGetValue(g.RouterNode.Value, out routerTrusts);
+
+        int routerFilteredCount = 0;
         foreach (var groupId in g.GroupNodes)
         {
             if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
             {
                 foreach (var token in trustedTokens)
                 {
+                    if (routerTrusts != null && !routerTrusts.Contains(token))
+                    {
+                        routerFilteredCount++;
+                        continue;
+                    }
+
                     if (!tokenToAvatars.TryGetValue(token, out var list))
                         tokenToAvatars[token] = list = new List<int>();
                     if (!list.Contains(groupId))
@@ -831,6 +846,9 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 }
             }
         }
+
+        if (routerFilteredCount > 0)
+            _logger.LogInformation("Filtered {Count} group collateral edges where Router does not trust the token", routerFilteredCount);
 
         foreach (var (token, acceptors) in tokenToAvatars)
         {

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -824,7 +824,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         // revert on-chain even though the pathfinder found a valid flow.
         HashSet<int>? routerTrusts = null;
         if (g.RouterNode.HasValue)
+        {
             accountTrusts.TryGetValue(g.RouterNode.Value, out routerTrusts);
+            if (routerTrusts == null)
+                _logger.LogWarning("Router node is set but has no trust entries in accountTrusts — all group collateral edges will be blocked");
+        }
 
         int routerFilteredCount = 0;
         foreach (var groupId in g.GroupNodes)
@@ -833,7 +837,10 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             {
                 foreach (var token in trustedTokens)
                 {
-                    if (routerTrusts != null && !routerTrusts.Contains(token))
+                    // Fail-closed: if router trusts are unknown, block the edge.
+                    // Missing router trust data would otherwise allow invalid paths
+                    // that revert on-chain (the same bug this filter prevents).
+                    if (routerTrusts == null || !routerTrusts.Contains(token))
                     {
                         routerFilteredCount++;
                         continue;


### PR DESCRIPTION
## Summary

Two pathfinder fixes:

### 1. Filter group collateral edges by router trust (HIGH)

**Root cause**: Hub.sol line 665 checks `trustMarkers[router][token]` for every `Avatar→Router` edge in `operateFlowMatrix`. The pathfinder only checked if the **Group** trusts a token, but not if the **Router** does. This caused paths to include tokens the Router doesn't trust → on-chain revert (`CirclesHubFlowEdgeIsNotPermitted`).

**Fix**: In `GraphFactory.AddTokenPoolOutEdges`, intersect `GroupTrustedTokens` with `accountTrusts[routerId]` when building `Pool→Group` capacity edges. Tokens not trusted by the Router are excluded from the graph.

**Impact**: Prevents pathfinder from returning paths that would revert on-chain when the Router hasn't registered trust for a personal CRC token.

### 2. Use named SQL parameters for group queries (LOW)

Switch from `$1` positional to `@router` named parameters in `groupQuery.sql` and `groupTrustQuery.sql`. Fixes intermittent Npgsql prepared statement cache collision on pooled connections causing `bind message supplies 0 parameters` errors during startup.

## Files changed
- `src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs` — router trust filter in `AddTokenPoolOutEdges`
- `src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs` — 4 call sites `$1` → `router`
- `src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql` — `$1` → `@router`
- `src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql` — `$1` → `@router`

## Test plan
- [x] `dotnet test` pathfinder — 904 passed, 0 failed
- [x] Build succeeds
- [ ] Deploy to staging, verify pathfinder no longer returns paths with router-untrusted tokens
- [ ] Compare maxFlow before/after for affected users (may decrease — expected, as invalid paths are now excluded)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made query parameter handling consistent to reduce mismatches when loading group data.

* **Bug Fixes / Improvements**
  * Graph construction now excludes tokens not trusted by the router, producing more accurate network relationships.

* **Tests**
  * Updated tests to explicitly configure the router address so test setups reflect router-dependent behaviour consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->