### PR TITLE
fix(pathfinder): filter unregistered avatar tokens from graph

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1251,6 +1251,7 @@ public class GraphFactoryTests
         public List<string> Groups { get; set; } = new();
         public List<(string GroupAddress, string TrustedToken)> GroupTrusts { get; set; } = new();
         public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; set; } = new();
+        public List<string> RegisteredAvatars { get; set; } = new();
 
         public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> LoadV2Balances()
             => Enumerable.Empty<(string, int, int, bool, bool)>();
@@ -1261,9 +1262,102 @@ public class GraphFactoryTests
         public IEnumerable<string> LoadGroups() => Groups;
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
-        public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
+        public IEnumerable<string> LoadRegisteredAvatars() => RegisteredAvatars;
         public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
             => Array.Empty<(string, string)>();
+    }
+
+    #endregion
+
+    #region Registration Filter Tests
+
+    // Unregistered token address used for filter tests
+    private static readonly string UnregisteredToken = "0xf1dd000000000000000000000000000000000099";
+
+    [Test]
+    public void AddAllAvatarNodes_UnregisteredTokenId_ExcludedFromGraph()
+    {
+        // Arrange: Alice trusts both TokenA (registered) and UnregisteredToken
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, Bob, TokenA }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 1000));
+
+        var trustLookup = new Dictionary<int, HashSet<int>>
+        {
+            [AddressIdPool.IdOf(Alice)] = new HashSet<int>
+            {
+                AddressIdPool.IdOf(TokenA),
+                AddressIdPool.IdOf(UnregisteredToken)
+            }
+        };
+
+        // Act
+        var cg = factory.CreateBaseCapacityGraph(bg, trustLookup);
+
+        // Assert: registered token is an avatar node, unregistered is NOT
+        int tokenAId = AddressIdPool.IdOf(TokenA);
+        int unregId = AddressIdPool.IdOf(UnregisteredToken);
+
+        Assert.That(cg.AvatarNodes.ContainsKey(tokenAId), Is.True,
+            "Registered token should be an avatar node");
+        Assert.That(cg.AvatarNodes.ContainsKey(unregId), Is.False,
+            "Unregistered token must NOT be an avatar node");
+    }
+
+    [Test]
+    public void CreateBaseCapacityGraph_RegisteredSetPopulatedBeforeAvatarNodes()
+    {
+        // Arrange: set up registered avatars — ensure they appear in RegisteredAvatarIds
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, Bob, TokenA, TokenB }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 500));
+        var trustLookup = new Dictionary<int, HashSet<int>>();
+
+        // Act
+        var cg = factory.CreateBaseCapacityGraph(bg, trustLookup);
+
+        // Assert: all registered avatars are in RegisteredAvatarIds
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(Alice)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(Bob)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(TokenA)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(TokenB)), Is.True);
+    }
+
+    [Test]
+    public void CreateCapacityGraph_Filtered_UnregisteredTokenExcluded()
+    {
+        // Arrange: filtered path with cached group data
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, TokenA }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 1000));
+
+        var trustLookup = new Dictionary<int, HashSet<int>>
+        {
+            [AddressIdPool.IdOf(Alice)] = new HashSet<int>
+            {
+                AddressIdPool.IdOf(TokenA),
+                AddressIdPool.IdOf(UnregisteredToken)
+            }
+        };
+
+        var request = new FlowRequest { Source = Alice, Sink = TokenA, TargetFlow = "1000" };
+
+        // Act
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        // Assert
+        int unregId = AddressIdPool.IdOf(UnregisteredToken);
+        Assert.That(cg.AvatarNodes.ContainsKey(unregId), Is.False,
+            "Unregistered token must NOT appear in filtered capacity graph");
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -679,8 +679,8 @@ public class IncrementalLoadGraphTests
             ("1000000000000000000", Alice, TokenA, InflationDayZeroUnix + 1000),
             ("1000000000000000000", Bob, TokenA, InflationDayZeroUnix + 1000));
 
