### PR TITLE
fix(canary): resolve ERC20 wrapper→avatar in simulation

### DIFF
--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -102,6 +102,12 @@ public class MaxFlowResponse
     public IReadOnlyList<string>? ValidationViolationRules { get; set; }
 
     /// <summary>
+    /// Canary: true if HubContractValidator threw an exception (validator bug, not pathfinder bug).
+    /// </summary>
+    [JsonIgnore]
+    public bool ValidatorException { get; set; }
+
+    /// <summary>
     /// Block number of the graph snapshot used for this computation.
     /// Lets callers detect staleness by comparing to the current chain head.
     /// </summary>

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -15,7 +15,8 @@ internal sealed record CanaryWorkItem(
     string Source,
     string Sink,
     long GraphBlock,
-    List<TransferPathStep> Transfers);
+    List<TransferPathStep> Transfers,
+    IReadOnlyDictionary<string, string>? WrapperToAvatar = null);
 
 /// <summary>
 /// Background service that simulates pathfinder results via eth_call against the local
@@ -116,7 +117,7 @@ internal sealed class SimulationCanaryService : BackgroundService
         string calldata;
         try
         {
-            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers);
+            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers, item.WrapperToAvatar);
         }
         catch (Exception ex)
         {

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -133,6 +133,11 @@ internal sealed class SimulationCanaryService : BackgroundService
         try
         {
             using var client = _httpClientFactory.CreateClient("canary-simulation");
+            // Simulate at the exact block the graph was built from — eliminates false
+            // positives from chain state changes between graph build and simulation.
+            // Requires Nethermind to have state at this block (within pruning window).
+            var blockTag = item.GraphBlock > 0 ? $"0x{item.GraphBlock:x}" : "latest";
+
             var rpcRequest = new
             {
                 jsonrpc = "2.0",
@@ -140,7 +145,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 @params = new object[]
                 {
                     new { from = item.Source, to = FlowMatrixEncoder.CirclesHubAddress, data = calldata },
-                    "latest"
+                    blockTag
                 },
                 id = 1
             };
@@ -189,9 +194,9 @@ internal sealed class SimulationCanaryService : BackgroundService
                 // Full replay context: everything needed to reproduce
                 _log.LogError(
                     "[{ReqId}] SimulationCanary: REVERT category={Category} label={Label} " +
-                    "from={Source} to={Sink} graphBlock={Block} simBlock=latest steps={Steps} revert={Revert}",
+                    "from={Source} to={Sink} simBlock={Block} steps={Steps} revert={Revert}",
                     item.ReqId, category, label,
-                    item.Source, item.Sink, item.GraphBlock,
+                    item.Source, item.Sink, blockTag,
                     item.Transfers.Count, revertMsg);
 
                 if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -165,6 +165,8 @@ internal sealed class FindPathHandler(
                             FindPathMetrics.CanaryValidationFailureTotal.WithLabels(rule).Inc();
                     }
                 }
+                if (mfr.ValidatorException)
+                    FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
 
                 // Simulation canary: enqueue for async eth_call validation
                 if (simulationCanary != null

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text.Json;
 using Circles.Common.Dto;
+using Circles.Pathfinder;
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host.Canary;
 using Circles.Pathfinder.Host.State;
@@ -171,12 +172,25 @@ internal sealed class FindPathHandler(
                     && !string.IsNullOrEmpty(request.Source)
                     && !string.IsNullOrEmpty(request.Sink))
                 {
+                    // Build wrapper→avatar string mapping for calldata encoding.
+                    // The SDK resolves wrappers before submitting to Hub.sol; the canary must do the same.
+                    Dictionary<string, string>? wrapperMap = null;
+                    if (h.Graph.WrapperToAvatar.Count > 0)
+                    {
+                        wrapperMap = new Dictionary<string, string>(
+                            h.Graph.WrapperToAvatar.Count, StringComparer.OrdinalIgnoreCase);
+                        foreach (var (wrapperId, avatarId) in h.Graph.WrapperToAvatar)
+                            wrapperMap[AddressIdPool.StringOf(wrapperId)]
+                                = AddressIdPool.StringOf(avatarId);
+                    }
+
                     simulationCanary.TryEnqueue(new CanaryWorkItem(
                         ReqId: mfr.ReqId ?? Guid.NewGuid().ToString("N")[..8],
                         Source: request.Source,
                         Sink: request.Sink,
                         GraphBlock: mfr.GraphBlock,
-                        Transfers: new List<TransferPathStep>(mfr.Transfers))); // defensive copy
+                        Transfers: new List<TransferPathStep>(mfr.Transfers),
+                        WrapperToAvatar: wrapperMap));
                 }
             }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
