### PR TITLE
fix(pathfinder): validate Router edges + consented-source group minting guard

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
@@ -213,10 +213,11 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Router edges should always be allowed through.
+    /// Consented Avatar→Router edge is rejected by safety net because Router
+    /// lacks advancedUsageFlags. Only Router→Avatar edge survives.
     /// </summary>
     [Test]
-    public void RouterEdges_AlwaysValid()
+    public void ConsentedAvatarToRouter_RejectedBySafetyNet()
     {
         // Arrange
         var capacityGraph = CreateCapacityGraph(
@@ -234,8 +235,8 @@ public class ConsentedFlowValidationTests
         // Act
         var result = ValidateConsentedFlow(edges, capacityGraph);
 
-        // Assert - router edges should pass through
-        Assert.That(result, Has.Count.EqualTo(2));
+        // Assert - consented Avatar→Router is caught; only Router→Bob survives
+        Assert.That(result, Has.Count.EqualTo(1));
     }
 
     /// <summary>
@@ -535,36 +536,127 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Group edges should NOT count as consent violations because they become router
-    /// edges after InsertRouterInTransfers, and router bypasses consent checks.
+    /// Non-consented Avatar→Group edges are skipped (become Avatar→Router→Group, standard trust applies).
     /// </summary>
     [Test]
     [Category("consented-flow")]
-    public void PathLevel_GroupEdges_NotCountedAsViolation()
+    public void PathLevel_NonConsentedAvatarToGroupEdge_Skipped()
     {
-        // Arrange: Alice(consented) → GroupX (group node)
         var groupId = AddressIdPool.IdOf("0xcf08consent_group");
 
         var capacityGraph = CreateCapacityGraph(
-            consentedAvatars: new HashSet<int> { Alice },
+            consentedAvatars: new HashSet<int> { Bob }, // Alice is NOT consented
             trustLookup: new Dictionary<int, HashSet<int>>
             {
-                { Alice, new HashSet<int>() } // Alice doesn't trust group — but it doesn't matter
+                { Alice, new HashSet<int>() }
             }
         );
         capacityGraph.AddGroup(groupId);
 
         var pathEdges = new List<(int From, int To, int Token, long Flow)>
         {
-            (Alice, groupId, AliceToken, 500) // Will become Avatar→Router→Group
+            (Alice, groupId, AliceToken, 500)
+        };
+
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        Assert.That(hasViolation, Is.False,
+            "Non-consented Avatar→Group edges should be skipped");
+    }
+
+    /// <summary>
+    /// Consented Avatar→Group edges are NOT skipped — after Router insertion,
+    /// Avatar(consented)→Router fails isPermittedFlow (Router lacks advancedUsageFlags).
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_ConsentedAvatarToGroupEdge_DetectsViolation()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf08consent_group2");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { Alice },
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                { Alice, new HashSet<int>() }
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (Alice, groupId, AliceToken, 500) // Consented→Group → will become Consented→Router → fails
+        };
+
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        Assert.That(hasViolation, Is.True,
+            "Consented Avatar→Group should be flagged — Router lacks advancedUsageFlags");
+    }
+
+    /// <summary>
+    /// Group→Avatar (mint) edges stay as-is after InsertRouterInTransfers and
+    /// must be consent-checked. Groups don't have advancedUsageFlags, so the
+    /// check passes — but the edge must NOT be skipped.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_GroupToAvatarEdge_IsConsentChecked_PassesWhenGroupNotConsented()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf09consent_group_mint");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { Alice }, // Only Alice consented, not the group
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                { groupId, new HashSet<int> { AliceToken } }
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (groupId, Alice, AliceToken, 500) // Group→Avatar mint edge (stays as-is)
         };
 
         // Act
         bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
 
-        // Assert — group edge should be skipped
+        // Assert — Group is not consented, so standard trust is sufficient → no violation
         Assert.That(hasViolation, Is.False,
-            "Group edges should be skipped (they become router edges which bypass consent)");
+            "Group→Avatar mint edge should pass: group has no advancedUsageFlags");
+    }
+
+    /// <summary>
+    /// Hypothetical: if a group DID have consented flow and didn't trust the recipient,
+    /// the consent check should catch it. This verifies the edge is NOT skipped.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_GroupToAvatarEdge_DetectsViolation_WhenGroupIsConsented()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf10consent_group_consented");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { groupId }, // Group has consented flow
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                // Group does NOT trust Alice
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (groupId, Alice, AliceToken, 500) // Group(consented)→Avatar — group doesn't trust Alice
+        };
+
+        // Act
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        // Assert — group is consented but doesn't trust recipient → violation detected
+        Assert.That(hasViolation, Is.True,
+            "Group→Avatar edge with consented group that doesn't trust recipient should be caught");
     }
 
     /// <summary>