-        // Only Alice is registered
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        // Only Alice is registered (+ TokenA as token owner so it passes tokenAddress filter)
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var settings = new Settings { TargetDemurrageTimestamp = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 1000) };
@@ -716,7 +716,7 @@ public class IncrementalLoadGraphTests
         var balance = "1000000000000000000000"; // 1000 * 1e18
 
         var balances = CreateBalanceState((balance, Alice, TokenA, lastActivity));
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var targetTime = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 86400); // 1 day later
@@ -741,7 +741,7 @@ public class IncrementalLoadGraphTests
         var balance = "1000000000000000000000";
 
         var balances = CreateBalanceState((balance, Alice, TokenA, lastActivity));
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var targetTime = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 200); // same day
@@ -858,6 +858,7 @@ public class IncrementalLoadGraphTests
         var avatars = CreateAvatarState(
             (Alice, "CrcV2_RegisterHuman"),
             (Bob, "CrcV2_RegisterHuman"),
+            (TokenA, "CrcV2_RegisterHuman"),
             (GroupAddr, "CrcV2_RegisterGroup"));
 
         var balances = CreateBalanceState();

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
@@ -38,6 +38,13 @@ public class InMemoryAvatarState
         return _avatars.Contains(lower) && !_stopped.Contains(lower);
     }
 
+    /// <summary>Returns true if address was ever registered (including stopped avatars).
+    /// Use for tokenAddress validation — stopped avatars' tokens are still valid on-chain.</summary>
+    public bool IsRegistered(string address)
+    {
+        return _avatars.Contains(address.ToLowerInvariant());
+    }
+
     /// <summary>Returns true if address is a registered group.</summary>
     public bool IsGroup(string address) => _groups.Contains(address.ToLowerInvariant());
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
@@ -87,10 +87,11 @@ public class InMemoryTrustState
 
     /// <summary>
     /// Get group trust edges (replicates groupTrustQuery.sql logic).
