### PR TITLE
fix(cache,pathfinder): stopped avatars are still registered per Hub.sol

### DIFF
--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -35,17 +35,11 @@ public class CacheWarmupService : BackgroundService
     /// </summary>
     private const string RegisteredAvatarsCte = @"
             registered_avatars AS MATERIALIZED (
-                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterOrganization"".""organization"" AND s.""blockNumber"" <= @toBlock)
+                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization"" WHERE ""blockNumber"" <= @toBlock
                 UNION ALL
-                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterGroup"".""group"" AND s.""blockNumber"" <= @toBlock)
+                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup"" WHERE ""blockNumber"" <= @toBlock
                 UNION ALL
-                SELECT avatar FROM ""CrcV2_RegisterHuman""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterHuman"".""avatar"" AND s.""blockNumber"" <= @toBlock)
+                SELECT avatar FROM ""CrcV2_RegisterHuman"" WHERE ""blockNumber"" <= @toBlock
             )";
 
     public CacheWarmupService(
@@ -499,7 +493,8 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loading V2 avatars...");
 
         // Load V2 avatars (humans and organizations) using Seed() for efficiency.
-        // Excludes stopped avatars so downstream registration checks auto-exclude their data.
+        // Stopped avatars are NOT excluded — Hub.sol stop() only prevents minting,
+        // it does not deregister the avatar. They can still transfer and be flow vertices.
         const string avatarSql = @"
             SELECT
                 r.""avatar"" as address,
@@ -507,11 +502,6 @@ public class CacheWarmupService : BackgroundService
                 'CrcV2_RegisterHuman' as type
             FROM ""CrcV2_RegisterHuman"" r
             WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""avatar""
-                    AND s.""blockNumber"" <= @toBlock
-              )
 
             UNION ALL
 
@@ -520,12 +510,7 @@ public class CacheWarmupService : BackgroundService
                 r.""timestamp"",
                 'CrcV2_RegisterOrganization' as type
             FROM ""CrcV2_RegisterOrganization"" r
-            WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""organization""
-                    AND s.""blockNumber"" <= @toBlock
-              )";
+            WHERE r.""blockNumber"" <= @toBlock";
 
         var v2Avatars = new Dictionary<string, (string Type, long Timestamp)>();
         var humanCount = 0;
@@ -566,12 +551,7 @@ public class CacheWarmupService : BackgroundService
                 r.""mint"",
                 r.""symbol""
             FROM ""CrcV2_RegisterGroup"" r
-            WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""group""
-                    AND s.""blockNumber"" <= @toBlock
-              )";
+            WHERE r.""blockNumber"" <= @toBlock";
 
         var groups = new Dictionary<string, (string Name, string Mint, string Symbol)>();
 

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -516,9 +516,8 @@ public class NotificationListenerService : BackgroundService
         // Process V2 RegisterGroup
         await ProcessV2RegisterGroupAsync(conn, fromBlock, toBlock, ct);
 
-        // Process V2 Stopped (remove deregistered avatars — must run before trust/transfers
-        // so downstream registration checks exclude stopped avatars)
-        await ProcessV2StoppedAsync(conn, fromBlock, toBlock, ct);
+        // Note: CrcV2_Stopped is NOT processed here — stop() only prevents minting,
+        // it does not deregister the avatar. Stopped avatars remain in V2Avatars/Groups.
 
         // Process V2 Trust (for group memberships)
         await ProcessV2TrustAsync(conn, fromBlock, toBlock, ct);
