### PR TITLE
fix(cache): BalancesController use IsValidToken for stopped avatar balances

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -150,8 +150,10 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Registration filter: both account and token must be registered
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    // Token-only filter: token owner must be registered.
+                    // Account is NOT checked — stopped avatars can still hold valid tokens.
+                    // Use IsValidBalance (checks both) only in pathfinder graph endpoints.
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     // Classify by checking the wrapper index first (O(1)).

--- a/src/Common/Circles.Common/CirclesInvariants.cs
+++ b/src/Common/Circles.Common/CirclesInvariants.cs
@@ -103,16 +103,27 @@ public static class CirclesInvariants
         if (!registrations.IsRegistered(account))
             return false;
 
-        // Check token validity
+        return IsValidToken(tokenAddress, registrations, wrapperLookup);
+    }
+
+    /// <summary>
+    /// Checks whether a token is valid (owner is registered).
+    /// Does NOT check the holder — use this for informational endpoints where
+    /// stopped/unregistered avatars may still hold valid tokens.
+    /// Use <see cref="IsValidBalance"/> for pathfinder graph filtering (checks both).
+    /// </summary>
+    public static bool IsValidToken(
+        string tokenAddress,
+        IRegistrationSet registrations,
+        IWrapperLookup? wrapperLookup)
+    {
         if (wrapperLookup != null && wrapperLookup.TryGetUnderlyingAvatar(tokenAddress, out var underlyingAvatar))
         {
-            // Wrapper token: underlying avatar must be registered
             if (!registrations.IsRegistered(underlyingAvatar))
                 return false;
         }
         else
         {
-            // Native ERC1155: tokenAddress IS the token owner — must be registered
             if (!registrations.IsRegistered(tokenAddress))
                 return false;
         }


### PR DESCRIPTION
## Summary
Fixes regression from #294 where stopped avatar balances returned 0.

- Stopped avatars can still hold valid tokens — balance API should show them
- Extract `CirclesInvariants.IsValidToken` (token-only check) from `IsValidBalance`
- `BalancesController` uses `IsValidToken` (all 3 endpoints: itemised, totalV2, total)
- `PathfinderGraphController` keeps `IsValidBalance` (checks both account + token)

## Test plan
- [x] 221 tests pass
- [ ] Verify stopped avatar balance is non-zero on staging