@@ -927,109 +1019,17 @@ public class ConsentedFlowValidationTests
         return graph;
     }
 
-    /// <summary>
-    /// Replicates the ValidateConsentedFlow logic from V2Pathfinder for testing.
-    /// This ensures we test the exact same logic without needing the full pathfinder.
-    /// </summary>
+    // Delegate to production V2Pathfinder methods (internal, accessible via InternalsVisibleTo)
+    // to avoid logic drift between test copies and production code.
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private static List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
-    {
-        // If no consent data available, pass all edges through
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-        {
-            return edges;
-        }
+        => _consentValidator.ValidateConsentedFlow(edges, capacityGraph);
 
-        var validEdges = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip pool nodes - they're not avatars
-            if (IsPoolNode(edge.From) || IsPoolNode(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // Skip router edges
-            if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.From))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // From has consented flow enabled - check additional requirements:
-            // 1. From must trust To
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(edge.From, out var fromTrusts)
-                               && fromTrusts.Contains(edge.To);
-            if (!fromTrustsTo)
-            {
-                // Invalid - From has consented flow but doesn't trust To
-                continue;
-            }
-
-            // 2. To must also have consented flow enabled
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.To))
-            {
-                // Invalid - To doesn't have consented flow enabled
-                continue;
-            }
-
-            // All checks passed
-            validEdges.Add(edge);
-        }
-
-        return validEdges;
-    }
-
-    private static bool IsPoolNode(int nodeId)
-    {
-        return AddressIdPool.IsBalanceNode(nodeId);
-    }
-
-    /// <summary>
-    /// Replicates the PathHasConsentViolation logic from V2Pathfinder for testing.
-    /// Checks if a collapsed path has any consent violation.
-    /// </summary>
     private static bool PathHasConsentViolation(
         List<(int From, int To, int Token, long Flow)> collapsedEdges,
         CapacityGraph capacityGraph)
-    {
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-            return false;
-
-        foreach (var (from, to, _, _) in collapsedEdges)
-        {
-            // Skip group edges — they become router edges later
-            if (capacityGraph.IsGroup(from) || capacityGraph.IsGroup(to))
-                continue;
-
-            // Skip pool nodes
-            if (IsPoolNode(from) || IsPoolNode(to))
-                continue;
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(from))
-                continue;
-
-            // From has consented flow — check requirements
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(from, out var fromTrusts)
-                                && fromTrusts.Contains(to);
-            if (!fromTrustsTo)
-                return true;
-
-            if (!capacityGraph.ConsentedAvatars.Contains(to))
-                return true;
-        }
-
-        return false;
-    }
+        => _consentValidator.PathHasConsentViolation(collapsedEdges, capacityGraph);
 
     #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ContractConformanceTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ContractConformanceTests.cs
@@ -182,7 +182,7 @@ public class ContractConformanceTests
     /// Router edges should always be permitted regardless of consent status.
     /// </summary>
     [Test]
-    public void IsPermittedFlow_RouterEdges_AlwaysPermitted()
+    public void IsPermittedFlow_ConsentedAvatarToRouter_RejectedBySafetyNet()
     {
         var graph = BuildGraphWithTrust(
             trusts: Array.Empty<(string, string)>(),
@@ -196,8 +196,8 @@ public class ContractConformanceTests
         };
 
         var validated = ValidateConsentedFlow(edges, graph);
-        Assert.That(validated.Count, Is.EqualTo(2),
-            "Router edges should bypass consent validation");
+        Assert.That(validated.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Avatar survives");
     }
 
     #endregion
@@ -621,43 +621,11 @@ public class ContractConformanceTests
         return graph;
     }
 
