### PR TITLE
feat(rpc): circles_getBlockByTimestamp + fix In/NotIn filter predicates

### DIFF
--- a/scripts/rpc-regression.sh
+++ b/scripts/rpc-regression.sh
@@ -284,36 +284,31 @@ if [[ "$SUBSCRIPTION_ENABLED" == "true" ]]; then
 fi
 
 # Start both test runs simultaneously
+# test-rpc.sh exits 1 when individual tests fail — that's expected.
+# We only abort if the output files weren't created (real script failure).
 (
-    if ! "$SCRIPT_DIR/test-rpc.sh" "$ENV_A_URL" --json --json-dir "$ENV_A_OUTPUT_DIR" > "$ENV_A_LOG" 2>&1; then
-        echo -e "${RED}Error: Failed to run tests against ${LABEL_A}${NC}" >&2
-        exit 1
-    fi
+    "$SCRIPT_DIR/test-rpc.sh" "$ENV_A_URL" --json --json-dir "$ENV_A_OUTPUT_DIR" > "$ENV_A_LOG" 2>&1 || true
 ) &
 ENV_A_PID=$!
 
 (
-    if ! "$SCRIPT_DIR/test-rpc.sh" "$ENV_B_URL" --json --json-dir "$ENV_B_OUTPUT_DIR" > "$ENV_B_LOG" 2>&1; then
-        echo -e "${RED}Error: Failed to run tests against ${LABEL_B}${NC}" >&2
-        exit 1
-    fi
+    "$SCRIPT_DIR/test-rpc.sh" "$ENV_B_URL" --json --json-dir "$ENV_B_OUTPUT_DIR" > "$ENV_B_LOG" 2>&1 || true
 ) &
 ENV_B_PID=$!
 
 # Wait for both to complete
 wait $ENV_A_PID
-ENV_A_EXIT=$?
 wait $ENV_B_PID
-ENV_B_EXIT=$?
 
-if [[ $ENV_A_EXIT -ne 0 ]]; then
-    echo -e "${RED}Error: Failed to run tests against ${LABEL_A}${NC}"
+# Verify output was actually produced (catches real failures like connection refused)
+if [[ ! -f "$ENV_A_LOG" ]] || ! command grep -q '"summary"' "$ENV_A_LOG" 2>/dev/null; then
+    echo -e "${RED}Error: ${LABEL_A} test run produced no results${NC}"
     echo -e "${RED}Check $ENV_A_LOG for details${NC}"
     exit 1
 fi
 
-if [[ $ENV_B_EXIT -ne 0 ]]; then
-    echo -e "${RED}Error: Failed to run tests against ${LABEL_B}${NC}"
+if [[ ! -f "$ENV_B_LOG" ]] || ! command grep -q '"summary"' "$ENV_B_LOG" 2>/dev/null; then
+    echo -e "${RED}Error: ${LABEL_B} test run produced no results${NC}"
     echo -e "${RED}Check $ENV_B_LOG for details${NC}"
     exit 1
 fi

--- a/scripts/test-http.sh
+++ b/scripts/test-http.sh
@@ -95,7 +95,7 @@ run_test() {
     local data="${5:-}"
 
     local url="${BASE_URL}${endpoint}"
-    local curl_args=(-s -w "\n%{http_code}" -X "$method")
+    local curl_args=(-s -w "\n%{http_code}" --max-time 15 -X "$method")
 
     if [[ -n "$data" ]]; then
         curl_args+=(-H "Content-Type: application/json" -d "$data")
@@ -116,19 +116,19 @@ run_test() {
     local result="fail"
     if [[ "$status" == "$expected_status" ]]; then
         result="pass"
-        ((PASSED++))
+        ((++PASSED))
         if [[ "$JSON_OUTPUT" != "true" ]]; then
             log_pass "$name (HTTP $status)"
         fi
     elif [[ "$status" == "000" ]]; then
         result="skip"
-        ((SKIPPED++))
+        ((++SKIPPED))
         if [[ "$JSON_OUTPUT" != "true" ]]; then
             log_skip "$name - Connection failed"
         fi
     else
         result="fail"
-        ((FAILED++))
+        ((++FAILED))
         if [[ "$JSON_OUTPUT" != "true" ]]; then
             log_fail "$name (expected $expected_status, got $status)"
         fi

--- a/scripts/test-rpc.sh
+++ b/scripts/test-rpc.sh
@@ -1923,7 +1923,7 @@ run_test_json "gas_estimation" "eth_estimateGas (with block param)" '{
 run_test_json "gas_estimation" "eth_estimateGas (EIP-1559 gas params)" '{
   "jsonrpc": "2.0",
   "method": "eth_estimateGas",
-  "params": [{"from": "'"$TEST_ADDR_2"'", "to": "'"$ROUTER_CONTRACT"'", "data": "0x2c3df1de000000000000000000000000'"${GROUP_ADDR_1:2}"'0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000100000000000000000000000042cedde51198d1773590311e2a340dc06b24cb37", "maxFeePerGas": "0x1000", "maxPriorityFeePerGas": "0x36"}],
+  "params": [{"from": "'"$TEST_ADDR_2"'", "to": "'"$ROUTER_CONTRACT"'", "data": "0x2c3df1de000000000000000000000000'"${GROUP_ADDR_1:2}"'0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000100000000000000000000000042cedde51198d1773590311e2a340dc06b24cb37", "maxFeePerGas": "0x30D40", "maxPriorityFeePerGas": "0x2710"}],
   "id": 1
 }'
 
@@ -1931,7 +1931,7 @@ run_test_json "gas_estimation" "eth_estimateGas (EIP-1559 gas params)" '{
 run_test_json "gas_estimation" "eth_estimateGas (full viem params)" '{
   "jsonrpc": "2.0",
   "method": "eth_estimateGas",
-  "params": [{"from": "'"$TEST_ADDR_2"'", "to": "'"$ROUTER_CONTRACT"'", "data": "0x2c3df1de000000000000000000000000'"${GROUP_ADDR_1:2}"'0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000100000000000000000000000042cedde51198d1773590311e2a340dc06b24cb37", "maxFeePerGas": "0x1000", "maxPriorityFeePerGas": "0x36", "nonce": "0x1"}],
+  "params": [{"from": "'"$TEST_ADDR_2"'", "to": "'"$ROUTER_CONTRACT"'", "data": "0x2c3df1de000000000000000000000000'"${GROUP_ADDR_1:2}"'0000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000000100000000000000000000000042cedde51198d1773590311e2a340dc06b24cb37", "maxFeePerGas": "0x30D40", "maxPriorityFeePerGas": "0x2710", "nonce": "0x1"}],
   "id": 1
 }'
 
@@ -1954,7 +1954,7 @@ run_test_json "gas_estimation" "eth_estimateGas (Safe execTransaction)" '{
 run_test_json "gas_estimation" "eth_estimateGas (Safe execTx + EIP-1559)" '{
   "jsonrpc": "2.0",
   "method": "eth_estimateGas",
-  "params": [{"from": "'"$SAFE_EXEC_OWNER"'", "to": "'"$HIGH_ACTIVITY_ADDR_1"'", "data": "'"$SAFE_EXEC_TX"'", "maxFeePerGas": "0x1000", "maxPriorityFeePerGas": "0x36"}],
+  "params": [{"from": "'"$SAFE_EXEC_OWNER"'", "to": "'"$HIGH_ACTIVITY_ADDR_1"'", "data": "'"$SAFE_EXEC_TX"'", "maxFeePerGas": "0x30D40", "maxPriorityFeePerGas": "0x2710"}],
   "id": 1
 }'
 

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -147,8 +147,9 @@ public class PathfinderGraphController : ControllerBase
             var account = kvp.Key[..separatorIndex];
             var tokenAddress = kvp.Key[(separatorIndex + 1)..];
 
-            // Only include balances for registered V2 avatars
-            if (!_caches.V2Avatars.ContainsKey(account))
+            // Only include balances for registered V2 avatars (humans, orgs, or groups)
+            if (!_caches.V2Avatars.ContainsKey(account)
+                && !_caches.Groups.ContainsKey(account))
                 continue;
 
             // Determine if this is a wrapper token
@@ -164,6 +165,14 @@ public class PathfinderGraphController : ControllerBase
                     && !_caches.Groups.ContainsKey(wrapperInfo.Avatar))
                     continue;
                 isStatic = wrapperInfo.CirclesType == 1;
+            }
+            else
+            {
+                // Native ERC1155: tokenAddress IS the token owner's address.
+                // Must be a registered avatar — unregistered tokens cause on-chain reverts.
+                if (!_caches.V2Avatars.ContainsKey(tokenAddress)
+                    && !_caches.Groups.ContainsKey(tokenAddress))
+                    continue;
             }
 
             // Convert decimal Circles → attoCircles BigInteger
@@ -302,6 +311,11 @@ public class PathfinderGraphController : ControllerBase
 
             // Skip revoked trust
             if (expiryTime > 0 && expiryTime <= now)
+                continue;
+
+            // Trustee must be a registered avatar — unregistered tokens cause on-chain reverts
+            if (!_caches.V2Avatars.ContainsKey(trustee)
+                && !_caches.Groups.ContainsKey(trustee))
                 continue;
 
             groupTrusts.Add(new PathfinderGroupTrustRow(

--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -79,6 +79,36 @@ public class MaxFlowResponse
     [JsonIgnore]
     public int ConsentSafetyNetRejected { get; set; }
 
+    /// <summary>
+    /// Pipeline request ID for log correlation across canary layers.
+    /// Not serialized — used internally for metrics and simulation canary.
+    /// </summary>
+    [JsonIgnore]
+    public string? ReqId { get; set; }
+
+    /// <summary>
+    /// Canary: number of Hub.sol rule violations detected by HubContractValidator.
+    /// Non-zero means the pathfinder produced output that would revert on-chain.
+    /// Not serialized — used internally for metrics.
+    /// </summary>
+    [JsonIgnore]
+    public int ValidationErrors { get; set; }
+
+    /// <summary>
+    /// Canary: rule names of validation violations, for per-rule metric labeling.
+    /// Not serialized — used internally for metrics.
+    /// </summary>
+    [JsonIgnore]
+    public IReadOnlyList<string>? ValidationViolationRules { get; set; }
+
+    /// <summary>
+    /// Block number of the graph snapshot used for this computation.
+    /// Lets callers detect staleness by comparing to the current chain head.
+    /// </summary>
+    [JsonPropertyName("graphBlock")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public long GraphBlock { get; set; }
+
     public MaxFlowResponse(string maxFlow, List<TransferPathStep> transfers, DebugPipelineStages? debug = null)
     {
         MaxFlow = maxFlow;

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -15,7 +15,8 @@ internal sealed record CanaryWorkItem(
     string Source,
     string Sink,
     long GraphBlock,
-    List<TransferPathStep> Transfers);
+    List<TransferPathStep> Transfers,
+    IReadOnlyDictionary<string, string>? WrapperToAvatar = null);
 
 /// <summary>
 /// Background service that simulates pathfinder results via eth_call against the local
@@ -116,7 +117,10 @@ internal sealed class SimulationCanaryService : BackgroundService
         string calldata;
         try
         {
-            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers);
+            // Hub.sol expects avatar addresses as token owners, not wrapper contract addresses.
+            // The SDK does this conversion client-side; the canary must do it before simulation.
+            var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
+            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, transfers);
         }
         catch (Exception ex)
         {
@@ -171,6 +175,9 @@ internal sealed class SimulationCanaryService : BackgroundService
 
             if (json.ValueKind == JsonValueKind.Undefined || json.ValueKind == JsonValueKind.Null)
             {
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: empty/null response from eth_call — node may be misconfigured",
+                    item.ReqId);
                 SimulationTotal.WithLabels("rpc_empty_response").Inc();
                 return;
             }
@@ -218,5 +225,40 @@ internal sealed class SimulationCanaryService : BackgroundService
         }
 
         QueueDepth.Set(_channel.Reader.Count);
