### PR TITLE
feat(rpc): circles_getBlockByTimestamp + fix In/NotIn filter predicates

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -34,6 +34,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 {
     // Note: Fields, constructor, and CreateConnectionAsync are in RpcModule/CirclesRpcModule.Core.cs
 
+    private const int MaxInFilterElements = 1000;
+
     #region GetTransactionHistory - Version-specific query builders
 
     /// <summary>
@@ -1018,20 +1020,28 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 return $"{column} NOT LIKE {paramName}";
 
             case FilterType.In:
-                if (predicate.Value is Array arr)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr));
-                    return $"{column} = ANY({paramName})";
-                }
-                return "";
+            {
+                var inValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (inValues == null)
+                    throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
+                if (inValues.Count == 0)
+                    return "1=0"; // empty IN matches nothing
+                if (inValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, inValues, parameters, negate: false);
+            }
 
             case FilterType.NotIn:
-                if (predicate.Value is Array arr2)
-                {
-                    parameters.Add(new NpgsqlParameter(paramName, arr2));
-                    return $"{column} != ALL({paramName})";
-                }
-                return "";
+            {
+                var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
+                if (notInValues == null)
+                    throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
+                if (notInValues.Count == 0)
+                    return "1=1"; // empty NOT IN excludes nothing
+                if (notInValues.Count > MaxInFilterElements)
+                    throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
+                return BuildInClause(column, paramName, notInValues, parameters, negate: true);
+            }
 
             case FilterType.IsNull:
                 return $"{column} IS NULL";
@@ -1268,7 +1278,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
                 if (notInValues.Count == 0)
                 {
-                    return "1=0 /* empty 'not in' filter */";
+                    return "1=1 /* empty 'not in' excludes nothing */";
                 }
 
                 return BuildInClause(column, paramName, notInValues, parameters, negate: true);

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -355,6 +355,19 @@ public interface ICirclesRpcModule
         string? cursor = null);
 
     // ========================================================================
+    // Block Lookup
+    // ========================================================================
+
+    /// <summary>
+    /// Returns the block number closest to the given Unix timestamp.
+    /// Useful for converting human-readable date ranges into block ranges for event queries.
+    /// </summary>
+    /// <param name="timestamp">Unix timestamp (seconds since epoch)</param>
+    /// <param name="direction">"before" (default) = closest block at or before timestamp,
+    /// "after" = closest block at or after timestamp</param>
+    Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before");
+
+    // ========================================================================
     // Generic Database Query
     // ========================================================================
 
@@ -648,6 +661,14 @@ public record HealthResponse(
     long Timestamp,
     string Database,
     string Index
+);
+
+/// <summary>
+/// Response for block-by-timestamp lookup.
+/// </summary>
+public record BlockByTimestampResponse(
+    [property: JsonPropertyName("blockNumber")] long BlockNumber,
+    [property: JsonPropertyName("timestamp")] long Timestamp
 );
 
 /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -152,6 +152,11 @@ public static class OpenRpcGenerator
             "Execute a structured database query with cursor pagination",
             "Server-side cursor pagination version of `circles_query`. Returns `{columns, rows, hasMore, nextCursor}`. Pass `nextCursor` as the `cursor` parameter in subsequent calls.\n\n**Use this for**: Iterating through large query results without loading everything into memory.\n\n**Tip**: Pair with `circles_tables` to discover available tables and their columns."),
 
+        // ── Block Lookup ─────────────────────────────────────────────────────
+        ("circles_getBlockByTimestamp", "GetBlockByTimestamp", "Blocks",
+            "Convert a Unix timestamp to the nearest block number",
+            "Returns the block number closest to the given Unix timestamp. Use `direction: \"before\"` (default) for the block at or before the timestamp, or `\"after\"` for the block at or after. Useful for converting human-readable date ranges into block ranges for `circles_events` queries.\n\n**Common use case**: An explorer wants events between Jan 1 and Feb 1 — call this twice to get fromBlock and toBlock, then pass them to `circles_events`."),
+
         // ── System ───────────────────────────────────────────────────────────
         ("circles_health", "GetHealth", "System",
             "Check service health and sync status",
@@ -457,6 +462,13 @@ public static class OpenRpcGenerator
                 "Maximum number of holders to return. Default: 100, max: 200."),
             Param("cursor", false, "string",
                 "Cursor from a previous response's nextCursor field for pagination (account address).")