-    /// <summary>
-    /// Replicates V2Pathfinder.ValidateConsentedFlow logic for unit testing.
-    /// </summary>
+    // Delegate to production method to avoid logic drift
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private static List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph graph)
-    {
-        if (graph.TrustLookup == null || graph.ConsentedAvatars.Count == 0)
-            return edges;
-
-        var valid = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip router edges
-            if (graph.IsRouter(edge.From) || graph.IsRouter(edge.To))
-            {
-                valid.Add(edge);
-                continue;
-            }
-
-            // Non-consented: standard trust sufficient
-            if (!graph.ConsentedAvatars.Contains(edge.From))
-            {
-                valid.Add(edge);
-                continue;
-            }
-
-            // Consented: From trusts To AND To consented
-            bool fromTrustsTo = graph.TrustLookup.TryGetValue(edge.From, out var trusts)
-                                && trusts.Contains(edge.To);
-            if (!fromTrustsTo) continue;
-            if (!graph.ConsentedAvatars.Contains(edge.To)) continue;
-
-            valid.Add(edge);
-        }
-
-        return valid;
-    }
+        => _consentValidator.ValidateConsentedFlow(edges, graph);
 
     #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/EdgeOrderingTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EdgeOrderingTests.cs
@@ -441,7 +441,7 @@ public class EdgeOrderingTests
     /// edges exist when validation runs, allowing the router-skip logic to work.
     /// </summary>
     [Test]
-    public void ConsentedFlowAvatar_GroupMint_RouterEdgesShouldBeSkipped()
+    public void ConsentedFlowAvatar_GroupMint_ConsentedToRouterCaughtBySafetyNet()
     {
         // Arrange: Avatar with consented flow sends to Group
         var capacityGraph = CreateCapacityGraphWithGroup(Group1, Router);
@@ -450,7 +450,6 @@ public class EdgeOrderingTests
         capacityGraph.ConsentedAvatars.Add(Source);
 
         // Set up trust lookup - Source does NOT trust Group directly
-        // (This would fail the consented flow check if not for the router skip)
         var trustLookup = new Dictionary<int, HashSet<int>>
         {
             [Source] = new HashSet<int>(), // Source trusts no one
@@ -470,15 +469,13 @@ public class EdgeOrderingTests
             ? InsertRouterInTransfersForTest(edgesBeforeRouterInsertion, capacityGraph)
             : edgesBeforeRouterInsertion;
 
-        // Now validate - router edges should be skipped
+        // Now validate - consented Avatar→Router is caught by safety net
         var validatedEdges = ValidateConsentedFlowForTest(edgesAfterRouterInsertion, capacityGraph);
 
-        // Assert: Both router edges should be present (router edges are skipped by validation)
-        Assert.That(validatedEdges.Count, Is.EqualTo(2),
-            "Both Avatar→Router and Router→Group edges should pass validation");
+        // Assert: Only Router→Group survives; consented Avatar→Router is rejected
+        Assert.That(validatedEdges.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Group survives");
 
-        Assert.That(validatedEdges.Any(e => e.From == Source && e.To == Router),
-            "Avatar→Router edge should be present");
         Assert.That(validatedEdges.Any(e => e.From == Router && e.To == Group1),
             "Router→Group edge should be present");
     }
@@ -525,12 +522,12 @@ public class EdgeOrderingTests
     }
 
     /// <summary>
-    /// When an avatar with consented flow sends through the router,
-    /// the router edges (Avatar→Router and Router→Group) should bypass
-    /// consented flow validation.
+    /// When a consented avatar sends through the router, the Avatar→Router edge
+    /// is caught by the safety net (Router lacks advancedUsageFlags).
+    /// Only Router→Group survives.
     /// </summary>
     [Test]
-    public void ConsentedFlowAvatar_RouterEdgesExplicitly_AreNotFiltered()
+    public void ConsentedFlowAvatar_RouterEdgesExplicitly_ConsentedToRouterRejected()
     {
         // Arrange: Avatar with consented flow, edges already have router
         var capacityGraph = CreateCapacityGraphWithGroup(Group1, Router);
@@ -557,9 +554,9 @@ public class EdgeOrderingTests
         // Act: Validate with router edges
         var validatedEdges = ValidateConsentedFlowForTest(edgesWithRouter, capacityGraph);
 
-        // Assert: Both edges should pass (router edges are skipped)
-        Assert.That(validatedEdges.Count, Is.EqualTo(2),
-            "Router edges should bypass consented flow validation");
+        // Assert: Consented Avatar→Router is caught; only Router→Group survives
+        Assert.That(validatedEdges.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Group survives");
     }
 
     /// <summary>
@@ -665,44 +662,11 @@ public class EdgeOrderingTests
         return result;
     }
 
-    // Test helper: Replicates ValidateConsentedFlow logic for testing
+    // Delegate to production method to avoid logic drift
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private List<FlowEdge> ValidateConsentedFlowForTest(List<FlowEdge> edges, CapacityGraph capacityGraph)
-    {
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-            return edges;
-
-        var validEdges = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip router edges
-            if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.From))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // From has consented flow - check additional requirements
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(edge.From, out var fromTrusts)
-                               && fromTrusts.Contains(edge.To);
-            if (!fromTrustsTo)
-                continue;
-
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.To))
-                continue;
-
-            validEdges.Add(edge);
-        }
-
-        return validEdges;
-    }
+        => _consentValidator.ValidateConsentedFlow(edges, capacityGraph);
 
     #endregion
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
@@ -423,8 +423,10 @@ public class EntityTypeFilterTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        // Group minting with consented flow should work when both parties consent
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -663,6 +665,9 @@ public class EntityTypeFilterTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -227,18 +227,62 @@ public class HubContractValidatorTests
     }
 
     [Test]