+    }
+
+    /// <summary>
+    /// Replaces wrapper contract addresses in TokenOwner fields with the underlying avatar address.
+    /// Hub.sol's operateFlowMatrix expects avatar addresses (circlesId), not wrapper contracts.
+    /// Returns the original list unchanged if no mapping is provided or no wrappers are found.
+    /// </summary>
+    private static IReadOnlyList<TransferPathStep> ResolveWrapperTokenOwners(
+        List<TransferPathStep> transfers,
+        IReadOnlyDictionary<string, string>? wrapperToAvatar)
+    {
+        if (wrapperToAvatar == null || wrapperToAvatar.Count == 0)
+            return transfers;
+
+        var resolved = new List<TransferPathStep>(transfers.Count);
+        foreach (var t in transfers)
+        {
+            var tokenOwner = t.TokenOwner.ToLowerInvariant();
+            if (wrapperToAvatar.TryGetValue(tokenOwner, out var avatar))
+            {
+                resolved.Add(new TransferPathStep
+                {
+                    From = t.From,
+                    To = t.To,
+                    TokenOwner = avatar,
+                    Value = t.Value
+                });
+            }
+            else
+            {
+                resolved.Add(t);
+            }
+        }
+
+        return resolved;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -1,0 +1,222 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Channels;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Simulation;
+using Prometheus;
+
+namespace Circles.Pathfinder.Host.Canary;
+
+/// <summary>
+/// Work item enqueued by FindPathHandler for background simulation.
+/// </summary>
+internal sealed record CanaryWorkItem(
+    string ReqId,
+    string Source,
+    string Sink,
+    long GraphBlock,
+    List<TransferPathStep> Transfers);
+
+/// <summary>
+/// Background service that simulates pathfinder results via eth_call against the local
+/// Nethermind node. Detects on-chain reverts that the pathfinder missed.
+///
+/// Architecture: bounded Channel (fire-and-forget, never blocks the response path).
+/// If the queue is full, the new work item is dropped (canary is best-effort).
+/// </summary>
+internal sealed class SimulationCanaryService : BackgroundService
+{
+    private readonly Channel<CanaryWorkItem> _channel;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<SimulationCanaryService> _log;
+    private readonly string _rpcUrl;
+
+    // Metrics
+    private static readonly Counter SimulationTotal = Metrics.CreateCounter(
+        "circles_canary_simulation_total",
+        "Total eth_call simulations attempted",
+        new CounterConfiguration { LabelNames = new[] { "result" } });
+
+    private static readonly Counter SimulationRevertTotal = Metrics.CreateCounter(
+        "circles_canary_simulation_revert_total",
+        "Simulated reverts by category and label",
+        new CounterConfiguration { LabelNames = new[] { "category", "label" } });
+
+    private static readonly Histogram SimulationDuration = Metrics.CreateHistogram(
+        "circles_canary_simulation_duration_seconds",
+        "eth_call simulation duration",
+        new HistogramConfiguration { Buckets = Histogram.ExponentialBuckets(0.005, 2, 10) });
+
+    private static readonly Gauge QueueDepth = Metrics.CreateGauge(
+        "circles_canary_simulation_queue_depth",
+        "Current number of pending simulation work items");
+
+    private static readonly Counter QueueDropped = Metrics.CreateCounter(
+        "circles_canary_simulation_queue_dropped_total",
+        "Work items dropped because the simulation queue was full");
+
+    public SimulationCanaryService(
+        Settings settings,
+        ILogger<SimulationCanaryService> log,
+        IHttpClientFactory httpClientFactory)
+    {
+        _log = log;
+        _httpClientFactory = httpClientFactory;
+        _rpcUrl = settings.NethermindRpcUrl;
+
+        int queueSize = int.TryParse(
+            Environment.GetEnvironmentVariable("CANARY_SIMULATION_QUEUE_SIZE"), out var qs) ? qs : 10;
+
+        // DropWrite: when queue is full, TryWrite returns false for the NEW item.
+        // Oldest items are more valuable (closer to the graph block actually served).
+        _channel = Channel.CreateBounded<CanaryWorkItem>(new BoundedChannelOptions(queueSize)
+        {
+            FullMode = BoundedChannelFullMode.DropWrite,
+            SingleReader = true
+        });
+    }
+
+    /// <summary>
+    /// Enqueue a work item for background simulation. Returns false if queue is full (dropped).
+    /// </summary>
+    public bool TryEnqueue(CanaryWorkItem item)
+    {
+        if (_channel.Writer.TryWrite(item))
+        {
+            QueueDepth.Set(_channel.Reader.Count);
+            return true;
+        }
+
+        QueueDropped.Inc();
+        return false;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _log.LogInformation("SimulationCanary started — rpcUrl={RpcUrl}, queue listening", _rpcUrl);
+
+        await foreach (var item in _channel.Reader.ReadAllAsync(stoppingToken))
+        {
+            QueueDepth.Set(_channel.Reader.Count);
+
+            try
+            {
+                await SimulateAsync(item, stoppingToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _log.LogError(ex, "[{ReqId}] SimulationCanary: unexpected error during simulation", item.ReqId);
+                SimulationTotal.WithLabels("error").Inc();
+            }
+        }
+    }
+
+    private async Task SimulateAsync(CanaryWorkItem item, CancellationToken ct)
+    {
+        string calldata;
+        try
+        {
+            calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, item.Transfers);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex,
+                "[{ReqId}] SimulationCanary: calldata encoding failed from={Source} to={Sink} block={Block} steps={Steps}",
+                item.ReqId, item.Source, item.Sink, item.GraphBlock, item.Transfers.Count);
+            SimulationTotal.WithLabels("encode_error").Inc();
+            return;
+        }
+
+        using var timer = SimulationDuration.NewTimer();
+
+        try
+        {
+            using var client = _httpClientFactory.CreateClient("canary-simulation");
+            var rpcRequest = new
+            {
+                jsonrpc = "2.0",
+                method = "eth_call",
+                @params = new object[]
+                {
+                    new { from = item.Source, to = FlowMatrixEncoder.CirclesHubAddress, data = calldata },
+                    "latest"
+                },
+                id = 1
+            };
+
+            var response = await client.PostAsJsonAsync(_rpcUrl, rpcRequest, ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: eth_call HTTP {StatusCode} from={Source} to={Sink}",
+                    item.ReqId, (int)response.StatusCode, item.Source, item.Sink);
+                SimulationTotal.WithLabels("rpc_http_error").Inc();
+                return;
+            }
+
+            JsonElement json;
+            try
+            {
+                json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            }
+            catch (JsonException jex)
+            {
+                _log.LogWarning(jex,
+                    "[{ReqId}] SimulationCanary: non-JSON response from={Source} to={Sink}",
+                    item.ReqId, item.Source, item.Sink);
+                SimulationTotal.WithLabels("rpc_parse_error").Inc();
+                return;
+            }
+
+            if (json.ValueKind == JsonValueKind.Undefined || json.ValueKind == JsonValueKind.Null)
+            {
+                SimulationTotal.WithLabels("rpc_empty_response").Inc();
+                return;
+            }
+
+            if (json.TryGetProperty("error", out var error))
+            {
+                var revertData = error.TryGetProperty("data", out var d) ? d.GetString() : null;
+                var revertMsg = error.TryGetProperty("message", out var m) ? m.GetString() : "unknown";
+
+                var (category, label) = RevertClassifier.Classify(revertData ?? revertMsg);
+
+                SimulationTotal.WithLabels("revert").Inc();
+                SimulationRevertTotal.WithLabels(category, label).Inc();
+
+                // Full replay context: everything needed to reproduce
+                _log.LogError(
+                    "[{ReqId}] SimulationCanary: REVERT category={Category} label={Label} " +
+                    "from={Source} to={Sink} graphBlock={Block} simBlock=latest steps={Steps} revert={Revert}",
+                    item.ReqId, category, label,
+                    item.Source, item.Sink, item.GraphBlock,
+                    item.Transfers.Count, revertMsg);
+
+                if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)
+                {
+                    _log.LogWarning(
+                        "[{ReqId}] SimulationCanary: revert has message but no data field — classification may be degraded",
+                        item.ReqId);
+                }
+            }
+            else
+            {
+                SimulationTotal.WithLabels("success").Inc();
+            }
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw; // propagate shutdown
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "[{ReqId}] SimulationCanary: eth_call failed (network/timeout) from={Source} to={Sink}",
+                item.ReqId, item.Source, item.Sink);
+            SimulationTotal.WithLabels("rpc_error").Inc();
+        }
+
+        QueueDepth.Set(_channel.Reader.Count);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Text.Json;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Host.Canary;
 using Circles.Pathfinder.Host.State;
 using Nethermind.Int256;
 using static Circles.Pathfinder.Tracing;
@@ -16,7 +17,8 @@ namespace Circles.Pathfinder.Host;
 internal sealed class FindPathHandler(
     Settings settings,
     SemaphoreSlim semaphore,
-    ILogger<FindPathHandler> log)
+    ILogger<FindPathHandler> log,
+    SimulationCanaryService? simulationCanary = null)
 {
     private const int MaxArrayEntries = 1000;
 
@@ -140,13 +142,42 @@ internal sealed class FindPathHandler(
 
             FindPathMetrics.SolverStatusTotal.WithLabels("success").Inc();
 
-            // Record consent metrics if applicable
+            // Record consent + canary metrics if applicable
             if (result is MaxFlowResponse mfr)
             {
+                // Stamp graph block for staleness detection (use graph's own block, not
+                // state.Current.Block which may have advanced during solving)
+                mfr.GraphBlock = h.Graph.Block;
+
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
                 if (mfr.ConsentSafetyNetRejected > 0)
                     FindPathMetrics.ConsentSafetyNetTriggeredTotal.Inc(mfr.ConsentSafetyNetRejected);
+
+                // Canary: record Hub.sol rule violations (observe-only)
+                if (mfr.ValidationErrors > 0)
+                {
+                    FindPathMetrics.CanaryValidationFailureTotal.WithLabels("any").Inc();
+                    if (mfr.ValidationViolationRules != null)
+                    {
+                        foreach (var rule in mfr.ValidationViolationRules)
+                            FindPathMetrics.CanaryValidationFailureTotal.WithLabels(rule).Inc();
+                    }
+                }
+
+                // Simulation canary: enqueue for async eth_call validation
+                if (simulationCanary != null
+                    && mfr.Transfers.Count > 0
+                    && !string.IsNullOrEmpty(request.Source)
+                    && !string.IsNullOrEmpty(request.Sink))
+                {
+                    simulationCanary.TryEnqueue(new CanaryWorkItem(
+                        ReqId: mfr.ReqId ?? Guid.NewGuid().ToString("N")[..8],
+                        Source: request.Source,
+                        Sink: request.Sink,
+                        GraphBlock: mfr.GraphBlock,
+                        Transfers: new List<TransferPathStep>(mfr.Transfers))); // defensive copy
+                }
             }
 
             return Results.Ok(result);

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -165,18 +165,47 @@ internal sealed class FindPathHandler(
                     }
                 }
 
-                // Simulation canary: enqueue for async eth_call validation
+                // Simulation canary: enqueue for async eth_call validation.
+                // Skip when request has simulated inputs — those paths depend on
+                // state that doesn't exist on-chain, so eth_call would always revert.
+                bool hasSimulated = (request.SimulatedBalances?.Count > 0)
+                                    || (request.SimulatedTrusts?.Count > 0);
+
                 if (simulationCanary != null
                     && mfr.Transfers.Count > 0
                     && !string.IsNullOrEmpty(request.Source)
-                    && !string.IsNullOrEmpty(request.Sink))
+                    && !string.IsNullOrEmpty(request.Sink)
+                    && !hasSimulated)
                 {
+                    // Build wrapper→avatar string mapping for the canary to resolve
+                    // wrapper contract addresses back to avatar addresses before eth_call.
+                    // Wrapped in try-catch: canary is best-effort and must never affect the response.
+                    Dictionary<string, string>? wrapperMap = null;
+                    try
+                    {
+                        if (h.Graph.WrapperToAvatar.Count > 0)
+                        {
+                            wrapperMap = new Dictionary<string, string>(
+                                h.Graph.WrapperToAvatar.Count, StringComparer.OrdinalIgnoreCase);
+                            foreach (var kv in h.Graph.WrapperToAvatar)
+                            {
+                                wrapperMap[AddressIdPool.StringOf(kv.Key)] = AddressIdPool.StringOf(kv.Value);
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        log.LogError(ex, "Failed to build wrapper map for canary — simulation will run without wrapper resolution");
+                        wrapperMap = null;
+                    }
+
                     simulationCanary.TryEnqueue(new CanaryWorkItem(
                         ReqId: mfr.ReqId ?? Guid.NewGuid().ToString("N")[..8],
                         Source: request.Source,
                         Sink: request.Sink,
                         GraphBlock: mfr.GraphBlock,
-                        Transfers: new List<TransferPathStep>(mfr.Transfers))); // defensive copy
+                        Transfers: new List<TransferPathStep>(mfr.Transfers), // defensive copy
+                        WrapperToAvatar: wrapperMap));
                 }
             }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
@@ -36,4 +36,11 @@ internal class FindPathMetrics
         Metrics.CreateCounter(
             "circles_consent_safetynet_triggered_total",
             "Times ValidateConsentedFlow safety net removed edges (indicates path-level filter gap)");
+
+    // Canary: validation failures detected by HubContractValidator (observe-only, never blocks)
+    public static readonly Counter CanaryValidationFailureTotal =
+        Metrics.CreateCounter(
+            "circles_canary_validation_failure_total",
+            "Hub.sol rule violations detected in pathfinder output (observe-only)",
+            new CounterConfiguration { LabelNames = new[] { "rule" } });
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -79,6 +79,15 @@ internal static class GraphUpdateMetrics
         "circles_consented_avatars_count",
         "Number of consented avatars in the capacity graph");
 
+    // Router trust coverage: total group-token edge candidates vs filtered
+    public static readonly Gauge RouterTrustCoverageTotal = Metrics.CreateGauge(
+        "circles_router_trust_coverage_total",
+        "Total group-token collateral edge candidates in the capacity graph");
+
+    public static readonly Gauge RouterTrustFilteredCount = Metrics.CreateGauge(
+        "circles_router_trust_filtered_count",
+        "Group-token edges filtered due to missing Router trust");
+
     // O4: DB query duration — labeled by query name (balances, trust, groups, group_trusts, consented_flow)
     public static readonly Histogram DbQueryDuration = Metrics.CreateHistogram(
         "circles_db_query_duration_seconds",

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -8,6 +8,7 @@ using Circles.Pathfinder;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host;
+using Circles.Pathfinder.Host.Canary;
 using Circles.Pathfinder.Host.State;
 using Circles.Pathfinder.Nodes;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -84,6 +85,18 @@ builder.Services.AddSingleton<CapacityGraphPool>(provider =>
 builder.Services.AddSingleton<V2Pathfinder>();
 builder.Services.AddSingleton<FindPathHandler>();
 builder.Services.AddHttpContextAccessor();
+
+// Simulation canary: async eth_call validation (opt-in via CANARY_SIMULATION_ENABLED=true)
+var canaryEnabled = string.Equals(
+    Environment.GetEnvironmentVariable("CANARY_SIMULATION_ENABLED"), "true",
+    StringComparison.OrdinalIgnoreCase);
+if (canaryEnabled)
+{
+    builder.Services.AddHttpClient("canary-simulation", c => c.Timeout = TimeSpan.FromSeconds(30));
+    builder.Services.AddSingleton<SimulationCanaryService>();
+    builder.Services.AddHostedService(p => p.GetRequiredService<SimulationCanaryService>());
+    Console.WriteLine("* Simulation canary enabled");
+}
 
 builder.Services.AddHostedService<NetworkStateUpdaterService>();
 builder.Services.AddHostedService<LogStatsService>();

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -144,6 +144,8 @@ public class NetworkStateUpdaterService : BackgroundService
                     GraphUpdateMetrics.EdgeCount.Set(currentSnap.Base.Edges.Count);
                     GraphUpdateMetrics.GroupCount.Set(currentSnap.Base.GroupNodes.Count);
                     GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
+                    GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
+                    GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
                 }
 
                 GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
@@ -636,6 +638,8 @@ public class NetworkStateUpdaterService : BackgroundService
                 GraphUpdateMetrics.EdgeCount.Set(currentSnap.Base.Edges.Count);
                 GraphUpdateMetrics.GroupCount.Set(currentSnap.Base.GroupNodes.Count);
                 GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
+                GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
+                GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
             }
             GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
