### PR TITLE
feat(rpc): add circles_getBlockByTimestamp + fix In/NotIn filters

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -34,6 +34,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 {
     // Note: Fields, constructor, and CreateConnectionAsync are in RpcModule/CirclesRpcModule.Core.cs
 
+    private const int MaxInFilterElements = 1000;
+
     #region GetTransactionHistory - Version-specific query builders
 
     /// <summary>
@@ -1018,20 +1020,24 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 return $"{column} NOT LIKE {paramName}";
 
             case FilterType.In:
-                if (predicate.Value is Array arr)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr));
-                    return $"{column} = ANY({paramName})";
-                }
-                return "";
+            {
+                var inValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (inValues == null)
+                    throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
+                if (inValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, inValues, parameters, negate: false);
+            }
 
             case FilterType.NotIn:
-                if (predicate.Value is Array arr2)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr2));
-                    return $"{column} != ALL({paramName})";
-                }
-                return "";
+            {
+                var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (notInValues == null)
+                    throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
+                if (notInValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, notInValues, parameters, negate: true);
+            }
 
             case FilterType.IsNull:
                 return $"{column} IS NULL";

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -355,6 +355,19 @@ public interface ICirclesRpcModule
         string? cursor = null);
 
     // ========================================================================
+    // Block Lookup
+    // ========================================================================
+
+    /// <summary>
+    /// Returns the block number closest to the given Unix timestamp.
+    /// Useful for converting human-readable date ranges into block ranges for event queries.
+    /// </summary>
+    /// <param name="timestamp">Unix timestamp (seconds since epoch)</param>
+    /// <param name="direction">"before" (default) = closest block at or before timestamp,
+    /// "after" = closest block at or after timestamp</param>
+    Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before");
+
+    // ========================================================================
     // Generic Database Query
     // ========================================================================
 
@@ -648,6 +661,14 @@ public record HealthResponse(
     long Timestamp,
     string Database,
     string Index
+);
+
+/// <summary>
+/// Response for block-by-timestamp lookup.
+/// </summary>
+public record BlockByTimestampResponse(
+    [property: JsonPropertyName("blockNumber")] long BlockNumber,
+    [property: JsonPropertyName("timestamp")] long Timestamp
 );
 
 /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -726,6 +726,7 @@ static async Task<object> DispatchSingleRequest(
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
             // System & Query Methods
+            "circles_getBlockByTimestamp" => await HandleGetBlockByTimestamp(request, rpcModule),
             "circles_events" => await HandleEventsLegacy(request, rpcModule),
             "circles_events_paginated" => await HandleEventsPaginated(request, rpcModule),
             "circles_health" => await HandleHealth(request, rpcModule),
@@ -1513,6 +1514,23 @@ static async Task<object> ReflectionHandler(JsonRpcRequest request, CirclesRpcMo
     }
 
     return result ?? new object();
+}
+
+static async Task<object> HandleGetBlockByTimestamp(JsonRpcRequest request, CirclesRpcModule rpcModule)
+{
+    var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
+
+    if (parameters == null || parameters.Length == 0 || parameters[0].ValueKind == JsonValueKind.Null)
+        throw new ArgumentException("timestamp parameter is required");
+
+    if (parameters[0].ValueKind != JsonValueKind.Number || !parameters[0].TryGetInt64(out var timestamp))
+        throw new ArgumentException("timestamp must be an integer");
+
+    string? direction = null;
+    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        direction = parameters[1].GetString();
+
+    return await rpcModule.GetBlockByTimestamp(timestamp, direction);
 }
 
 static async Task<object> HandleHealth(JsonRpcRequest request, CirclesRpcModule rpcModule)

--- a/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
@@ -51,6 +51,7 @@ public static class RpcMethodClassifier
         "circles_getGroupMembers", "circles_getGroupMemberships",
         "circles_getTransactionHistory", "circles_getTransferData", "circles_getTokenHolders",
         "circlesV2_findPath",