-    public void Rule4_RouterEdge_BypassesCheck()
+    public void Rule4_RouterEdge_WithTrust_Passes()
     {
-        var state = new MockContractState { Router = Router }; // No trusts at all
-        // Router → Group edge should be skipped entirely
+        // Hub.sol _verifyFlowMatrix calls isPermittedFlow on ALL edges including Router.
+        // Avatar→Router: isTrusted(Router, tokenOwner) must hold
+        // Router→Group: isTrusted(Group, tokenOwner) must hold
+        var state = new MockContractState
+        {
+            Router = Router,
+            Groups = { GroupA },
+            Trusts =
+            {
+                (Router.ToLower(), Alice.ToLower()),  // Router trusts Alice's token
+                (GroupA.ToLower(), Alice.ToLower()),   // GroupA trusts Alice's token
+            }
+        };
         var steps = new[]
         {
-            Step(Router, GroupA, Alice),
-            Step(Alice, Router, Alice),
+            Step(Alice, Router, Alice),   // Avatar→Router
+            Step(Router, GroupA, Alice),  // Router→Group
         };
         var violations = new List<ValidationViolation>();
         HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
-        Assert.That(violations, Is.Empty, "Router edges should bypass isPermittedFlow");
+        Assert.That(violations, Is.Empty, "Router edges with valid trust should pass");
+    }
+
+    [Test]
+    public void Rule4_AvatarToRouter_NoTrust_Fails()
+    {
+        // Avatar→Router: isTrusted(Router, tokenOwner) — Router must trust the token
+        var state = new MockContractState
+        {
+            Router = Router,
+            // No trusts — Router does NOT trust Alice's token
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Rule, Is.EqualTo("IsPermittedFlow"));
+    }
+
+    [Test]
+    public void Rule4_RouterToGroup_NoTrust_Fails()
+    {
+        // Router→Group: isTrusted(Group, tokenOwner) — Group must trust the token
+        var state = new MockContractState
+        {
+            Router = Router,
+            Groups = { GroupA },
+            // No trusts — GroupA does NOT trust Alice's token
+        };
+        var steps = new[] { Step(Router, GroupA, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Rule, Is.EqualTo("IsPermittedFlow"));
     }
 
     // ═══════════════════════════════════════════
@@ -596,5 +640,37 @@ public class HubContractValidatorTests
 
         Assert.That(errors, Is.Empty,
             $"Quantized+groups graph ({avatars} avatars, {groups} groups) validator errors:\n{string.Join("\n", errors)}");
+    }
+
+    // ═══════════════════════════════════════════
+    // CapacityGraphContractState.IsTrusted — GroupTrustedTokens fallback
+    // ═══════════════════════════════════════════
+
+    [Test]
+    public void IsTrusted_GroupInGroupTrustedTokensOnly_ReturnsTrue()
+    {
+        // Groups are excluded from TrustLookup (trustQuery.sql WHERE group IS NULL).
+        // IsTrusted must fall back to GroupTrustedTokens for group trusters.
+        var graph = new CapacityGraph();
+        var groupId = AddressIdPool.IdOf("0xee00000000000000000000000000000000group1");
+        var tokenId = AddressIdPool.IdOf("0xee00000000000000000000000000000000token1");
+        var untrustedId = AddressIdPool.IdOf("0xee00000000000000000000000000000000token2");
+
+        graph.AddGroup(groupId);
+        graph.GroupTrustedTokens[groupId] = new HashSet<int> { tokenId };
+        // TrustLookup has NO entry for the group (matches production)
+        graph.TrustLookup = new Dictionary<int, HashSet<int>>();
+
+        var state = new CapacityGraphContractState(graph);
+
+        Assert.That(state.IsTrusted(
+            AddressIdPool.StringOf(groupId),
+            AddressIdPool.StringOf(tokenId)), Is.True,
+            "Group trusting token via GroupTrustedTokens should return true");
+
+        Assert.That(state.IsTrusted(
+            AddressIdPool.StringOf(groupId),
+            AddressIdPool.StringOf(untrustedId)), Is.False,
+            "Group not trusting token should return false");
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
@@ -112,8 +112,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        // Group minting with wrapped collateral, quantized, consented
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -198,8 +200,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        // Should use only collateralB (100 CRC) via group minting with consent
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -242,7 +246,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
@@ -217,18 +217,33 @@ public class PipelineMethodTests
     }
 
     [Test]