@@ -213,10 +213,11 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Router edges should always be allowed through.
+    /// Consented Avatar→Router edge is rejected by safety net because Router
+    /// lacks advancedUsageFlags. Only Router→Avatar edge survives.
     /// </summary>
     [Test]
-    public void RouterEdges_AlwaysValid()
+    public void ConsentedAvatarToRouter_RejectedBySafetyNet()
     {
         // Arrange
         var capacityGraph = CreateCapacityGraph(
@@ -234,8 +235,8 @@ public class ConsentedFlowValidationTests
         // Act
         var result = ValidateConsentedFlow(edges, capacityGraph);
 
-        // Assert - router edges should pass through
-        Assert.That(result, Has.Count.EqualTo(2));
+        // Assert - consented Avatar→Router is caught; only Router→Bob survives
+        Assert.That(result, Has.Count.EqualTo(1));
     }
 
     /// <summary>
@@ -535,36 +536,127 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Group edges should NOT count as consent violations because they become router
-    /// edges after InsertRouterInTransfers, and router bypasses consent checks.
+    /// Non-consented Avatar→Group edges are skipped (become Avatar→Router→Group, standard trust applies).
     /// </summary>
     [Test]
     [Category("consented-flow")]
-    public void PathLevel_GroupEdges_NotCountedAsViolation()
+    public void PathLevel_NonConsentedAvatarToGroupEdge_Skipped()
     {
-        // Arrange: Alice(consented) → GroupX (group node)
         var groupId = AddressIdPool.IdOf("0xcf08consent_group");
 
         var capacityGraph = CreateCapacityGraph(
-            consentedAvatars: new HashSet<int> { Alice },
+            consentedAvatars: new HashSet<int> { Bob }, // Alice is NOT consented
             trustLookup: new Dictionary<int, HashSet<int>>
             {
-                { Alice, new HashSet<int>() } // Alice doesn't trust group — but it doesn't matter
+                { Alice, new HashSet<int>() }
             }
         );
         capacityGraph.AddGroup(groupId);
 
         var pathEdges = new List<(int From, int To, int Token, long Flow)>
         {
-            (Alice, groupId, AliceToken, 500) // Will become Avatar→Router→Group
+            (Alice, groupId, AliceToken, 500)
+        };
+
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        Assert.That(hasViolation, Is.False,
+            "Non-consented Avatar→Group edges should be skipped");
+    }
+
+    /// <summary>
+    /// Consented Avatar→Group edges are NOT skipped — after Router insertion,
+    /// Avatar(consented)→Router fails isPermittedFlow (Router lacks advancedUsageFlags).
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_ConsentedAvatarToGroupEdge_DetectsViolation()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf08consent_group2");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { Alice },
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                { Alice, new HashSet<int>() }
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (Alice, groupId, AliceToken, 500) // Consented→Group → will become Consented→Router → fails
+        };
+
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        Assert.That(hasViolation, Is.True,
+            "Consented Avatar→Group should be flagged — Router lacks advancedUsageFlags");
+    }
+
+    /// <summary>
+    /// Group→Avatar (mint) edges stay as-is after InsertRouterInTransfers and
+    /// must be consent-checked. Groups don't have advancedUsageFlags, so the
+    /// check passes — but the edge must NOT be skipped.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_GroupToAvatarEdge_IsConsentChecked_PassesWhenGroupNotConsented()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf09consent_group_mint");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { Alice }, // Only Alice consented, not the group
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                { groupId, new HashSet<int> { AliceToken } }
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (groupId, Alice, AliceToken, 500) // Group→Avatar mint edge (stays as-is)
         };
 
         // Act
         bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
 
-        // Assert — group edge should be skipped
+        // Assert — Group is not consented, so standard trust is sufficient → no violation
         Assert.That(hasViolation, Is.False,
-            "Group edges should be skipped (they become router edges which bypass consent)");
+            "Group→Avatar mint edge should pass: group has no advancedUsageFlags");
+    }
+
+    /// <summary>
+    /// Hypothetical: if a group DID have consented flow and didn't trust the recipient,
+    /// the consent check should catch it. This verifies the edge is NOT skipped.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void PathLevel_GroupToAvatarEdge_DetectsViolation_WhenGroupIsConsented()
+    {
+        var groupId = AddressIdPool.IdOf("0xcf10consent_group_consented");
+
+        var capacityGraph = CreateCapacityGraph(
+            consentedAvatars: new HashSet<int> { groupId }, // Group has consented flow
+            trustLookup: new Dictionary<int, HashSet<int>>
+            {
+                // Group does NOT trust Alice
+            }
+        );
+        capacityGraph.AddGroup(groupId);
+
+        var pathEdges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (groupId, Alice, AliceToken, 500) // Group(consented)→Avatar — group doesn't trust Alice
+        };
+
+        // Act
+        bool hasViolation = PathHasConsentViolation(pathEdges, capacityGraph);
+
+        // Assert — group is consented but doesn't trust recipient → violation detected
+        Assert.That(hasViolation, Is.True,
+            "Group→Avatar edge with consented group that doesn't trust recipient should be caught");
     }
 
     /// <summary>
@@ -927,109 +1019,17 @@ public class ConsentedFlowValidationTests
         return graph;
     }
 
-    /// <summary>
-    /// Replicates the ValidateConsentedFlow logic from V2Pathfinder for testing.
-    /// This ensures we test the exact same logic without needing the full pathfinder.
-    /// </summary>
+    // Delegate to production V2Pathfinder methods (internal, accessible via InternalsVisibleTo)
+    // to avoid logic drift between test copies and production code.
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private static List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
-    {
-        // If no consent data available, pass all edges through
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-        {
-            return edges;
-        }
+        => _consentValidator.ValidateConsentedFlow(edges, capacityGraph);
 
-        var validEdges = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip pool nodes - they're not avatars
-            if (IsPoolNode(edge.From) || IsPoolNode(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // Skip router edges
-            if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.From))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // From has consented flow enabled - check additional requirements:
-            // 1. From must trust To
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(edge.From, out var fromTrusts)
-                               && fromTrusts.Contains(edge.To);
-            if (!fromTrustsTo)
-            {
-                // Invalid - From has consented flow but doesn't trust To
-                continue;
-            }
-
-            // 2. To must also have consented flow enabled
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.To))
-            {
-                // Invalid - To doesn't have consented flow enabled
-                continue;
-            }
-
-            // All checks passed
-            validEdges.Add(edge);
-        }
-
-        return validEdges;
-    }
-
-    private static bool IsPoolNode(int nodeId)
-    {
-        return AddressIdPool.IsBalanceNode(nodeId);
-    }
-
-    /// <summary>
-    /// Replicates the PathHasConsentViolation logic from V2Pathfinder for testing.
-    /// Checks if a collapsed path has any consent violation.
-    /// </summary>
     private static bool PathHasConsentViolation(
         List<(int From, int To, int Token, long Flow)> collapsedEdges,
         CapacityGraph capacityGraph)
-    {
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-            return false;
-
-        foreach (var (from, to, _, _) in collapsedEdges)
-        {
-            // Skip group edges — they become router edges later
-            if (capacityGraph.IsGroup(from) || capacityGraph.IsGroup(to))
-                continue;
-
-            // Skip pool nodes
-            if (IsPoolNode(from) || IsPoolNode(to))
-                continue;
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(from))
-                continue;
-
-            // From has consented flow — check requirements
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(from, out var fromTrusts)
-                                && fromTrusts.Contains(to);
-            if (!fromTrustsTo)
-                return true;
-
-            if (!capacityGraph.ConsentedAvatars.Contains(to))
-                return true;
-        }
-
-        return false;
-    }
+        => _consentValidator.PathHasConsentViolation(collapsedEdges, capacityGraph);
 
     #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ContractConformanceTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ContractConformanceTests.cs
@@ -182,7 +182,7 @@ public class ContractConformanceTests
     /// Router edges should always be permitted regardless of consent status.
     /// </summary>
     [Test]
-    public void IsPermittedFlow_RouterEdges_AlwaysPermitted()
+    public void IsPermittedFlow_ConsentedAvatarToRouter_RejectedBySafetyNet()
     {
         var graph = BuildGraphWithTrust(
             trusts: Array.Empty<(string, string)>(),
@@ -196,8 +196,8 @@ public class ContractConformanceTests
         };
 
         var validated = ValidateConsentedFlow(edges, graph);
-        Assert.That(validated.Count, Is.EqualTo(2),
-            "Router edges should bypass consent validation");
+        Assert.That(validated.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Avatar survives");
     }
 
     #endregion
@@ -621,43 +621,11 @@ public class ContractConformanceTests
         return graph;
     }
 
-    /// <summary>
-    /// Replicates V2Pathfinder.ValidateConsentedFlow logic for unit testing.
-    /// </summary>
+    // Delegate to production method to avoid logic drift
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private static List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph graph)
-    {
-        if (graph.TrustLookup == null || graph.ConsentedAvatars.Count == 0)
-            return edges;
-
-        var valid = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip router edges
-            if (graph.IsRouter(edge.From) || graph.IsRouter(edge.To))
-            {
-                valid.Add(edge);
-                continue;
-            }
-
-            // Non-consented: standard trust sufficient
-            if (!graph.ConsentedAvatars.Contains(edge.From))
-            {
-                valid.Add(edge);
-                continue;
-            }
-
-            // Consented: From trusts To AND To consented
-            bool fromTrustsTo = graph.TrustLookup.TryGetValue(edge.From, out var trusts)
-                                && trusts.Contains(edge.To);
-            if (!fromTrustsTo) continue;
-            if (!graph.ConsentedAvatars.Contains(edge.To)) continue;
-
-            valid.Add(edge);
-        }
-
-        return valid;
-    }
+        => _consentValidator.ValidateConsentedFlow(edges, graph);
 
     #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/EdgeOrderingTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EdgeOrderingTests.cs
@@ -441,7 +441,7 @@ public class EdgeOrderingTests
     /// edges exist when validation runs, allowing the router-skip logic to work.
     /// </summary>
     [Test]
-    public void ConsentedFlowAvatar_GroupMint_RouterEdgesShouldBeSkipped()
+    public void ConsentedFlowAvatar_GroupMint_ConsentedToRouterCaughtBySafetyNet()
     {
         // Arrange: Avatar with consented flow sends to Group
         var capacityGraph = CreateCapacityGraphWithGroup(Group1, Router);
@@ -450,7 +450,6 @@ public class EdgeOrderingTests
         capacityGraph.ConsentedAvatars.Add(Source);
 
         // Set up trust lookup - Source does NOT trust Group directly
-        // (This would fail the consented flow check if not for the router skip)
         var trustLookup = new Dictionary<int, HashSet<int>>
         {
             [Source] = new HashSet<int>(), // Source trusts no one
@@ -470,15 +469,13 @@ public class EdgeOrderingTests
             ? InsertRouterInTransfersForTest(edgesBeforeRouterInsertion, capacityGraph)
             : edgesBeforeRouterInsertion;
 
-        // Now validate - router edges should be skipped
+        // Now validate - consented Avatar→Router is caught by safety net
         var validatedEdges = ValidateConsentedFlowForTest(edgesAfterRouterInsertion, capacityGraph);
 
-        // Assert: Both router edges should be present (router edges are skipped by validation)
-        Assert.That(validatedEdges.Count, Is.EqualTo(2),
-            "Both Avatar→Router and Router→Group edges should pass validation");
+        // Assert: Only Router→Group survives; consented Avatar→Router is rejected
+        Assert.That(validatedEdges.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Group survives");
 
-        Assert.That(validatedEdges.Any(e => e.From == Source && e.To == Router),
-            "Avatar→Router edge should be present");
         Assert.That(validatedEdges.Any(e => e.From == Router && e.To == Group1),
             "Router→Group edge should be present");
     }
@@ -525,12 +522,12 @@ public class EdgeOrderingTests
     }
 
     /// <summary>
-    /// When an avatar with consented flow sends through the router,
-    /// the router edges (Avatar→Router and Router→Group) should bypass
-    /// consented flow validation.
+    /// When a consented avatar sends through the router, the Avatar→Router edge
+    /// is caught by the safety net (Router lacks advancedUsageFlags).
+    /// Only Router→Group survives.
     /// </summary>
     [Test]
-    public void ConsentedFlowAvatar_RouterEdgesExplicitly_AreNotFiltered()
+    public void ConsentedFlowAvatar_RouterEdgesExplicitly_ConsentedToRouterRejected()
     {
         // Arrange: Avatar with consented flow, edges already have router
         var capacityGraph = CreateCapacityGraphWithGroup(Group1, Router);
@@ -557,9 +554,9 @@ public class EdgeOrderingTests
         // Act: Validate with router edges
         var validatedEdges = ValidateConsentedFlowForTest(edgesWithRouter, capacityGraph);
 
-        // Assert: Both edges should pass (router edges are skipped)
-        Assert.That(validatedEdges.Count, Is.EqualTo(2),
-            "Router edges should bypass consented flow validation");
+        // Assert: Consented Avatar→Router is caught; only Router→Group survives
+        Assert.That(validatedEdges.Count, Is.EqualTo(1),
+            "Consented Avatar→Router is caught by safety net; only Router→Group survives");
     }
 
     /// <summary>
@@ -665,44 +662,11 @@ public class EdgeOrderingTests
         return result;
     }
 
