### PR TITLE
fix(cache): balance filtering uses token-only check across all layers

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -150,8 +150,10 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Registration filter: both account and token must be registered
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    // Token-only filter: token owner must be registered.
+                    // Account is NOT checked — stopped avatars can still hold valid tokens.
+                    // Use IsValidBalance (checks both) only in pathfinder graph endpoints.
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     // Classify by checking the wrapper index first (O(1)).

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -326,7 +326,7 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
@@ -394,7 +394,7 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -742,7 +742,9 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loading V2 balances from view...");
 
         // Build balances from transfers bounded to the warmup target block.
-        // Registration filter matches balanceQuery.sql: both account AND tokenAddress must be registered.
+        // Token-only filter: tokenAddress (= token owner) must be registered.
+        // Account is NOT filtered — stopped avatars can still hold valid tokens.
+        // (PathfinderGraphController applies the stricter IsValidBalance check at read time.)
         const string sql = @"
             WITH " + RegisteredAvatarsCte + @",
             account_balances AS (
@@ -779,7 +781,6 @@ public class CacheWarmupService : BackgroundService
             )
             SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
             FROM account_balances ab
-            INNER JOIN registered_avatars ra_account ON ra_account.avatar = ab.account
             INNER JOIN registered_avatars ra_token ON ra_token.avatar = ab.""tokenAddress""
             WHERE ab.account != '0x0000000000000000000000000000000000000000'";
 
@@ -872,8 +873,7 @@ public class CacheWarmupService : BackgroundService
                        SUM(CASE WHEN account = t.""from"" THEN t.amount ELSE 0 END) > 0
             )
             SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
-            FROM account_balances ab
-            INNER JOIN registered_avatars ra ON ra.avatar = ab.account";
+            FROM account_balances ab";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("toBlock", toBlock);

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -984,9 +984,9 @@ public class NotificationListenerService : BackgroundService
                 var fromLower = from.ToLowerInvariant();
                 var toLower = to.ToLowerInvariant();
 
-                // Update sender balance — account + token must be valid
+                // Update sender balance — token must be valid (account may be stopped but still holds tokens)
                 if (from != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(fromLower, tokenAddress, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenAddress, _registrations, _wrapperLookup))
                 {
                     var fromKey = $"{fromLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(fromKey))
@@ -998,9 +998,9 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance — account + token must be valid
+                // Update receiver balance — token must be valid
                 if (to != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(toLower, tokenAddress, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenAddress, _registrations, _wrapperLookup))
                 {
                     var toKey = $"{toLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(toKey))
@@ -1091,9 +1091,9 @@ public class NotificationListenerService : BackgroundService
                 var fromLower = from.ToLowerInvariant();
                 var toLower = to.ToLowerInvariant();
 
-                // Update sender balance — account + token must be valid
+                // Update sender balance — token must be valid (account may be stopped)
                 if (from != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(fromLower, tokenKey, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
                 {
                     var fromKey = $"{fromLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(fromKey))
@@ -1105,9 +1105,9 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance — account + token must be valid
+                // Update receiver balance — token must be valid
                 if (to != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(toLower, tokenKey, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
                 {
                     var toKey = $"{toLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(toKey))

--- a/src/Common/Circles.Common/CirclesInvariants.cs
+++ b/src/Common/Circles.Common/CirclesInvariants.cs
@@ -103,16 +103,27 @@ public static class CirclesInvariants
         if (!registrations.IsRegistered(account))
             return false;
 
-        // Check token validity
+        return IsValidToken(tokenAddress, registrations, wrapperLookup);
+    }
+
+    /// <summary>
+    /// Checks whether a token is valid (owner is registered).
+    /// Does NOT check the holder — use this for informational endpoints where
+    /// stopped/unregistered avatars may still hold valid tokens.
+    /// Use <see cref="IsValidBalance"/> for pathfinder graph filtering (checks both).
+    /// </summary>
+    public static bool IsValidToken(
+        string tokenAddress,
+        IRegistrationSet registrations,
+        IWrapperLookup? wrapperLookup)
+    {
         if (wrapperLookup != null && wrapperLookup.TryGetUnderlyingAvatar(tokenAddress, out var underlyingAvatar))
         {
-            // Wrapper token: underlying avatar must be registered
             if (!registrations.IsRegistered(underlyingAvatar))
                 return false;
         }
         else
         {
-            // Native ERC1155: tokenAddress IS the token owner — must be registered
             if (!registrations.IsRegistered(tokenAddress))
                 return false;
         }


### PR DESCRIPTION
## Summary
Fixes regression from #294/#300 where stopped avatar balances returned 0.

The rule: balance API shows token holdings regardless of account registration status (stopped avatars still hold tokens). Pathfinder graph filters both (Hub.sol requires registered flow vertices).

### Changes
- `IsValidToken` extracted from `IsValidBalance` (token-only check)
- Warmup SQL: removed account JOIN, kept tokenAddress filter
- Incremental balance writes: `IsValidToken` instead of `IsValidBalance`
- BalancesController: all 3 V2 endpoints use `IsValidToken`
- PathfinderGraphController: keeps `IsValidBalance` (correct for graph)

### Review agent confirmed
- No unregistered token leakage paths
- No stopped-avatar balance hidden from API
- `IsValidBalance` only used in PathfinderGraphController

## Test plan
- [x] 221 tests pass
- [ ] Verify stopped avatar balance non-zero on staging
- [ ] Verify pathfinder graph still excludes stopped avatars