-    public void Consent_GroupEdge_Skipped()
+    public void Consent_ConsentedAvatarToGroup_DetectsViolation()
     {
         var graph = MakeGraph(
             groups: new[] { Group1 },
             consented: new[] { A },
             trustLookup: new() { { A, new HashSet<int>() } }); // A trusts nobody
 
-        // A(consented) → Group: should be skipped (group becomes router edge later)
+        // A(consented) → Group: NOT skipped — Router lacks advancedUsageFlags
+        var edges = new List<(int From, int To, int Token, long Flow)> { (A, Group1, TokenA, 100) };
+
+        Assert.That(_pathfinder.PathHasConsentViolation(edges, graph), Is.True,
+            "Consented Avatar→Group detected — Router lacks advancedUsageFlags");
+    }
+
+    [Test]
+    public void Consent_NonConsentedAvatarToGroup_Skipped()
+    {
+        var graph = MakeGraph(
+            groups: new[] { Group1 },
+            consented: new[] { B }, // B is consented, not A
+            trustLookup: new() { { A, new HashSet<int>() } });
+
+        // A(non-consented) → Group: skipped (standard trust applies after Router insertion)
         var edges = new List<(int From, int To, int Token, long Flow)> { (A, Group1, TokenA, 100) };
 
         Assert.That(_pathfinder.PathHasConsentViolation(edges, graph), Is.False,
-            "Group edges skipped — they become router edges");
+            "Non-consented Avatar→Group skipped — standard trust path");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
@@ -38,7 +38,8 @@ public class PropertyBasedTests
         double trustDensity = 0.3,
         bool withRouter = true,
         bool withConsent = false,
-        double consentRate = 0.5)
+        double consentRate = 0.5,
+        double routerTrustDensity = 1.0)
     {
         var graph = new CapacityGraph();
         var avatars = new List<int>(avatarCount);
@@ -66,9 +67,10 @@ public class PropertyBasedTests
         }
 
         // Router (use 'b' prefix — valid hex)
+        int routerId = -1;
         if (withRouter)
         {
-            int routerId = AddressIdPool.IdOf($"{prefix}b{0:d33}");
+            routerId = AddressIdPool.IdOf($"{prefix}b{0:d33}");
             graph.SetRouter(routerId);
         }
 
@@ -118,6 +120,28 @@ public class PropertyBasedTests
                 graph.GroupTrustedTokens[grp] = groupTrusts;
                 trustLookup[grp] = groupTrusts;
             }
+        }
+
+        // Router trusts a subset of group-trusted tokens (controlled by routerTrustDensity).
+        // At density=1.0 all group collateral edges pass; at <1.0 some are filtered,
+        // exercising the routerFilteredCount code path in GraphFactory.AddTokenPoolOutEdges.
+        if (withRouter && routerId >= 0 && groups.Count > 0)
+        {
+            var routerTrusts = new HashSet<int>();
+            foreach (var grp in groups)
+            {
+                if (graph.GroupTrustedTokens.TryGetValue(grp, out var gTrusts))
+                {
+                    foreach (var token in gTrusts)
+                    {
+                        if (rng.NextDouble() < routerTrustDensity)
+                            routerTrusts.Add(token);
+                    }
+                }
+            }
+
+            if (routerTrusts.Count > 0)
+                trustLookup[routerId] = routerTrusts;
         }
 
         graph.TrustLookup = trustLookup;
