### PR TITLE
feat(pathfinder): canary validation + eth_call simulation

### DIFF
--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -79,6 +79,29 @@ public class MaxFlowResponse
     [JsonIgnore]
     public int ConsentSafetyNetRejected { get; set; }
 
+    /// <summary>
+    /// Canary: number of Hub.sol rule violations detected by HubContractValidator.
+    /// Non-zero means the pathfinder produced output that would revert on-chain.
+    /// Not serialized — used internally for metrics.
+    /// </summary>
+    [JsonIgnore]
+    public int ValidationErrors { get; set; }
+
+    /// <summary>
+    /// Canary: rule names of validation violations, for per-rule metric labeling.
+    /// Not serialized — used internally for metrics.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string>? ValidationViolationRules { get; set; }
+
+    /// <summary>
+    /// Block number of the graph snapshot used for this computation.
+    /// Lets callers detect staleness by comparing to the current chain head.
+    /// </summary>
+    [JsonPropertyName("graphBlock")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public long GraphBlock { get; set; }
+
     public MaxFlowResponse(string maxFlow, List<TransferPathStep> transfers, DebugPipelineStages? debug = null)
     {
         MaxFlow = maxFlow;

--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -80,6 +80,13 @@ public class MaxFlowResponse
     public int ConsentSafetyNetRejected { get; set; }
 
     /// <summary>
+    /// Pipeline request ID for log correlation across canary layers.
+    /// Not serialized — used internally for metrics and simulation canary.
+    /// </summary>
+    [JsonIgnore]
+    public string? ReqId { get; set; }
+
+    /// <summary>
     /// Canary: number of Hub.sol rule violations detected by HubContractValidator.
     /// Non-zero means the pathfinder produced output that would revert on-chain.
     /// Not serialized — used internally for metrics.

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -1,0 +1,222 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Channels;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Simulation;
+using Prometheus;
+
+namespace Circles.Pathfinder.Host.Canary;
+
+/// <summary>
+/// Work item enqueued by FindPathHandler for background simulation.
+/// </summary>
+internal sealed record CanaryWorkItem(
+    string ReqId,
+    string Source,
+    string Sink,
+    long GraphBlock,
+    List<TransferPathStep> Transfers);
+
+/// <summary>
+/// Background service that simulates pathfinder results via eth_call against the local
+/// Nethermind node. Detects on-chain reverts that the pathfinder missed.
+///
+/// Architecture: bounded Channel (fire-and-forget, never blocks the response path).
+/// If the queue is full, the new work item is dropped (canary is best-effort).
+/// </summary>
+internal sealed class SimulationCanaryService : BackgroundService
+{
+    private readonly Channel<CanaryWorkItem> _channel;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<SimulationCanaryService> _log;
+    private readonly string _rpcUrl;
+
+    // Metrics
+    private static readonly Counter SimulationTotal = Metrics.CreateCounter(
+        "circles_canary_simulation_total",
+        "Total eth_call simulations attempted",
+        new CounterConfiguration { LabelNames = new[] { "result" } });
+
+    private static readonly Counter SimulationRevertTotal = Metrics.CreateCounter(
+        "circles_canary_simulation_revert_total",
+        "Simulated reverts by category and label",
+        new CounterConfiguration { LabelNames = new[] { "category", "label" } });
+
+    private static readonly Histogram SimulationDuration = Metrics.CreateHistogram(
+        "circles_canary_simulation_duration_seconds",
+        "eth_call simulation duration",
+        new HistogramConfiguration { Buckets = Histogram.ExponentialBuckets(0.005, 2, 10) });
+
+    private static readonly Gauge QueueDepth = Metrics.CreateGauge(
+        "circles_canary_simulation_queue_depth",
+        "Current number of pending simulation work items");
+
+    private static readonly Counter QueueDropped = Metrics.CreateCounter(
+        "circles_canary_simulation_queue_dropped_total",
+        "Work items dropped because the simulation queue was full");
+
+    public SimulationCanaryService(
+        Settings settings,
+        ILogger<SimulationCanaryService> log,
+        IHttpClientFactory httpClientFactory)
+    {
+        _log = log;
+        _httpClientFactory = httpClientFactory;
+        _rpcUrl = settings.NethermindRpcUrl;
+
+        int queueSize = int.TryParse(
+            Environment.GetEnvironmentVariable("CANARY_SIMULATION_QUEUE_SIZE"), out var qs) ? qs : 10;
+
+        // DropWrite: when queue is full, TryWrite returns false for the NEW item.
+        // Oldest items are more valuable (closer to the graph block actually served).
+        _channel = Channel.CreateBounded<CanaryWorkItem>(new BoundedChannelOptions(queueSize)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true
+        });
+    }
+
+    /// <summary>
+    /// Enqueue a work item for background simulation. Returns false if queue is full (dropped).
+    /// </summary>
+    public bool TryEnqueue(CanaryWorkItem item)
+    {
+        if (_channel.Writer.TryWrite(item))
+        {
+            QueueDepth.Set(_channel.Reader.Count);
+            return true;
+        }
+
+        QueueDropped.Inc();
+        return false;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _log.LogInformation("SimulationCanary started — rpcUrl={RpcUrl}, queue listening", _rpcUrl);
+
+        await foreach (var item in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            QueueDepth.Set(_channel.Reader.Count);
+
+            try
+            {
+                await SimulateAsync(item, stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _log.LogError(ex, "[{ReqId}] SimulationCanary: unexpected error during simulation", item.ReqId);
+                SimulationTotal.WithLabels("error").Inc();
+            }
+        }
+    }
+
+    private async Task SimulateAsync(CanaryWorkItem item, CancellationToken ct)
+    {
+        string calldata;
+        try
+        {
+            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex,
+                "[{ReqId}] SimulationCanary: calldata encoding failed from={Source} to={Sink} block={Block} steps={Steps}",
+                item.ReqId, item.Source, item.Sink, item.GraphBlock, item.Transfers.Count);
+            SimulationTotal.WithLabels("encode_error").Inc();
+            return;
+        }
+
+        using var timer = SimulationDuration.NewTimer();
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("canary-simulation");
+            var rpcRequest = new
+            {
+                jsonrpc = "2.0",
+                method = "eth_call",
+                @params = new object[]
+                {
+                    new { from = item.Source, to = FlowMatrixEncoder.CirclesHubAddress, data = calldata },
+                    "latest"
+                },
+                id = 1
+            };
+
+            var response = await client.PostAsJsonAsync(_rpcUrl, rpcRequest, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: eth_call HTTP {StatusCode} from={Source} to={Sink}",
+                    item.ReqId, (int)response.StatusCode, item.Source, item.Sink);
+                SimulationTotal.WithLabels("rpc_http_error").Inc();
+                return;
+            }
+
+            JsonElement json;
+            try
+            {
+                json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            }
+            catch (JsonException jex)
+            {
+                _log.LogWarning(jex,
+                    "[{ReqId}] SimulationCanary: non-JSON response from={Source} to={Sink}",
+                    item.ReqId, item.Source, item.Sink);
+                SimulationTotal.WithLabels("rpc_parse_error").Inc();
+                return;
+            }
+
+            if (json.ValueKind == JsonValueKind.Undefined || json.ValueKind == JsonValueKind.Null)
+            {
+                SimulationTotal.WithLabels("rpc_empty_response").Inc();
+                return;
+            }
+
+            if (json.TryGetProperty("error", out var error))
+            {
+                var revertData = error.TryGetProperty("data", out var d) ? d.GetString() : null;
+                var revertMsg = error.TryGetProperty("message", out var m) ? m.GetString() : "unknown";
+
+                var (category, label) = RevertClassifier.Classify(revertData ?? revertMsg);
+
+                SimulationTotal.WithLabels("revert").Inc();
+                SimulationRevertTotal.WithLabels(category, label).Inc();
+
+                // Full replay context: everything needed to reproduce
+                _log.LogError(
+                    "[{ReqId}] SimulationCanary: REVERT category={Category} label={Label} " +
+                    "from={Source} to={Sink} graphBlock={Block} simBlock=latest steps={Steps} revert={Revert}",
+                    item.ReqId, category, label,
+                    item.Source, item.Sink, item.GraphBlock,
+                    item.Transfers.Count, revertMsg);
+
+                if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    _log.LogWarning(
+                        "[{ReqId}] SimulationCanary: revert has message but no data field — classification may be degraded",
+                        item.ReqId);
+                }
+            }
+            else
+            {
+                SimulationTotal.WithLabels("success").Inc();
+            }
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // propagate shutdown
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "[{ReqId}] SimulationCanary: eth_call failed (network/timeout) from={Source} to={Sink}",
+                item.ReqId, item.Source, item.Sink);
+            SimulationTotal.WithLabels("rpc_error").Inc();
+        }
+
+        QueueDepth.Set(_channel.Reader.Count);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Host.Canary;
 using Circles.Pathfinder.Host.State;
 using Nethermind.Int256;
 using static Circles.Pathfinder.Tracing;
