### PR TITLE
fix(pathfinder): audit follow-up hardening — 6 fixes

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -24,6 +24,7 @@ public class NetworkStateUpdaterService : BackgroundService
     };
     private readonly ILogger<NetworkStateUpdaterService> _log;
     private readonly CapacityGraphPool _pool;
+    private readonly LoadGraph _loadGraph;
 
     // Incremental state (only used when IncrementalEnabled=true)
     // Internal for testability (InternalsVisibleTo: Circles.Pathfinder.Tests)
@@ -44,21 +45,19 @@ public class NetworkStateUpdaterService : BackgroundService
     public NetworkStateUpdaterService(NetworkState networkState,
         Circles.Pathfinder.Host.Settings settings,
         ILogger<NetworkStateUpdaterService> log,
-        CapacityGraphPool pool)
+        CapacityGraphPool pool,
+        LoadGraph loadGraph)
     {
         _networkState = networkState;
         _settings = settings;
         _log = log;
         _pool = pool;
+        _loadGraph = loadGraph;
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var loadGraph = new LoadGraph(_settings);
-
-        // Wire DB query timing to Prometheus histogram
-        loadGraph.OnQueryCompleted = (queryName, elapsed) =>
-            GraphUpdateMetrics.DbQueryDuration.WithLabels(queryName).Observe(elapsed.TotalSeconds);
+        var loadGraph = _loadGraph;
 
         // Initialize cache graph client if enabled
         if (_settings.UseCacheGraphSource)
@@ -282,7 +281,19 @@ public class NetworkStateUpdaterService : BackgroundService
         }
         else
         {
-            await IncrementalUpdate(loadGraph, lastBlock, ct);
+            try
+            {
+                await IncrementalUpdate(loadGraph, lastBlock, ct);
+            }
+            catch (Exception ex)
+            {
+                // Partial delta application may have corrupted in-memory state
+                // (ApplyTransfer is not idempotent). Force a full refresh on the
+                // next cycle to rebuild from scratch.
+                _lastFullRefreshBlock = -1;
+                _log.LogWarning(ex, "Incremental update failed at block {Block}, forcing full refresh on next cycle", lastBlock);
+                throw;
+            }
         }
 
         _lastProcessedBlock = lastBlock;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheSourceDriftResetTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheSourceDriftResetTests.cs
@@ -31,7 +31,7 @@ public class CacheSourceDriftResetTests
         var pool = new CapacityGraphPool("0xf000000000000000000000000000000000000001", dummyLoadGraph);
         var state = new NetworkState();
         var log = NullLogger<NetworkStateUpdaterService>.Instance;