+        "circles_getBlockByTimestamp",
         "circles_events", "circles_events_paginated",
         "circles_health", "circles_tables", "circles_query", "circles_paginated_query",
         "circles_getProfileView", "circles_getTrustNetworkSummary",

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
@@ -151,6 +151,59 @@ public partial class CirclesRpcModule
         );
     }
 
+    public async Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before")
+    {
+        if (timestamp < 0)
+            throw new ArgumentException("timestamp must be non-negative");
+
+        if (direction != null
+            && !string.Equals(direction, "before", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("direction must be 'before' or 'after'");
+
+        var isAfter = string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase);
+
+        var sql = isAfter
+            ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" >= @ts ORDER BY ""timestamp"" ASC LIMIT 1"
+            : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" <= @ts ORDER BY ""timestamp"" DESC LIMIT 1";
+
+        await using var connection = await CreateConnectionAsync();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        cmd.CommandTimeout = 30;
+        cmd.Parameters.AddWithValue("ts", timestamp);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                reader.GetInt64(0),
+                reader.GetInt64(1)
+            );
+        }
+
+        // No block found — return nearest boundary (earliest indexed block for "before", latest for "after")
+        await reader.CloseAsync();
+        await using var fallbackCmd = new NpgsqlCommand(
+            isAfter
+                ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" DESC LIMIT 1"
+                : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" ASC LIMIT 1",
+            connection);
+        fallbackCmd.CommandTimeout = 30;
+
+        await using var fallbackReader = await fallbackCmd.ExecuteReaderAsync();
+        if (await fallbackReader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                fallbackReader.GetInt64(0),
+                fallbackReader.GetInt64(1)
+            );
+        }
+
+        throw new InvalidOperationException("No blocks found in System_Block table");
+    }
+
     public Task<TableNamespace[]> GetTables()
     {
         var namespaces = new List<TableNamespace>();


### PR DESCRIPTION
## Summary
- Add `circles_getBlockByTimestamp(timestamp, direction?)` RPC method — converts Unix timestamps to block numbers via `System_Block` lookup. Enables the explorer at circles-explorer.dev to scope date-range queries to the correct block range instead of crawling backwards 500 blocks at a time (~1,900 requests for a 1-month range).
- Fix `circles_events` `In`/`NotIn` filter predicates silently dropping. `ObjectToInferredTypeConverter` deserializes arrays as `JsonElement`, but `BuildFilterPredicateClause` only handled `Array` — the filter was silently dropped, returning unfiltered results. Now reuses the type-preserving `TryExtractEnumerableFilterValues` + `BuildInClause` infrastructure from `circles_query`.
- Hardening from 6-agent audit: input validation, query timeouts, array size cap (1000), proper error codes.

## API
```
circles_getBlockByTimestamp(timestamp, direction?)
  timestamp: Unix seconds (required, integer, >= 0)
  direction: "before" (default) | "after"
  returns: { blockNumber: long, timestamp: long }
```

## Test plan
- [x] 137 RPC tests pass, 0 fail
- [x] Build succeeds (0 errors)
- [ ] Manual test against staging: `curl -X POST localhost:8081 -d '{"jsonrpc":"2.0","method":"circles_getBlockByTimestamp","params":[1738281600],"id":1}'`
- [ ] Verify `In` filter works: `circles_events(null, 0, null, null, [{"Type":"FilterPredicate","FilterType":"In","Column":"transactionHash","Value":["0x..."]}])`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added background validation simulation service for enhanced observability.
* Added new RPC method to query blocks by timestamp with directional support.

**Bug Fixes**
* Corrected avatar and group registration filtering in balance and trust calculations.
* Fixed Router trust validation to properly enforce trust requirements.
* Improved consent validation to reject unauthorised avatar-to-group transfers.
* Refined wrapper token filtering to exclude unregistered token addresses.

**Improvements**
* Enhanced validation error tracking and reporting in responses.
* Added observability metrics for Router trust coverage and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->