### PR TITLE
fix(pathfinder): resolve wrapper addresses in canary simulation

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -15,7 +15,8 @@ internal sealed record CanaryWorkItem(
     string Source,
     string Sink,
     long GraphBlock,
-    List<TransferPathStep> Transfers);
+    List<TransferPathStep> Transfers,
+    IReadOnlyDictionary<string, string>? WrapperToAvatar = null);
 
 /// <summary>
 /// Background service that simulates pathfinder results via eth_call against the local
@@ -116,7 +117,10 @@ internal sealed class SimulationCanaryService : BackgroundService
         string calldata;
         try
         {
-            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers);
+            // Hub.sol expects avatar addresses as token owners, not wrapper contract addresses.
+            // The SDK does this conversion client-side; the canary must do it before simulation.
+            var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
+            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, transfers);
         }
         catch (Exception ex)
         {
@@ -171,6 +175,9 @@ internal sealed class SimulationCanaryService : BackgroundService
 
             if (json.ValueKind == JsonValueKind.Undefined || json.ValueKind == JsonValueKind.Null)
             {
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: empty/null response from eth_call — node may be misconfigured",
+                    item.ReqId);
                 SimulationTotal.WithLabels("rpc_empty_response").Inc();
                 return;
             }
@@ -218,5 +225,40 @@ internal sealed class SimulationCanaryService : BackgroundService
         }
 
         QueueDepth.Set(_channel.Reader.Count);
+    }
+
+    /// <summary>
+    /// Replaces wrapper contract addresses in TokenOwner fields with the underlying avatar address.
+    /// Hub.sol's operateFlowMatrix expects avatar addresses (circlesId), not wrapper contracts.
+    /// Returns the original list unchanged if no mapping is provided or no wrappers are found.
+    /// </summary>
+    private static IReadOnlyList<TransferPathStep> ResolveWrapperTokenOwners(
+        List<TransferPathStep> transfers,
+        IReadOnlyDictionary<string, string>? wrapperToAvatar)
+    {
+        if (wrapperToAvatar == null || wrapperToAvatar.Count == 0)
+            return transfers;
+
+        var resolved = new List<TransferPathStep>(transfers.Count);
+        foreach (var t in transfers)
+        {
+            var tokenOwner = t.TokenOwner.ToLowerInvariant();
+            if (wrapperToAvatar.TryGetValue(tokenOwner, out var avatar))
+            {
+                resolved.Add(new TransferPathStep
+                {
+                    From = t.From,
+                    To = t.To,
+                    TokenOwner = avatar,
+                    Value = t.Value
+                });
+            }
+            else
+            {
+                resolved.Add(t);
+            }
+        }
+
+        return resolved;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -165,18 +165,47 @@ internal sealed class FindPathHandler(
                     }
                 }
 
-                // Simulation canary: enqueue for async eth_call validation
+                // Simulation canary: enqueue for async eth_call validation.
+                // Skip when request has simulated inputs — those paths depend on
+                // state that doesn't exist on-chain, so eth_call would always revert.
+                bool hasSimulated = (request.SimulatedBalances?.Count > 0)
+                                    || (request.SimulatedTrusts?.Count > 0);
+
                 if (simulationCanary != null
                     && mfr.Transfers.Count > 0
                     && !string.IsNullOrEmpty(request.Source)
-                    && !string.IsNullOrEmpty(request.Sink))
+                    && !string.IsNullOrEmpty(request.Sink)
+                    && !hasSimulated)
                 {
+                    // Build wrapper→avatar string mapping for the canary to resolve
+                    // wrapper contract addresses back to avatar addresses before eth_call.
+                    // Wrapped in try-catch: canary is best-effort and must never affect the response.
+                    Dictionary<string, string>? wrapperMap = null;
+                    try
+                    {
+                        if (h.Graph.WrapperToAvatar.Count > 0)
+                        {
+                            wrapperMap = new Dictionary<string, string>(
+                                h.Graph.WrapperToAvatar.Count, StringComparer.OrdinalIgnoreCase);
+                            foreach (var kv in h.Graph.WrapperToAvatar)
+                            {
+                                wrapperMap[AddressIdPool.StringOf(kv.Key)] = AddressIdPool.StringOf(kv.Value);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogError(ex, "Failed to build wrapper map for canary — simulation will run without wrapper resolution");
+                        wrapperMap = null;
+                    }
+
                     simulationCanary.TryEnqueue(new CanaryWorkItem(
                         ReqId: mfr.ReqId ?? Guid.NewGuid().ToString("N")[..8],
                         Source: request.Source,
                         Sink: request.Sink,
                         GraphBlock: mfr.GraphBlock,
-                        Transfers: new List<TransferPathStep>(mfr.Transfers))); // defensive copy
+                        Transfers: new List<TransferPathStep>(mfr.Transfers), // defensive copy
+                        WrapperToAvatar: wrapperMap));
                 }
             }
 


### PR DESCRIPTION
## Summary

Eliminates two classes of false-positive reverts from the eth_call simulation canary (#283):

- **Wrapper→avatar resolution**: `withWrap=true` responses include ERC20 wrapper contract addresses as `tokenOwner`. Hub.sol expects the underlying avatar address (the SDK converts client-side). The canary now resolves wrappers via `CapacityGraph.WrapperToAvatar` before building calldata.
- **Skip simulated requests**: Requests with `SimulatedBalances` or `SimulatedTrusts` inject synthetic state that doesn't exist on-chain — eth_call always reverts for these.

Additional hardening from code review:
- Wrapper map construction wrapped in try-catch (canary must never affect the response path)
- Log warning on empty eth_call responses

**Before**: canary logs flooded with `avatar_not_registered` and `flow_edge_not_permitted` false positives on staging.
**After**: only genuine pathfinder bugs trigger canary alerts.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `./scripts/test.sh pathfinder` — all pass
- [ ] Deploy to staging → verify canary `REVERT category=bug` logs stop for wrapper/simulated cases
- [ ] `circles_canary_simulation_revert_total` metric should drop to near-zero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional background simulation service for validating transfer paths against on-chain conditions.

* **Improvements**
  * Enhanced filtering to ensure only registered avatars and tokens participate in balance calculations and trust relationships.
  * Strengthened validation of avatar-to-router transfers by requiring explicit trust relationships.
  * Added metrics for monitoring router trust coverage.

* **Bug Fixes**
  * Improved consent safety checks for group minting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->