@@ -966,6 +990,53 @@ public class PropertyBasedTests
             "Same input should produce same MaxFlow");
         Assert.That(result1.Transfers.Count, Is.EqualTo(result2.Transfers.Count),
             "Same input should produce same number of transfers");
+    }
+
+    #endregion
+
+    #region Property: Router trust density filtering
+
+    /// <summary>
+    /// With routerTrustDensity &lt; 1.0, some group collateral tokens are not trusted by the Router.
+    /// Paths through filtered tokens should not appear in the output. MaxFlow may be reduced or zero,
+    /// but the pathfinder must never crash and flow conservation must hold.
+    /// </summary>
+    [Test]
+    [Repeat(10)]
+    public void PartialRouterTrust_NeverCrashes_FlowConserved()
+    {
+        var rng = new Random(TestContext.CurrentContext.CurrentRepeatCount + 50000);
+        int avatars = rng.Next(4, 10);
+        int groups = rng.Next(1, 3);
+
+        var graph = BuildSyntheticGraph(avatars, groups, DefaultBalance, rng,
+            trustDensity: 0.5, withRouter: true, routerTrustDensity: 0.5);
+        var (source, sink) = PickSourceSink(graph, rng);
+
+        var pathfinder = new V2Pathfinder();
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+        };
+        UInt256 target = CirclesConverter.BlowUpToUInt256(DefaultBalance);
+
+        MaxFlowResponse result;
+        try
+        {
+            result = pathfinder.ComputeMaxFlowWithPath(graph, request, target);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("BAD_INPUT"))
+        {
+            return; // Empty graph is valid
+        }
+
+        // Must not crash. Flow conservation: if transfers exist, check balance at intermediaries.
+        if (result.Transfers != null && result.Transfers.Count > 0)
+        {
+            AssertFlowConservation(result.Transfers,
+                AddressIdPool.StringOf(source), AddressIdPool.StringOf(sink));
+        }
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
@@ -427,7 +427,10 @@ public class WrapperFilterMatrixTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow, "Wrapped collateral + group mint + consent should work");
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     // ─────────────── SWAP MODE + WRAPPER ───────────────

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -30,8 +30,9 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Track which tokens each group trusts
     public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();
 
-    // Track avatars that have enabled consented flow
-    public HashSet<int> ConsentedAvatars { get; set; } = new HashSet<int>();
+    // Track avatars that have enabled consented flow.
+    // Set during graph construction, immutable after publication to CapacityGraphPool.
+    public HashSet<int> ConsentedAvatars { get; internal set; } = new HashSet<int>();
 
     // Track all registered V2 avatar IDs (cached to avoid per-request DB queries)
     public HashSet<int> RegisteredAvatarIds { get; } = new HashSet<int>();

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -531,7 +531,12 @@ public class V2Pathfinder
      * Mirrors Hub.sol:668-676 isPermittedFlow():
      * - If From NOT consented → standard trust sufficient
      * - If From consented → requires isTrusted(From, To) && advancedUsageFlags[To]
-     * Router edges skipped (router has no consent, Hub.sol:723 uses Router as sender).
+     *
+     * Router edges are skipped here — this is the post-insertion counterpart of
+     * the IsGroup(to) skip in PathHasConsentViolation. Both exempt group-minting
+     * paths from consent checks: PathHasConsentViolation skips Avatar→Group
+     * (pre-insertion), this method skips Avatar→Router and Router→Group
+     * (post-insertion). Removing either skip breaks the symmetry.
      *
      * Since path-level consent filtering in CollapseBalanceNodes should catch
      * all violations BEFORE aggregation, this method should never filter
@@ -540,7 +545,7 @@ public class V2Pathfinder
      * Still removes edges for safety (better to produce reduced flow than
      * let the contract revert).
      * --------------------------------------------------------------------- */
-    private List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
+    internal List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
     {
         // If no consent data available, pass all edges through
         if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
@@ -560,7 +565,19 @@ public class V2Pathfinder
                 continue;
             }
 
