### PR TITLE
fix(cache): filter unregistered avatar tokens from pathfinder graph snapshot

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -147,8 +147,9 @@ public class PathfinderGraphController : ControllerBase
             var account = kvp.Key[..separatorIndex];
             var tokenAddress = kvp.Key[(separatorIndex + 1)..];
 
-            // Only include balances for registered V2 avatars
-            if (!_caches.V2Avatars.ContainsKey(account))
+            // Only include balances for registered V2 avatars (humans, orgs, or groups)
+            if (!_caches.V2Avatars.ContainsKey(account)
+                && !_caches.Groups.ContainsKey(account))
                 continue;
 
             // Determine if this is a wrapper token

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -165,6 +165,14 @@ public class PathfinderGraphController : ControllerBase
                     continue;
                 isStatic = wrapperInfo.CirclesType == 1;
             }
+            else
+            {
+                // Native ERC1155: tokenAddress IS the token owner's address.
+                // Must be a registered avatar — unregistered tokens cause on-chain reverts.
+                if (!_caches.V2Avatars.ContainsKey(tokenAddress)
+                    && !_caches.Groups.ContainsKey(tokenAddress))
+                    continue;
+            }
 
             // Convert decimal Circles → attoCircles BigInteger
             var attoBalance = CirclesConverter.CirclesToAttoCircles(kvp.Value);
@@ -302,6 +310,11 @@ public class PathfinderGraphController : ControllerBase
 
             // Skip revoked trust
             if (expiryTime > 0 && expiryTime <= now)
+                continue;
+
+            // Trustee must be a registered avatar — unregistered tokens cause on-chain reverts
+            if (!_caches.V2Avatars.ContainsKey(trustee)
+                && !_caches.Groups.ContainsKey(trustee))
                 continue;
 
             groupTrusts.Add(new PathfinderGroupTrustRow(


### PR DESCRIPTION
## Summary

Companion to #287. The cache service's pathfinder graph builder had the same registration filter gaps:

- **`BuildBalances()`**: filtered `account` (holder) by `V2Avatars` but NOT `tokenAddress` for native ERC1155 tokens
- **`BuildGroupTrusts()`**: did not filter `trustee` against registered avatars

Both gaps allowed unregistered avatar tokens to leak into the pathfinder graph when `USE_CACHE_GRAPH_SOURCE=true` (staging default).

### Changes

`PathfinderGraphController.cs`:
- `BuildBalances()`: added `else` branch — when token is NOT a wrapper, check `tokenAddress` against `V2Avatars` and `Groups`
- `BuildGroupTrusts()`: added `trustee` check against `V2Avatars` and `Groups`

### Context

PRs #282, #285 were also checked for cache-layer applicability:
- #282 (router trust filter) — no cache fix needed, handled in `GraphFactory`
- #285 (consent validation) — no cache fix needed, handled in `V2Pathfinder`

## Test plan

- [x] Build succeeds (0 errors)
- [ ] Deploy to staging with `USE_CACHE_GRAPH_SOURCE=true` (default)
- [ ] Run `diagnose-swap.sh` — verify no more `AvatarMustBeRegistered` reverts
- [ ] Compare with `USE_CACHE_GRAPH_SOURCE=false` to verify identical behavior