-    // Test helper: Replicates ValidateConsentedFlow logic for testing
+    // Delegate to production method to avoid logic drift
+    private static readonly V2Pathfinder _consentValidator = new();
+
     private List<FlowEdge> ValidateConsentedFlowForTest(List<FlowEdge> edges, CapacityGraph capacityGraph)
-    {
-        if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
-            return edges;
-
-        var validEdges = new List<FlowEdge>(edges.Count);
-
-        foreach (var edge in edges)
-        {
-            // Skip router edges
-            if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // If From doesn't have consented flow, standard trust is sufficient
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.From))
-            {
-                validEdges.Add(edge);
-                continue;
-            }
-
-            // From has consented flow - check additional requirements
-            bool fromTrustsTo = capacityGraph.TrustLookup.TryGetValue(edge.From, out var fromTrusts)
-                               && fromTrusts.Contains(edge.To);
-            if (!fromTrustsTo)
-                continue;
-
-            if (!capacityGraph.ConsentedAvatars.Contains(edge.To))
-                continue;
-
-            validEdges.Add(edge);
-        }
-
-        return validEdges;
-    }
+        => _consentValidator.ValidateConsentedFlow(edges, capacityGraph);
 
     #endregion
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/EntityTypeFilterTests.cs
@@ -423,8 +423,10 @@ public class EntityTypeFilterTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        // Group minting with consented flow should work when both parties consent
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -663,6 +665,9 @@ public class EntityTypeFilterTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1251,6 +1251,7 @@ public class GraphFactoryTests
         public List<string> Groups { get; set; } = new();
         public List<(string GroupAddress, string TrustedToken)> GroupTrusts { get; set; } = new();
         public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; set; } = new();
+        public List<string> RegisteredAvatars { get; set; } = new();
 
         public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> LoadV2Balances()
             => Enumerable.Empty<(string, int, int, bool, bool)>();
@@ -1261,9 +1262,102 @@ public class GraphFactoryTests
         public IEnumerable<string> LoadGroups() => Groups;
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
-        public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
+        public IEnumerable<string> LoadRegisteredAvatars() => RegisteredAvatars;
         public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
             => Array.Empty<(string, string)>();
+    }
+
+    #endregion
+
+    #region Registration Filter Tests
+
+    // Unregistered token address used for filter tests
+    private static readonly string UnregisteredToken = "0xf1dd000000000000000000000000000000000099";
+
+    [Test]
+    public void AddAllAvatarNodes_UnregisteredTokenId_ExcludedFromGraph()
+    {
+        // Arrange: Alice trusts both TokenA (registered) and UnregisteredToken
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, Bob, TokenA }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 1000));
+
+        var trustLookup = new Dictionary<int, HashSet<int>>
+        {
+            [AddressIdPool.IdOf(Alice)] = new HashSet<int>
+            {
+                AddressIdPool.IdOf(TokenA),
+                AddressIdPool.IdOf(UnregisteredToken)
+            }
+        };
+
+        // Act
+        var cg = factory.CreateBaseCapacityGraph(bg, trustLookup);
+
+        // Assert: registered token is an avatar node, unregistered is NOT
+        int tokenAId = AddressIdPool.IdOf(TokenA);
+        int unregId = AddressIdPool.IdOf(UnregisteredToken);
+
+        Assert.That(cg.AvatarNodes.ContainsKey(tokenAId), Is.True,
+            "Registered token should be an avatar node");
+        Assert.That(cg.AvatarNodes.ContainsKey(unregId), Is.False,
+            "Unregistered token must NOT be an avatar node");
+    }
+
+    [Test]
+    public void CreateBaseCapacityGraph_RegisteredSetPopulatedBeforeAvatarNodes()
+    {
+        // Arrange: set up registered avatars — ensure they appear in RegisteredAvatarIds
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, Bob, TokenA, TokenB }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 500));
+        var trustLookup = new Dictionary<int, HashSet<int>>();
+
+        // Act
+        var cg = factory.CreateBaseCapacityGraph(bg, trustLookup);
+
+        // Assert: all registered avatars are in RegisteredAvatarIds
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(Alice)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(Bob)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(TokenA)), Is.True);
+        Assert.That(cg.RegisteredAvatarIds.Contains(AddressIdPool.IdOf(TokenB)), Is.True);
+    }
+
+    [Test]
+    public void CreateCapacityGraph_Filtered_UnregisteredTokenExcluded()
+    {
+        // Arrange: filtered path with cached group data
+        var mock = new MockLoadGraph
+        {
+            RegisteredAvatars = new List<string> { Alice, TokenA }
+        };
+        var factory = MakeFactory(mock);
+        var bg = MakeBalanceGraph((Alice, TokenA, 1000));
+
+        var trustLookup = new Dictionary<int, HashSet<int>>
+        {
+            [AddressIdPool.IdOf(Alice)] = new HashSet<int>
+            {
+                AddressIdPool.IdOf(TokenA),
+                AddressIdPool.IdOf(UnregisteredToken)
+            }
+        };
+
+        var request = new FlowRequest { Source = Alice, Sink = TokenA, TargetFlow = "1000" };
+
+        // Act
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        // Assert
+        int unregId = AddressIdPool.IdOf(UnregisteredToken);
+        Assert.That(cg.AvatarNodes.ContainsKey(unregId), Is.False,
+            "Unregistered token must NOT appear in filtered capacity graph");
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -656,4 +656,36 @@ public class HubContractValidatorTests
         Assert.That(errors, Is.Empty,
             $"Quantized+groups graph ({avatars} avatars, {groups} groups) validator errors:\n{string.Join("\n", errors)}");
     }
+
+    // ═══════════════════════════════════════════
+    // CapacityGraphContractState.IsTrusted — GroupTrustedTokens fallback
+    // ═══════════════════════════════════════════
+
+    [Test]
+    public void IsTrusted_GroupInGroupTrustedTokensOnly_ReturnsTrue()
+    {
+        // Groups are excluded from TrustLookup (trustQuery.sql WHERE group IS NULL).
+        // IsTrusted must fall back to GroupTrustedTokens for group trusters.
+        var graph = new CapacityGraph();
+        var groupId = AddressIdPool.IdOf("0xee00000000000000000000000000000000group1");
+        var tokenId = AddressIdPool.IdOf("0xee00000000000000000000000000000000token1");
+        var untrustedId = AddressIdPool.IdOf("0xee00000000000000000000000000000000token2");
+
+        graph.AddGroup(groupId);
+        graph.GroupTrustedTokens[groupId] = new HashSet<int> { tokenId };
+        // TrustLookup has NO entry for the group (matches production)
+        graph.TrustLookup = new Dictionary<int, HashSet<int>>();
+
+        var state = new CapacityGraphContractState(graph);
+
+        Assert.That(state.IsTrusted(
+            AddressIdPool.StringOf(groupId),
+            AddressIdPool.StringOf(tokenId)), Is.True,
+            "Group trusting token via GroupTrustedTokens should return true");
+
+        Assert.That(state.IsTrusted(
+            AddressIdPool.StringOf(groupId),
+            AddressIdPool.StringOf(untrustedId)), Is.False,
+            "Group not trusting token should return false");
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -227,18 +227,77 @@ public class HubContractValidatorTests
     }
 
     [Test]
-    public void Rule4_RouterEdge_BypassesCheck()
+    public void Rule4_RouterToGroup_BypassesCheck()
     {
-        var state = new MockContractState { Router = Router }; // No trusts at all
-        // Router → Group edge should be skipped entirely
-        var steps = new[]
+        var state = new MockContractState
         {
-            Step(Router, GroupA, Alice),
-            Step(Alice, Router, Alice),
+            Router = Router,
+            Groups = { GroupA },
         };
+        var steps = new[] { Step(Router, GroupA, Alice) };
         var violations = new List<ValidationViolation>();
         HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
-        Assert.That(violations, Is.Empty, "Router edges should bypass isPermittedFlow");
+        Assert.That(violations, Is.Empty, "Router→Group should bypass isPermittedFlow (internal group mint)");
+    }
+
+    [Test]
+    public void Rule4_AvatarToRouter_Trusted_Passes()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            Trusts = { (Router, Alice) }, // Router trusts Alice's token
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Is.Empty, "Avatar→Router should pass when Router trusts tokenOwner");
+    }
+
+    [Test]
+    public void Rule4_AvatarToRouter_Untrusted_Fails()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // No trusts — Router does NOT trust Alice's token
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Message, Does.Contain("Avatar→Router"));
+        Assert.That(violations[0].Message, Does.Contain("does not trust token owner"));
+    }
+
+    [Test]
+    public void Rule4_RouterToNonGroup_FallsThrough_StandardValidation()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // Alice is NOT a group — Router→Alice falls through to standard isPermittedFlow
+            // Standard: isTrusted(to=Alice, tokenOwner=Bob)
+            Trusts = { (Alice.ToLowerInvariant(), Bob.ToLowerInvariant()) },
+        };
+        var steps = new[] { Step(Router, Alice, Bob) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Is.Empty, "Router→NonGroup should use standard validation and pass when trusted");
+    }
+
+    [Test]
+    public void Rule4_RouterToNonGroup_Untrusted_Fails()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // Alice is NOT a group, Alice does NOT trust Bob's token
+        };
+        var steps = new[] { Step(Router, Alice, Bob) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        Assert.That(violations, Has.Count.EqualTo(1), "Router→NonGroup with no trust should fail standard validation");
     }
 
     // ═══════════════════════════════════════════

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -679,8 +679,8 @@ public class IncrementalLoadGraphTests
             ("1000000000000000000", Alice, TokenA, InflationDayZeroUnix + 1000),
             ("1000000000000000000", Bob, TokenA, InflationDayZeroUnix + 1000));
 
-        // Only Alice is registered
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        // Only Alice is registered (+ TokenA as token owner so it passes tokenAddress filter)
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var settings = new Settings { TargetDemurrageTimestamp = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 1000) };
@@ -716,7 +716,7 @@ public class IncrementalLoadGraphTests
         var balance = "1000000000000000000000"; // 1000 * 1e18
 
         var balances = CreateBalanceState((balance, Alice, TokenA, lastActivity));
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var targetTime = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 86400); // 1 day later
@@ -741,7 +741,7 @@ public class IncrementalLoadGraphTests
         var balance = "1000000000000000000000";
 
         var balances = CreateBalanceState((balance, Alice, TokenA, lastActivity));
-        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"));
+        var avatars = CreateAvatarState((Alice, "CrcV2_RegisterHuman"), (TokenA, "CrcV2_RegisterHuman"));
         var trusts = CreateTrustState();
 
         var targetTime = DateTimeOffset.FromUnixTimeSeconds(InflationDayZeroUnix + 200); // same day
@@ -858,6 +858,7 @@ public class IncrementalLoadGraphTests
         var avatars = CreateAvatarState(
             (Alice, "CrcV2_RegisterHuman"),
             (Bob, "CrcV2_RegisterHuman"),
+            (TokenA, "CrcV2_RegisterHuman"),
             (GroupAddr, "CrcV2_RegisterGroup"));
 
         var balances = CreateBalanceState();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/KitchenSinkTests.cs
@@ -112,8 +112,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        // Group minting with wrapped collateral, quantized, consented
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -198,8 +200,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        // Should use only collateralB (100 CRC) via group minting with consent
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]
@@ -242,7 +246,10 @@ public class KitchenSinkTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("96000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow);
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
@@ -217,18 +217,33 @@ public class PipelineMethodTests
     }
 
     [Test]
-    public void Consent_GroupEdge_Skipped()
+    public void Consent_ConsentedAvatarToGroup_DetectsViolation()
     {
         var graph = MakeGraph(
             groups: new[] { Group1 },
             consented: new[] { A },
             trustLookup: new() { { A, new HashSet<int>() } }); // A trusts nobody
 
-        // A(consented) → Group: should be skipped (group becomes router edge later)
+        // A(consented) → Group: NOT skipped — Router lacks advancedUsageFlags
+        var edges = new List<(int From, int To, int Token, long Flow)> { (A, Group1, TokenA, 100) };
+
+        Assert.That(_pathfinder.PathHasConsentViolation(edges, graph), Is.True,
+            "Consented Avatar→Group detected — Router lacks advancedUsageFlags");
+    }
+
+    [Test]
+    public void Consent_NonConsentedAvatarToGroup_Skipped()
+    {
+        var graph = MakeGraph(
+            groups: new[] { Group1 },
+            consented: new[] { B }, // B is consented, not A
+            trustLookup: new() { { A, new HashSet<int>() } });
+
+        // A(non-consented) → Group: skipped (standard trust applies after Router insertion)
         var edges = new List<(int From, int To, int Token, long Flow)> { (A, Group1, TokenA, 100) };
 
         Assert.That(_pathfinder.PathHasConsentViolation(edges, graph), Is.False,
-            "Group edges skipped — they become router edges");
+            "Non-consented Avatar→Group skipped — standard trust path");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
@@ -38,7 +38,8 @@ public class PropertyBasedTests
         double trustDensity = 0.3,
         bool withRouter = true,
         bool withConsent = false,
-        double consentRate = 0.5)
+        double consentRate = 0.5,
+        double routerTrustDensity = 1.0)
     {
         var graph = new CapacityGraph();
         var avatars = new List<int>(avatarCount);
@@ -120,16 +121,22 @@ public class PropertyBasedTests
             }
         }
 
-        // Router must trust all tokens that groups trust as collateral.
-        // Hub.sol:665 checks trustMarkers[Router][tokenOwner] for every
-        // Avatar→Router edge in operateFlowMatrix.
+        // Router trusts a subset of group-trusted tokens (controlled by routerTrustDensity).
+        // At density=1.0 all group collateral edges pass; at <1.0 some are filtered,
+        // exercising the routerFilteredCount code path in GraphFactory.AddTokenPoolOutEdges.
         if (withRouter && graph.RouterNode.HasValue)
         {
             var routerTrusts = new HashSet<int>();
             foreach (var grp in groups)
             {
-                if (graph.GroupTrustedTokens.TryGetValue(grp, out var gt))
-                    routerTrusts.UnionWith(gt);
+                if (graph.GroupTrustedTokens.TryGetValue(grp, out var gTrusts))
+                {
+                    foreach (var token in gTrusts)
+                    {
+                        if (rng.NextDouble() < routerTrustDensity)
+                            routerTrusts.Add(token);
+                    }
+                }
             }
 
             if (routerTrusts.Count > 0)
@@ -982,6 +989,53 @@ public class PropertyBasedTests
             "Same input should produce same MaxFlow");
         Assert.That(result1.Transfers.Count, Is.EqualTo(result2.Transfers.Count),
             "Same input should produce same number of transfers");