@@ -16,7 +17,8 @@ namespace Circles.Pathfinder.Host;
 internal sealed class FindPathHandler(
     Settings settings,
     SemaphoreSlim semaphore,
-    ILogger<FindPathHandler> log)
+    ILogger<FindPathHandler> log,
+    SimulationCanaryService? simulationCanary = null)
 {
     private const int MaxArrayEntries = 1000;
 
@@ -161,6 +163,20 @@ internal sealed class FindPathHandler(
                         foreach (var rule in mfr.ValidationViolationRules)
                             FindPathMetrics.CanaryValidationFailureTotal.WithLabels(rule).Inc();
                     }
+                }
+
+                // Simulation canary: enqueue for async eth_call validation
+                if (simulationCanary != null
+                    && mfr.Transfers.Count > 0
+                    && !string.IsNullOrEmpty(request.Source)
+                    && !string.IsNullOrEmpty(request.Sink))
+                {
+                    simulationCanary.TryEnqueue(new CanaryWorkItem(
+                        ReqId: Guid.NewGuid().ToString("N")[..8],
+                        Source: request.Source,
+                        Sink: request.Sink,
+                        GraphBlock: mfr.GraphBlock,
+                        Transfers: new List<TransferPathStep>(mfr.Transfers))); // defensive copy
                 }
             }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -172,7 +172,7 @@ internal sealed class FindPathHandler(
                     && !string.IsNullOrEmpty(request.Sink))
                 {
                     simulationCanary.TryEnqueue(new CanaryWorkItem(
-                        ReqId: Guid.NewGuid().ToString("N")[..8],
+                        ReqId: mfr.ReqId ?? Guid.NewGuid().ToString("N")[..8],
                         Source: request.Source,
                         Sink: request.Sink,
                         GraphBlock: mfr.GraphBlock,

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -140,13 +140,28 @@ internal sealed class FindPathHandler(
 
             FindPathMetrics.SolverStatusTotal.WithLabels("success").Inc();
 
-            // Record consent metrics if applicable
+            // Record consent + canary metrics if applicable
             if (result is MaxFlowResponse mfr)
             {
+                // Stamp graph block for staleness detection (use graph's own block, not
+                // state.Current.Block which may have advanced during solving)
+                mfr.GraphBlock = h.Graph.Block;
+
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
                 if (mfr.ConsentSafetyNetRejected > 0)
                     FindPathMetrics.ConsentSafetyNetTriggeredTotal.Inc(mfr.ConsentSafetyNetRejected);
+
+                // Canary: record Hub.sol rule violations (observe-only)
+                if (mfr.ValidationErrors > 0)
+                {
+                    FindPathMetrics.CanaryValidationFailureTotal.WithLabels("any").Inc();
+                    if (mfr.ValidationViolationRules != null)
+                    {
+                        foreach (var rule in mfr.ValidationViolationRules)
+                            FindPathMetrics.CanaryValidationFailureTotal.WithLabels(rule).Inc();
+                    }
+                }
             }
 
             return Results.Ok(result);

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
@@ -36,4 +36,11 @@ internal class FindPathMetrics
         Metrics.CreateCounter(
             "circles_consent_safetynet_triggered_total",
             "Times ValidateConsentedFlow safety net removed edges (indicates path-level filter gap)");
+
+    // Canary: validation failures detected by HubContractValidator (observe-only, never blocks)
+    public static readonly Counter CanaryValidationFailureTotal =
+        Metrics.CreateCounter(
+            "circles_canary_validation_failure_total",
+            "Hub.sol rule violations detected in pathfinder output (observe-only)",
+            new CounterConfiguration { LabelNames = new[] { "rule" } });
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -79,6 +79,15 @@ internal static class GraphUpdateMetrics
         "circles_consented_avatars_count",
         "Number of consented avatars in the capacity graph");
 
+    // Router trust coverage: total group-token edge candidates vs filtered
+    public static readonly Gauge RouterTrustCoverageTotal = Metrics.CreateGauge(
+        "circles_router_trust_coverage_total",
+        "Total group-token collateral edge candidates in the capacity graph");
+
+    public static readonly Gauge RouterTrustFilteredCount = Metrics.CreateGauge(
+        "circles_router_trust_filtered_count",
+        "Group-token edges filtered due to missing Router trust");
+
     // O4: DB query duration — labeled by query name (balances, trust, groups, group_trusts, consented_flow)
     public static readonly Histogram DbQueryDuration = Metrics.CreateHistogram(
         "circles_db_query_duration_seconds",

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -8,6 +8,7 @@ using Circles.Pathfinder;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host;
+using Circles.Pathfinder.Host.Canary;
 using Circles.Pathfinder.Host.State;
 using Circles.Pathfinder.Nodes;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -84,6 +85,18 @@ builder.Services.AddSingleton<CapacityGraphPool>(provider =>
 builder.Services.AddSingleton<V2Pathfinder>();
 builder.Services.AddSingleton<FindPathHandler>();
 builder.Services.AddHttpContextAccessor();
+
+// Simulation canary: async eth_call validation (opt-in via CANARY_SIMULATION_ENABLED=true)
+var canaryEnabled = string.Equals(
+    Environment.GetEnvironmentVariable("CANARY_SIMULATION_ENABLED"), "true",
+    StringComparison.OrdinalIgnoreCase);
+if (canaryEnabled)
+{
+    builder.Services.AddHttpClient("canary-simulation", c => c.Timeout = TimeSpan.FromSeconds(30));
+    builder.Services.AddSingleton<SimulationCanaryService>();
+    builder.Services.AddHostedService(p => p.GetRequiredService<SimulationCanaryService>());
+    Console.WriteLine("* Simulation canary enabled");
+}
 
 builder.Services.AddHostedService<NetworkStateUpdaterService>();
 builder.Services.AddHostedService<LogStatsService>();

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -144,6 +144,8 @@ public class NetworkStateUpdaterService : BackgroundService
                     GraphUpdateMetrics.EdgeCount.Set(currentSnap.Base.Edges.Count);
                     GraphUpdateMetrics.GroupCount.Set(currentSnap.Base.GroupNodes.Count);
                     GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
+                    GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
+                    GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
                 }
 
                 GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
@@ -636,6 +638,8 @@ public class NetworkStateUpdaterService : BackgroundService
                 GraphUpdateMetrics.EdgeCount.Set(currentSnap.Base.Edges.Count);
                 GraphUpdateMetrics.GroupCount.Set(currentSnap.Base.GroupNodes.Count);
                 GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
+                GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
+                GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
             }
             GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -227,18 +227,77 @@ public class HubContractValidatorTests
     }
 
     [Test]
-    public void Rule4_RouterEdge_BypassesCheck()
+    public void Rule4_RouterToGroup_BypassesCheck()
     {
-        var state = new MockContractState { Router = Router }; // No trusts at all
-        // Router → Group edge should be skipped entirely
-        var steps = new[]
+        var state = new MockContractState
         {
-            Step(Router, GroupA, Alice),
-            Step(Alice, Router, Alice),
+            Router = Router,
+            Groups = { GroupA },
         };
+        var steps = new[] { Step(Router, GroupA, Alice) };
         var violations = new List<ValidationViolation>();
         HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
-        Assert.That(violations, Is.Empty, "Router edges should bypass isPermittedFlow");
+        Assert.That(violations, Is.Empty, "Router→Group should bypass isPermittedFlow (internal group mint)");
+    }
+
+    [Test]
+    public void Rule4_AvatarToRouter_Trusted_Passes()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            Trusts = { (Router, Alice) }, // Router trusts Alice's token
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Is.Empty, "Avatar→Router should pass when Router trusts tokenOwner");
+    }
+
+    [Test]
+    public void Rule4_AvatarToRouter_Untrusted_Fails()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // No trusts — Router does NOT trust Alice's token
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Message, Does.Contain("Avatar→Router"));
+        Assert.That(violations[0].Message, Does.Contain("does not trust token owner"));
+    }
+
+    [Test]
+    public void Rule4_RouterToNonGroup_FallsThrough_StandardValidation()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // Alice is NOT a group — Router→Alice falls through to standard isPermittedFlow
+            // Standard: isTrusted(to=Alice, tokenOwner=Bob)
+            Trusts = { (Alice.ToLowerInvariant(), Bob.ToLowerInvariant()) },
+        };
+        var steps = new[] { Step(Router, Alice, Bob) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Is.Empty, "Router→NonGroup should use standard validation and pass when trusted");
+    }
+
+    [Test]
+    public void Rule4_RouterToNonGroup_Untrusted_Fails()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // Alice is NOT a group, Alice does NOT trust Bob's token
+        };
+        var steps = new[] { Step(Router, Alice, Bob) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1), "Router→NonGroup with no trust should fail standard validation");
     }
 
     // ═══════════════════════════════════════════

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
@@ -120,6 +120,22 @@ public class PropertyBasedTests
             }
         }
 