+        ],
+        ["circles_getBlockByTimestamp"] =
+        [
+            Param("timestamp", true, "integer",
+                "Unix timestamp in seconds (e.g., 1700000000 for 2023-11-14). Must be non-negative."),
+            Param("direction", false, "string",
+                "Lookup direction: 'before' (default) returns block at or before timestamp, 'after' returns block at or after. Useful for range queries: use 'after' for fromBlock, 'before' for toBlock.")
         ],
         ["circles_health"] =
         [
@@ -1114,6 +1126,28 @@ public static class OpenRpcGenerator
                 [
                     new() { Name = "tokenAddress", Value = ExampleToken },
                     new() { Name = "limit", Value = 100 },
+                ],
+            }
+        ],
+        ["circles_getBlockByTimestamp"] =
+        [
+            new()
+            {
+                Name = "Find block at a date (before)",
+                Description = "Get the block at or before 2025-01-31 00:00:00 UTC",
+                Params =
+                [
+                    new() { Name = "timestamp", Value = 1738281600 },
+                ],
+            },
+            new()
+            {
+                Name = "Find block at a date (after)",
+                Description = "Get the block at or after 2025-02-28 00:00:00 UTC",
+                Params =
+                [
+                    new() { Name = "timestamp", Value = 1740700800 },
+                    new() { Name = "direction", Value = "after" },
                 ],
             }
         ],

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -726,6 +726,7 @@ static async Task<object> DispatchSingleRequest(
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
             // System & Query Methods
+            "circles_getBlockByTimestamp" => await HandleGetBlockByTimestamp(request, rpcModule),
             "circles_events" => await HandleEventsLegacy(request, rpcModule),
             "circles_events_paginated" => await HandleEventsPaginated(request, rpcModule),
             "circles_health" => await HandleHealth(request, rpcModule),
@@ -1513,6 +1514,23 @@ static async Task<object> ReflectionHandler(JsonRpcRequest request, CirclesRpcMo
     }
 
     return result ?? new object();
+}
+
+static async Task<object> HandleGetBlockByTimestamp(JsonRpcRequest request, CirclesRpcModule rpcModule)
+{
+    var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
+
+    if (parameters == null || parameters.Length == 0 || parameters[0].ValueKind == JsonValueKind.Null)
+        throw new ArgumentException("timestamp parameter is required");
+
+    if (parameters[0].ValueKind != JsonValueKind.Number || !parameters[0].TryGetInt64(out var timestamp))
+        throw new ArgumentException("timestamp must be an integer");
+
+    string? direction = null;
+    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        direction = parameters[1].GetString();
+
+    return await rpcModule.GetBlockByTimestamp(timestamp, direction);
 }
 
 static async Task<object> HandleHealth(JsonRpcRequest request, CirclesRpcModule rpcModule)

--- a/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
@@ -51,6 +51,7 @@ public static class RpcMethodClassifier
         "circles_getGroupMembers", "circles_getGroupMemberships",
         "circles_getTransactionHistory", "circles_getTransferData", "circles_getTokenHolders",
         "circlesV2_findPath",
+        "circles_getBlockByTimestamp",
         "circles_events", "circles_events_paginated",
         "circles_health", "circles_tables", "circles_query", "circles_paginated_query",
         "circles_getProfileView", "circles_getTrustNetworkSummary",

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Helpers.cs
@@ -151,6 +151,59 @@ public partial class CirclesRpcModule
         );
     }
 
+    public async Task<BlockByTimestampResponse> GetBlockByTimestamp(long timestamp, string? direction = "before")
+    {
+        if (timestamp < 0)
+            throw new ArgumentException("timestamp must be non-negative");
+
+        if (direction != null
+            && !string.Equals(direction, "before", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase))
+            throw new ArgumentException("direction must be 'before' or 'after'");
+
+        var isAfter = string.Equals(direction, "after", StringComparison.OrdinalIgnoreCase);
+
+        var sql = isAfter
+            ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" >= @ts ORDER BY ""timestamp"" ASC LIMIT 1"
+            : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block""
+               WHERE ""timestamp"" <= @ts ORDER BY ""timestamp"" DESC LIMIT 1";
+
+        await using var connection = await CreateConnectionAsync();
+        await using var cmd = new NpgsqlCommand(sql, connection);
+        cmd.CommandTimeout = 30;
+        cmd.Parameters.AddWithValue("ts", timestamp);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (await reader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                reader.GetInt64(0),
+                reader.GetInt64(1)
+            );
+        }
+
+        // No block found — return nearest boundary (earliest indexed block for "before", latest for "after")
+        await reader.CloseAsync();
+        await using var fallbackCmd = new NpgsqlCommand(
+            isAfter
+                ? @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" DESC LIMIT 1"
+                : @"SELECT ""blockNumber"", ""timestamp"" FROM ""System_Block"" ORDER BY ""blockNumber"" ASC LIMIT 1",
+            connection);
+        fallbackCmd.CommandTimeout = 30;
+
+        await using var fallbackReader = await fallbackCmd.ExecuteReaderAsync();
+        if (await fallbackReader.ReadAsync())
+        {
+            return new BlockByTimestampResponse(
+                fallbackReader.GetInt64(0),
+                fallbackReader.GetInt64(1)
+            );
+        }
+
+        throw new InvalidOperationException("No blocks found in System_Block table");
+    }
+
     public Task<TableNamespace[]> GetTables()
     {
         var namespaces = new List<TableNamespace>();


### PR DESCRIPTION
## Summary
- Add `circles_getBlockByTimestamp(timestamp, direction?)` — converts Unix timestamps to block numbers via `System_Block` lookup
- Fix `circles_events` `In`/`NotIn` filters silently dropping (JsonElement deserialization bug) — reuses type-preserving `TryExtractEnumerableFilterValues` + `BuildInClause` from `circles_query`
- Fix pre-existing empty `NotIn` bug in `circles_query` (returned `1=0` instead of `1=1`)
- Input validation, query timeouts, array size cap, OpenRPC spec entry

## Verified on staging
Already deployed and tested on staging (PRs #290, #292). All 13 filter types + SQL injection + edge cases verified (26 test cases).

## Test plan
- [x] 137 RPC tests pass, 0 fail
- [x] Comprehensive filter testing on staging (26 cases, all pass)
- [x] SQL injection rejected on all vectors