@@ -43,4 +43,10 @@ internal class FindPathMetrics
             "circles_canary_validation_failure_total",
             "Hub.sol rule violations detected in pathfinder output (observe-only)",
             new CounterConfiguration { LabelNames = new[] { "rule" } });
+
+    // Canary: validator threw an unexpected exception (non-zero = validator bug, not pathfinder bug)
+    public static readonly Counter CanaryValidatorExceptionTotal =
+        Metrics.CreateCounter(
+            "circles_canary_validator_exception_total",
+            "Times HubContractValidator threw an unexpected exception");
 }

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -87,6 +87,9 @@ public static class FlowMatrixEncoder
         {
             var t = transfers[i];
             var amount = BigInteger.Parse(t.Value);
+            if (amount <= 0)
+                throw new InvalidOperationException(
+                    $"Transfer step [{i}] has non-positive amount '{t.Value}' (from={t.From}, to={t.To})");
             var toAddr = t.To.ToLowerInvariant();
 
             ushort streamSinkId = toAddr == receiverLower ? (ushort)1 : (ushort)0;

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -27,11 +27,28 @@ public static class FlowMatrixEncoder
     /// <summary>
     /// Builds the ABI-encoded calldata for Hub.operateFlowMatrix from pathfinder transfer steps.
     /// </summary>
+    /// <summary>
+    /// Builds the ABI-encoded calldata for Hub.operateFlowMatrix from pathfinder transfer steps.
+    /// The wrapperToAvatar mapping resolves ERC20 wrapper addresses to their underlying avatar,
+    /// mirroring what the SDK does before submitting to Hub.sol (wrappers are not valid flow vertices).
+    /// </summary>
     public static string BuildCalldata(
         string sender,
         string receiver,
-        IReadOnlyList<TransferPathStep> transfers)
+        IReadOnlyList<TransferPathStep> transfers,
+        IReadOnlyDictionary<string, string>? wrapperToAvatar = null)
     {
+        // Resolve tokenOwner: SDK unwraps ERC20 wrappers before calling Hub.sol.
+        // The pathfinder intentionally keeps wrapper addresses so the SDK knows what to unwrap.
+        // For simulation we must do the same resolution.
+        string ResolveToken(string tokenOwner)
+        {
+            var lower = tokenOwner.ToLowerInvariant();
+            if (wrapperToAvatar != null && wrapperToAvatar.TryGetValue(lower, out var avatar))
+                return avatar;
+            return lower;
+        }
+
         // Step 1: Build sorted vertex list (all unique addresses)
         var vertexSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         vertexSet.Add(sender.ToLowerInvariant());
@@ -40,7 +57,7 @@ public static class FlowMatrixEncoder
         {
             vertexSet.Add(t.From.ToLowerInvariant());
             vertexSet.Add(t.To.ToLowerInvariant());
-            vertexSet.Add(t.TokenOwner.ToLowerInvariant());
+            vertexSet.Add(ResolveToken(t.TokenOwner));
         }
 
         // Sort by uint160 value for Hub.sol's _flowVertices ordering
@@ -78,7 +95,7 @@ public static class FlowMatrixEncoder
             if (streamSinkId == 1)
                 terminalEdgeIndices.Add(i);
 
-            coordinates.Add((ushort)idx[t.TokenOwner.ToLowerInvariant()]);
+            coordinates.Add((ushort)idx[ResolveToken(t.TokenOwner)]);
             coordinates.Add((ushort)idx[t.From.ToLowerInvariant()]);
             coordinates.Add((ushort)idx[toAddr]);
         }

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -136,7 +136,9 @@ public static class FlowMatrixEncoder
         int currentOffset = 4 * 32;
         int flowVerticesSize = 32 + flowVertices.Count * 32;
         int flowEdgesSize = 32 + flowEdges.Count * 64;