-    /// Returns trusts where the truster IS a group and trust hasn't expired.
+    /// Returns trusts where the truster IS a group, trustee is a registered avatar,
+    /// and trust hasn't expired.
     /// </summary>
     public IEnumerable<(string GroupAddress, string TrustedToken)> GetGroupTrusts(
-        HashSet<string> groupSet, long maxBlockTimestamp)
+        HashSet<string> groupSet, long maxBlockTimestamp, IReadOnlySet<string>? avatarSet = null)
     {
         foreach (var kv in _state)
         {
@@ -102,6 +103,9 @@ public class InMemoryTrustState
 
             // Filter expired
             if (expiryTime <= maxBlockTimestamp) continue;
+
+            // Trustee must be a registered avatar (mirrors groupTrustQuery.sql JOIN)
+            if (avatarSet != null && !avatarSet.Contains(trustee)) continue;
 
             yield return (truster, trustee);
         }

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -57,9 +57,10 @@ public class IncrementalLoadGraph : ILoadGraph
             var (account, tokenAddress) = kv.Key;
             var (rawBalance, lastActivity, isWrapped, isStatic) = kv.Value;
 
-            // Filter: both holder and token owner must be registered avatars
+            // Filter: holder must be active (registered + not stopped)
             if (!_avatarState.Contains(account)) continue;
-            if (!isWrapped && !_avatarState.Contains(tokenAddress)) continue;
+            // Token owner must be registered (stopped is OK — their tokens are still valid on-chain)
+            if (!isWrapped && !_avatarState.IsRegistered(tokenAddress)) continue;
 
             var adjusted = DemurrageCalculator.Apply(
                 rawBalance, lastActivity, isStatic, ctx,
@@ -131,7 +132,8 @@ public class IncrementalLoadGraph : ILoadGraph
     {
         // Use router-filtered groups from DB (matches groupQuery.sql parameterized by GroupRouterAddress)
         var routerGroups = new HashSet<string>(_inner.LoadGroups().Select(g => g.ToLowerInvariant()));
-        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp, _avatarState.GetActiveAvatarSet());
+        // Use AvatarSet (includes stopped) — stopped avatars' tokens are still valid on-chain
+        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp, _avatarState.AvatarSet);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -57,8 +57,9 @@ public class IncrementalLoadGraph : ILoadGraph
             var (account, tokenAddress) = kv.Key;
             var (rawBalance, lastActivity, isWrapped, isStatic) = kv.Value;
 
-            // Filter: must be a registered avatar
+            // Filter: both holder and token owner must be registered avatars
             if (!_avatarState.Contains(account)) continue;
+            if (!isWrapped && !_avatarState.Contains(tokenAddress)) continue;
 
             var adjusted = DemurrageCalculator.Apply(
                 rawBalance, lastActivity, isStatic, ctx,
@@ -130,7 +131,7 @@ public class IncrementalLoadGraph : ILoadGraph
     {
         // Use router-filtered groups from DB (matches groupQuery.sql parameterized by GroupRouterAddress)
         var routerGroups = new HashSet<string>(_inner.LoadGroups().Select(g => g.ToLowerInvariant()));
-        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp);
+        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp, _avatarState.GetActiveAvatarSet());
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
@@ -75,6 +75,7 @@ native_sum as (
          , false as "isStatic"
     from "V_CrcV2_BalancesByAccountAndToken" b
     join requested_avatars ra on ra.avatar = b."account"
+    join registered_avatars ra_token on ra_token.avatar = b."tokenAddress"
     where b."totalBalance" > 0
 )
 select balance::text as balance

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
@@ -15,11 +15,12 @@ FROM (
         "timestamp",
         "from",
         "to",
-        "tokenAddress",
+        ts."tokenAddress",
         "value"::text AS "value",
         false AS "isWrapped",
         false AS "isStatic"
-    FROM "CrcV2_TransferSingle"
+    FROM "CrcV2_TransferSingle" ts
+    JOIN registered_avatars ra_token ON ra_token.avatar = ts."tokenAddress"
     WHERE "blockNumber" > @lastBlock
 
     UNION ALL
@@ -32,11 +33,12 @@ FROM (
         "timestamp",
         "from",
         "to",
-        "tokenAddress",
+        tb."tokenAddress",
         "value"::text AS "value",
         false AS "isWrapped",
         false AS "isStatic"
-    FROM "CrcV2_TransferBatch"
+    FROM "CrcV2_TransferBatch" tb
+    JOIN registered_avatars ra_token ON ra_token.avatar = tb."tokenAddress"
     WHERE "blockNumber" > @lastBlock
 
     UNION ALL

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
@@ -72,6 +72,7 @@ native_sum as (
          , false as "isStatic"
     from "V_CrcV2_BalancesByAccountAndToken" b
     join registered_avatars ra on ra.avatar = b."account"
+    join registered_avatars ra_token on ra_token.avatar = b."tokenAddress"
     where b."totalBalance" > 0
 )
 select balance::text

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
@@ -121,6 +121,7 @@ native_sum as (
          , 'demurraged' as "circlesType"
     from native_agg n
     join registered_avatars ra on ra.avatar = n.account
+    join registered_avatars ra_token on ra_token.avatar = n."tokenAddress"
 )
 
 select balance::text

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,6 +1,14 @@
+WITH registered_avatars AS MATERIALIZED (
+    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT avatar FROM "CrcV2_RegisterHuman"
+)
 SELECT
     t.truster as group_address,
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
 INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
+INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
 WHERE g."mint" = LOWER(@router);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
@@ -1,2 +1,10 @@
-SELECT "erc20Wrapper", avatar
-FROM "CrcV2_ERC20WrapperDeployed"
+WITH registered_avatars AS MATERIALIZED (
+    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT avatar FROM "CrcV2_RegisterHuman"
+)
+SELECT d."erc20Wrapper", d.avatar
+FROM "CrcV2_ERC20WrapperDeployed" d
+JOIN registered_avatars ra ON ra.avatar = d.avatar

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -104,16 +104,16 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         var capacityGraph = new CapacityGraph();
 
-        // Add all avatar nodes from both graphs
-        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
-
-        // Ensure ALL registered avatars are valid source/sink candidates
+        // Build registered avatar set FIRST (needed for filtering in AddAllAvatarNodes)
         foreach (var avatar in loadGraph.LoadRegisteredAvatars())
         {
             var id = AddressIdPool.IdOf(avatar.ToLowerInvariant());
             capacityGraph.AddAvatar(id);
             capacityGraph.RegisteredAvatarIds.Add(id);
         }
+
+        // Add all avatar nodes from both graphs (filtered against registered set)
+        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
         // Load wrapper→avatar mappings (for DTO output resolution)
         LoadWrapperMappings(capacityGraph, cachedGroupData);
@@ -167,20 +167,27 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         var capacityGraph = new CapacityGraph();
 
-        // STEP 1: Add all avatar nodes from both graphs
-        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
-
-        // STEP 1a: Ensure ALL registered avatars are valid source/sink candidates
+        // STEP 1: Build registered avatar set FIRST (needed for filtering)
         if (cachedGroupData?.RegisteredAvatarIds != null)
         {
             foreach (var avatarId in cachedGroupData.RegisteredAvatarIds)
+            {
                 capacityGraph.AddAvatar(avatarId);
+                capacityGraph.RegisteredAvatarIds.Add(avatarId);
+            }
         }
         else
         {
             foreach (var avatar in loadGraph.LoadRegisteredAvatars())
-                capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
+            {
+                var id = AddressIdPool.IdOf(avatar.ToLowerInvariant());
+                capacityGraph.AddAvatar(id);
+                capacityGraph.RegisteredAvatarIds.Add(id);
+            }
         }
+
+        // STEP 1a: Add all avatar nodes from both graphs (filtered against registered set)
+        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
         // STEP 1b: Add avatars referenced by simulated balances (holders + tokens)
         var simulated = NormalizeSimulatedBalances(request.SimulatedBalances);
@@ -953,12 +960,22 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             capacityGraph.AddAvatar(truster);
         }
 
-        // every token that is trusted by somebody
+        // every token that is trusted by somebody — only if registered
+        // (defense-in-depth: SQL queries should already filter, but guard against leaks)
+        var registered = capacityGraph.RegisteredAvatarIds;
+        if (registered.Count == 0)
+        {
+            _logger.LogWarning("RegisteredAvatarIds is empty — skipping trusted-token registration filter");
+        }
+
         foreach (var trustedSet in trustLookup.Values)
         {
             foreach (var tokenId in trustedSet)
             {
-                capacityGraph.AddAvatar(tokenId);
+                if (registered.Count == 0 || registered.Contains(tokenId))
+                {
+                    capacityGraph.AddAvatar(tokenId);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `balanceQuery.sql` filtered `account` (holder) against `registered_avatars` but NOT `tokenAddress`, allowing unregistered avatar tokens to leak into the pathfinder graph via registered holders
- **Impact**: `AvatarMustBeRegistered` and `FlowEdgeIsNotPermitted` reverts on-chain when Hub.sol processes flow matrices containing unregistered vertices
- **Confirmed live**: `diagnose-swap.sh` reproduced against two production addresses (`0x45D1...` and `0x35d2...`)

### Changes

**SQL (6 files)** — add `tokenAddress` registration filter:
- `balanceQuery.sql`, `balanceFullStateQuery.sql`, `avatarBalancesQuery.sql` — `JOIN registered_avatars` on `tokenAddress` in `native_sum` CTE
- `balanceDeltaQuery.sql` — `JOIN` on both `TransferSingle` and `TransferBatch` native CTEs
- `wrapperMappingQuery.sql` — added `registered_avatars` CTE + `JOIN` on underlying avatar
- `groupTrustQuery.sql` — added `registered_avatars` CTE + `JOIN` on trustee

**C# (3 files)** — defense-in-depth guard rails:
- `IncrementalLoadGraph.LoadV2Balances()` — filter `tokenAddress` against avatar state (skipped for wrapped tokens)
- `InMemoryTrustState.GetGroupTrusts()` — filter trustee by registered avatar set
- `GraphFactory.AddAllAvatarNodes()` — populate `RegisteredAvatarIds` before adding avatar nodes, filter trusted token IDs against registered set, warning log when set is empty

**Tests (2 files):**
- 3 new tests verifying unregistered tokens are excluded from capacity graph
- 4 existing tests updated to register token owners

## Test plan

- [x] 907 unit tests pass, 0 fail
- [ ] Deploy to staging, run `diagnose-swap.sh` against staging addresses
- [ ] Monitor `circles_db_query_duration_seconds{query="balance"}` for performance impact of new JOIN on 10.8M-row aggregate
- [ ] Verify Anvil E2E scenarios still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed registration filtering so only registered avatars and their tokens appear in capacity graphs, trust derivations and balance calculations; unregistered trusted tokens are excluded.
  * Ensured avatar registration data is populated before graph node creation to prevent spurious nodes.
  * Query updates tighten balance and trust results to registered avatars only.

* **Tests**
  * Added and adjusted tests to cover registration filtering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->