+        // Router must trust all tokens that groups trust as collateral.
+        // Hub.sol:665 checks trustMarkers[Router][tokenOwner] for every
+        // Avatar→Router edge in operateFlowMatrix.
+        if (withRouter && graph.RouterNode.HasValue)
+        {
+            var routerTrusts = new HashSet<int>();
+            foreach (var grp in groups)
+            {
+                if (graph.GroupTrustedTokens.TryGetValue(grp, out var gt))
+                    routerTrusts.UnionWith(gt);
+            }
+
+            if (routerTrusts.Count > 0)
+                trustLookup[graph.RouterNode.Value] = routerTrusts;
+        }
+
         graph.TrustLookup = trustLookup;
 
         // Each avatar holds their own personal token (balance)

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -43,6 +43,13 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Trust lookup for consented flow validation (truster -> set of trustees)
     public IReadOnlyDictionary<int, HashSet<int>>? TrustLookup { get; set; }
 
+    // Router trust coverage metrics (set during graph build)
+    public int TotalGroupTokenEdges { get; set; }
+    public int RouterFilteredEdges { get; set; }
+
+    // Block number of the snapshot this graph was built from (for replay logging)
+    public long Block { get; set; }
+
     public void AddTokenNode(int tokenId, int? poolNodeId = null)
     {
         // Note: We deliberately create token pool ids via BalanceNodeIdOf(...) so they’re marked “balance‑ish”.

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -69,6 +69,7 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
 
             // build ad-hoc filtered graph, using cached group/consent data to skip DB queries
             var g = _gf.CreateCapacityGraph(balances, trust, r, _cachedGroupData);
+            g.Block = snap.Block; // propagate block for replay logging
             return Task.FromResult(new CapacityGraphHandle(g));
         }
 