+    }
+
+    #endregion
+
+    #region Property: Router trust density filtering
+
+    /// <summary>
+    /// With routerTrustDensity &lt; 1.0, some group collateral tokens are not trusted by the Router.
+    /// Paths through filtered tokens should not appear in the output. MaxFlow may be reduced or zero,
+    /// but the pathfinder must never crash and flow conservation must hold.
+    /// </summary>
+    [Test]
+    [Repeat(10)]
+    public void PartialRouterTrust_NeverCrashes_FlowConserved()
+    {
+        var rng = new Random(TestContext.CurrentContext.CurrentRepeatCount + 50000);
+        int avatars = rng.Next(4, 10);
+        int groups = rng.Next(1, 3);
+
+        var graph = BuildSyntheticGraph(avatars, groups, DefaultBalance, rng,
+            trustDensity: 0.5, withRouter: true, routerTrustDensity: 0.5);
+        var (source, sink) = PickSourceSink(graph, rng);
+
+        var pathfinder = new V2Pathfinder();
+        var request = new FlowRequest
+        {
+            Source = AddressIdPool.StringOf(source),
+            Sink = AddressIdPool.StringOf(sink),
+        };
+        UInt256 target = CirclesConverter.BlowUpToUInt256(DefaultBalance);
+
+        MaxFlowResponse result;
+        try
+        {
+            result = pathfinder.ComputeMaxFlowWithPath(graph, request, target);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("BAD_INPUT"))
+        {
+            return; // Empty graph is valid
+        }
+
+        // Must not crash. Flow conservation: if transfers exist, check balance at intermediaries.
+        if (result.Transfers.Count > 0)
+        {
+            AssertFlowConservation(result.Transfers,
+                AddressIdPool.StringOf(source), AddressIdPool.StringOf(sink));
+        }
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PropertyBasedTests.cs
@@ -120,6 +120,22 @@ public class PropertyBasedTests
             }
         }
 
+        // Router must trust all tokens that groups trust as collateral.
+        // Hub.sol:665 checks trustMarkers[Router][tokenOwner] for every
+        // Avatar→Router edge in operateFlowMatrix.
+        if (withRouter && graph.RouterNode.HasValue)
+        {
+            var routerTrusts = new HashSet<int>();
+            foreach (var grp in groups)
+            {
+                if (graph.GroupTrustedTokens.TryGetValue(grp, out var gt))
+                    routerTrusts.UnionWith(gt);
+            }
+
+            if (routerTrusts.Count > 0)
+                trustLookup[graph.RouterNode.Value] = routerTrusts;
+        }
+
         graph.TrustLookup = trustLookup;
 
         // Each avatar holds their own personal token (balance)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrapperFilterMatrixTests.cs
@@ -427,7 +427,10 @@ public class WrapperFilterMatrixTests
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = false });
         var result = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, UInt256.Parse("1000000000000000000"));
 
-        AssertMaxFlowPositive(result.MaxFlow, "Wrapped collateral + group mint + consent should work");
+        // Consented source cannot do group minting — Router lacks advancedUsageFlags on-chain.
+        Assert.That(result.MaxFlow, Is.EqualTo("0"), "Consented source→Group correctly yields zero flow");
+        Assert.That(result.Transfers, Is.Null.Or.Empty, "No transfer steps when all paths are consent-blocked");
+        Assert.That(result.ConsentDroppedPaths, Is.GreaterThan(0), "At least one path dropped by consent filter");
     }
 
     // ─────────────── SWAP MODE + WRAPPER ───────────────

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
@@ -38,6 +38,13 @@ public class InMemoryAvatarState
         return _avatars.Contains(lower) && !_stopped.Contains(lower);
     }
 
+    /// <summary>Returns true if address was ever registered (including stopped avatars).
+    /// Use for tokenAddress validation — stopped avatars' tokens are still valid on-chain.</summary>
+    public bool IsRegistered(string address)
+    {
+        return _avatars.Contains(address.ToLowerInvariant());
+    }
+
     /// <summary>Returns true if address is a registered group.</summary>
     public bool IsGroup(string address) => _groups.Contains(address.ToLowerInvariant());
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryTrustState.cs
@@ -87,10 +87,11 @@ public class InMemoryTrustState
 
     /// <summary>
     /// Get group trust edges (replicates groupTrustQuery.sql logic).
-    /// Returns trusts where the truster IS a group and trust hasn't expired.
+    /// Returns trusts where the truster IS a group, trustee is a registered avatar,
+    /// and trust hasn't expired.
     /// </summary>
     public IEnumerable<(string GroupAddress, string TrustedToken)> GetGroupTrusts(
-        HashSet<string> groupSet, long maxBlockTimestamp)
+        HashSet<string> groupSet, long maxBlockTimestamp, IReadOnlySet<string>? avatarSet = null)
     {
         foreach (var kv in _state)
         {
@@ -102,6 +103,9 @@ public class InMemoryTrustState
 
             // Filter expired
             if (expiryTime <= maxBlockTimestamp) continue;
+
+            // Trustee must be a registered avatar (mirrors groupTrustQuery.sql JOIN)
+            if (avatarSet != null && !avatarSet.Contains(trustee)) continue;
 
             yield return (truster, trustee);
         }

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -57,8 +57,10 @@ public class IncrementalLoadGraph : ILoadGraph
             var (account, tokenAddress) = kv.Key;
             var (rawBalance, lastActivity, isWrapped, isStatic) = kv.Value;
 
-            // Filter: must be a registered avatar
+            // Filter: holder must be active (registered + not stopped)
             if (!_avatarState.Contains(account)) continue;
+            // Token owner must be registered (stopped is OK — their tokens are still valid on-chain)
+            if (!isWrapped && !_avatarState.IsRegistered(tokenAddress)) continue;
 
             var adjusted = DemurrageCalculator.Apply(
                 rawBalance, lastActivity, isStatic, ctx,
@@ -130,7 +132,8 @@ public class IncrementalLoadGraph : ILoadGraph
     {
         // Use router-filtered groups from DB (matches groupQuery.sql parameterized by GroupRouterAddress)
         var routerGroups = new HashSet<string>(_inner.LoadGroups().Select(g => g.ToLowerInvariant()));
-        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp);
+        // Use AvatarSet (includes stopped) — stopped avatars' tokens are still valid on-chain
+        return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp, _avatarState.AvatarSet);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/avatarBalancesQuery.sql
@@ -75,6 +75,7 @@ native_sum as (
          , false as "isStatic"
     from "V_CrcV2_BalancesByAccountAndToken" b
     join requested_avatars ra on ra.avatar = b."account"
+    join registered_avatars ra_token on ra_token.avatar = b."tokenAddress"
     where b."totalBalance" > 0
 )
 select balance::text as balance

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceDeltaQuery.sql
@@ -15,11 +15,12 @@ FROM (
         "timestamp",
         "from",
         "to",
-        "tokenAddress",
+        ts."tokenAddress",
         "value"::text AS "value",
         false AS "isWrapped",
         false AS "isStatic"
-    FROM "CrcV2_TransferSingle"
+    FROM "CrcV2_TransferSingle" ts
+    JOIN registered_avatars ra_token ON ra_token.avatar = ts."tokenAddress"
     WHERE "blockNumber" > @lastBlock
 
     UNION ALL
@@ -32,11 +33,12 @@ FROM (
         "timestamp",
         "from",
         "to",
-        "tokenAddress",
+        tb."tokenAddress",
         "value"::text AS "value",
         false AS "isWrapped",
         false AS "isStatic"
-    FROM "CrcV2_TransferBatch"
+    FROM "CrcV2_TransferBatch" tb
+    JOIN registered_avatars ra_token ON ra_token.avatar = tb."tokenAddress"
     WHERE "blockNumber" > @lastBlock
 
     UNION ALL

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceFullStateQuery.sql
@@ -72,6 +72,7 @@ native_sum as (
          , false as "isStatic"
     from "V_CrcV2_BalancesByAccountAndToken" b
     join registered_avatars ra on ra.avatar = b."account"
+    join registered_avatars ra_token on ra_token.avatar = b."tokenAddress"
     where b."totalBalance" > 0
 )
 select balance::text

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/balanceQuery.sql
@@ -121,6 +121,7 @@ native_sum as (
          , 'demurraged' as "circlesType"
     from native_agg n
     join registered_avatars ra on ra.avatar = n.account
+    join registered_avatars ra_token on ra_token.avatar = n."tokenAddress"
 )
 
 select balance::text

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,6 +1,14 @@
+WITH registered_avatars AS MATERIALIZED (
+    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT avatar FROM "CrcV2_RegisterHuman"
+)
 SELECT
     t.truster as group_address,
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
 INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
+INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
 WHERE g."mint" = LOWER(@router);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
@@ -1,2 +1,10 @@
-SELECT "erc20Wrapper", avatar
-FROM "CrcV2_ERC20WrapperDeployed"
+WITH registered_avatars AS MATERIALIZED (
+    SELECT organization AS avatar FROM "CrcV2_RegisterOrganization"
+    UNION ALL
+    SELECT "group" AS avatar FROM "CrcV2_RegisterGroup"
+    UNION ALL
+    SELECT avatar FROM "CrcV2_RegisterHuman"
+)
+SELECT d."erc20Wrapper", d.avatar
+FROM "CrcV2_ERC20WrapperDeployed" d
+JOIN registered_avatars ra ON ra.avatar = d.avatar

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -30,8 +30,11 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Track which tokens each group trusts
     public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();
 
-    // Track avatars that have enabled consented flow
-    public HashSet<int> ConsentedAvatars { get; set; } = new HashSet<int>();
+    /// <summary>
+    /// Avatars with Hub.sol advancedUsageFlags enabled (consented flow).
+    /// Set during graph construction, immutable after publication to CapacityGraphPool.
+    /// </summary>
+    public HashSet<int> ConsentedAvatars { get; internal set; } = new HashSet<int>();
 
     // Track all registered V2 avatar IDs (cached to avoid per-request DB queries)
     public HashSet<int> RegisteredAvatarIds { get; } = new HashSet<int>();

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -43,6 +43,13 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Trust lookup for consented flow validation (truster -> set of trustees)
     public IReadOnlyDictionary<int, HashSet<int>>? TrustLookup { get; set; }
 
+    // Router trust coverage metrics (set during graph build)
+    public int TotalGroupTokenEdges { get; set; }
+    public int RouterFilteredEdges { get; set; }
+
+    // Block number of the snapshot this graph was built from (for replay logging)
+    public long Block { get; set; }
+
     public void AddTokenNode(int tokenId, int? poolNodeId = null)
     {
         // Note: We deliberately create token pool ids via BalanceNodeIdOf(...) so they’re marked “balance‑ish”.

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -69,6 +69,7 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
 
             // build ad-hoc filtered graph, using cached group/consent data to skip DB queries
             var g = _gf.CreateCapacityGraph(balances, trust, r, _cachedGroupData);
+            g.Block = snap.Block; // propagate block for replay logging
             return Task.FromResult(new CapacityGraphHandle(g));
         }
 
@@ -146,10 +147,18 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
     public static bool IsWrapOnly(FlowRequest r) => false;
 }
 
-public sealed class CapacityGraphSnapshot(long block, CapacityGraph @base)
+public sealed class CapacityGraphSnapshot
 {
-    public long Block { get; } = block;
-    public CapacityGraph Base { get; } = @base;
+    public long Block { get; }
+    public CapacityGraph Base { get; }
+
+    public CapacityGraphSnapshot(long block, CapacityGraph @base)
+    {
+        Block = block;
+        Base = @base;
+        // Stamp block on the graph so V2Pathfinder can log it without access to the snapshot
+        @base.Block = block;
+    }
 }
 
 /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -104,16 +104,16 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         var capacityGraph = new CapacityGraph();
 
-        // Add all avatar nodes from both graphs
-        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
-
-        // Ensure ALL registered avatars are valid source/sink candidates
+        // Build registered avatar set FIRST (needed for filtering in AddAllAvatarNodes)
         foreach (var avatar in loadGraph.LoadRegisteredAvatars())
         {
             var id = AddressIdPool.IdOf(avatar.ToLowerInvariant());
             capacityGraph.AddAvatar(id);
             capacityGraph.RegisteredAvatarIds.Add(id);
         }
+
+        // Add all avatar nodes from both graphs (filtered against registered set)
+        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
         // Load wrapper→avatar mappings (for DTO output resolution)
         LoadWrapperMappings(capacityGraph, cachedGroupData);
@@ -169,20 +169,27 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         var capacityGraph = new CapacityGraph();
 
-        // STEP 1: Add all avatar nodes from both graphs
-        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
-
-        // STEP 1a: Ensure ALL registered avatars are valid source/sink candidates
+        // STEP 1: Build registered avatar set FIRST (needed for filtering)
         if (cachedGroupData?.RegisteredAvatarIds != null)
         {
             foreach (var avatarId in cachedGroupData.RegisteredAvatarIds)
+            {
                 capacityGraph.AddAvatar(avatarId);
+                capacityGraph.RegisteredAvatarIds.Add(avatarId);
+            }
         }
         else
         {
             foreach (var avatar in loadGraph.LoadRegisteredAvatars())
-                capacityGraph.AddAvatar(AddressIdPool.IdOf(avatar.ToLowerInvariant()));
+            {
+                var id = AddressIdPool.IdOf(avatar.ToLowerInvariant());
+                capacityGraph.AddAvatar(id);
+                capacityGraph.RegisteredAvatarIds.Add(id);
+            }
         }
+
+        // STEP 1a: Add all avatar nodes from both graphs (filtered against registered set)
+        AddAllAvatarNodes(capacityGraph, balanceGraph, trustLookup);
 
         // STEP 1b: Add avatars referenced by simulated balances (holders + tokens)
         var simulated = NormalizeSimulatedBalances(request.SimulatedBalances);
@@ -963,12 +970,22 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             capacityGraph.AddAvatar(truster);
         }
 
-        // every token that is trusted by somebody
+        // every token that is trusted by somebody — only if registered
+        // (defense-in-depth: SQL queries should already filter, but guard against leaks)
+        var registered = capacityGraph.RegisteredAvatarIds;
+        if (registered.Count == 0)
+        {
+            _logger.LogWarning("RegisteredAvatarIds is empty — skipping trusted-token registration filter");
+        }
+
         foreach (var trustedSet in trustLookup.Values)
         {
             foreach (var tokenId in trustedSet)
             {
-                capacityGraph.AddAvatar(tokenId);
+                if (registered.Count == 0 || registered.Contains(tokenId))
+                {
+                    capacityGraph.AddAvatar(tokenId);
+                }
             }
         }
     }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -134,10 +134,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             new HashSet<int>(), new HashSet<int>(), new HashSet<int>());
 
         // Add ALL trust-based out-edges (no filters)