-            // Skip router edges
+            // Catch consented Avatar→Router edges that PathHasConsentViolation should have dropped.
+            // Router lacks advancedUsageFlags — consented senders cannot send to it.
+            if (capacityGraph.IsRouter(edge.To) && capacityGraph.ConsentedAvatars.Contains(edge.From))
+            {
+                _logger.LogError(
+                    "[ValidateConsentedFlow] SAFETY-NET: consented avatar {From}→Router should have been caught by PathHasConsentViolation",
+                    AddressIdPool.StringOf(edge.From)[..10]);
+                rejected++;
+                continue;
+            }
+
+            // Skip remaining router edges — Router is never consented, so standard trust applies.
+            // This is the post-insertion counterpart of the IsGroup(to) skip in PathHasConsentViolation.
             if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
             {
                 validEdges.Add(edge);
@@ -682,9 +699,20 @@ public class V2Pathfinder
 
         if (droppedPaths > 0)
         {
-            _logger.LogInformation("[CollapseBalanceNodes] Dropped {DroppedPaths}/{TotalPaths} paths due to consent {Mode}",
-                droppedPaths, pathsWithFlow.Count,
-                _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            if (droppedPaths == pathsWithFlow.Count)
+            {
+                _logger.LogWarning(
+                    "[CollapseBalanceNodes] ALL {TotalPaths} paths dropped due to consent {Mode} — result will be zero flow. " +
+                    "Source or intermediaries may have advancedUsageFlags preventing group minting paths.",
+                    pathsWithFlow.Count,
+                    _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            }
+            else
+            {
+                _logger.LogInformation("[CollapseBalanceNodes] Dropped {DroppedPaths}/{TotalPaths} paths due to consent {Mode}",
+                    droppedPaths, pathsWithFlow.Count,
+                    _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            }
         }
 
         /* ---------------- materialise collapsed edges ---------------------- */
@@ -769,9 +797,9 @@ public class V2Pathfinder
      * For each edge: if From is consented → check isTrusted(From, To) AND
      * ConsentedAvatars.Contains(To).
      *
-     * Skip edges where From or To is a group — these become router edges
-     * after InsertRouterInTransfers, and the router bypasses consent checks.
-     * The consented-flow-router-006 scenario depends on this.
+     * Skip Avatar→Group edges (where To is a group) — these become
+     * Avatar→Router→Group after InsertRouterInTransfers.
+     * Group→Avatar (mint) edges stay as-is and must be consent-checked.
      * --------------------------------------------------------------------- */
     internal bool PathHasConsentViolation(
         List<(int From, int To, int Token, long Flow)> collapsedEdges,
@@ -783,8 +811,11 @@ public class V2Pathfinder
 
         foreach (var (from, to, _, _) in collapsedEdges)
         {
-            // Skip group edges — they become router edges later (router bypasses consent)
-            if (capacityGraph.IsGroup(from) || capacityGraph.IsGroup(to))
+            // Skip Avatar→Group edges ONLY when sender is NOT consented.
+            // Non-consented: safe — standard trust applies after Router insertion.
+            // Consented: DO NOT skip — after Router insertion, Avatar(consented)→Router
+            // fails isPermittedFlow because Router lacks advancedUsageFlags.
+            if (capacityGraph.IsGroup(to) && !capacityGraph.ConsentedAvatars.Contains(from))
                 continue;
 
             // Skip pool nodes (shouldn't exist after collapse, but safety check)
@@ -824,6 +855,12 @@ public class V2Pathfinder
 
         foreach (var (from, to, _, _) in edges)
         {
+            // Skip Avatar→Group edges ONLY when sender is NOT consented.
+            // Consented sender → Group becomes Consented → Router after insertion,
+            // which fails isPermittedFlow (Router lacks advancedUsageFlags).
+            if (graph.IsGroup(to) && !graph.ConsentedAvatars.Contains(from))
+                continue;
+
             if (from != sourceId && from != sinkId && graph.ConsentedAvatars.Contains(from))
                 return true;
             if (to != sourceId && to != sinkId && graph.ConsentedAvatars.Contains(to))

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -38,7 +38,9 @@ public sealed class CapacityGraphContractState : IContractState
 
     /// <summary>
     /// Hub.sol: isTrusted(truster, circlesId) — does truster accept circlesId's token?
-    /// Maps to CapacityGraph.TrustLookup[trusterId].Contains(circlesIdId).
+    /// Checks TrustLookup first (avatar trusts from trustQuery.sql).
+    /// Falls back to GroupTrustedTokens for group trusters (excluded from TrustLookup
+    /// by trustQuery.sql's WHERE group IS NULL filter, stored separately).
     /// Returns true (permissive) if TrustLookup is null to avoid false positives.
     /// </summary>
     public bool IsTrusted(string truster, string circlesId)
@@ -55,9 +57,15 @@ public sealed class CapacityGraphContractState : IContractState
         if (!AddressIdPool.TryIdOf(circlesIdLower, out int circlesIdId))
             return true;
 
-        if (!_graph.TrustLookup.TryGetValue(trusterId, out var trustedSet))
-            return false; // Truster exists but trusts nothing
+        if (_graph.TrustLookup.TryGetValue(trusterId, out var trustedSet))
+            return trustedSet.Contains(circlesIdId);
 
-        return trustedSet.Contains(circlesIdId);
+        // Groups are excluded from TrustLookup (trustQuery.sql filters them out).
+        // Their trust data lives in GroupTrustedTokens (from groupTrustQuery.sql).
+        if (_graph.IsGroup(trusterId))
+            return _graph.GroupTrustedTokens.TryGetValue(trusterId, out var groupTrusts)
+                   && groupTrusts.Contains(circlesIdId);
+
+        return false; // Truster exists but trusts nothing
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -198,25 +198,19 @@ public static class HubContractValidator
     //       return isTrusted(_from, _to) && advancedUsageFlags[_to];
     //   }
     //
-    // Router edges bypass this check entirely (Hub.sol uses Router as _sender
-    // for group mints, not subject to isPermittedFlow).
+    // Hub.sol's _verifyFlowMatrix calls isPermittedFlow for ALL edges,
+    // including Router edges. No address is exempt.
     // ────────────────────────────────────────────
     internal static void ValidateIsPermittedFlow(
         IReadOnlyList<TransferPathStep> steps,
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
-
         for (int i = 0; i < steps.Count; i++)
         {
             var from = steps[i].From.ToLowerInvariant();
             var to = steps[i].To.ToLowerInvariant();
             var tokenOwner = steps[i].TokenOwner.ToLowerInvariant();
-
-            // Router bypasses isPermittedFlow
-            if (router != null && (from == router || to == router))
-                continue;
 
             if (!state.HasAdvancedUsageFlags(from))
             {


### PR DESCRIPTION
## Summary
- Remove blanket Router bypass from `HubContractValidator.ValidateIsPermittedFlow` — Hub.sol's `_verifyFlowMatrix` checks ALL edges including Router (confirmed via contract source)
- Narrow `PathHasConsentViolation` group skip: consented Avatar→Group edges are no longer skipped, preventing silent on-chain reverts (Router lacks `advancedUsageFlags`)
- Add `GroupTrustedTokens` fallback in `CapacityGraphContractState.IsTrusted` — groups are excluded from `TrustLookup` by SQL; their trust data lives separately
- Safety net (`ValidateConsentedFlow`) now catches consented→Router edges as defense-in-depth
- `LogWarning` when all paths are consent-dropped (previously silent `Info`)
- Replace 4 duplicated consent test helpers with production method delegates (prevents drift)
- `ConsentedAvatars` setter → `internal set`

## Production impact
**Zero with default config** (`PATHFINDER_DISABLE_CONSENTED_FLOW=true`). All consent code paths are no-ops. Changes only activate if explicitly set to `false`, in which case they prevent silent on-chain reverts for consented avatars doing group minting.

## Test plan
- [x] 1,328 tests pass, 0 failures
- [x] 8 new unit tests (Router trust validation, GroupTrustedTokens fallback, consent group edge cases)
- [x] 10 scenario tests updated (consented-source group minting correctly yields zero flow)
- [x] `routerTrustDensity` property test exercises partial Router trust filtering
- [x] 6-agent multi-angle audit + 3-agent review on final implementation
- [ ] Verify on staging: `SELECT count(*) FROM "V_CrcV2_Avatars" WHERE "advancedUsageFlags" IS NOT NULL` — if 0, no behavioral change possible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added safety-net validation to detect and reject problematic consented pathways to routers.
  * Enhanced permission checks to validate all edge types uniformly, including router relationships.
  * Improved group trust validation to consult GroupTrustedTokens when determining authorisation.

* **Bug Fixes**
  * Fixed consent violation detection for complex avatar-to-group routing scenarios.
  * Corrected trust resolution logic to properly handle group-based trust relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->