-        return new NetworkStateUpdaterService(state, hostSettings, log, pool);
+        return new NetworkStateUpdaterService(state, hostSettings, log, pool, dummyLoadGraph);
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -115,7 +115,8 @@ public class GraphFactoryTests
     [Test]
     public void CreateCapacityGraph_AddsAllAvatarNodesFromBalanceAndTrust()
     {
-        var factory = MakeFactory();
+        var mock = new MockLoadGraph { RegisteredAvatars = new List<string> { Alice, Bob, TokenA } };
+        var factory = MakeFactory(mock);
         var balance = MakeBalanceGraph((Alice, TokenA, 1000));
         var trust = MakeTrust((Bob, TokenA));
 
@@ -670,23 +671,22 @@ public class GraphFactoryTests
 
     /// <summary>
     /// Regression: a wrapper address for an unregistered avatar that enters through trust
-    /// should be in AvatarNodes (from AddAllAvatarNodes) but must NOT create capacity edges
-    /// if its wrapped balance is skipped (WithWrap=false). This means it cannot be a flow
-    /// intermediary — preventing AvatarMustBeRegistered contract reverts.
-    /// Bug: Trust query returned wrapper trustee → AddAllAvatarNodes added it → graph included
-    /// an unregistered vertex → Hub.sol rejected with 0xc14c0700.
+    /// must NOT appear in AvatarNodes at all (fail-closed registration filter).
+    /// Previously the empty RegisteredAvatarIds bypass allowed unregistered wrappers in,
+    /// which caused Hub.sol AvatarMustBeRegistered reverts.
     /// </summary>
     [Test]
     public void GraphFactory_UnregisteredWrapperTrustee_CannotBeFlowIntermediary()
     {
-        // WrapperAddr is trusted by Bob but has no balance and is unregistered
+        // WrapperAddr is trusted by Bob but is unregistered
         var WrapperAddr = "0xf1wr000000000000000000000000000000000009";
-        var factory = MakeFactory();
+        // Only register Alice, Bob, TokenA — NOT WrapperAddr
+        var mock = new MockLoadGraph { RegisteredAvatars = new List<string> { Alice, Bob, TokenA } };
+        var factory = MakeFactory(mock);
         var bg = new BalanceGraph();
         int aliceId = AddressIdPool.IdOf(Alice);
         int tokenAId = AddressIdPool.IdOf(TokenA);
         bg.AddAvatar(aliceId);
-        // Alice holds TokenA (not wrapped)
         bg.AddBalance(aliceId, tokenAId, 500, isWrapped: false, isStatic: false);
 
         // Bob trusts WrapperAddr token AND TokenA
@@ -696,15 +696,13 @@ public class GraphFactoryTests
         var cg = factory.CreateCapacityGraph(bg, trust, request);
 
         int wrapperId = AddressIdPool.IdOf(WrapperAddr);
-        // WrapperAddr should be in AvatarNodes (from trust lookup)
-        Assert.That(cg.AvatarNodes.ContainsKey(wrapperId), Is.True,
-            "Wrapper address should be registered as avatar node from trust");
+        // Unregistered wrapper must NOT be in AvatarNodes (fail-closed filter)
+        Assert.That(cg.AvatarNodes.ContainsKey(wrapperId), Is.False,
+            "Unregistered wrapper should be excluded from AvatarNodes");
 
-        // But it should have NO outbound capacity edges (no balance → no H→Pool edges)
-        // This means it can never be a flow intermediary
-        var wrapperOutbound = cg.Edges.Where(e => e.From == wrapperId).ToList();
-        Assert.That(wrapperOutbound, Is.Empty,
-            "Wrapper with no balance should have no outbound edges → cannot be intermediary");
+        // Registered TokenA should still be in AvatarNodes
+        Assert.That(cg.AvatarNodes.ContainsKey(tokenAId), Is.True,
+            "Registered token should be in AvatarNodes");
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/NetworkStateUpdaterServiceTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/NetworkStateUpdaterServiceTests.cs
@@ -56,8 +56,9 @@ public class NetworkStateUpdaterServiceTests
         var mockLoadGraph = new MockLoadGraph();
         pool ??= new CapacityGraphPool(RouterAddr, mockLoadGraph);
         var logger = NullLogger<NetworkStateUpdaterService>.Instance;
+        var dummyLoadGraph = new LoadGraph("Host=localhost;Database=dummy;Username=x;Password=x", new Circles.Pathfinder.Settings());
 
-        return new NetworkStateUpdaterService(networkState, settings, logger, pool);
+        return new NetworkStateUpdaterService(networkState, settings, logger, pool, dummyLoadGraph);
     }
 
     #region ResetIncrementalState

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -38,6 +38,7 @@
         <None Remove="Data\Queries\stoppedAvatarsDeltaQuery.sql" />
         <None Remove="Data\Queries\blockHashQuery.sql" />
         <None Remove="Data\Queries\wrapperMappingQuery.sql" />
+        <None Remove="Data\Queries\registeredAvatarsCte.sql" />
         <EmbeddedResource Include="Data\Queries\balanceQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\groupQuery.sql" />
@@ -54,6 +55,7 @@
         <EmbeddedResource Include="Data\Queries\stoppedAvatarsDeltaQuery.sql" />
         <EmbeddedResource Include="Data\Queries\blockHashQuery.sql" />
         <EmbeddedResource Include="Data\Queries\wrapperMappingQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\registeredAvatarsCte.sql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -118,21 +118,33 @@ namespace Circles.Pathfinder.Data
 
         private static readonly ConcurrentDictionary<string, string> _queryCache = new();
 
+        // Shared CTE body loaded once — injected into queries via {{registered_avatars_cte_body}}
+        private static readonly Lazy<string> RegisteredAvatarsCteBody = new(() =>
+            ReadEmbeddedResource("registeredAvatarsCte.sql"));
+
+        private static string ReadEmbeddedResource(string resourceName)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            var fullResourceName = $"Circles.Pathfinder.Data.Queries.{resourceName}";
+
+            using var stream = assembly.GetManifestResourceStream(fullResourceName);
+            if (stream == null)
+                throw new FileNotFoundException($"SQL query resource not found: {fullResourceName}");
+
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd();
+        }
+
         private static string LoadQueryFromResource(string resourceName)
         {
             return _queryCache.GetOrAdd(resourceName, static name =>
             {
-                var assembly = Assembly.GetExecutingAssembly();
-                var fullResourceName = $"Circles.Pathfinder.Data.Queries.{name}";
+                var sql = ReadEmbeddedResource(name);
 
-                using var stream = assembly.GetManifestResourceStream(fullResourceName);
-                if (stream == null)
-                {
-                    throw new FileNotFoundException($"SQL query resource not found: {fullResourceName}");
-                }
+                if (sql.Contains("{{registered_avatars_cte_body}}"))
+                    sql = sql.Replace("{{registered_avatars_cte_body}}", RegisteredAvatarsCteBody.Value);
 
-                using var reader = new StreamReader(stream);
-                return reader.ReadToEnd();
+                return sql;
             });
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
@@ -2,12 +2,7 @@ with requested_avatars as (
     select unnest(@avatars::text[]) as avatar
 ),
 registered_avatars as materialized (
-    select organization as avatar from "CrcV2_RegisterOrganization"
-    union all
-    select "group" as avatar from "CrcV2_RegisterGroup"
-    union all
-    select avatar from "CrcV2_RegisterHuman"
-),
+{{registered_avatars_cte_body}}),
 static_wrapper_transfers as (
     select t."timestamp"
          , t."tokenAddress"

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
@@ -1,10 +1,5 @@
 WITH registered_avatars AS MATERIALIZED (
-    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
-    UNION ALL
-    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
-    UNION ALL
-    SELECT avatar FROM "CrcV2_RegisterHuman"
-)
+{{registered_avatars_cte_body}})
 SELECT "timestamp", "from", "to", "tokenAddress", "value", "isWrapped", "isStatic"
 FROM (
     SELECT

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
@@ -1,10 +1,5 @@
 with registered_avatars as materialized (
-    select organization as avatar from "CrcV2_RegisterOrganization"
-    union all
-    select "group" as avatar from "CrcV2_RegisterGroup"
-    union all
-    select avatar from "CrcV2_RegisterHuman"
-),
+{{registered_avatars_cte_body}}),
 static_wrapper_transfers as (
     select t."timestamp"
          , t."tokenAddress"

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
@@ -12,12 +12,7 @@
 --      blockNumber, transactionIndex, logIndex, transactionHash that were never read).
 
 with registered_avatars as materialized (
-    select organization as avatar from "CrcV2_RegisterOrganization"
-    union all
-    select "group" as avatar from "CrcV2_RegisterGroup"
-    union all
-    select avatar from "CrcV2_RegisterHuman"
-),
+{{registered_avatars_cte_body}}),
 
 -- Static ERC20 wrapper transfers (circlesType = 1)
 static_wrapper_transfers as (

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,10 +1,5 @@
 WITH registered_avatars AS MATERIALIZED (
-    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
-    UNION ALL
-    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
-    UNION ALL
-    SELECT avatar FROM "CrcV2_RegisterHuman"
-)
+{{registered_avatars_cte_body}})
 SELECT
     t.truster as group_address,
     t.trustee as trusted_token

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/registeredAvatarsCte.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/registeredAvatarsCte.sql
@@ -1,0 +1,5 @@
+    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT avatar FROM "CrcV2_RegisterHuman"

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
@@ -1,10 +1,5 @@
 WITH registered_avatars AS MATERIALIZED (
-    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
-    UNION ALL
-    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
-    UNION ALL
-    SELECT avatar FROM "CrcV2_RegisterHuman"
-)
+{{registered_avatars_cte_body}})
 SELECT d."erc20Wrapper", d.avatar
 FROM "CrcV2_ERC20WrapperDeployed" d
 JOIN registered_avatars ra ON ra.avatar = d.avatar

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -220,10 +220,18 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         LoadConsentedFlowFlags(capacityGraph, cachedGroupData);
 
         // STEP 1g: Add simulated consented avatars (for testing)