@@ -146,10 +147,18 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
     public static bool IsWrapOnly(FlowRequest r) => false;
 }
 
-public sealed class CapacityGraphSnapshot(long block, CapacityGraph @base)
+public sealed class CapacityGraphSnapshot
 {
-    public long Block { get; } = block;
-    public CapacityGraph Base { get; } = @base;
+    public long Block { get; }
+    public CapacityGraph Base { get; }
+
+    public CapacityGraphSnapshot(long block, CapacityGraph @base)
+    {
+        Block = block;
+        Base = @base;
+        // Stamp block on the graph so V2Pathfinder can log it without access to the snapshot
+        @base.Block = block;
+    }
 }
 
 /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -134,10 +134,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             new HashSet<int>(), new HashSet<int>(), new HashSet<int>());
 
         // Add ALL trust-based out-edges (no filters)
-        AddTokenPoolOutEdges(
+        var (totalGroupTokenEdges, routerFilteredCount) = AddTokenPoolOutEdges(
             capacityGraph, trustLookup,
             virtualSink: null, virtualSinkTrustedTokens: new HashSet<int>(),
             sinkId: null, new HashSet<int>(), new HashSet<int>());
+        capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
+        capacityGraph.RouterFilteredEdges = routerFilteredCount;
 
         // Add ALL group minting edges (no filters)
         AddGroupMintingEdges(
@@ -459,7 +461,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         // STEP 6/7/8: Add trust-based out-edges from TokenPool→avatars (+ virtual sink in swap mode)
         // Groups can now receive tokens directly
-        AddTokenPoolOutEdges(
+        var (totalGroupTokenEdges, routerFilteredCount) = AddTokenPoolOutEdges(
             capacityGraph,
             mergedTrust,
             virtualSinkAddress,
@@ -467,6 +469,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             sinkId,
             toTokensFilter,
             excludedToTokensFilter);
+        capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
+        capacityGraph.RouterFilteredEdges = routerFilteredCount;
 
         // STEP 8: Add Group minting edges (Group → Avatar with group token)
         AddGroupMintingEdges(
@@ -784,8 +788,9 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
     }
 
-    // Modified version of AddTokenPoolOutEdges that allows Groups to receive tokens directly
-    private void AddTokenPoolOutEdges(
+    // Modified version of AddTokenPoolOutEdges that allows Groups to receive tokens directly.
+    // Returns (totalGroupTokenEdges, routerFilteredCount) for metrics.
+    private (int TotalGroupTokenEdges, int RouterFilteredCount) AddTokenPoolOutEdges(
         CapacityGraph g,
         IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
         int? virtualSink,
@@ -831,12 +836,15 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
 
         int routerFilteredCount = 0;
+        int totalGroupTokenEdges = 0;
         foreach (var groupId in g.GroupNodes)
         {
             if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
             {
                 foreach (var token in trustedTokens)
                 {
+                    totalGroupTokenEdges++;
+
                     // Fail-closed: if router trusts are unknown, block the edge.
                     // Missing router trust data would otherwise allow invalid paths
                     // that revert on-chain (the same bug this filter prevents).
@@ -878,6 +886,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 g.AddCapacityEdge(pool, virtualSink.Value, t, long.MaxValue);
             }
         }
+
+        return (totalGroupTokenEdges, routerFilteredCount);
     }
 
     // Add Group → Avatar edges for group token minting

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -52,6 +52,13 @@ public static class FlowMatrixEncoder
         for (int i = 0; i < flowVertices.Count; i++)
             idx[flowVertices[i]] = i;
 
+        if (flowVertices.Count > ushort.MaxValue + 1)
+            throw new InvalidOperationException(
+                $"operateFlowMatrix supports at most {ushort.MaxValue + 1} vertices; got {flowVertices.Count}.");
+        if (transfers.Count > ushort.MaxValue + 1)
+            throw new InvalidOperationException(
+                $"operateFlowMatrix supports at most {ushort.MaxValue + 1} flow edges; got {transfers.Count}.");
+
         // Step 2: Build flow edges and coordinates
         var flowEdges = new List<(ushort streamSinkId, BigInteger amount)>();
         var coordinates = new List<ushort>();
@@ -76,11 +83,9 @@ public static class FlowMatrixEncoder
             coordinates.Add((ushort)idx[toAddr]);
         }
 
-        if (terminalEdgeIndices.Count == 0 && transfers.Count > 0)
-        {
-            flowEdges[transfers.Count - 1] = (1, flowEdges[transfers.Count - 1].amount);
-            terminalEdgeIndices.Add(transfers.Count - 1);
-        }
+        if (transfers.Count > 0 && terminalEdgeIndices.Count == 0)
+            throw new InvalidOperationException(
+                "Cannot build operateFlowMatrix calldata: no transfer terminates at the requested receiver.");
 
         var senderCoordinate = (ushort)idx[senderLower];
         var terminalEdgeIds = terminalEdgeIndices.Select(i => (ushort)i).ToArray();

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -1,0 +1,163 @@
+using System.Numerics;
+using System.Text;
+using Circles.Common;
+using Circles.Common.Dto;
+
+namespace Circles.Pathfinder.Simulation;
+
+/// <summary>
+/// Encodes pathfinder TransferPathStep[] into Hub.sol operateFlowMatrix calldata.
+/// Extracted from AnvilExecutionHelper for use in the production simulation canary.
+/// </summary>
+public static class FlowMatrixEncoder
+{
+    // Hub.sol V2 contract address on Gnosis chain
+    public const string CirclesHubAddress = "0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8";
+
+    // Pre-computed: keccak256("operateFlowMatrix(address[],(uint16,uint192)[],(uint16,uint16[],bytes)[],bytes)")[..4]
+    private static readonly string MethodSelector = ComputeMethodSelector();
+
+    private static string ComputeMethodSelector()
+    {
+        var hash = KeccakHelper.ComputeHash(
+            "operateFlowMatrix(address[],(uint16,uint192)[],(uint16,uint16[],bytes)[],bytes)");
+        return BitConverter.ToString(hash, 0, 4).Replace("-", "").ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Builds the ABI-encoded calldata for Hub.operateFlowMatrix from pathfinder transfer steps.
+    /// </summary>
+    public static string BuildCalldata(
+        string sender,
+        string receiver,
+        IReadOnlyList<TransferPathStep> transfers)
+    {
+        // Step 1: Build sorted vertex list (all unique addresses)
+        var vertexSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        vertexSet.Add(sender.ToLowerInvariant());
+        vertexSet.Add(receiver.ToLowerInvariant());
+        foreach (var t in transfers)
+        {
+            vertexSet.Add(t.From.ToLowerInvariant());
+            vertexSet.Add(t.To.ToLowerInvariant());
+            vertexSet.Add(t.TokenOwner.ToLowerInvariant());
+        }
+
+        // Sort by uint160 value for Hub.sol's _flowVertices ordering
+        var flowVertices = vertexSet
+            .OrderBy(v => BigInteger.Parse("0" + v.Replace("0x", ""), System.Globalization.NumberStyles.HexNumber))
+            .ToList();
+
+        var idx = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < flowVertices.Count; i++)
+            idx[flowVertices[i]] = i;
+
+        // Step 2: Build flow edges and coordinates
+        var flowEdges = new List<(ushort streamSinkId, BigInteger amount)>();
+        var coordinates = new List<ushort>();
+        var receiverLower = receiver.ToLowerInvariant();
+        var senderLower = sender.ToLowerInvariant();
+        var terminalEdgeIndices = new List<int>();
+
+        for (int i = 0; i < transfers.Count; i++)
+        {
+            var t = transfers[i];
+            var amount = BigInteger.Parse(t.Value);
+            var toAddr = t.To.ToLowerInvariant();
+
+            ushort streamSinkId = toAddr == receiverLower ? (ushort)1 : (ushort)0;
+            flowEdges.Add((streamSinkId, amount));
+
+            if (streamSinkId == 1)
+                terminalEdgeIndices.Add(i);
+
+            coordinates.Add((ushort)idx[t.TokenOwner.ToLowerInvariant()]);
+            coordinates.Add((ushort)idx[t.From.ToLowerInvariant()]);
+            coordinates.Add((ushort)idx[toAddr]);
+        }
+
+        if (terminalEdgeIndices.Count == 0 && transfers.Count > 0)
+        {
+            flowEdges[transfers.Count - 1] = (1, flowEdges[transfers.Count - 1].amount);
+            terminalEdgeIndices.Add(transfers.Count - 1);
+        }
+
+        var senderCoordinate = (ushort)idx[senderLower];
+        var terminalEdgeIds = terminalEdgeIndices.Select(i => (ushort)i).ToArray();
+        var packedCoordinates = PackCoordinates(coordinates);
+
+        return AbiEncode(flowVertices, flowEdges, senderCoordinate, terminalEdgeIds, packedCoordinates);
+    }
+
+    private static string PackCoordinates(List<ushort> coordinates)
+    {
+        var bytes = new byte[coordinates.Count * 2];
+        for (int i = 0; i < coordinates.Count; i++)
+        {
+            bytes[i * 2] = (byte)(coordinates[i] >> 8);
+            bytes[i * 2 + 1] = (byte)(coordinates[i] & 0xFF);
+        }
+        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+    }
+
+    private static string AbiEncode(
+        List<string> flowVertices,
+        List<(ushort streamSinkId, BigInteger amount)> flowEdges,
+        ushort senderCoordinate,
+        ushort[] terminalEdgeIds,
+        string packedCoordinates)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0x");
+        sb.Append(MethodSelector);
+
+        int currentOffset = 4 * 32;
+        int flowVerticesSize = 32 + flowVertices.Count * 32;
+        int flowEdgesSize = 32 + flowEdges.Count * 64;
+        int streamsSize = 32 + 32 + 32 + 32 + 32 + 32 + terminalEdgeIds.Length * 32 + 32;
+        int packedCoordinatesSize = 32 + ((packedCoordinates.Length / 2 + 31) / 32) * 32;
+
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += flowVerticesSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += flowEdgesSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += streamsSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+
+        // flowVertices
+        sb.Append(flowVertices.Count.ToString("x").PadLeft(64, '0'));
+        foreach (var v in flowVertices)
+            sb.Append(v.Replace("0x", "").PadLeft(64, '0'));
+
+        // flowEdges
+        sb.Append(flowEdges.Count.ToString("x").PadLeft(64, '0'));
+        foreach (var (streamSinkId, amount) in flowEdges)
+        {
+            sb.Append(streamSinkId.ToString("x").PadLeft(64, '0'));
+            sb.Append(amount.ToString("x").PadLeft(64, '0'));
+        }
+
+        // streams (single stream)
+        sb.Append("1".PadLeft(64, '0'));
+        sb.Append("20".PadLeft(64, '0'));
+        int streamDataOffset = 3 * 32;
+        sb.Append(senderCoordinate.ToString("x").PadLeft(64, '0'));
+        sb.Append(streamDataOffset.ToString("x").PadLeft(64, '0'));
+        int flowEdgeIdsSize = 32 + terminalEdgeIds.Length * 32;
+        sb.Append((streamDataOffset + flowEdgeIdsSize).ToString("x").PadLeft(64, '0'));
+        sb.Append(terminalEdgeIds.Length.ToString("x").PadLeft(64, '0'));
+        foreach (var id in terminalEdgeIds)
+            sb.Append(id.ToString("x").PadLeft(64, '0'));
+        sb.Append("0".PadLeft(64, '0'));
+
+        // packedCoordinates
+        var coordBytes = new byte[packedCoordinates.Length / 2];
+        for (int i = 0; i < coordBytes.Length; i++)
+            coordBytes[i] = Convert.ToByte(packedCoordinates.Substring(i * 2, 2), 16);
+        sb.Append(coordBytes.Length.ToString("x").PadLeft(64, '0'));
+        sb.Append(packedCoordinates.PadRight(((packedCoordinates.Length + 63) / 64) * 64, '0'));
+
+        return sb.ToString();
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -1,0 +1,49 @@
+namespace Circles.Pathfinder.Simulation;
+
+/// <summary>
+/// Classifies eth_call revert reasons into actionable categories.
+/// "bug" = pathfinder produced invalid output (graph stale, logic error).
+/// "input" = user request cannot succeed (sink can't receive ERC1155, etc.).
+/// "unknown" = needs manual investigation.
+/// </summary>
+public static class RevertClassifier
+{
+    // Hub.sol Circles-specific error selectors (from circles-contracts-v2/src/errors/Errors.sol)
+    // CirclesErrorAddressUintArgs(address,uint256,uint8) — type 1 (0x20-0x3F)
+    private const string FlowEdgeIsNotPermitted = "0x5e418dba";
+    // CirclesErrorOneAddressArg(address,uint8) — type 1 (0x20-0x3F)
+    private const string AvatarMustBeRegistered = "0xc14c0700";
+    // OpenZeppelin ERC1155 errors
+    private const string ERC1155InsufficientBalance = "0x03dee4c5";
+    private const string ERC1155InvalidReceiver = "0x57f447ce";
+
+    public static (string Category, string Label) Classify(string? revertData)
+    {
+        if (string.IsNullOrEmpty(revertData))
+            return ("unknown", "empty_revert");
+
+        var lower = revertData.ToLowerInvariant();
+
+        // Check for known error selectors in the revert data
+        if (Contains(lower, FlowEdgeIsNotPermitted))
+            return ("bug", "flow_edge_not_permitted");
+
+        if (Contains(lower, AvatarMustBeRegistered))
+            return ("bug", "avatar_not_registered");
+
+        if (Contains(lower, ERC1155InsufficientBalance))
+            return ("bug", "insufficient_balance");
+
+        if (Contains(lower, ERC1155InvalidReceiver))
+            return ("input", "invalid_receiver");
+
+        // Generic revert string patterns
+        if (lower.Contains("execution reverted"))
+            return ("unknown", "generic_revert");
+
+        return ("unknown", "unrecognized");
+    }
+
+    private static bool Contains(string data, string selector)
+        => data.Contains(selector[2..]); // strip 0x prefix for matching
+}

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -503,6 +503,7 @@ public class V2Pathfinder
             ctx.Transfers,
             ctx.DebugStages)
         {
+            ReqId = ctx.ReqId,
             ConsentDroppedPaths = ctx.ConsentDroppedPaths,
             ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected,
             ValidationErrors = ctx.ValidationErrors,

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -126,6 +126,10 @@ public class V2Pathfinder
         public int ConsentDroppedPaths { get; set; }
         public int ConsentSafetyNetRejected { get; set; }
         public DebugPipelineStages? DebugStages { get; set; }
+
+        // Canary: HubContractValidator results (runs in Release mode)
+        public int ValidationErrors { get; set; }
+        public IReadOnlyList<string>? ValidationViolationRules { get; set; }
     }
 
     /* ======================================================================
@@ -145,13 +149,34 @@ public class V2Pathfinder
 
         if (!capacityGraph.AvatarNodes.ContainsKey(sourceId))
         {
-            _logger.LogWarning("[{ReqId}] Source '{Source}' not in graph snapshot — returning zero flow", reqId, request.Source);
+            _logger.LogWarning("[{ReqId}] Source '{Source}' not in graph snapshot (block={Block}) — returning zero flow",
+                reqId, request.Source, capacityGraph.Block);
             return null;
         }
         if (!capacityGraph.AvatarNodes.ContainsKey(effSink))
         {
-            _logger.LogWarning("[{ReqId}] Sink '{Sink}' not in graph snapshot — returning zero flow", reqId, request.Sink);
+            _logger.LogWarning("[{ReqId}] Sink '{Sink}' not in graph snapshot (block={Block}) — returning zero flow",
+                reqId, request.Sink, capacityGraph.Block);
             return null;
+        }
+
+        // Replay log: everything needed to reconstruct this request against the test environment
+        {
+            var flags = new List<string>(4);
+            if (request.WithWrap == true) flags.Add("withWrap");
+            if (request.QuantizedMode == true) flags.Add("quantized");
+            if (request.MaxTransfers.HasValue) flags.Add($"maxTransfers={request.MaxTransfers}");
+            if (request.FromTokens?.Count > 0) flags.Add($"fromTokens={request.FromTokens.Count}");
+            if (request.ToTokens?.Count > 0) flags.Add($"toTokens={request.ToTokens.Count}");
+            if (request.ExcludedFromTokens?.Count > 0) flags.Add($"exclFrom={request.ExcludedFromTokens.Count}");
+            if (request.ExcludedToTokens?.Count > 0) flags.Add($"exclTo={request.ExcludedToTokens.Count}");
+            if (request.SimulatedBalances?.Count > 0) flags.Add($"simBal={request.SimulatedBalances.Count}");
+            if (request.SimulatedTrusts?.Count > 0) flags.Add($"simTrust={request.SimulatedTrusts.Count}");
+
+            _logger.LogInformation(
+                "[{ReqId}] Request: from={Source} to={Sink} amount={Amount} block={Block} flags=[{Flags}]",
+                reqId, request.Source, request.Sink, targetFlow, capacityGraph.Block,
+                flags.Count > 0 ? string.Join(",", flags) : "none");
         }
 
         _logger.LogInformation("[{ReqId}] Graph: avatars={Avatars}, groups={Groups}, edges={Edges}",
@@ -414,22 +439,44 @@ public class V2Pathfinder
             });
         }
 
-#if DEBUG
+        // Debug: compact transfer summary for replay analysis
+        if (ctx.Transfers.Count > 0 && _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        {
+            static string Trunc(string s) => s[..Math.Min(10, s.Length)];
+            var summary = string.Join(" | ", ctx.Transfers.Select(t =>
+                $"{Trunc(t.From)}→{Trunc(t.To)} token={Trunc(t.TokenOwner)} val={t.Value}"));
+            _logger.LogDebug("[{ReqId}] Transfers: {Summary}", ctx.ReqId, summary);
+        }
+
+        // Canary: run HubContractValidator on every response (observe-only, NEVER blocks)
         if (ctx.Transfers.Count > 0)
         {
-            var debugState = new Validation.CapacityGraphContractState(ctx.Graph);
-            var debugValidation = Validation.HubContractValidator.Validate(
-                ctx.Transfers, ctx.Request.Source!, ctx.Request.Sink!, debugState);
-            if (!debugValidation.IsValid)
+            try
             {
-                var errors = debugValidation.Violations
-                    .Where(v => v.Severity == "error")
-                    .Select(v => $"[{v.Rule}] {v.Message}");
-                _logger.LogError("[{ReqId}] HubContractValidator REJECTED output: {Violations}",
-                    ctx.ReqId, string.Join("; ", errors));
+                var contractState = new Validation.CapacityGraphContractState(ctx.Graph);
+                var validation = Validation.HubContractValidator.Validate(
+                    ctx.Transfers, ctx.Request.Source!, ctx.Request.Sink!, contractState);
+
+                var errorViolations = validation.Violations.Where(v => v.Severity == "error").ToList();
+                if (errorViolations.Count > 0)
+                {
+                    var errors = errorViolations.Select(v => $"[{v.Rule}] {v.Message}");
+                    _logger.LogError(
+                        "[{ReqId}] Canary: REJECTED from={Source} to={Sink} block={Block} violations: {Violations}",
+                        ctx.ReqId, ctx.Request.Source, ctx.Request.Sink, ctx.Graph.Block,
+                        string.Join("; ", errors));
+                }
+
+                ctx.ValidationErrors = errorViolations.Count;
+                ctx.ValidationViolationRules = errorViolations.Select(v => v.Rule).ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[{ReqId}] Canary: validator threw unexpected exception (observe-only, not blocking response)",
+                    ctx.ReqId);
             }
         }
-#endif
     }
 
     /* ======================================================================
@@ -446,8 +493,10 @@ public class V2Pathfinder
         }
 
         ctx.TotalStopwatch.Stop();
-        _logger.LogInformation("[{ReqId}] Result: maxFlow={MaxFlow}, steps={Steps}, totalMs={TotalMs}",
-            ctx.ReqId, maxFlowWei, ctx.Transfers.Count, ctx.TotalStopwatch.ElapsedMilliseconds);
+        _logger.LogInformation(
+            "[{ReqId}] Result: from={Source} to={Sink} maxFlow={MaxFlow}, steps={Steps}, block={Block}, totalMs={TotalMs}",
+            ctx.ReqId, ctx.Request.Source, ctx.Request.Sink, maxFlowWei,
+            ctx.Transfers.Count, ctx.Graph.Block, ctx.TotalStopwatch.ElapsedMilliseconds);
 
         return new MaxFlowResponse(
             maxFlowWei.ToString(CultureInfo.InvariantCulture),
@@ -455,7 +504,9 @@ public class V2Pathfinder
             ctx.DebugStages)
         {
             ConsentDroppedPaths = ctx.ConsentDroppedPaths,
-            ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected
+            ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected,
+            ValidationErrors = ctx.ValidationErrors,
+            ValidationViolationRules = ctx.ValidationViolationRules
         };
     }
 

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -198,8 +198,10 @@ public static class HubContractValidator
     //       return isTrusted(_from, _to) && advancedUsageFlags[_to];
     //   }
     //
-    // Router edges bypass this check entirely (Hub.sol uses Router as _sender
-    // for group mints, not subject to isPermittedFlow).
+    // Router edge handling (Hub.sol:665, Hub.sol:723):
+    //   Router→Group: internal group mint — Router is _sender, isPermittedFlow N/A.
+    //   Avatar→Router: Hub.sol:665 checks trustMarkers[Router][tokenOwner].expiry.
+    //   Router→NonGroup: fall through to normal validation (fail-closed).
     // ────────────────────────────────────────────
     internal static void ValidateIsPermittedFlow(
         IReadOnlyList<TransferPathStep> steps,
@@ -214,9 +216,24 @@ public static class HubContractValidator
             var to = steps[i].To.ToLowerInvariant();
             var tokenOwner = steps[i].TokenOwner.ToLowerInvariant();
 
-            // Router bypasses isPermittedFlow
-            if (router != null && (from == router || to == router))
+            // Router→Group: internal group mint — Hub.sol uses Router as _sender,
+            // isPermittedFlow does not apply (Hub.sol:723). Safe to skip.
+            if (router != null && from == router && state.IsGroup(to))
                 continue;
+
+            // Avatar→Router: Hub.sol:665 checks trustMarkers[Router][tokenOwner].expiry
+            // Router must trust the token owner for this transfer to succeed.
+            if (router != null && to == router)
+            {
+                if (!state.IsTrusted(router, tokenOwner))
+                {
+                    violations.Add(new ValidationViolation(
+                        "IsPermittedFlow",
+                        $"Edge {i}: Avatar→Router — Router does not trust token owner '{tokenOwner[..Math.Min(10, tokenOwner.Length)]}'",
+                        i, "error"));
+                }
+                continue;
+            }
 
             if (!state.HasAdvancedUsageFlags(from))
             {


### PR DESCRIPTION
## Summary

Two-layer canary system that detects pathfinder results that would revert on-chain:

**Layer 1 — C# HubContractValidator (every request, ~5μs):**
- Fix Router bypass: Avatar→Router now validates `isTrusted(router, tokenOwner)` per Hub.sol:665
- Runs in Release mode on every `/findPath` response (was `#if DEBUG` only)
- Try-catch guarded — observe-only, never blocks responses
- `circles_canary_validation_failure_total{rule}` Prometheus counter

**Layer 2 — eth_call simulation (every request with transfers, ~50ms async):**
- Fire-and-forget background service simulates `operateFlowMatrix` via `eth_call` against local Nethermind
- Classifies reverts: `bug` (FlowEdgeIsNotPermitted, AvatarMustBeRegistered, InsufficientBalance) vs `input` (ERC1155InvalidReceiver)
- Logs full replay context: source, sink, graphBlock, step count, revert reason
- Opt-in: `CANARY_SIMULATION_ENABLED=true` (default false), bounded queue with `DropWrite`

**Also included:**
- `graphBlock` field in MaxFlowResponse JSON for staleness detection
- Replay-quality diagnostic logging: block, source, sink, amount, flags in every request log
- Router trust coverage gauges: `circles_router_trust_coverage_total` / `_filtered_count`
- 5 new validator tests (Router→Group bypass, Avatar→Router trusted/untrusted, Router→NonGroup)

## Test plan
- [x] 908 pathfinder tests pass, 5 project suites green
- [x] 4 review agents ran (code-reviewer, silent-failure-hunter ×2, test-analyzer), all findings fixed
- [ ] Deploy to staging1 with `CANARY_SIMULATION_ENABLED=false` — verify C# canary logs
- [ ] Enable simulation canary on staging1 — verify eth_call metrics
- [ ] Compare canary revert rate vs production error rate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional simulation canary for background validation and replayable simulations (opt‑in)
  * New router trust coverage metrics exposed for graph updates
  * More detailed validation error reporting with per‑rule labels

* **Bug Fixes**
  * Corrected router trust handling for avatar→router and router→non‑group flows

* **Tests**
  * Expanded test coverage for flow validation scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->