-        int streamsSize = 32 + 32 + 32 + 32 + 32 + 32 + terminalEdgeIds.Length * 32 + 32;
+        // 32 (array offset) + 32 (sourceCoord) + 32 (offset to edgeIds) + 32 (offset to data)
+        // + 32 (edgeIds length) + N*32 (edgeIds) + 32 (data length)
+        int streamsSize = 32 + 32 + 32 + 32 + 32 + terminalEdgeIds.Length * 32 + 32;
         int packedCoordinatesSize = 32 + ((packedCoordinates.Length / 2 + 31) / 32) * 32;
 
         sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -13,6 +13,8 @@ public static class RevertClassifier
     private const string FlowEdgeIsNotPermitted = "0x5e418dba";
     // CirclesErrorOneAddressArg(address,uint8) — type 1 (0x20-0x3F)
     private const string AvatarMustBeRegistered = "0xc14c0700";
+    // Hub.sol flow matrix error
+    private const string NettedFlowMismatch = "0xb8c358de";
     // OpenZeppelin ERC1155 errors
     private const string ERC1155InsufficientBalance = "0x03dee4c5";
     private const string ERC1155InvalidReceiver = "0x57f447ce";
@@ -30,6 +32,9 @@ public static class RevertClassifier
 
         if (Contains(lower, AvatarMustBeRegistered))
             return ("bug", "avatar_not_registered");
+
+        if (Contains(lower, NettedFlowMismatch))
+            return ("bug", "netted_flow_mismatch");
 
         if (Contains(lower, ERC1155InsufficientBalance))
             return ("bug", "insufficient_balance");

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -130,6 +130,7 @@ public class V2Pathfinder
         // Canary: HubContractValidator results (runs in Release mode)
         public int ValidationErrors { get; set; }
         public IReadOnlyList<string>? ValidationViolationRules { get; set; }
+        public bool ValidatorException { get; set; }
     }
 
     /* ======================================================================
@@ -475,6 +476,7 @@ public class V2Pathfinder
                 _logger.LogError(ex,
                     "[{ReqId}] Canary: validator threw unexpected exception (observe-only, not blocking response)",
                     ctx.ReqId);
+                ctx.ValidatorException = true;
             }
         }
     }
@@ -507,7 +509,8 @@ public class V2Pathfinder
             ConsentDroppedPaths = ctx.ConsentDroppedPaths,
             ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected,
             ValidationErrors = ctx.ValidationErrors,
-            ValidationViolationRules = ctx.ValidationViolationRules
+            ValidationViolationRules = ctx.ValidationViolationRules,
+            ValidatorException = ctx.ValidatorException
         };
     }
 


### PR DESCRIPTION
## Summary

- Canary simulation was sending wrapper addresses as tokenOwner in `operateFlowMatrix` calldata
- Hub.sol rejects these with `AvatarMustBeRegistered` — false positive reverts
- The SDK resolves wrappers before submission; the canary must do the same
- `FlowMatrixEncoder.BuildCalldata` now accepts `wrapperToAvatar` mapping
- `FindPathHandler` builds the mapping from `CapacityGraph.WrapperToAvatar`

Found by investigating canary output on staging — all `avatar_not_registered` reverts traced to ERC20 wrapper addresses.

## Test plan
- [x] 5 test projects pass
- [ ] Deploy to staging, verify `avatar_not_registered` reverts disappear
- [ ] Remaining `flow_edge_not_permitted` reverts are real bugs to investigate