@@ -645,41 +644,6 @@ public class NotificationListenerService : BackgroundService
         if (count > 0)
         {
             _logger.LogDebug("Processed {Count} V2 group registrations", count);
-        }
-    }
-
-    private async Task ProcessV2StoppedAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
-    {
-        const string sql = @"
-            SELECT s.""blockNumber"", s.""avatar""
-            FROM ""CrcV2_Stopped"" s
-            WHERE s.""blockNumber"" >= @fromBlock AND s.""blockNumber"" <= @toBlock
-            ORDER BY s.""blockNumber"", s.""transactionIndex"", s.""logIndex""";
-
-        await using var cmd = new NpgsqlCommand(sql, conn);
-        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
-        cmd.Parameters.AddWithValue("toBlock", toBlock);
-
-        var count = 0;
-        await using (var reader = await cmd.ExecuteReaderAsync(ct))
-        {
-            while (await reader.ReadAsync(ct))
-            {
-                var blockNumber = reader.GetInt64(0);
-                var avatar = reader.GetString(1).ToLowerInvariant();
-
-                // Remove from V2Avatars AND Groups — downstream registration checks will
-                // auto-exclude this avatar's trust, balances, wrappers, and consent flags.
-                // Groups can also be stopped (Hub.sol stop() works for any registered avatar).
-                _caches.V2Avatars.Remove(blockNumber, avatar);
-                _caches.Groups.Remove(blockNumber, avatar);
-                count++;
-            }
-        }
-
-        if (count > 0)
-        {
-            _logger.LogInformation("Processed {Count} V2 stopped events (removed from V2Avatars)", count);
         }
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -507,8 +507,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void StoppedAvatar_ExcludedFromContains()
+    public void StoppedAvatar_StillInContains()
     {
+        // Hub.sol stop() only prevents minting — avatar remains registered
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -518,14 +519,16 @@ public class InMemoryAvatarStateTests
 
         state.InitializeStoppedAvatars(new[] { Alice });
 
-        Assert.That(state.Contains(Alice), Is.False);
+        Assert.That(state.Contains(Alice), Is.True, "Stopped avatars are still registered");
         Assert.That(state.Contains(Bob), Is.True);
         Assert.That(state.StoppedCount, Is.EqualTo(1));
+        Assert.That(state.IsStopped(Alice), Is.True);
     }
 
     [Test]
-    public void MarkStopped_ExcludesFromContains()
+    public void MarkStopped_StillInContains()
     {
+        // Hub.sol stop() only prevents minting — avatar remains registered
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
 
@@ -533,7 +536,8 @@ public class InMemoryAvatarStateTests
 
         state.MarkStopped(Alice);
 
-        Assert.That(state.Contains(Alice), Is.False);
+        Assert.That(state.Contains(Alice), Is.True, "Stopped avatars are still registered");
+        Assert.That(state.IsStopped(Alice), Is.True, "IsStopped tracks the stop event");
     }
 
     [Test]
@@ -544,8 +548,9 @@ public class InMemoryAvatarStateTests
         state.MarkStopped(Alice);
 
         var snapshot = state.Snapshot();
-        Assert.That(snapshot.Contains(Alice), Is.False);
+        Assert.That(snapshot.Contains(Alice), Is.True, "Stopped avatars remain in snapshot");
         Assert.That(snapshot.StoppedCount, Is.EqualTo(1));
+        Assert.That(snapshot.IsStopped(Alice), Is.True);
     }
 
     [Test]
@@ -580,8 +585,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void GetActiveAvatarSet_MarkStopped_InvalidatesCache()
+    public void GetActiveAvatarSet_MarkStopped_DoesNotExclude()
     {
+        // Hub.sol stop() only prevents minting — GetActiveAvatarSet includes stopped
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -595,12 +601,12 @@ public class InMemoryAvatarStateTests
         state.MarkStopped(Alice);
 
         var set2 = state.GetActiveAvatarSet();
-        Assert.That(set2, Has.Count.EqualTo(1));
-        Assert.That(set2.Contains(Alice), Is.False);
+        Assert.That(set2, Has.Count.EqualTo(2), "Stopped avatars remain in active set");
+        Assert.That(set2.Contains(Alice), Is.True);
     }
 
     [Test]
-    public void GetActiveAvatarSet_InitializeFromFullLoad_InvalidatesCache()
+    public void GetActiveAvatarSet_InitializeFromFullLoad_ReplacesSet()
     {
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
@@ -616,8 +622,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void GetActiveAvatarSet_InitializeStoppedAvatars_InvalidatesCache()
+    public void GetActiveAvatarSet_InitializeStoppedAvatars_DoesNotExclude()
     {
+        // Stopped avatars remain in active set — stop() only prevents minting
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -631,8 +638,8 @@ public class InMemoryAvatarStateTests
         state.InitializeStoppedAvatars(new[] { Bob });
 
         var set2 = state.GetActiveAvatarSet();
-        Assert.That(set2, Has.Count.EqualTo(1));
-        Assert.That(set2.Contains(Bob), Is.False);
+        Assert.That(set2, Has.Count.EqualTo(2), "Stopped avatars remain in active set");
+        Assert.That(set2.Contains(Bob), Is.True);
     }
 }
 
@@ -831,8 +838,9 @@ public class IncrementalLoadGraphTests
     }
 
     [Test]
-    public void LoadRegisteredAvatars_ExcludesStoppedAvatars()
+    public void LoadRegisteredAvatars_IncludesStoppedAvatars()
     {
+        // Hub.sol stop() only prevents minting — stopped avatars remain registered
         var avatars = CreateAvatarState(
             (Alice, "CrcV2_RegisterHuman"),
             (Bob, "CrcV2_RegisterHuman"));
@@ -845,7 +853,7 @@ public class IncrementalLoadGraphTests
         var registered = incGraph.LoadRegisteredAvatars().ToHashSet();
 
         Assert.That(registered.Contains(Alice), Is.True);
-        Assert.That(registered.Contains(Bob), Is.False);
+        Assert.That(registered.Contains(Bob), Is.True, "Stopped avatars are still registered");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
@@ -3,43 +3,40 @@ namespace Circles.Pathfinder.Data;
 /// <summary>
 /// In-memory set of registered avatars and groups.
 /// Used to filter trust/balance edges to only include registered participants.
-/// Stopped avatars (D13) are excluded from Contains() checks.
+///
+/// Hub.sol stop() only prevents future minting — it does NOT deregister the avatar.
+/// Stopped avatars remain registered, can transfer, and can be flow vertices.
+/// The _stopped set is retained for informational/metric purposes only.
 /// </summary>
 public class InMemoryAvatarState
 {
     private readonly HashSet<string> _avatars = new();
     private readonly HashSet<string> _groups = new();
     private readonly HashSet<string> _stopped = new();
-    private HashSet<string>? _cachedActiveSet;
 
     /// <summary>Total number of registered avatars (including stopped).</summary>
     public int Count => _avatars.Count;
     /// <summary>Number of registered groups.</summary>
     public int GroupCount => _groups.Count;
-    /// <summary>Number of stopped avatars.</summary>
+    /// <summary>Number of stopped avatars (informational only — they're still registered).</summary>
     public int StoppedCount => _stopped.Count;
 
-    /// <summary>All registered avatars (including groups), excluding stopped.</summary>
+    /// <summary>All registered avatars (including groups and stopped).</summary>
     public HashSet<string> AvatarSet => _avatars;
 
     /// <summary>Only registered groups (subset of avatars).</summary>
     public HashSet<string> GetGroupSet() => _groups;
 
-    /// <summary>All registered avatars excluding stopped avatars. Cached until mutation.</summary>
-    public IReadOnlySet<string> GetActiveAvatarSet()
-    {
-        return _cachedActiveSet ??= _avatars.Where(a => !_stopped.Contains(a)).ToHashSet();
-    }
+    /// <summary>All registered avatars. Stopped avatars are included (still registered per Hub.sol).</summary>
+    public IReadOnlySet<string> GetActiveAvatarSet() => _avatars;
 
-    /// <summary>Returns true if address is a registered, non-stopped avatar.</summary>
+    /// <summary>Returns true if address is a registered avatar (including stopped).</summary>
     public bool Contains(string address)
     {
-        var lower = address.ToLowerInvariant();
-        return _avatars.Contains(lower) && !_stopped.Contains(lower);
+        return _avatars.Contains(address.ToLowerInvariant());
     }
 
-    /// <summary>Returns true if address was ever registered (including stopped avatars).
-    /// Use for tokenAddress validation — stopped avatars' tokens are still valid on-chain.</summary>
+    /// <summary>Returns true if address was ever registered (same as Contains — stopped are registered).</summary>
     public bool IsRegistered(string address)
     {
         return _avatars.Contains(address.ToLowerInvariant());
@@ -54,7 +51,6 @@ public class InMemoryAvatarState
     /// </summary>
     public void InitializeFromFullLoad(IEnumerable<(string Avatar, string Type)> rows)
     {
-        _cachedActiveSet = null;
         _avatars.Clear();
         _groups.Clear();
         foreach (var row in rows)
@@ -66,27 +62,27 @@ public class InMemoryAvatarState
     }
 
     /// <summary>
-    /// Load stopped avatars (full state). Clears and repopulates the stopped set.
+    /// Load stopped avatars (informational only — does not affect registration checks).
     /// </summary>
     public void InitializeStoppedAvatars(IEnumerable<string> stoppedAvatars)
     {
-        _cachedActiveSet = null;
         _stopped.Clear();
         foreach (var avatar in stoppedAvatars)
             _stopped.Add(avatar.ToLowerInvariant());
     }
 
-    /// <summary>Mark an avatar as stopped (incremental delta).</summary>
+    /// <summary>Mark an avatar as stopped (informational only).</summary>
     public void MarkStopped(string avatar)
     {
-        _cachedActiveSet = null;
         _stopped.Add(avatar.ToLowerInvariant());
     }
+
+    /// <summary>Returns true if the avatar has been stopped (informational — they're still registered).</summary>
+    public bool IsStopped(string address) => _stopped.Contains(address.ToLowerInvariant());
 
     /// <summary>Register a new avatar (incremental delta). Groups added to both sets.</summary>
     public void AddAvatar(string avatar, string type)
     {
-        _cachedActiveSet = null;
         avatar = avatar.ToLowerInvariant();
         _avatars.Add(avatar);
         if (type == "CrcV2_RegisterGroup")


### PR DESCRIPTION
## Summary
Hub.sol `stop()` only prevents minting — does NOT deregister. Removes all stopped-avatar exclusions from cache (#294 regression) and pathfinder (pre-existing bug).

- Cache: remove `NOT EXISTS CrcV2_Stopped` from `RegisteredAvatarsCte`, avatar/group warmup SQL, remove `ProcessV2StoppedAsync`
- Pathfinder: `InMemoryAvatarState.Contains()` / `GetActiveAvatarSet()` no longer exclude stopped

## Test plan
- [x] 221 cache tests pass
- [x] 917 pathfinder tests pass
- [ ] Verify stopped avatar balance non-zero on staging