-        AddTokenPoolOutEdges(
+        var (totalGroupTokenEdges, routerFilteredCount) = AddTokenPoolOutEdges(
             capacityGraph, trustLookup,
             virtualSink: null, virtualSinkTrustedTokens: new HashSet<int>(),
             sinkId: null, new HashSet<int>(), new HashSet<int>());
+        capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
+        capacityGraph.RouterFilteredEdges = routerFilteredCount;
 
         // Add ALL group minting edges (no filters)
         AddGroupMintingEdges(
@@ -459,7 +461,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         // STEP 6/7/8: Add trust-based out-edges from TokenPool→avatars (+ virtual sink in swap mode)
         // Groups can now receive tokens directly
-        AddTokenPoolOutEdges(
+        var (totalGroupTokenEdges, routerFilteredCount) = AddTokenPoolOutEdges(
             capacityGraph,
             mergedTrust,
             virtualSinkAddress,
@@ -467,6 +469,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             sinkId,
             toTokensFilter,
             excludedToTokensFilter);
+        capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
+        capacityGraph.RouterFilteredEdges = routerFilteredCount;
 
         // STEP 8: Add Group minting edges (Group → Avatar with group token)
         AddGroupMintingEdges(
@@ -784,8 +788,9 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
     }
 
-    // Modified version of AddTokenPoolOutEdges that allows Groups to receive tokens directly
-    private void AddTokenPoolOutEdges(
+    // Modified version of AddTokenPoolOutEdges that allows Groups to receive tokens directly.
+    // Returns (totalGroupTokenEdges, routerFilteredCount) for metrics.
+    private (int TotalGroupTokenEdges, int RouterFilteredCount) AddTokenPoolOutEdges(
         CapacityGraph g,
         IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
         int? virtualSink,
@@ -831,12 +836,15 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
 
         int routerFilteredCount = 0;
+        int totalGroupTokenEdges = 0;
         foreach (var groupId in g.GroupNodes)
         {
             if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
             {
                 foreach (var token in trustedTokens)
                 {
+                    totalGroupTokenEdges++;
+
                     // Fail-closed: if router trusts are unknown, block the edge.
                     // Missing router trust data would otherwise allow invalid paths
                     // that revert on-chain (the same bug this filter prevents).
@@ -878,6 +886,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 g.AddCapacityEdge(pool, virtualSink.Value, t, long.MaxValue);
             }
         }
+
+        return (totalGroupTokenEdges, routerFilteredCount);
     }
 
     // Add Group → Avatar edges for group token minting

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/FlowMatrixEncoder.cs
@@ -1,0 +1,168 @@
+using System.Numerics;
+using System.Text;
+using Circles.Common;
+using Circles.Common.Dto;
+
+namespace Circles.Pathfinder.Simulation;
+
+/// <summary>
+/// Encodes pathfinder TransferPathStep[] into Hub.sol operateFlowMatrix calldata.
+/// Extracted from AnvilExecutionHelper for use in the production simulation canary.
+/// </summary>
+public static class FlowMatrixEncoder
+{
+    // Hub.sol V2 contract address on Gnosis chain
+    public const string CirclesHubAddress = "0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8";
+
+    // Pre-computed: keccak256("operateFlowMatrix(address[],(uint16,uint192)[],(uint16,uint16[],bytes)[],bytes)")[..4]
+    private static readonly string MethodSelector = ComputeMethodSelector();
+
+    private static string ComputeMethodSelector()
+    {
+        var hash = KeccakHelper.ComputeHash(
+            "operateFlowMatrix(address[],(uint16,uint192)[],(uint16,uint16[],bytes)[],bytes)");
+        return BitConverter.ToString(hash, 0, 4).Replace("-", "").ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Builds the ABI-encoded calldata for Hub.operateFlowMatrix from pathfinder transfer steps.
+    /// </summary>
+    public static string BuildCalldata(
+        string sender,
+        string receiver,
+        IReadOnlyList<TransferPathStep> transfers)
+    {
+        // Step 1: Build sorted vertex list (all unique addresses)
+        var vertexSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        vertexSet.Add(sender.ToLowerInvariant());
+        vertexSet.Add(receiver.ToLowerInvariant());
+        foreach (var t in transfers)
+        {
+            vertexSet.Add(t.From.ToLowerInvariant());
+            vertexSet.Add(t.To.ToLowerInvariant());
+            vertexSet.Add(t.TokenOwner.ToLowerInvariant());
+        }
+
+        // Sort by uint160 value for Hub.sol's _flowVertices ordering
+        var flowVertices = vertexSet
+            .OrderBy(v => BigInteger.Parse("0" + v.Replace("0x", ""), System.Globalization.NumberStyles.HexNumber))
+            .ToList();
+
+        var idx = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < flowVertices.Count; i++)
+            idx[flowVertices[i]] = i;
+
+        if (flowVertices.Count > ushort.MaxValue + 1)
+            throw new InvalidOperationException(
+                $"operateFlowMatrix supports at most {ushort.MaxValue + 1} vertices; got {flowVertices.Count}.");
+        if (transfers.Count > ushort.MaxValue + 1)
+            throw new InvalidOperationException(
+                $"operateFlowMatrix supports at most {ushort.MaxValue + 1} flow edges; got {transfers.Count}.");
+
+        // Step 2: Build flow edges and coordinates
+        var flowEdges = new List<(ushort streamSinkId, BigInteger amount)>();
+        var coordinates = new List<ushort>();
+        var receiverLower = receiver.ToLowerInvariant();
+        var senderLower = sender.ToLowerInvariant();
+        var terminalEdgeIndices = new List<int>();
+
+        for (int i = 0; i < transfers.Count; i++)
+        {
+            var t = transfers[i];
+            var amount = BigInteger.Parse(t.Value);
+            var toAddr = t.To.ToLowerInvariant();
+
+            ushort streamSinkId = toAddr == receiverLower ? (ushort)1 : (ushort)0;
+            flowEdges.Add((streamSinkId, amount));
+
+            if (streamSinkId == 1)
+                terminalEdgeIndices.Add(i);
+
+            coordinates.Add((ushort)idx[t.TokenOwner.ToLowerInvariant()]);
+            coordinates.Add((ushort)idx[t.From.ToLowerInvariant()]);
+            coordinates.Add((ushort)idx[toAddr]);
+        }
+
+        if (transfers.Count > 0 && terminalEdgeIndices.Count == 0)
+            throw new InvalidOperationException(
+                "Cannot build operateFlowMatrix calldata: no transfer terminates at the requested receiver.");
+
+        var senderCoordinate = (ushort)idx[senderLower];
+        var terminalEdgeIds = terminalEdgeIndices.Select(i => (ushort)i).ToArray();
+        var packedCoordinates = PackCoordinates(coordinates);
+
+        return AbiEncode(flowVertices, flowEdges, senderCoordinate, terminalEdgeIds, packedCoordinates);
+    }
+
+    private static string PackCoordinates(List<ushort> coordinates)
+    {
+        var bytes = new byte[coordinates.Count * 2];
+        for (int i = 0; i < coordinates.Count; i++)
+        {
+            bytes[i * 2] = (byte)(coordinates[i] >> 8);
+            bytes[i * 2 + 1] = (byte)(coordinates[i] & 0xFF);
+        }
+        return BitConverter.ToString(bytes).Replace("-", "").ToLowerInvariant();
+    }
+
+    private static string AbiEncode(
+        List<string> flowVertices,
+        List<(ushort streamSinkId, BigInteger amount)> flowEdges,
+        ushort senderCoordinate,
+        ushort[] terminalEdgeIds,
+        string packedCoordinates)
+    {
+        var sb = new StringBuilder();
+        sb.Append("0x");
+        sb.Append(MethodSelector);
+
+        int currentOffset = 4 * 32;
+        int flowVerticesSize = 32 + flowVertices.Count * 32;
+        int flowEdgesSize = 32 + flowEdges.Count * 64;
+        int streamsSize = 32 + 32 + 32 + 32 + 32 + 32 + terminalEdgeIds.Length * 32 + 32;
+        int packedCoordinatesSize = 32 + ((packedCoordinates.Length / 2 + 31) / 32) * 32;
+
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += flowVerticesSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += flowEdgesSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+        currentOffset += streamsSize;
+        sb.Append(currentOffset.ToString("x").PadLeft(64, '0'));
+
+        // flowVertices
+        sb.Append(flowVertices.Count.ToString("x").PadLeft(64, '0'));
+        foreach (var v in flowVertices)
+            sb.Append(v.Replace("0x", "").PadLeft(64, '0'));
+
+        // flowEdges
+        sb.Append(flowEdges.Count.ToString("x").PadLeft(64, '0'));
+        foreach (var (streamSinkId, amount) in flowEdges)
+        {
+            sb.Append(streamSinkId.ToString("x").PadLeft(64, '0'));
+            sb.Append(amount.ToString("x").PadLeft(64, '0'));
+        }
+
+        // streams (single stream)
+        sb.Append("1".PadLeft(64, '0'));
+        sb.Append("20".PadLeft(64, '0'));
+        int streamDataOffset = 3 * 32;
+        sb.Append(senderCoordinate.ToString("x").PadLeft(64, '0'));
+        sb.Append(streamDataOffset.ToString("x").PadLeft(64, '0'));
+        int flowEdgeIdsSize = 32 + terminalEdgeIds.Length * 32;
+        sb.Append((streamDataOffset + flowEdgeIdsSize).ToString("x").PadLeft(64, '0'));
+        sb.Append(terminalEdgeIds.Length.ToString("x").PadLeft(64, '0'));
+        foreach (var id in terminalEdgeIds)
+            sb.Append(id.ToString("x").PadLeft(64, '0'));
+        sb.Append("0".PadLeft(64, '0'));
+
+        // packedCoordinates
+        var coordBytes = new byte[packedCoordinates.Length / 2];
+        for (int i = 0; i < coordBytes.Length; i++)
+            coordBytes[i] = Convert.ToByte(packedCoordinates.Substring(i * 2, 2), 16);
+        sb.Append(coordBytes.Length.ToString("x").PadLeft(64, '0'));
+        sb.Append(packedCoordinates.PadRight(((packedCoordinates.Length + 63) / 64) * 64, '0'));
+
+        return sb.ToString();
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -1,0 +1,49 @@
+namespace Circles.Pathfinder.Simulation;
+
+/// <summary>
+/// Classifies eth_call revert reasons into actionable categories.
+/// "bug" = pathfinder produced invalid output (graph stale, logic error).
+/// "input" = user request cannot succeed (sink can't receive ERC1155, etc.).
+/// "unknown" = needs manual investigation.
+/// </summary>
+public static class RevertClassifier
+{
+    // Hub.sol Circles-specific error selectors (from circles-contracts-v2/src/errors/Errors.sol)
+    // CirclesErrorAddressUintArgs(address,uint256,uint8) — type 1 (0x20-0x3F)
+    private const string FlowEdgeIsNotPermitted = "0x5e418dba";
+    // CirclesErrorOneAddressArg(address,uint8) — type 1 (0x20-0x3F)
+    private const string AvatarMustBeRegistered = "0xc14c0700";
+    // OpenZeppelin ERC1155 errors
+    private const string ERC1155InsufficientBalance = "0x03dee4c5";
+    private const string ERC1155InvalidReceiver = "0x57f447ce";
+
+    public static (string Category, string Label) Classify(string? revertData)
+    {
+        if (string.IsNullOrEmpty(revertData))
+            return ("unknown", "empty_revert");
+
+        var lower = revertData.ToLowerInvariant();
+
+        // Check for known error selectors in the revert data
+        if (Contains(lower, FlowEdgeIsNotPermitted))
+            return ("bug", "flow_edge_not_permitted");
+
+        if (Contains(lower, AvatarMustBeRegistered))
+            return ("bug", "avatar_not_registered");
+
+        if (Contains(lower, ERC1155InsufficientBalance))
+            return ("bug", "insufficient_balance");
+
+        if (Contains(lower, ERC1155InvalidReceiver))
+            return ("input", "invalid_receiver");
+
+        // Generic revert string patterns
+        if (lower.Contains("execution reverted"))
+            return ("unknown", "generic_revert");
+
+        return ("unknown", "unrecognized");
+    }
+
+    private static bool Contains(string data, string selector)
+        => data.Contains(selector[2..]); // strip 0x prefix for matching
+}

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -126,6 +126,10 @@ public class V2Pathfinder
         public int ConsentDroppedPaths { get; set; }
         public int ConsentSafetyNetRejected { get; set; }
         public DebugPipelineStages? DebugStages { get; set; }
+
+        // Canary: HubContractValidator results (runs in Release mode)
+        public int ValidationErrors { get; set; }
+        public IReadOnlyList<string>? ValidationViolationRules { get; set; }
     }
 
     /* ======================================================================
@@ -145,13 +149,34 @@ public class V2Pathfinder
 
         if (!capacityGraph.AvatarNodes.ContainsKey(sourceId))
         {
-            _logger.LogWarning("[{ReqId}] Source '{Source}' not in graph snapshot — returning zero flow", reqId, request.Source);
+            _logger.LogWarning("[{ReqId}] Source '{Source}' not in graph snapshot (block={Block}) — returning zero flow",
+                reqId, request.Source, capacityGraph.Block);
             return null;
         }
         if (!capacityGraph.AvatarNodes.ContainsKey(effSink))
         {
-            _logger.LogWarning("[{ReqId}] Sink '{Sink}' not in graph snapshot — returning zero flow", reqId, request.Sink);
+            _logger.LogWarning("[{ReqId}] Sink '{Sink}' not in graph snapshot (block={Block}) — returning zero flow",
+                reqId, request.Sink, capacityGraph.Block);
             return null;
+        }
+
+        // Replay log: everything needed to reconstruct this request against the test environment
+        {
+            var flags = new List<string>(4);
+            if (request.WithWrap == true) flags.Add("withWrap");
+            if (request.QuantizedMode == true) flags.Add("quantized");
+            if (request.MaxTransfers.HasValue) flags.Add($"maxTransfers={request.MaxTransfers}");
+            if (request.FromTokens?.Count > 0) flags.Add($"fromTokens={request.FromTokens.Count}");
+            if (request.ToTokens?.Count > 0) flags.Add($"toTokens={request.ToTokens.Count}");
+            if (request.ExcludedFromTokens?.Count > 0) flags.Add($"exclFrom={request.ExcludedFromTokens.Count}");
+            if (request.ExcludedToTokens?.Count > 0) flags.Add($"exclTo={request.ExcludedToTokens.Count}");
+            if (request.SimulatedBalances?.Count > 0) flags.Add($"simBal={request.SimulatedBalances.Count}");
+            if (request.SimulatedTrusts?.Count > 0) flags.Add($"simTrust={request.SimulatedTrusts.Count}");
+
+            _logger.LogInformation(
+                "[{ReqId}] Request: from={Source} to={Sink} amount={Amount} block={Block} flags=[{Flags}]",
+                reqId, request.Source, request.Sink, targetFlow, capacityGraph.Block,
+                flags.Count > 0 ? string.Join(",", flags) : "none");
         }
 
         _logger.LogInformation("[{ReqId}] Graph: avatars={Avatars}, groups={Groups}, edges={Edges}",
@@ -414,22 +439,44 @@ public class V2Pathfinder
             });
         }
 
-#if DEBUG
+        // Debug: compact transfer summary for replay analysis
+        if (ctx.Transfers.Count > 0 && _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        {
+            static string Trunc(string s) => s[..Math.Min(10, s.Length)];
+            var summary = string.Join(" | ", ctx.Transfers.Select(t =>
+                $"{Trunc(t.From)}→{Trunc(t.To)} token={Trunc(t.TokenOwner)} val={t.Value}"));
+            _logger.LogDebug("[{ReqId}] Transfers: {Summary}", ctx.ReqId, summary);
+        }
+
+        // Canary: run HubContractValidator on every response (observe-only, NEVER blocks)
         if (ctx.Transfers.Count > 0)
         {
-            var debugState = new Validation.CapacityGraphContractState(ctx.Graph);
-            var debugValidation = Validation.HubContractValidator.Validate(
-                ctx.Transfers, ctx.Request.Source!, ctx.Request.Sink!, debugState);
-            if (!debugValidation.IsValid)
+            try
             {
-                var errors = debugValidation.Violations
-                    .Where(v => v.Severity == "error")
-                    .Select(v => $"[{v.Rule}] {v.Message}");
-                _logger.LogError("[{ReqId}] HubContractValidator REJECTED output: {Violations}",
-                    ctx.ReqId, string.Join("; ", errors));
+                var contractState = new Validation.CapacityGraphContractState(ctx.Graph);
+                var validation = Validation.HubContractValidator.Validate(
+                    ctx.Transfers, ctx.Request.Source!, ctx.Request.Sink!, contractState);
+
+                var errorViolations = validation.Violations.Where(v => v.Severity == "error").ToList();
+                if (errorViolations.Count > 0)
+                {
+                    var errors = errorViolations.Select(v => $"[{v.Rule}] {v.Message}");
+                    _logger.LogError(
+                        "[{ReqId}] Canary: REJECTED from={Source} to={Sink} block={Block} violations: {Violations}",
+                        ctx.ReqId, ctx.Request.Source, ctx.Request.Sink, ctx.Graph.Block,
+                        string.Join("; ", errors));
+                }
+
+                ctx.ValidationErrors = errorViolations.Count;
+                ctx.ValidationViolationRules = errorViolations.Select(v => v.Rule).ToList();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "[{ReqId}] Canary: validator threw unexpected exception (observe-only, not blocking response)",
+                    ctx.ReqId);
             }
         }
-#endif
     }
 
     /* ======================================================================
@@ -446,16 +493,21 @@ public class V2Pathfinder
         }
 
         ctx.TotalStopwatch.Stop();
-        _logger.LogInformation("[{ReqId}] Result: maxFlow={MaxFlow}, steps={Steps}, totalMs={TotalMs}",
-            ctx.ReqId, maxFlowWei, ctx.Transfers.Count, ctx.TotalStopwatch.ElapsedMilliseconds);
+        _logger.LogInformation(
+            "[{ReqId}] Result: from={Source} to={Sink} maxFlow={MaxFlow}, steps={Steps}, block={Block}, totalMs={TotalMs}",
+            ctx.ReqId, ctx.Request.Source, ctx.Request.Sink, maxFlowWei,
+            ctx.Transfers.Count, ctx.Graph.Block, ctx.TotalStopwatch.ElapsedMilliseconds);
 
         return new MaxFlowResponse(
             maxFlowWei.ToString(CultureInfo.InvariantCulture),
             ctx.Transfers,
             ctx.DebugStages)
         {
+            ReqId = ctx.ReqId,
             ConsentDroppedPaths = ctx.ConsentDroppedPaths,
-            ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected
+            ConsentSafetyNetRejected = ctx.ConsentSafetyNetRejected,
+            ValidationErrors = ctx.ValidationErrors,
+            ValidationViolationRules = ctx.ValidationViolationRules
         };
     }
 

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -583,7 +583,12 @@ public class V2Pathfinder
      * Mirrors Hub.sol:668-676 isPermittedFlow():
      * - If From NOT consented → standard trust sufficient
      * - If From consented → requires isTrusted(From, To) && advancedUsageFlags[To]
-     * Router edges skipped (router has no consent, Hub.sol:723 uses Router as sender).
+     *
+     * Router edges are skipped here — this is the post-insertion counterpart of
+     * the IsGroup(to) skip in PathHasConsentViolation. Both exempt group-minting
+     * paths from consent checks: PathHasConsentViolation skips Avatar→Group
+     * (pre-insertion), this method skips Avatar→Router and Router→Group
+     * (post-insertion). Removing either skip breaks the symmetry.
      *
      * Since path-level consent filtering in CollapseBalanceNodes should catch
      * all violations BEFORE aggregation, this method should never filter
@@ -592,7 +597,12 @@ public class V2Pathfinder
      * Still removes edges for safety (better to produce reduced flow than
      * let the contract revert).
      * --------------------------------------------------------------------- */
-    private List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
+    /// <summary>
+    /// Safety-net consent validation on post-router-insertion edges.
+    /// Removes edges violating Hub.sol isPermittedFlow consent rules.
+    /// Should never filter anything if PathHasConsentViolation works correctly.
+    /// </summary>
+    internal List<FlowEdge> ValidateConsentedFlow(List<FlowEdge> edges, CapacityGraph capacityGraph)
     {
         // If no consent data available, pass all edges through
         if (capacityGraph.TrustLookup == null || capacityGraph.ConsentedAvatars.Count == 0)
@@ -612,7 +622,19 @@ public class V2Pathfinder
                 continue;
             }
 
-            // Skip router edges
+            // Catch consented Avatar→Router edges that PathHasConsentViolation should have dropped.
+            // Router lacks advancedUsageFlags — consented senders cannot send to it.
+            if (capacityGraph.IsRouter(edge.To) && capacityGraph.ConsentedAvatars.Contains(edge.From))
+            {
+                _logger.LogError(
+                    "[ValidateConsentedFlow] SAFETY-NET: consented avatar {From}→Router should have been caught by PathHasConsentViolation",
+                    AddressIdPool.StringOf(edge.From)[..10]);
+                rejected++;
+                continue;
+            }
+
+            // Skip remaining router edges — Router is never consented, so standard trust applies.
+            // This is the post-insertion counterpart of the IsGroup(to) skip in PathHasConsentViolation.
             if (capacityGraph.IsRouter(edge.From) || capacityGraph.IsRouter(edge.To))
             {
                 validEdges.Add(edge);
@@ -734,9 +756,20 @@ public class V2Pathfinder
 
         if (droppedPaths > 0)
         {
-            _logger.LogInformation("[CollapseBalanceNodes] Dropped {DroppedPaths}/{TotalPaths} paths due to consent {Mode}",
-                droppedPaths, pathsWithFlow.Count,
-                _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            if (droppedPaths == pathsWithFlow.Count)
+            {
+                _logger.LogWarning(
+                    "[CollapseBalanceNodes] ALL {TotalPaths} paths dropped due to consent {Mode} — result will be zero flow. " +
+                    "Source or intermediaries may have advancedUsageFlags preventing group minting paths.",
+                    pathsWithFlow.Count,
+                    _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            }
+            else
+            {
+                _logger.LogInformation("[CollapseBalanceNodes] Dropped {DroppedPaths}/{TotalPaths} paths due to consent {Mode}",
+                    droppedPaths, pathsWithFlow.Count,
+                    _settings.ExcludeConsentedIntermediaries ? "intermediary exclusion" : "violations");
+            }
         }
 
         /* ---------------- materialise collapsed edges ---------------------- */
@@ -821,10 +854,14 @@ public class V2Pathfinder
      * For each edge: if From is consented → check isTrusted(From, To) AND
      * ConsentedAvatars.Contains(To).
      *
-     * Skip edges where From or To is a group — these become router edges
-     * after InsertRouterInTransfers, and the router bypasses consent checks.
-     * The consented-flow-router-006 scenario depends on this.
+     * Skip Avatar→Group edges (where To is a group) — these become
+     * Avatar→Router→Group after InsertRouterInTransfers.
+     * Group→Avatar (mint) edges stay as-is and must be consent-checked.
      * --------------------------------------------------------------------- */
+    /// <summary>
+    /// Checks if a collapsed path has any consent rule violation per Hub.sol isPermittedFlow.
+    /// Consented sender→Group edges are not skipped (Router lacks advancedUsageFlags).
+    /// </summary>
     internal bool PathHasConsentViolation(
         List<(int From, int To, int Token, long Flow)> collapsedEdges,
         CapacityGraph capacityGraph)
@@ -835,8 +872,11 @@ public class V2Pathfinder
 
         foreach (var (from, to, _, _) in collapsedEdges)
         {
-            // Skip group edges — they become router edges later (router bypasses consent)
-            if (capacityGraph.IsGroup(from) || capacityGraph.IsGroup(to))
+            // Skip Avatar→Group edges ONLY when sender is NOT consented.
+            // Non-consented: safe — standard trust applies after Router insertion.
+            // Consented: DO NOT skip — after Router insertion, Avatar(consented)→Router
+            // fails isPermittedFlow because Router lacks advancedUsageFlags.
+            if (capacityGraph.IsGroup(to) && !capacityGraph.ConsentedAvatars.Contains(from))
                 continue;
 
             // Skip pool nodes (shouldn't exist after collapse, but safety check)
@@ -868,6 +908,10 @@ public class V2Pathfinder
      * is true — instead of validating consent rules, we simply exclude
      * consented avatars from intermediary positions entirely.
      * --------------------------------------------------------------------- */
+    /// <summary>
+    /// Checks if a collapsed path routes through any consented avatar as an intermediary.
+    /// Used in ExcludeConsentedIntermediaries mode as a conservative alternative to consent validation.
+    /// </summary>
     internal bool PathHasConsentedIntermediary(
         List<(int From, int To, int Token, long Flow)> edges,
         CapacityGraph graph, int sourceId, int sinkId)
@@ -876,6 +920,12 @@ public class V2Pathfinder
 
         foreach (var (from, to, _, _) in edges)
         {
+            // Skip Avatar→Group edges ONLY when sender is NOT consented.
+            // Consented sender → Group becomes Consented → Router after insertion,
+            // which fails isPermittedFlow (Router lacks advancedUsageFlags).
+            if (graph.IsGroup(to) && !graph.ConsentedAvatars.Contains(from))
+                continue;
+
             if (from != sourceId && from != sinkId && graph.ConsentedAvatars.Contains(from))
                 return true;
             if (to != sourceId && to != sinkId && graph.ConsentedAvatars.Contains(to))

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -38,7 +38,9 @@ public sealed class CapacityGraphContractState : IContractState
 
     /// <summary>
     /// Hub.sol: isTrusted(truster, circlesId) — does truster accept circlesId's token?
-    /// Maps to CapacityGraph.TrustLookup[trusterId].Contains(circlesIdId).
+    /// Checks TrustLookup first (avatar trusts from trustQuery.sql).
+    /// Falls back to GroupTrustedTokens for group trusters (excluded from TrustLookup
+    /// by trustQuery.sql's WHERE group IS NULL filter, stored separately).
     /// Returns true (permissive) if TrustLookup is null to avoid false positives.
     /// </summary>
     public bool IsTrusted(string truster, string circlesId)
@@ -55,9 +57,15 @@ public sealed class CapacityGraphContractState : IContractState
         if (!AddressIdPool.TryIdOf(circlesIdLower, out int circlesIdId))
             return true;
 
-        if (!_graph.TrustLookup.TryGetValue(trusterId, out var trustedSet))
-            return false; // Truster exists but trusts nothing
+        if (_graph.TrustLookup.TryGetValue(trusterId, out var trustedSet))
+            return trustedSet.Contains(circlesIdId);
 
-        return trustedSet.Contains(circlesIdId);
+        // Groups are excluded from TrustLookup (trustQuery.sql filters them out).
+        // Their trust data lives in GroupTrustedTokens (from groupTrustQuery.sql).
+        if (_graph.IsGroup(trusterId))
+            return _graph.GroupTrustedTokens.TryGetValue(trusterId, out var groupTrusts)
+                   && groupTrusts.Contains(circlesIdId);
+
+        return false; // Truster exists but trusts nothing
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -198,8 +198,10 @@ public static class HubContractValidator
     //       return isTrusted(_from, _to) && advancedUsageFlags[_to];
     //   }
     //
-    // Router edges bypass this check entirely (Hub.sol uses Router as _sender
-    // for group mints, not subject to isPermittedFlow).
+    // Router edge handling (Hub.sol:665, Hub.sol:723):
+    //   Router→Group: internal group mint — Router is _sender, isPermittedFlow N/A.
+    //   Avatar→Router: Hub.sol:665 checks trustMarkers[Router][tokenOwner].expiry.
+    //   Router→NonGroup: fall through to normal validation (fail-closed).
     // ────────────────────────────────────────────
     internal static void ValidateIsPermittedFlow(
         IReadOnlyList<TransferPathStep> steps,
@@ -214,9 +216,24 @@ public static class HubContractValidator
             var to = steps[i].To.ToLowerInvariant();
             var tokenOwner = steps[i].TokenOwner.ToLowerInvariant();
 
-            // Router bypasses isPermittedFlow
-            if (router != null && (from == router || to == router))
+            // Router→Group: internal group mint — Hub.sol uses Router as _sender,
+            // isPermittedFlow does not apply (Hub.sol:723). Safe to skip.
+            if (router != null && from == router && state.IsGroup(to))
                 continue;
+
+            // Avatar→Router: Hub.sol:665 checks trustMarkers[Router][tokenOwner].expiry
+            // Router must trust the token owner for this transfer to succeed.
+            if (router != null && to == router)
+            {
+                if (!state.IsTrusted(router, tokenOwner))
+                {
+                    violations.Add(new ValidationViolation(
+                        "IsPermittedFlow",
+                        $"Edge {i}: Avatar→Router — Router does not trust token owner '{tokenOwner[..Math.Min(10, tokenOwner.Length)]}'",
+                        i, "error"));
+                }
+                continue;
+            }
 
             if (!state.HasAdvancedUsageFlags(from))
             {

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -1024,6 +1024,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 var inValues = TryExtractEnumerableFilterValues(predicate.Value);
                 if (inValues == null)
                     throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
+                if (inValues.Count == 0)
+                    return "1=0"; // empty IN matches nothing
                 if (inValues.Count > MaxInFilterElements)
                     throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
                 return BuildInClause(column, paramName, inValues, parameters, negate: false);
@@ -1034,6 +1036,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
                 if (notInValues == null)
                     throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
+                if (notInValues.Count == 0)
+                    return "1=1"; // empty NOT IN excludes nothing
                 if (notInValues.Count > MaxInFilterElements)
                     throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
                 return BuildInClause(column, paramName, notInValues, parameters, negate: true);
@@ -1274,7 +1278,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
                 if (notInValues.Count == 0)
                 {
-                    return "1=0 /* empty 'not in' filter */";
+                    return "1=1 /* empty 'not in' excludes nothing */";
                 }
 
                 return BuildInClause(column, paramName, notInValues, parameters, negate: true);

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -34,6 +34,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 {
     // Note: Fields, constructor, and CreateConnectionAsync are in RpcModule/CirclesRpcModule.Core.cs
 
+    private const int MaxInFilterElements = 1000;
+
     #region GetTransactionHistory - Version-specific query builders
 
     /// <summary>
@@ -1018,20 +1020,24 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 return $"{column} NOT LIKE {paramName}";
 
             case FilterType.In:
-                if (predicate.Value is Array arr)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr));
-                    return $"{column} = ANY({paramName})";
-                }
-                return "";
+            {
+                var inValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (inValues == null)
+                    throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
+                if (inValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, inValues, parameters, negate: false);
+            }
 
             case FilterType.NotIn:
-                if (predicate.Value is Array arr2)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr2));
-                    return $"{column} != ALL({paramName})";
-                }
-                return "";
+            {
+                var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (notInValues == null)
+                    throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
+                if (notInValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, notInValues, parameters, negate: true);
+            }
 
             case FilterType.IsNull:
                 return $"{column} IS NULL";

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -355,6 +355,19 @@ public interface ICirclesRpcModule
         string? cursor = null);
 
     // ========================================================================
+    // Block Lookup
+    // ========================================================================
+
+    /// <summary>
+    /// Returns the block number closest to the given Unix timestamp.
+    /// Useful for converting human-readable date ranges into block ranges for event queries.
+    /// </summary>
+    /// <param name="timestamp">Unix timestamp (seconds since epoch)</param>
+    /// <param name="direction">"before" (default) = closest block at or before timestamp,
+    /// "after" = closest block at or after timestamp</param>
+    Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before");
+
+    // ========================================================================
     // Generic Database Query
     // ========================================================================
 
@@ -648,6 +661,14 @@ public record HealthResponse(
     long Timestamp,
     string Database,
     string Index
+);
+
+/// <summary>
+/// Response for block-by-timestamp lookup.
+/// </summary>
+public record BlockByTimestampResponse(
+    [property: JsonPropertyName("blockNumber")] long BlockNumber,
+    [property: JsonPropertyName("timestamp")] long Timestamp
 );
 
 /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -152,6 +152,11 @@ public static class OpenRpcGenerator
             "Execute a structured database query with cursor pagination",
             "Server-side cursor pagination version of `circles_query`. Returns `{columns, rows, hasMore, nextCursor}`. Pass `nextCursor` as the `cursor` parameter in subsequent calls.\n\n**Use this for**: Iterating through large query results without loading everything into memory.\n\n**Tip**: Pair with `circles_tables` to discover available tables and their columns."),
 
+        // ── Block Lookup ─────────────────────────────────────────────────────
+        ("circles_getBlockByTimestamp", "GetBlockByTimestamp", "Blocks",
+            "Convert a Unix timestamp to the nearest block number",
+            "Returns the block number closest to the given Unix timestamp. Use `direction: \"before\"` (default) for the block at or before the timestamp, or `\"after\"` for the block at or after. Useful for converting human-readable date ranges into block ranges for `circles_events` queries.\n\n**Common use case**: An explorer wants events between Jan 1 and Feb 1 — call this twice to get fromBlock and toBlock, then pass them to `circles_events`."),
+
         // ── System ───────────────────────────────────────────────────────────
         ("circles_health", "GetHealth", "System",
             "Check service health and sync status",
@@ -457,6 +462,13 @@ public static class OpenRpcGenerator
                 "Maximum number of holders to return. Default: 100, max: 200."),
             Param("cursor", false, "string",
                 "Cursor from a previous response's nextCursor field for pagination (account address).")
+        ],
+        ["circles_getBlockByTimestamp"] =
+        [
+            Param("timestamp", true, "integer",
+                "Unix timestamp in seconds (e.g., 1700000000 for 2023-11-14). Must be non-negative."),
+            Param("direction", false, "string",
+                "Lookup direction: 'before' (default) returns block at or before timestamp, 'after' returns block at or after. Useful for range queries: use 'after' for fromBlock, 'before' for toBlock.")
         ],
         ["circles_health"] =
         [
@@ -1114,6 +1126,28 @@ public static class OpenRpcGenerator
                 [
                     new() { Name = "tokenAddress", Value = ExampleToken },
                     new() { Name = "limit", Value = 100 },
+                ],
+            }
+        ],
+        ["circles_getBlockByTimestamp"] =
+        [
+            new()
+            {
+                Name = "Find block at a date (before)",
+                Description = "Get the block at or before 2025-01-31 00:00:00 UTC",
+                Params =
+                [
+                    new() { Name = "timestamp", Value = 1738281600 },
+                ],
+            },
+            new()
+            {
+                Name = "Find block at a date (after)",
+                Description = "Get the block at or after 2025-02-28 00:00:00 UTC",
+                Params =
+                [
+                    new() { Name = "timestamp", Value = 1740700800 },
+                    new() { Name = "direction", Value = "after" },
                 ],
             }
         ],

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -726,6 +726,7 @@ static async Task<object> DispatchSingleRequest(
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
             // System & Query Methods
+            "circles_getBlockByTimestamp" => await HandleGetBlockByTimestamp(request, rpcModule),
             "circles_events" => await HandleEventsLegacy(request, rpcModule),
             "circles_events_paginated" => await HandleEventsPaginated(request, rpcModule),
             "circles_health" => await HandleHealth(request, rpcModule),
@@ -1513,6 +1514,23 @@ static async Task<object> ReflectionHandler(JsonRpcRequest request, CirclesRpcMo
     }
 
     return result ?? new object();
+}
+
+static async Task<object> HandleGetBlockByTimestamp(JsonRpcRequest request, CirclesRpcModule rpcModule)
+{
+    var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
+
+    if (parameters == null || parameters.Length == 0 || parameters[0].ValueKind == JsonValueKind.Null)
+        throw new ArgumentException("timestamp parameter is required");
+
+    if (parameters[0].ValueKind != JsonValueKind.Number || !parameters[0].TryGetInt64(out var timestamp))
+        throw new ArgumentException("timestamp must be an integer");
+
+    string? direction = null;
+    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        direction = parameters[1].GetString();
+
+    return await rpcModule.GetBlockByTimestamp(timestamp, direction);
 }
 
 static async Task<object> HandleHealth(JsonRpcRequest request, CirclesRpcModule rpcModule)

--- a/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
@@ -51,6 +51,7 @@ public static class RpcMethodClassifier
         "circles_getGroupMembers", "circles_getGroupMemberships",
         "circles_getTransactionHistory", "circles_getTransferData", "circles_getTokenHolders",
         "circlesV2_findPath",
+        "circles_getBlockByTimestamp",
         "circles_events", "circles_events_paginated",
         "circles_health", "circles_tables", "circles_query", "circles_paginated_query",
         "circles_getProfileView", "circles_getTrustNetworkSummary",

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
@@ -151,6 +151,59 @@ public partial class CirclesRpcModule
         );
     }
 
+    public async Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before")
+    {
+        if (timestamp < 0)
+            throw new ArgumentException("timestamp must be non-negative");
+
+        if (direction != null
+            && !string.Equals(direction, "before", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("direction must be 'before' or 'after'");
+
+        var isAfter = string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase);
+
+        var sql = isAfter
+            ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" >= @ts ORDER BY ""timestamp"" ASC LIMIT 1"
+            : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" <= @ts ORDER BY ""timestamp"" DESC LIMIT 1";
+
+        await using var connection = await CreateConnectionAsync();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        cmd.CommandTimeout = 30;
+        cmd.Parameters.AddWithValue("ts", timestamp);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                reader.GetInt64(0),
+                reader.GetInt64(1)
+            );
+        }
+
+        // No block found — return nearest boundary (earliest indexed block for "before", latest for "after")
+        await reader.CloseAsync();
+        await using var fallbackCmd = new NpgsqlCommand(
+            isAfter
+                ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" DESC LIMIT 1"
+                : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" ASC LIMIT 1",
+            connection);
+        fallbackCmd.CommandTimeout = 30;
+
+        await using var fallbackReader = await fallbackCmd.ExecuteReaderAsync();
+        if (await fallbackReader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                fallbackReader.GetInt64(0),
+                fallbackReader.GetInt64(1)
+            );
+        }
+
+        throw new InvalidOperationException("No blocks found in System_Block table");
+    }
+
     public Task<TableNamespace[]> GetTables()
     {
         var namespaces = new List<TableNamespace>();


### PR DESCRIPTION
## Summary
- Add `circles_getBlockByTimestamp(timestamp, direction?)` RPC method — converts Unix timestamps to block numbers via `System_Block` lookup. Enables explorer date-range queries without client-side block guessing.
- Fix `circles_events` `In`/`NotIn` filter predicates silently dropping when `ObjectToInferredTypeConverter` deserializes arrays as `JsonElement`. Reuses type-preserving `TryExtractEnumerableFilterValues` + `BuildInClause` from `circles_query` path.
- Empty `In` → `1=0` (matches nothing), empty `NotIn` → `1=1` (excludes nothing). Also fixes pre-existing bug in `circles_query` where empty `NotIn` incorrectly returned `1=0`.
- Add `circles_getBlockByTimestamp` to OpenRPC spec with params + examples.
- Hardening: input validation, query timeouts, `MaxInFilterElements` cap (1000), proper `-32602` errors.

## Verified on staging
All 13 filter types tested (Equals, NotEquals, GT, GTE, LT, LTE, Like, ILike, NotLike, In, NotIn, Conjunction AND/OR), plus SQL injection attempts, empty arrays, scalar errors, both `circles_events` and `circles_query` paths.

## Test plan
- [x] 137 RPC tests pass, 0 fail
- [x] Deployed and verified on staging (26/26 smoke tests)
- [x] Comprehensive filter testing (26 test cases)
- [x] SQL injection rejected on all vectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `circles_getBlockByTimestamp` RPC method for querying blocks by Unix timestamp with "before"/"after" directional lookup.
  * Introduced simulation canary service for background path validation (opt-in via environment configuration).

* **Bug Fixes**
  * Improved consent validation logic for avatar-to-router and avatar-to-group path filtering.
  * Enhanced registered avatar filtering across balance and trust queries.
  * Fixed EIP-1559 gas parameter values in RPC test cases.

* **Tests**
  * Expanded contract conformance and consent validation test coverage.
  * Updated assertions to reflect corrected router trust and group-minting behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->