+        // Capped at 100 to limit AddressIdPool growth from user input
         if (request?.SimulatedConsentedAvatars != null && request.SimulatedConsentedAvatars.Count > 0)
         {
+            const int maxSimulatedConsentedAvatars = 100;
+            if (request.SimulatedConsentedAvatars.Count > maxSimulatedConsentedAvatars)
+            {
+                _logger.LogWarning("SimulatedConsentedAvatars count {Count} exceeds limit {Limit}, truncating",
+                    request.SimulatedConsentedAvatars.Count, maxSimulatedConsentedAvatars);
+            }
+
             int addedCount = 0;
-            foreach (var avatar in request.SimulatedConsentedAvatars)
+            foreach (var avatar in request.SimulatedConsentedAvatars.Take(maxSimulatedConsentedAvatars))
             {
                 if (string.IsNullOrWhiteSpace(avatar))
                     continue;
@@ -259,26 +267,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         var sourceEqualsSink = request?.Source?.Trim().ToLowerInvariant() == request?.Sink?.Trim().ToLowerInvariant();
 
-        // Setup key filters
-        var toTokensFilter = request?.ToTokens?
-                                 .Select(AddressIdPool.IdOf)
-                                 .ToHashSet()
-                             ?? new HashSet<int>();
-
-        var fromTokensFilter = request?.FromTokens?
-                                   .Select(AddressIdPool.IdOf)
-                                   .ToHashSet()
-                               ?? new HashSet<int>();
-
-        var excludedFromTokensFilter = request?.ExcludedFromTokens?
-                                           .Select(AddressIdPool.IdOf)
-                                           .ToHashSet()
-                                       ?? new HashSet<int>();
-
-        var excludedToTokensFilter = request?.ExcludedToTokens?
-                                         .Select(AddressIdPool.IdOf)
-                                         .ToHashSet()
-                                     ?? new HashSet<int>();
+        // Setup key filters — use TryIdOf to avoid permanently allocating unknown
+        // addresses in the global AddressIdPool (M2: unbounded memory growth).
+        // Addresses not already in the pool can't match any graph node.
+        var toTokensFilter = ResolveFilterAddresses(request?.ToTokens);
+        var fromTokensFilter = ResolveFilterAddresses(request?.FromTokens);
+        var excludedFromTokensFilter = ResolveFilterAddresses(request?.ExcludedFromTokens);
+        var excludedToTokensFilter = ResolveFilterAddresses(request?.ExcludedToTokens);
 
         // STEP 1h: Expand filters with wrapper IDs when withWrap is enabled.
         // User-provided filters contain avatar addresses, but wrapped balances use wrapper
@@ -303,22 +298,26 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         if (sourceId != null && capacityGraph.IsGroup(sourceId.Value))
         {
-            throw new ArgumentException($"Groups cannot be source. '{request!.Source}' is a group.");
+            _logger.LogWarning("Rejected source '{Source}': address is a group", request!.Source);
+            throw new ArgumentException("Invalid source address.");
         }
 
         if (sinkId != null && capacityGraph.IsGroup(sinkId.Value))
         {
-            throw new ArgumentException($"Groups cannot be sink. '{request!.Sink}' is a group.");
+            _logger.LogWarning("Rejected sink '{Sink}': address is a group", request!.Sink);
+            throw new ArgumentException("Invalid sink address.");
         }
 
         if (sourceId != null && capacityGraph.IsRouter(sourceId.Value))
         {
-            throw new ArgumentException($"Router cannot be source. '{request!.Source}' is the router.");
+            _logger.LogWarning("Rejected source '{Source}': address is the router", request!.Source);
+            throw new ArgumentException("Invalid source address.");
         }
 
         if (sinkId != null && capacityGraph.IsRouter(sinkId.Value))
         {
-            throw new ArgumentException($"Router cannot be sink. '{request!.Sink}' is the router.");
+            _logger.LogWarning("Rejected sink '{Sink}': address is the router", request!.Sink);
+            throw new ArgumentException("Invalid sink address.");
         }
 
         // STEP 2a: Filter ToTokens to only include tokens the sink actually trusts
@@ -972,22 +971,41 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         // every token that is trusted by somebody — only if registered
         // (defense-in-depth: SQL queries should already filter, but guard against leaks)
+        // Fail-closed: if RegisteredAvatarIds is empty, no trusted tokens are added.
         var registered = capacityGraph.RegisteredAvatarIds;
         if (registered.Count == 0)
         {
-            _logger.LogWarning("RegisteredAvatarIds is empty — skipping trusted-token registration filter");
+            _logger.LogError("RegisteredAvatarIds is empty — no trusted tokens will be added to graph");
         }
 
         foreach (var trustedSet in trustLookup.Values)
         {
             foreach (var tokenId in trustedSet)
             {
-                if (registered.Count == 0 || registered.Contains(tokenId))
+                if (registered.Contains(tokenId))
                 {
                     capacityGraph.AddAvatar(tokenId);
                 }
             }
         }
+    }
+
+    /// <summary>
+    /// Resolves user-supplied filter addresses to AddressIdPool IDs without allocating
+    /// new entries for unknown addresses (prevents unbounded memory growth from attacker input).
+    /// </summary>
+    private static HashSet<int> ResolveFilterAddresses(IReadOnlyList<string>? addresses)
+    {
+        if (addresses == null || addresses.Count == 0)
+            return new HashSet<int>();
+
+        var result = new HashSet<int>(addresses.Count);
+        foreach (var addr in addresses)
+        {
+            if (AddressIdPool.TryIdOf(addr, out var id))
+                result.Add(id);
+        }
+        return result;
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Six fixes from the 2026-03-27 multi-angle pathfinder audit:

- **H6**: Eliminate dual Npgsql connection pools — inject DI `LoadGraph` into `NetworkStateUpdaterService` instead of creating a second default pool (120 connections → 20)
- **H5**: Force full refresh on incremental update failure — `_lastFullRefreshBlock = -1` on exception prevents double-counted deltas from non-idempotent `ApplyTransfer`
- **M2**: Prevent unbounded `AddressIdPool` growth — `TryIdOf` for user-supplied filter addresses, cap `simulatedConsentedAvatars` at 100
- **M4**: Remove avatar type enumeration from error messages — generic "Invalid source/sink address" to clients, detailed log server-side
- **Fail-closed `AddAllAvatarNodes`**: Remove `Count == 0` bypass that silently disabled registration filter when `RegisteredAvatarIds` was empty
- **C6**: Deduplicate `registered_avatars` CTE — extract 3-table UNION into `registeredAvatarsCte.sql` template with `{{registered_avatars_cte_body}}` substitution (was copy-pasted in 6 SQL files)

Wrapper→avatar resolution (Fix 3) was already addressed in PR #289 — skipped here.

## Test plan

- [x] Full test suite: 1158 passed, 0 failed (917 pathfinder + 18 index + 86 common + 137 rpc)
- [x] Two test fixtures updated for fail-closed behavior (`CreateCapacityGraph_AddsAllAvatarNodesFromBalanceAndTrust`, `GraphFactory_UnregisteredWrapperTrustee_CannotBeFlowIntermediary`)
- [ ] Deploy to staging and verify pathfinder serves requests normally
- [ ] Check Prometheus metrics: `circles_db_query_duration_seconds` still reports (single pool)
- [ ] Verify no `RegisteredAvatarIds is empty` errors in logs