### PR TITLE
feat(cache,pathfinder): unified trust & registration invariant enforcement

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
@@ -1,0 +1,417 @@
+using System.Numerics;
+using System.Text.Json;
+using Circles.Cache.Service.Caches;
+using Circles.Cache.Service.Controllers;
+using Circles.Cache.Service.Models;
+using Circles.Common;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Circles.Cache.Service.Tests;
+
+/// <summary>
+/// Conformance tests that verify the PathfinderGraphController output correctly
+/// filters data through the shared CirclesInvariants predicates.
+///
+/// These tests use a synthetic cache populated with both registered and unregistered
+/// addresses, and verify that the controller output contains ONLY valid entries.
+///
+/// Key invariants tested:
+/// 1. Balances: only registered accounts with registered token owners
+/// 2. Trust: only registered truster/trustee, non-group trusters, non-expired
+/// 3. GroupTrusts: only router-group trusters, registered trustees
+/// 4. Wrappers: only wrappers whose underlying avatar is registered
+/// 5. ConsentedFlow: only registered avatars
+/// </summary>
+public class CachePathfinderConformanceTests
+{
+    // Registered addresses
+    private const string Human1 = "0x0000000000000000000000000000000000000001";
+    private const string Human2 = "0x0000000000000000000000000000000000000002";
+    private const string Org1 = "0x0000000000000000000000000000000000000003";
+    private const string RouterGroup = "0x0000000000000000000000000000000000000004";
+    private const string NonRouterGroup = "0x0000000000000000000000000000000000000005";
+    private const string StandardTreasuryMint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
+
+    // Unregistered address (never added to avatars/groups)
+    private const string Unregistered = "0x0000000000000000000000000000000000000099";
+
+    // Wrapper addresses
+    private const string Wrapper1 = "0x0000000000000000000000000000000000000011";
+    private const string WrapperUnregistered = "0x0000000000000000000000000000000000000012";
+
+    private const long Block = 100;
+    private const long CurrentTimestamp = 10000;
+    // Must be after wall-clock time since BuildTrust uses DateTimeOffset.UtcNow
+    private static readonly long FutureExpiry = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 86400 * 365;
+    private const long PastExpiry = 500;
+
+    /// <summary>
+    /// Creates a cache container seeded with both valid and invalid test data.
+    /// </summary>
+    private static CacheContainer CreateSeededCache()
+    {
+        var caches = new CacheContainer(rollbackCapacity: 4);
+
+        // --- Register avatars ---
+        caches.V2Avatars.Add(Block, Human1, ("Human", Block));
+        caches.V2Avatars.Add(Block, Human2, ("Human", Block));
+        caches.V2Avatars.Add(Block, Org1, ("Organization", Block));
+
+        // --- Register groups ---
+        caches.Groups.Add(Block, RouterGroup, ("RouterGroup", StandardTreasuryMint, "RG"));
+        caches.Groups.Add(Block, NonRouterGroup, ("NonRouterGroup", "0xothermint", "NRG"));
+
+        // --- Wrappers ---
+        caches.UpsertWrapper(Block, Wrapper1, Human1, 0); // valid: underlying is registered
+        caches.UpsertWrapper(Block, WrapperUnregistered, Unregistered, 0); // INVALID: underlying is unregistered
+
+        // --- V2 Balances ---
+        // Valid: registered account, registered token owner (native)
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Human1}:{Human2}", 100m);
+        caches.V2LastActivity.Add(Block, $"{Human1}:{Human2}", CurrentTimestamp);
+        // Valid: registered account, group token
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Human1}:{RouterGroup}", 50m);
+        caches.V2LastActivity.Add(Block, $"{Human1}:{RouterGroup}", CurrentTimestamp);
+        // INVALID: unregistered account
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Unregistered}:{Human1}", 200m);
+        caches.V2LastActivity.Add(Block, $"{Unregistered}:{Human1}", CurrentTimestamp);
+        // INVALID: unregistered token owner
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Human1}:{Unregistered}", 150m);
+        caches.V2LastActivity.Add(Block, $"{Human1}:{Unregistered}", CurrentTimestamp);
+        // Valid: wrapper token with registered underlying
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Human2}:{Wrapper1}", 75m);
+        caches.V2LastActivity.Add(Block, $"{Human2}:{Wrapper1}", CurrentTimestamp);
+        // INVALID: wrapper token with unregistered underlying
+        caches.V2BalancesByAccountAndToken.Add(Block, $"{Human1}:{WrapperUnregistered}", 60m);
+        caches.V2LastActivity.Add(Block, $"{Human1}:{WrapperUnregistered}", CurrentTimestamp);
+
+        // --- V2 Trust ---
+        // Valid: human trusts human, not expired
+        caches.UpsertV2Trust(Block, Human1, Human2, FutureExpiry);
+        // Valid: human trusts group
+        caches.UpsertV2Trust(Block, Human1, RouterGroup, FutureExpiry);
+        // Valid: human trusts non-router group (this is where old code had a bug!)
+        caches.UpsertV2Trust(Block, Human2, NonRouterGroup, FutureExpiry);
+        // INVALID: unregistered truster
+        caches.UpsertV2Trust(Block, Unregistered, Human1, FutureExpiry);
+        // INVALID: unregistered trustee
+        caches.UpsertV2Trust(Block, Human1, Unregistered, FutureExpiry);
+        // INVALID: expired trust
+        caches.UpsertV2Trust(Block, Human2, Org1, PastExpiry);
+        // Group trust (should appear in GroupTrusts, NOT in Trust)
+        caches.UpsertV2Trust(Block, RouterGroup, Human1, FutureExpiry);
+        caches.UpsertV2Trust(Block, RouterGroup, Unregistered, FutureExpiry); // INVALID trustee
+
+        // --- Consented flow flags ---
+        var consentFlag = new byte[32];
+        consentFlag[31] = 0x01; // bit 0 set = consented
+        caches.ConsentedFlowFlags.Add(Block, Human1, consentFlag);
+        caches.ConsentedFlowFlags.Add(Block, Unregistered, consentFlag); // INVALID: unregistered
+
+        caches.RebuildSecondaryIndexes();
+        return caches;
+    }
+
+    private static PathfinderGraphController CreateController(CacheContainer caches)
+    {
+        var state = new CacheServiceState(rollbackCapacity: 4);
+        state.WarmupTargetBlock = Block;
+        state.LastProcessedBlock = Block;
+        state.WarmupComplete = true;
+
+        var controller = new PathfinderGraphController(
+            caches,
+            state,
+            NullLogger<PathfinderGraphController>.Instance);
+
+        // Create a minimal HttpContext so the controller can read headers
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+
+        return controller;
+    }
+
+    // --- Balance Conformance ---
+
+    [Fact]
+    public void Balances_ExcludeUnregisteredAccounts()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("balances");
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as PathfinderGraphResponse;
+        response.Should().NotBeNull();
+
+        var accounts = response!.Balances!.Select(b => b.Account).ToHashSet();
+        accounts.Should().NotContain(Unregistered, "unregistered accounts must be filtered");
+    }
+
+    [Fact]
+    public void Balances_ExcludeUnregisteredTokenOwners()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("balances");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        // Should not contain a balance where tokenAddress = Unregistered
+        var tokenAddresses = response!.Balances!.Select(b => b.TokenAddress).ToHashSet();
+        tokenAddresses.Should().NotContain(Unregistered, "unregistered token owners must be filtered");
+    }
+
+    [Fact]
+    public void Balances_ExcludeWrappersWithUnregisteredUnderlying()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("balances");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var tokenAddresses = response!.Balances!.Select(b => b.TokenAddress).ToHashSet();
+        tokenAddresses.Should().NotContain(WrapperUnregistered,
+            "wrappers with unregistered underlying avatar must be filtered");
+    }
+
+    [Fact]
+    public void Balances_IncludeValidEntries()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("balances");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        // Valid entries: Human1:Human2, Human1:RouterGroup, Human2:Wrapper1
+        response!.Balances!.Count.Should().Be(3, "exactly 3 valid balance entries should remain");
+    }
+
+    // --- Trust Conformance ---
+
+    [Fact]
+    public void Trust_ExcludeUnregisteredTrusterOrTrustee()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("trust");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var addresses = response!.Trust!
+            .SelectMany(t => new[] { t.Truster, t.Trustee })
+            .ToHashSet();
+        addresses.Should().NotContain(Unregistered, "unregistered addresses must not appear in trust edges");
+    }
+
+    [Fact]
+    public void Trust_ExcludeExpiredEdges()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("trust");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        // Human2 -> Org1 has PastExpiry (500), currentTimestamp is ~now (>>500)
+        var human2Trusts = response!.Trust!.Where(t => t.Truster == Human2).Select(t => t.Trustee).ToList();
+        human2Trusts.Should().NotContain(Org1, "expired trust edges must be filtered");
+    }
+
+    [Fact]
+    public void Trust_ExcludeGroupTrusters()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("trust");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var trusters = response!.Trust!.Select(t => t.Truster).ToHashSet();
+        trusters.Should().NotContain(RouterGroup, "group trusters must be excluded from Trust (handled in GroupTrusts)");
+    }
+
+    [Fact]
+    public void Trust_IncludeNonRouterGroupAsTrustee()
+    {
+        // BUG FIX verification: old code checked routerGroups.Contains(trustee) which missed non-router groups
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("trust");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var trustees = response!.Trust!.Select(t => t.Trustee).ToHashSet();
+        trustees.Should().Contain(NonRouterGroup,
+            "non-router groups as trustees should be included (they're registered avatars)");
+    }
+
+    // --- GroupTrust Conformance ---
+
+    [Fact]
+    public void GroupTrusts_OnlyRouterGroups()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("grouptrusts");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var groups = response!.GroupTrusts!.Select(gt => gt.GroupAddress).ToHashSet();
+        groups.Should().OnlyContain(g => g == RouterGroup, "only router groups should appear as group trusters");
+    }
+
+    [Fact]
+    public void GroupTrusts_ExcludeUnregisteredTrustees()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("grouptrusts");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var trustees = response!.GroupTrusts!.Select(gt => gt.TrustedToken).ToHashSet();
+        trustees.Should().NotContain(Unregistered, "unregistered trustees must be filtered from group trusts");
+    }
+
+    [Fact]
+    public void GroupTrusts_IncludeValidEntries()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("grouptrusts");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        // RouterGroup trusts Human1 (valid), RouterGroup trusts Unregistered (invalid)
+        response!.GroupTrusts!.Count.Should().Be(1, "only one valid group trust edge should remain");
+        response.GroupTrusts[0].TrustedToken.Should().Be(Human1);
+    }
+
+    // --- WrapperMapping Conformance ---
+
+    [Fact]
+    public void WrapperMappings_ExcludeUnregisteredUnderlying()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("wrappermappings");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var underlyingAvatars = response!.WrapperMappings!.Select(w => w.UnderlyingAvatar).ToHashSet();
+        underlyingAvatars.Should().NotContain(Unregistered.ToLowerInvariant(),
+            "wrappers with unregistered underlying must be filtered");
+    }
+
+    [Fact]
+    public void WrapperMappings_IncludeValidEntries()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("wrappermappings");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        response!.WrapperMappings!.Count.Should().Be(1, "only one valid wrapper mapping should remain");
+        response.WrapperMappings[0].WrapperAddress.Should().Be(Wrapper1);
+    }
+
+    // --- ConsentedFlow Conformance ---
+
+    [Fact]
+    public void ConsentedFlow_ExcludeUnregisteredAvatars()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("consentedflow");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        var avatars = response!.ConsentedFlow!.Select(c => c.Avatar).ToHashSet();
+        avatars.Should().NotContain(Unregistered, "unregistered avatars must not have consented flow flags");
+    }
+
+    [Fact]
+    public void ConsentedFlow_IncludeValidEntries()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph("consentedflow");
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        response!.ConsentedFlow!.Count.Should().Be(1, "only one valid consented flow flag should remain");
+        response.ConsentedFlow[0].Avatar.Should().Be(Human1);
+    }
+
+    // --- Cross-cutting: no unregistered address appears in ANY section ---
+
+    [Fact]
+    public void FullGraph_NoUnregisteredAddressInAnySection()
+    {
+        var caches = CreateSeededCache();
+        var controller = CreateController(caches);
+        var result = controller.GetGraph(null); // all sections
+
+        var ok = result.Result as OkObjectResult;
+        var response = ok!.Value as PathfinderGraphResponse;
+
+        // Collect all addresses from all sections
+        var allAddresses = new HashSet<string>();
+
+        foreach (var b in response!.Balances!)
+        {
+            allAddresses.Add(b.Account);
+            allAddresses.Add(b.TokenAddress);
+        }
+
+        foreach (var t in response.Trust!)
+        {
+            allAddresses.Add(t.Truster);
+            allAddresses.Add(t.Trustee);
+        }
+
+        foreach (var gt in response.GroupTrusts!)
+        {
+            allAddresses.Add(gt.GroupAddress);
+            allAddresses.Add(gt.TrustedToken);
+        }
+
+        foreach (var c in response.ConsentedFlow!)
+        {
+            allAddresses.Add(c.Avatar);
+        }
+
+        foreach (var w in response.WrapperMappings!)
+        {
+            allAddresses.Add(w.UnderlyingAvatar);
+        }
+
+        allAddresses.Should().NotContain(Unregistered);
+        allAddresses.Should().NotContain(Unregistered.ToLowerInvariant());
+    }
+}

--- a/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
@@ -50,7 +50,7 @@ public class CirclesInvariantsTests
     [Fact]
     public void IsValidTrustEdge_BothRegistered_NotExpired_NonGroup_ReturnsTrue()
     {
-        CirclesInvariants.IsValidTrustEdge(Human1, Human2, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Human1, Human2, 9999, 1000, Registrations)
             .Should().BeTrue();
     }
 
@@ -62,24 +62,24 @@ public class CirclesInvariantsTests
     }
 
     [Fact]
-    public void IsValidTrustEdge_ZeroExpiry_TreatedAsIndefinite()
+    public void IsValidTrustEdge_ZeroExpiry_TreatedAsUntrust()
     {
-        // expiryTime == 0 means never-set / indefinite → active
+        // expiryTime == 0 is explicit untrust in Hub.sol — write path removes these entries
         CirclesInvariants.IsValidTrustEdge(Human1, Human2, 0, 1000, Registrations)
-            .Should().BeTrue();
+            .Should().BeFalse();
     }
 
     [Fact]
     public void IsValidTrustEdge_UnregisteredTruster_ReturnsFalse()
     {
-        CirclesInvariants.IsValidTrustEdge(Unregistered, Human2, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Unregistered, Human2, 9999, 1000, Registrations)
             .Should().BeFalse();
     }
 
     [Fact]
     public void IsValidTrustEdge_UnregisteredTrustee_ReturnsFalse()
     {
-        CirclesInvariants.IsValidTrustEdge(Human1, Unregistered, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Human1, Unregistered, 9999, 1000, Registrations)
             .Should().BeFalse();
     }
 
@@ -87,7 +87,7 @@ public class CirclesInvariantsTests
     public void IsValidTrustEdge_GroupAsTruster_ReturnsFalse()
     {
         // Group trusters are excluded — handled separately as group trust edges
-        CirclesInvariants.IsValidTrustEdge(Group1, Human1, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Group1, Human1, 9999, 1000, Registrations)
             .Should().BeFalse();
     }
 
@@ -95,7 +95,7 @@ public class CirclesInvariantsTests
     public void IsValidTrustEdge_GroupAsTrustee_ReturnsTrue()
     {
         // Groups CAN be trustees (someone can trust a group's token)
-        CirclesInvariants.IsValidTrustEdge(Human1, Group1, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Human1, Group1, 9999, 1000, Registrations)
             .Should().BeTrue();
     }
 
@@ -104,7 +104,7 @@ public class CirclesInvariantsTests
     {
         // Non-router groups are still registered avatars — they can be trustees
         // BUG FIX: Old code checked routerGroups only, missing non-router groups
-        CirclesInvariants.IsValidTrustEdge(Human1, Group2, 0, 1000, Registrations)
+        CirclesInvariants.IsValidTrustEdge(Human1, Group2, 9999, 1000, Registrations)
             .Should().BeTrue();
     }
 
@@ -113,21 +113,21 @@ public class CirclesInvariantsTests
     [Fact]
     public void IsValidGroupTrustEdge_RouterGroup_RegisteredTrustee_ReturnsTrue()
     {
-        CirclesInvariants.IsValidGroupTrustEdge(Group1, Human1, 0, 1000, Registrations, RouterGroups)
+        CirclesInvariants.IsValidGroupTrustEdge(Group1, Human1, 9999, 1000, Registrations, RouterGroups)
             .Should().BeTrue();
     }
 
     [Fact]
     public void IsValidGroupTrustEdge_NonRouterGroup_ReturnsFalse()
     {
-        CirclesInvariants.IsValidGroupTrustEdge(Group2, Human1, 0, 1000, Registrations, RouterGroups)
+        CirclesInvariants.IsValidGroupTrustEdge(Group2, Human1, 9999, 1000, Registrations, RouterGroups)
             .Should().BeFalse();
     }
 
     [Fact]
     public void IsValidGroupTrustEdge_UnregisteredTrustee_ReturnsFalse()
     {
-        CirclesInvariants.IsValidGroupTrustEdge(Group1, Unregistered, 0, 1000, Registrations, RouterGroups)
+        CirclesInvariants.IsValidGroupTrustEdge(Group1, Unregistered, 9999, 1000, Registrations, RouterGroups)
             .Should().BeFalse();
     }
 
@@ -207,14 +207,14 @@ public class CirclesInvariantsTests
     [Fact]
     public void IsValidGroupMembership_RegisteredGroupAndMember_ReturnsTrue()
     {
-        CirclesInvariants.IsValidGroupMembership(Group1, Human1, 0, 1000, Registrations)
+        CirclesInvariants.IsValidGroupMembership(Group1, Human1, 9999, 1000, Registrations)
             .Should().BeTrue();
     }
 
     [Fact]
     public void IsValidGroupMembership_UnregisteredMember_ReturnsFalse()
     {
-        CirclesInvariants.IsValidGroupMembership(Group1, Unregistered, 0, 1000, Registrations)
+        CirclesInvariants.IsValidGroupMembership(Group1, Unregistered, 9999, 1000, Registrations)
             .Should().BeFalse();
     }
 
@@ -222,7 +222,7 @@ public class CirclesInvariantsTests
     public void IsValidGroupMembership_NonGroupAddress_ReturnsFalse()
     {
         // Human address as "group" — not a group
-        CirclesInvariants.IsValidGroupMembership(Human1, Human2, 0, 1000, Registrations)
+        CirclesInvariants.IsValidGroupMembership(Human1, Human2, 9999, 1000, Registrations)
             .Should().BeFalse();
     }
 

--- a/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
@@ -1,0 +1,312 @@
+using Circles.Cache.Service.Caches;
+using Circles.Common;
+using FluentAssertions;
+using Xunit;
+
+namespace Circles.Cache.Service.Tests;
+
+/// <summary>
+/// Tests for the shared <see cref="CirclesInvariants"/> predicates.
+/// Verifies that the single source of truth for registration, trust, balance,
+/// and group validity behaves correctly and consistently.
+/// </summary>
+public class CirclesInvariantsTests
+{
+    private const string Human1 = "0xaaaa";
+    private const string Human2 = "0xbbbb";
+    private const string Org1 = "0xcccc";
+    private const string Group1 = "0xdddd";
+    private const string Group2 = "0xeeee"; // non-router group
+    private const string Unregistered = "0xffff";
+    private const string Wrapper1 = "0x1111";
+    private const string RouterGroup1Mint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
+
+    private static readonly HashSet<string> Avatars = new() { Human1, Human2, Org1 };
+    private static readonly HashSet<string> Groups = new() { Group1, Group2 };
+    private static readonly HashSet<string> RouterGroups = new() { Group1 };
+
+    private static readonly IRegistrationSet Registrations =
+        new HashSetRegistrationSet(
+            new HashSet<string>(Avatars.Concat(Groups)),
+            Groups);
+
+    // --- IsRegisteredAvatar ---
+
+    [Theory]
+    [InlineData(Human1, true)]
+    [InlineData(Human2, true)]
+    [InlineData(Org1, true)]
+    [InlineData(Group1, true)]
+    [InlineData(Group2, true)]
+    [InlineData(Unregistered, false)]
+    [InlineData("", false)]
+    public void IsRegisteredAvatar_CorrectForAllTypes(string address, bool expected)
+    {
+        CirclesInvariants.IsRegisteredAvatar(address, Registrations).Should().Be(expected);
+    }
+
+    // --- IsValidTrustEdge ---
+
+    [Fact]
+    public void IsValidTrustEdge_BothRegistered_NotExpired_NonGroup_ReturnsTrue()
+    {
+        CirclesInvariants.IsValidTrustEdge(Human1, Human2, 0, 1000, Registrations)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_ExpiredTrust_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidTrustEdge(Human1, Human2, 500, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_ZeroExpiry_TreatedAsIndefinite()
+    {
+        // expiryTime == 0 means never-set / indefinite → active
+        CirclesInvariants.IsValidTrustEdge(Human1, Human2, 0, 1000, Registrations)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_UnregisteredTruster_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidTrustEdge(Unregistered, Human2, 0, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_UnregisteredTrustee_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidTrustEdge(Human1, Unregistered, 0, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_GroupAsTruster_ReturnsFalse()
+    {
+        // Group trusters are excluded — handled separately as group trust edges
+        CirclesInvariants.IsValidTrustEdge(Group1, Human1, 0, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_GroupAsTrustee_ReturnsTrue()
+    {
+        // Groups CAN be trustees (someone can trust a group's token)
+        CirclesInvariants.IsValidTrustEdge(Human1, Group1, 0, 1000, Registrations)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidTrustEdge_NonRouterGroupAsTrustee_StillReturnsTrue()
+    {
+        // Non-router groups are still registered avatars — they can be trustees
+        // BUG FIX: Old code checked routerGroups only, missing non-router groups
+        CirclesInvariants.IsValidTrustEdge(Human1, Group2, 0, 1000, Registrations)
+            .Should().BeTrue();
+    }
+
+    // --- IsValidGroupTrustEdge ---
+
+    [Fact]
+    public void IsValidGroupTrustEdge_RouterGroup_RegisteredTrustee_ReturnsTrue()
+    {
+        CirclesInvariants.IsValidGroupTrustEdge(Group1, Human1, 0, 1000, Registrations, RouterGroups)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidGroupTrustEdge_NonRouterGroup_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidGroupTrustEdge(Group2, Human1, 0, 1000, Registrations, RouterGroups)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidGroupTrustEdge_UnregisteredTrustee_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidGroupTrustEdge(Group1, Unregistered, 0, 1000, Registrations, RouterGroups)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidGroupTrustEdge_Expired_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidGroupTrustEdge(Group1, Human1, 500, 1000, Registrations, RouterGroups)
+            .Should().BeFalse();
+    }
+
+    // --- IsValidBalance ---
+
+    [Fact]
+    public void IsValidBalance_NativeToken_BothRegistered_ReturnsTrue()
+    {
+        // Native ERC1155: tokenAddress = token owner
+        CirclesInvariants.IsValidBalance(Human1, Human2, Registrations, null)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidBalance_NativeToken_UnregisteredAccount_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidBalance(Unregistered, Human1, Registrations, null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidBalance_NativeToken_UnregisteredTokenOwner_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidBalance(Human1, Unregistered, Registrations, null)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidBalance_WrapperToken_RegisteredUnderlying_ReturnsTrue()
+    {
+        var wrapperLookup = new TestWrapperLookup(new Dictionary<string, string> { [Wrapper1] = Human2 });
+
+        CirclesInvariants.IsValidBalance(Human1, Wrapper1, Registrations, wrapperLookup)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidBalance_WrapperToken_UnregisteredUnderlying_ReturnsFalse()
+    {
+        var wrapperLookup = new TestWrapperLookup(new Dictionary<string, string> { [Wrapper1] = Unregistered });
+
+        CirclesInvariants.IsValidBalance(Human1, Wrapper1, Registrations, wrapperLookup)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidBalance_GroupToken_ReturnsTrue()
+    {
+        // Groups can be token owners (group token held by a human)
+        CirclesInvariants.IsValidBalance(Human1, Group1, Registrations, null)
+            .Should().BeTrue();
+    }
+
+    // --- IsValidWrapperMapping ---
+
+    [Fact]
+    public void IsValidWrapperMapping_RegisteredAvatar_ReturnsTrue()
+    {
+        CirclesInvariants.IsValidWrapperMapping(Human1, Registrations).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidWrapperMapping_UnregisteredAvatar_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidWrapperMapping(Unregistered, Registrations).Should().BeFalse();
+    }
+
+    // --- IsValidGroupMembership ---
+
+    [Fact]
+    public void IsValidGroupMembership_RegisteredGroupAndMember_ReturnsTrue()
+    {
+        CirclesInvariants.IsValidGroupMembership(Group1, Human1, 0, 1000, Registrations)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidGroupMembership_UnregisteredMember_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidGroupMembership(Group1, Unregistered, 0, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidGroupMembership_NonGroupAddress_ReturnsFalse()
+    {
+        // Human address as "group" — not a group
+        CirclesInvariants.IsValidGroupMembership(Human1, Human2, 0, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValidGroupMembership_Expired_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidGroupMembership(Group1, Human1, 500, 1000, Registrations)
+            .Should().BeFalse();
+    }
+
+    // --- IsValidConsentedFlowFlag ---
+
+    [Fact]
+    public void IsValidConsentedFlowFlag_RegisteredAvatar_ReturnsTrue()
+    {
+        CirclesInvariants.IsValidConsentedFlowFlag(Human1, Registrations).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValidConsentedFlowFlag_UnregisteredAvatar_ReturnsFalse()
+    {
+        CirclesInvariants.IsValidConsentedFlowFlag(Unregistered, Registrations).Should().BeFalse();
+    }
+
+    // --- CacheRegistrationSet adapter ---
+
+    [Fact]
+    public void CacheRegistrationSet_IncludesHumansOrgsAndGroups()
+    {
+        var caches = new CacheContainer(rollbackCapacity: 4);
+        caches.V2Avatars.Add(1, Human1, ("Human", 100));
+        caches.V2Avatars.Add(1, Org1, ("Organization", 100));
+        caches.Groups.Add(1, Group1, ("TestGroup", RouterGroup1Mint, "TG"));
+
+        var registrations = new CacheRegistrationSet(caches);
+
+        registrations.IsRegistered(Human1).Should().BeTrue("humans are in V2Avatars");
+        registrations.IsRegistered(Org1).Should().BeTrue("orgs are in V2Avatars");
+        registrations.IsRegistered(Group1).Should().BeTrue("groups are in Groups cache");
+        registrations.IsRegistered(Unregistered).Should().BeFalse();
+
+        registrations.IsGroup(Group1).Should().BeTrue();
+        registrations.IsGroup(Human1).Should().BeFalse();
+    }
+
+    // --- CacheWrapperLookup adapter ---
+
+    [Fact]
+    public void CacheWrapperLookup_ResolvesWrapperToAvatar()
+    {
+        var caches = new CacheContainer(rollbackCapacity: 4);
+        caches.UpsertWrapper(1, Wrapper1, Human1, 0);
+
+        var lookup = new CacheWrapperLookup(caches);
+
+        lookup.TryGetUnderlyingAvatar(Wrapper1, out var avatar).Should().BeTrue();
+        avatar.Should().Be(Human1.ToLowerInvariant());
+    }
+
+    [Fact]
+    public void CacheWrapperLookup_ReturnsFalseForNonWrapper()
+    {
+        var caches = new CacheContainer(rollbackCapacity: 4);
+        var lookup = new CacheWrapperLookup(caches);
+
+        lookup.TryGetUnderlyingAvatar(Human1, out _).Should().BeFalse();
+    }
+
+    // --- Helper ---
+
+    private class TestWrapperLookup : IWrapperLookup
+    {
+        private readonly Dictionary<string, string> _mappings;
+        public TestWrapperLookup(Dictionary<string, string> mappings) => _mappings = mappings;
+
+        public bool TryGetUnderlyingAvatar(string tokenAddress, out string underlyingAvatar)
+        {
+            if (_mappings.TryGetValue(tokenAddress, out var avatar))
+            {
+                underlyingAvatar = avatar;
+                return true;
+            }
+            underlyingAvatar = string.Empty;
+            return false;
+        }
+    }
+}

--- a/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
@@ -151,11 +151,13 @@ public class ControllerTests
     [Fact]
     public void GetTokenBalances_ShouldReturnV2Balances()
     {
-        // Arrange
+        // Arrange — use hex addresses so registration works (tokenId IS the token owner)
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
-        var tokenId = "123456789012345678901234567890";
+        var tokenId = "0x42cedde51198d1773590311e2a340dc06b24cb37";
         var balance = 1250.75m;
 
+        _cache.V2Avatars.Add(1000, address, ("Human", 1000));
+        _cache.V2Avatars.Add(1000, tokenId, ("Human", 1000));
         _cache.V2BalancesByAccountAndToken.Add(2000, $"{address}:{tokenId}", balance);
         _cache.RebuildSecondaryIndexes();
 
@@ -195,8 +197,11 @@ public class ControllerTests
     {
         // Arrange
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        var v2TokenOwner = "0x42cedde51198d1773590311e2a340dc06b24cb37";
+        _cache.V2Avatars.Add(1000, address, ("Human", 1000));
+        _cache.V2Avatars.Add(1000, v2TokenOwner, ("Human", 1000));
         _cache.V1BalancesByAccountAndToken.Add(1000, $"{address}:0xtoken1", 100m); // V1 CRC (will be converted)
-        _cache.V2BalancesByAccountAndToken.Add(2000, $"{address}:12345", 200m);    // V2 already in Circles
+        _cache.V2BalancesByAccountAndToken.Add(2000, $"{address}:{v2TokenOwner}", 200m); // V2 already in Circles
         _cache.RebuildSecondaryIndexes();
 
         var controller = CreateBalancesController();
@@ -469,6 +474,8 @@ public class ControllerTests
         // Arrange
         var group = "0xgroup000000000000000000000000000000000000";
         var member = "0xmember0000000000000000000000000000000000";
+        _cache.Groups.Add(1000, group, ("TestGroup", "0xmint", "TG"));
+        _cache.V2Avatars.Add(1000, member, ("Human", 1000));
         var key = $"{group}:{member}";
         _cache.GroupMemberships.Add(1200, key, (member, 1735689600L));
         _cache.RebuildSecondaryIndexes();
@@ -492,6 +499,8 @@ public class ControllerTests
         // Arrange
         var group = "0xgroup000000000000000000000000000000000000";
         var member = "0xmember0000000000000000000000000000000000";
+        _cache.Groups.Add(1000, group, ("TestGroup", "0xmint", "TG"));
+        _cache.V2Avatars.Add(1000, member, ("Human", 1000));
         var key = $"{group}:{member}";
         _cache.GroupMemberships.Add(1200, key, (member, 1735689600L));
         _cache.RebuildSecondaryIndexes();
@@ -661,7 +670,9 @@ public class ControllerTests
         var wrapperAddr = "0xwrapper0000000000000000000000000000000000";
         var erc1155Id = "0xavatar00000000000000000000000000000000000";
 
-        // Register wrapper and avatar
+        // Register account, wrapper underlying, and ERC1155 token owner
+        _cache.V2Avatars.Add(2000, address, ("CrcV2_RegisterHuman", 12345L));
+        _cache.V2Avatars.Add(2000, "0xunderlying", ("CrcV2_RegisterHuman", 12345L));
         _cache.UpsertWrapper(2000, wrapperAddr, "0xunderlying", 0); // demurraged wrapper
         _cache.V2Avatars.Add(2000, erc1155Id, ("CrcV2_RegisterHuman", 12345L));
 
@@ -702,6 +713,9 @@ public class ControllerTests
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var v1Trustee = "0xtrustee0000000000000000000000000000000000";
         var v2Trustee = "0xtrustee2000000000000000000000000000000000";
+        // Register V2 addresses for registration filter
+        _cache.V2Avatars.Add(1000, address, ("Human", 1000));
+        _cache.V2Avatars.Add(1000, v2Trustee, ("Human", 1000));
         _cache.V1TrustRelations.Add(1000, $"{address}:{v1Trustee}", 42L);
         _cache.V2TrustRelations.Add(2000, $"{address}:{v2Trustee}", 1735689600L);
         _cache.V1TrustRelations.Add(1100, $"0xanother:{address}", 15L);
@@ -752,6 +766,12 @@ public class ControllerTests
     {
         // Arrange
         var address = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
+        // Register all V2 addresses
+        _cache.V2Avatars.Add(1000, address, ("Human", 1000));
+        _cache.V2Avatars.Add(1000, "0xactive", ("Human", 1000));
+        _cache.V2Avatars.Add(1000, "0xexpired", ("Human", 1000));
+        _cache.V2Avatars.Add(1000, "0xincomingactive", ("Human", 1000));
+        _cache.V2Avatars.Add(1000, "0xincomingexpired", ("Human", 1000));
         _cache.V2TrustRelations.Add(2000, $"{address}:0xactive", 2000L);
         _cache.V2TrustRelations.Add(2000, $"{address}:0xexpired", 1000L);
         _cache.V2TrustRelations.Add(2000, $"0xincomingactive:{address}", 3000L);
@@ -788,6 +808,11 @@ public class ControllerTests
         // Arrange
         var group = "0xgroup000000000000000000000000000000000000";
         var member = "0xmember0000000000000000000000000000000000";
+        // Register groups and members
+        _cache.Groups.Add(1000, group, ("TestGroup", "0xmint", "TG"));
+        _cache.Groups.Add(1000, "0xothergroup", ("OtherGroup", "0xmint", "OG"));
+        _cache.V2Avatars.Add(1000, member, ("Human", 1000));
+        _cache.V2Avatars.Add(1000, "0xexpiredmember", ("Human", 1000));
         _cache.GroupMemberships.Add(1200, $"{group}:{member}", (member, 2000L));
         _cache.GroupMemberships.Add(1200, $"{group}:0xexpiredmember", ("0xexpiredmember", 1000L));
         _cache.GroupMemberships.Add(1200, $"0xothergroup:{member}", (member, 1000L));

--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -132,6 +132,7 @@ public class PathfinderGraphControllerTests
         var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, token, ("CrcV2_RegisterHuman", 1704067200L)); // token owner must be registered
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 1.5m);
         // Set a recent lastActivity so demurrage is minimal
         var recentTimestamp = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds() - 60;
@@ -566,6 +567,7 @@ public class PathfinderGraphControllerTests
         var account = "0xde374ece6fa50e781e81aac78e811b33d16912c7";
         var token = "0x42cedde51198d1773590311e2a340dc06b24cb37";
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, token, ("CrcV2_RegisterHuman", 1704067200L)); // token owner must be registered
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token}", 100m);
 
         // lastActivity 30 days ago — should show noticeable demurrage
@@ -700,6 +702,8 @@ public class PathfinderGraphControllerTests
         var now = (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.V2Avatars.Add(1000, token1, ("CrcV2_RegisterHuman", 1704067200L)); // token owners must be registered
+        _cache.V2Avatars.Add(1000, token2, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token1}", 1.0m);
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{token2}", 2.0m);
         _cache.V2LastActivity.Add(1000, $"{account}:{token1}", now);

--- a/src/Cache/Circles.Cache.Service/Caches/CacheInvariantAdapters.cs
+++ b/src/Cache/Circles.Cache.Service/Caches/CacheInvariantAdapters.cs
@@ -1,0 +1,57 @@
+using Circles.Common;
+
+namespace Circles.Cache.Service.Caches;
+
+/// <summary>
+/// Adapts the CacheContainer's avatar and group caches to the
+/// <see cref="IRegistrationSet"/> interface used by <see cref="CirclesInvariants"/>.
+/// </summary>
+public sealed class CacheRegistrationSet : IRegistrationSet
+{
+    private readonly CacheContainer _caches;
+
+    public CacheRegistrationSet(CacheContainer caches)
+    {
+        _caches = caches;
+    }
+
+    public bool IsRegistered(string address)
+    {
+        return _caches.V2Avatars.ContainsKey(address)
+            || _caches.Groups.ContainsKey(address);
+    }
+
+    public bool IsGroup(string address)
+    {
+        return _caches.Groups.ContainsKey(address);
+    }
+}
+
+/// <summary>
+/// Adapts the CacheContainer's ERC20 wrapper cache to the
+/// <see cref="IWrapperLookup"/> interface used by <see cref="CirclesInvariants"/>.
+/// </summary>
+public sealed class CacheWrapperLookup : IWrapperLookup
+{
+    private readonly CacheContainer _caches;
+
+    public CacheWrapperLookup(CacheContainer caches)
+    {
+        _caches = caches;
+    }
+
+    public bool TryGetUnderlyingAvatar(string tokenAddress, out string underlyingAvatar)
+    {
+        // Read from the RollbackCache directly (same data source as BuildBalances wrapper check).
+        // The secondary index (_erc20WrapperToAvatar) may not be populated in unit tests that
+        // use Erc20WrapperAddresses.Add() directly.
+        if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var info))
+        {
+            underlyingAvatar = info.Avatar;
+            return true;
+        }
+
+        underlyingAvatar = string.Empty;
+        return false;
+    }
+}

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -4,6 +4,7 @@ using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
 using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
+// CacheRegistrationSet + CacheWrapperLookup for invariant filtering
 
 namespace Circles.Cache.Service.Controllers;
 
@@ -142,11 +143,17 @@ public class BalancesController : ControllerBase
             }
 
             // Query V2 balances - use secondary index for O(1) lookup
+            var registrations = new CacheRegistrationSet(_caches);
+            var wrapperLookup = new CacheWrapperLookup(_caches);
             foreach (var tokenId in _caches.GetTokenIdsForAddress(addressLower, isV1: false))
             {
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
+                    // Registration filter: both account and token must be registered
+                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                        continue;
+
                     // Classify by checking the wrapper index first (O(1)).
                     // Cache keys are hex addresses for BOTH ERC1155 and ERC20 wrappers,
                     // so we can't use string format to distinguish them.
@@ -309,14 +316,17 @@ public class BalancesController : ControllerBase
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
 
             // Use secondary index for O(1) lookup
+            var registrations = new CacheRegistrationSet(_caches);
+            var wrapperLookup = new CacheWrapperLookup(_caches);
             var total = 0m;
             foreach (var tokenId in _caches.GetTokenIdsForAddress(addressLower, isV1: false))
             {
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Only inflationary wrappers skip demurrage (static amounts).
-                    // GetWrapperInfo returns null for ERC1155 tokens → isInflationary=false → demurrage applied correctly.
+                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                        continue;
+
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
                     var isInflationary = wrapperInfo?.CirclesType == 1;
 
@@ -360,14 +370,12 @@ public class BalancesController : ControllerBase
             var nowUnix = (ulong)timestamp;
 
             // Sum V1 balances using secondary index
-            // V1 balances are stored as raw CRC, need to convert to time-circles
             var v1Total = 0m;
             foreach (var tokenId in _caches.GetTokenIdsForAddress(addressLower, isV1: true))
             {
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V1BalancesByAccountAndToken.TryGetValue(key, out var crcBalance))
                 {
-                    // Convert from CRC (decimal) to Circles using time-based inflation
                     var attoCrc = CirclesConverter.CirclesToAttoCircles(crcBalance);
                     var attoCircles = CirclesConverter.AttoCrcToAttoCircles(attoCrc, nowUnix);
                     var circles = CirclesConverter.AttoCirclesToCircles(attoCircles);
@@ -376,14 +384,17 @@ public class BalancesController : ControllerBase
             }
 
             // Sum V2 balances using secondary index, applying demurrage at query time
+            var registrations = new CacheRegistrationSet(_caches);
+            var wrapperLookup = new CacheWrapperLookup(_caches);
             var v2Total = 0m;
             foreach (var tokenId in _caches.GetTokenIdsForAddress(addressLower, isV1: false))
             {
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Only inflationary wrappers skip demurrage (static amounts).
-                    // GetWrapperInfo returns null for ERC1155 tokens → isInflationary=false → demurrage applied correctly.
+                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                        continue;
+
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
                     var isInflationary = wrapperInfo?.CirclesType == 1;
 

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -150,8 +150,10 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    // Registration filter: both account and token must be registered
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    // Token-only filter: token owner must be registered.
+                    // Account is NOT checked — stopped avatars can still hold valid tokens.
+                    // Use IsValidBalance (checks both) only in pathfinder graph endpoints.
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     // Classify by checking the wrapper index first (O(1)).

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -326,7 +326,7 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
@@ -394,7 +394,7 @@ public class BalancesController : ControllerBase
                 var key = $"{addressLower}:{tokenId}";
                 if (_caches.V2BalancesByAccountAndToken.TryGetValue(key, out var balance))
                 {
-                    if (!CirclesInvariants.IsValidBalance(addressLower, tokenId, registrations, wrapperLookup))
+                    if (!CirclesInvariants.IsValidToken(tokenId, registrations, wrapperLookup))
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);

--- a/src/Cache/Circles.Cache.Service/Controllers/GroupMembershipsController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/GroupMembershipsController.cs
@@ -1,5 +1,6 @@
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
+using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Circles.Cache.Service.Controllers;
@@ -40,8 +41,14 @@ public class GroupMembershipsController : ControllerBase
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             var currentBlockTimestamp = _state.CurrentBlockTimestamp;
 
+            var registrations = new CacheRegistrationSet(_caches);
+
+            // Short-circuit: if the group itself is stopped/unregistered, return empty
+            if (!registrations.IsGroup(groupLower))
+                return Ok(new GroupMembersResponse(groupLower, Array.Empty<GroupMembershipResponse>(), lastBlock, timestamp));
+
             var members = _caches.GetGroupMembers(groupLower)
-                .Where(m => m.ExpiryTime > currentBlockTimestamp)
+                .Where(m => m.ExpiryTime > currentBlockTimestamp && registrations.IsRegistered(m.Member))
                 .Select(m => new GroupMembershipResponse(
                     Group: groupLower,
                     Member: m.Member,
@@ -81,8 +88,14 @@ public class GroupMembershipsController : ControllerBase
             var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             var currentBlockTimestamp = _state.CurrentBlockTimestamp;
 
+            var registrations = new CacheRegistrationSet(_caches);
+
+            // Short-circuit: if the member is stopped/unregistered, return empty
+            if (!registrations.IsRegistered(memberLower))
+                return Ok(new MemberGroupsResponse(memberLower, Array.Empty<GroupMembershipResponse>(), lastBlock, timestamp));
+
             var groups = _caches.GetMemberGroups(memberLower)
-                .Where(g => g.ExpiryTime > currentBlockTimestamp)
+                .Where(g => g.ExpiryTime > currentBlockTimestamp && registrations.IsGroup(g.Group))
                 .Select(g => new GroupMembershipResponse(
                     Group: g.Group,
                     Member: memberLower,

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -74,6 +74,8 @@ public class PathfinderGraphController : ControllerBase
         try
         {
             // Pre-compute shared lookups once per request
+            var registrations = new CacheRegistrationSet(_caches);
+            var wrapperLookup = new CacheWrapperLookup(_caches);
             var routerGroups = sections.Contains("trust") || sections.Contains("groups") || sections.Contains("grouptrusts")
                 ? GetRouterFilteredGroups()
                 : null;
@@ -85,13 +87,13 @@ public class PathfinderGraphController : ControllerBase
                 SchemaVersion: SchemaVersion,
                 LastProcessedBlock: lastBlock,
                 Timestamp: timestamp,
-                Balances: sections.Contains("balances") ? BuildBalances() : null,
-                Trust: sections.Contains("trust") ? BuildTrust(routerGroups!, avatarToWrappers!) : null,
+                Balances: sections.Contains("balances") ? BuildBalances(registrations, wrapperLookup) : null,
+                Trust: sections.Contains("trust") ? BuildTrust(registrations, routerGroups!, avatarToWrappers!) : null,
                 Groups: sections.Contains("groups") ? BuildGroups(routerGroups!) : null,
-                GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(routerGroups!) : null,
-                ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow() : null,
+                GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(registrations, routerGroups!) : null,
+                ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow(registrations) : null,
                 Avatars: sections.Contains("avatars") ? BuildAvatars() : null,
-                WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings() : null
+                WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings(registrations) : null
             );
 
             _logger.LogDebug(
@@ -130,7 +132,7 @@ public class PathfinderGraphController : ControllerBase
     /// Applies demurrage from lastActivity → now for demurraged balances.
     /// Converts static (inflationary) balances to demurraged equivalent at target day.
     /// </summary>
-    private List<PathfinderBalanceRow> BuildBalances()
+    private List<PathfinderBalanceRow> BuildBalances(IRegistrationSet registrations, IWrapperLookup wrapperLookup)
     {
         var balances = new List<PathfinderBalanceRow>();
         var targetDay = CirclesConverter.DayFromTimestamp(DateTimeOffset.UtcNow, V2InflationDayZero);
@@ -147,22 +149,17 @@ public class PathfinderGraphController : ControllerBase
             var account = kvp.Key[..separatorIndex];
             var tokenAddress = kvp.Key[(separatorIndex + 1)..];
 
-            // Only include balances for registered V2 avatars
-            if (!_caches.V2Avatars.ContainsKey(account))
+            // Shared invariant: account + token must be registered
+            if (!CirclesInvariants.IsValidBalance(account, tokenAddress, registrations, wrapperLookup))
                 continue;
 
-            // Determine if this is a wrapper token
+            // Determine if this is a wrapper token (for demurrage handling)
             var isWrapped = false;
             var isStatic = false;
 
             if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var wrapperInfo))
             {
                 isWrapped = true;
-                // Wrapper underlying can be any registered avatar type, including groups.
-                // In cache state, groups are tracked in Groups cache and may be absent from V2Avatars.
-                if (!_caches.V2Avatars.ContainsKey(wrapperInfo.Avatar)
-                    && !_caches.Groups.ContainsKey(wrapperInfo.Avatar))
-                    continue;
                 isStatic = wrapperInfo.CirclesType == 1;
             }
 
@@ -212,6 +209,7 @@ public class PathfinderGraphController : ControllerBase
     /// Derives wrapper trust edges: if trustee has a wrapper, emit (truster, wrapperAddress) too.
     /// </summary>
     private List<PathfinderTrustRow> BuildTrust(
+        IRegistrationSet registrations,
         HashSet<string> routerGroups,
         Dictionary<string, List<string>> avatarToWrappers)
     {
@@ -228,17 +226,8 @@ public class PathfinderGraphController : ControllerBase
             var trustee = kvp.Key[(separatorIndex + 1)..];
             var expiryTime = kvp.Value;
 
-            // Skip revoked trust (expiryTime == 0 means indefinite/never set which is active)
-            if (expiryTime > 0 && expiryTime <= now)
-                continue;
-
-            // Both must be registered (avatars or groups)
-            if (!_caches.V2Avatars.ContainsKey(truster) ||
-                (!_caches.V2Avatars.ContainsKey(trustee) && !routerGroups.Contains(trustee)))
-                continue;
-
-            // Skip group trusters — they're handled separately in GroupTrusts
-            if (routerGroups.Contains(truster))
+            // Shared invariant: both registered, not expired, non-group truster
+            if (!CirclesInvariants.IsValidTrustEdge(truster, trustee, expiryTime, now, registrations))
                 continue;
 
             // Native trust edge
@@ -281,7 +270,7 @@ public class PathfinderGraphController : ControllerBase
     /// <summary>
     /// Builds group trust rows — trust edges where truster is a router-filtered group.
     /// </summary>
-    private List<PathfinderGroupTrustRow> BuildGroupTrusts(HashSet<string> routerGroups)
+    private List<PathfinderGroupTrustRow> BuildGroupTrusts(IRegistrationSet registrations, HashSet<string> routerGroups)
     {
         var groupTrusts = new List<PathfinderGroupTrustRow>();
         var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -296,12 +285,8 @@ public class PathfinderGraphController : ControllerBase
             var trustee = kvp.Key[(separatorIndex + 1)..];
             var expiryTime = kvp.Value;
 
-            // Only group trusters from the router-filtered set
-            if (!routerGroups.Contains(truster))
-                continue;
-
-            // Skip revoked trust
-            if (expiryTime > 0 && expiryTime <= now)
+            // Shared invariant: router group truster, registered trustee, not expired
+            if (!CirclesInvariants.IsValidGroupTrustEdge(truster, trustee, expiryTime, now, registrations, routerGroups))
                 continue;
 
             groupTrusts.Add(new PathfinderGroupTrustRow(
@@ -330,14 +315,13 @@ public class PathfinderGraphController : ControllerBase
     /// Builds wrapper→avatar mapping rows from the Erc20WrapperAddresses cache.
     /// Only includes wrappers whose underlying avatar is registered.
     /// </summary>
-    private List<PathfinderWrapperMappingRow> BuildWrapperMappings()
+    private List<PathfinderWrapperMappingRow> BuildWrapperMappings(IRegistrationSet registrations)
     {
         var mappings = new List<PathfinderWrapperMappingRow>();
         foreach (var kvp in _caches.Erc20WrapperAddresses.ReadOnlyDictionary)
         {
-            // Keep mappings for wrappers of humans/orgs and groups alike.
-            if (!_caches.V2Avatars.ContainsKey(kvp.Value.Avatar)
-                && !_caches.Groups.ContainsKey(kvp.Value.Avatar))
+            // Shared invariant: underlying avatar must be registered
+            if (!CirclesInvariants.IsValidWrapperMapping(kvp.Value.Avatar, registrations))
                 continue;
 
             mappings.Add(new PathfinderWrapperMappingRow(
@@ -352,14 +336,14 @@ public class PathfinderGraphController : ControllerBase
     /// Builds consented flow rows from the ConsentedFlowFlags cache.
     /// Extracts bit 0 of byte[31] to determine consent status.
     /// </summary>
-    private List<PathfinderConsentedFlowRow> BuildConsentedFlow()
+    private List<PathfinderConsentedFlowRow> BuildConsentedFlow(IRegistrationSet registrations)
     {
         var consent = new List<PathfinderConsentedFlowRow>();
 
         foreach (var kvp in _caches.ConsentedFlowFlags.ReadOnlyDictionary)
         {
-            // Only include flags for registered V2 avatars (mirrors BuildBalances/BuildTrust filters)
-            if (!_caches.V2Avatars.ContainsKey(kvp.Key))
+            // Shared invariant: avatar must be registered
+            if (!CirclesInvariants.IsValidConsentedFlowFlag(kvp.Key, registrations))
                 continue;
 
             var flagBytes = kvp.Value;

--- a/src/Cache/Circles.Cache.Service/Controllers/TrustRelationsController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/TrustRelationsController.cs
@@ -1,5 +1,6 @@
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
+using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Circles.Cache.Service.Controllers;
@@ -74,9 +75,11 @@ public class TrustRelationsController : ControllerBase
             // Get V2 trust relations if version is null or 2
             if (version is null or 2)
             {
+                var registrations = new CacheRegistrationSet(_caches);
+
                 foreach (var (trustee, expiryTime) in _caches.GetTrustsFor(addressLower, isV1: false))
                 {
-                    if (expiryTime <= currentBlockTimestamp)
+                    if (!CirclesInvariants.IsValidTrustEdge(addressLower, trustee, expiryTime, currentBlockTimestamp, registrations))
                         continue;
 
                     trusts.Add(new TrustRelationResponse(
@@ -91,7 +94,7 @@ public class TrustRelationsController : ControllerBase
 
                 foreach (var (truster, expiryTime) in _caches.GetTrustedByFor(addressLower, isV1: false))
                 {
-                    if (expiryTime <= currentBlockTimestamp)
+                    if (!CirclesInvariants.IsValidTrustEdge(truster, addressLower, expiryTime, currentBlockTimestamp, registrations))
                         continue;
 
                     trustedBy.Add(new TrustRelationResponse(

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -831,11 +831,11 @@ public class CacheWarmupService : BackgroundService
         // Aggregate wrapper transfers up to the warmup target block.
         // Without the block filter, transfers arriving during warmup would be double-counted
         // when gap processing re-applies them as deltas on top of the seeded balances.
-        // Registration filter: account must be registered (matches balanceQuery.sql).
-        // Wrapper deployer registration is already enforced by ReplayV2Erc20WrapperDeployedAsync.
+        // No registration filter here — wrapper token validity is enforced at read time
+        // via IsValidToken, and wrapper deployer registration is already enforced by
+        // ReplayV2Erc20WrapperDeployedAsync which filters by underlying avatar.
         const string sql = @"
-            WITH " + RegisteredAvatarsCte + @",
-            account_balances AS (
+            WITH account_balances AS (
                 SELECT
                     account,
                     ""tokenAddress"",

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -742,7 +742,9 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loading V2 balances from view...");
 
         // Build balances from transfers bounded to the warmup target block.
-        // Registration filter matches balanceQuery.sql: both account AND tokenAddress must be registered.
+        // Token-only filter: tokenAddress (= token owner) must be registered.
+        // Account is NOT filtered — stopped avatars can still hold valid tokens.
+        // (PathfinderGraphController applies the stricter IsValidBalance check at read time.)
         const string sql = @"
             WITH " + RegisteredAvatarsCte + @",
             account_balances AS (
@@ -779,7 +781,6 @@ public class CacheWarmupService : BackgroundService
             )
             SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
             FROM account_balances ab
-            INNER JOIN registered_avatars ra_account ON ra_account.avatar = ab.account
             INNER JOIN registered_avatars ra_token ON ra_token.avatar = ab.""tokenAddress""
             WHERE ab.account != '0x0000000000000000000000000000000000000000'";
 
@@ -872,8 +873,7 @@ public class CacheWarmupService : BackgroundService
                        SUM(CASE WHEN account = t.""from"" THEN t.amount ELSE 0 END) > 0
             )
             SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
-            FROM account_balances ab
-            INNER JOIN registered_avatars ra ON ra.avatar = ab.account";
+            FROM account_balances ab";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("toBlock", toBlock);

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -35,17 +35,11 @@ public class CacheWarmupService : BackgroundService
     /// </summary>
     private const string RegisteredAvatarsCte = @"
             registered_avatars AS MATERIALIZED (
-                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterOrganization"".""organization"" AND s.""blockNumber"" <= @toBlock)
+                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization"" WHERE ""blockNumber"" <= @toBlock
                 UNION ALL
-                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterGroup"".""group"" AND s.""blockNumber"" <= @toBlock)
+                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup"" WHERE ""blockNumber"" <= @toBlock
                 UNION ALL
-                SELECT avatar FROM ""CrcV2_RegisterHuman""
-                WHERE ""blockNumber"" <= @toBlock
-                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterHuman"".""avatar"" AND s.""blockNumber"" <= @toBlock)
+                SELECT avatar FROM ""CrcV2_RegisterHuman"" WHERE ""blockNumber"" <= @toBlock
             )";
 
     public CacheWarmupService(
@@ -499,7 +493,8 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loading V2 avatars...");
 
         // Load V2 avatars (humans and organizations) using Seed() for efficiency.
-        // Excludes stopped avatars so downstream registration checks auto-exclude their data.
+        // Stopped avatars are NOT excluded — Hub.sol stop() only prevents minting,
+        // it does not deregister the avatar. They can still transfer and be flow vertices.
         const string avatarSql = @"
             SELECT
                 r.""avatar"" as address,
@@ -507,11 +502,6 @@ public class CacheWarmupService : BackgroundService
                 'CrcV2_RegisterHuman' as type
             FROM ""CrcV2_RegisterHuman"" r
             WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""avatar""
-                    AND s.""blockNumber"" <= @toBlock
-              )
 
             UNION ALL
 
@@ -520,12 +510,7 @@ public class CacheWarmupService : BackgroundService
                 r.""timestamp"",
                 'CrcV2_RegisterOrganization' as type
             FROM ""CrcV2_RegisterOrganization"" r
-            WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""organization""
-                    AND s.""blockNumber"" <= @toBlock
-              )";
+            WHERE r.""blockNumber"" <= @toBlock";
 
         var v2Avatars = new Dictionary<string, (string Type, long Timestamp)>();
         var humanCount = 0;
@@ -566,12 +551,7 @@ public class CacheWarmupService : BackgroundService
                 r.""mint"",
                 r.""symbol""
             FROM ""CrcV2_RegisterGroup"" r
-            WHERE r.""blockNumber"" <= @toBlock
-              AND NOT EXISTS (
-                  SELECT 1 FROM ""CrcV2_Stopped"" s
-                  WHERE s.""avatar"" = r.""group""
-                    AND s.""blockNumber"" <= @toBlock
-              )";
+            WHERE r.""blockNumber"" <= @toBlock";
 
         var groups = new Dictionary<string, (string Name, string Mint, string Symbol)>();
 

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -28,6 +28,26 @@ public class CacheWarmupService : BackgroundService
     private DateTime _lastReminderLogTime = DateTime.MinValue;
     private readonly TimeSpan _reminderInterval = TimeSpan.FromMinutes(5);
 
+    /// <summary>
+    /// SQL CTE that materializes all registered V2 avatars (humans, orgs, groups) up to @toBlock.
+    /// Used as a filter in warmup queries to ensure only registered addresses enter the cache.
+    /// Single source of truth — change here to update all warmup queries.
+    /// </summary>
+    private const string RegisteredAvatarsCte = @"
+            registered_avatars AS MATERIALIZED (
+                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization""
+                WHERE ""blockNumber"" <= @toBlock
+                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterOrganization"".""organization"" AND s.""blockNumber"" <= @toBlock)
+                UNION ALL
+                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup""
+                WHERE ""blockNumber"" <= @toBlock
+                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterGroup"".""group"" AND s.""blockNumber"" <= @toBlock)
+                UNION ALL
+                SELECT avatar FROM ""CrcV2_RegisterHuman""
+                WHERE ""blockNumber"" <= @toBlock
+                  AND NOT EXISTS (SELECT 1 FROM ""CrcV2_Stopped"" s WHERE s.""avatar"" = ""CrcV2_RegisterHuman"".""avatar"" AND s.""blockNumber"" <= @toBlock)
+            )";
+
     public CacheWarmupService(
         ILogger<CacheWarmupService> logger,
         CacheServiceSettings settings,
@@ -478,7 +498,8 @@ public class CacheWarmupService : BackgroundService
     {
         _logger.LogInformation("Loading V2 avatars...");
 
-        // Load V2 avatars (humans and organizations) using Seed() for efficiency
+        // Load V2 avatars (humans and organizations) using Seed() for efficiency.
+        // Excludes stopped avatars so downstream registration checks auto-exclude their data.
         const string avatarSql = @"
             SELECT
                 r.""avatar"" as address,
@@ -486,6 +507,11 @@ public class CacheWarmupService : BackgroundService
                 'CrcV2_RegisterHuman' as type
             FROM ""CrcV2_RegisterHuman"" r
             WHERE r.""blockNumber"" <= @toBlock
+              AND NOT EXISTS (
+                  SELECT 1 FROM ""CrcV2_Stopped"" s
+                  WHERE s.""avatar"" = r.""avatar""
+                    AND s.""blockNumber"" <= @toBlock
+              )
 
             UNION ALL
 
@@ -494,7 +520,12 @@ public class CacheWarmupService : BackgroundService
                 r.""timestamp"",
                 'CrcV2_RegisterOrganization' as type
             FROM ""CrcV2_RegisterOrganization"" r
-            WHERE r.""blockNumber"" <= @toBlock";
+            WHERE r.""blockNumber"" <= @toBlock
+              AND NOT EXISTS (
+                  SELECT 1 FROM ""CrcV2_Stopped"" s
+                  WHERE s.""avatar"" = r.""organization""
+                    AND s.""blockNumber"" <= @toBlock
+              )";
 
         var v2Avatars = new Dictionary<string, (string Type, long Timestamp)>();
         var humanCount = 0;
@@ -535,7 +566,12 @@ public class CacheWarmupService : BackgroundService
                 r.""mint"",
                 r.""symbol""
             FROM ""CrcV2_RegisterGroup"" r
-            WHERE r.""blockNumber"" <= @toBlock";
+            WHERE r.""blockNumber"" <= @toBlock
+              AND NOT EXISTS (
+                  SELECT 1 FROM ""CrcV2_Stopped"" s
+                  WHERE s.""avatar"" = r.""group""
+                    AND s.""blockNumber"" <= @toBlock
+              )";
 
         var groups = new Dictionary<string, (string Name, string Mint, string Symbol)>();
 
@@ -565,12 +601,15 @@ public class CacheWarmupService : BackgroundService
     {
         _logger.LogInformation("Loading V2 ERC20 wrappers...");
 
+        // Only load wrappers whose underlying avatar is registered (matches wrapperMappingQuery.sql)
         const string sql = @"
+            WITH " + RegisteredAvatarsCte + @"
             SELECT
                 e.""avatar"",
                 e.""erc20Wrapper"",
                 e.""circlesType""
             FROM ""CrcV2_ERC20WrapperDeployed"" e
+            INNER JOIN registered_avatars ra ON ra.avatar = e.""avatar""
             WHERE e.""blockNumber"" <= @toBlock";
 
         // Key by wrapper address (not avatar) to support avatars with multiple wrappers
@@ -703,8 +742,10 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loading V2 balances from view...");
 
         // Build balances from transfers bounded to the warmup target block.
+        // Registration filter matches balanceQuery.sql: both account AND tokenAddress must be registered.
         const string sql = @"
-            WITH account_balances AS (
+            WITH " + RegisteredAvatarsCte + @",
+            account_balances AS (
                 SELECT
                     account,
                     ""tokenAddress"",
@@ -736,9 +777,11 @@ public class CacheWarmupService : BackgroundService
                 GROUP BY account, ""tokenAddress""
                 HAVING SUM(delta) > 0
             )
-            SELECT account, ""tokenAddress"", balance, last_activity
-            FROM account_balances
-            WHERE account != '0x0000000000000000000000000000000000000000'";
+            SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
+            FROM account_balances ab
+            INNER JOIN registered_avatars ra_account ON ra_account.avatar = ab.account
+            INNER JOIN registered_avatars ra_token ON ra_token.avatar = ab.""tokenAddress""
+            WHERE ab.account != '0x0000000000000000000000000000000000000000'";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("toBlock", toBlock);
@@ -807,8 +850,11 @@ public class CacheWarmupService : BackgroundService
         // Aggregate wrapper transfers up to the warmup target block.
         // Without the block filter, transfers arriving during warmup would be double-counted
         // when gap processing re-applies them as deltas on top of the seeded balances.
+        // Registration filter: account must be registered (matches balanceQuery.sql).
+        // Wrapper deployer registration is already enforced by ReplayV2Erc20WrapperDeployedAsync.
         const string sql = @"
-            WITH account_balances AS (
+            WITH " + RegisteredAvatarsCte + @",
+            account_balances AS (
                 SELECT
                     account,
                     ""tokenAddress"",
@@ -825,8 +871,9 @@ public class CacheWarmupService : BackgroundService
                 HAVING SUM(CASE WHEN account = t.""to"" THEN t.amount ELSE 0 END) -
                        SUM(CASE WHEN account = t.""from"" THEN t.amount ELSE 0 END) > 0
             )
-            SELECT account, ""tokenAddress"", balance, last_activity
-            FROM account_balances";
+            SELECT ab.account, ab.""tokenAddress"", ab.balance, ab.last_activity
+            FROM account_balances ab
+            INNER JOIN registered_avatars ra ON ra.avatar = ab.account";
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("toBlock", toBlock);
@@ -1295,8 +1342,10 @@ public class CacheWarmupService : BackgroundService
         var targetTimestamp = await GetMaxTimestampUpToBlockAsync(conn, toBlock, ct);
 
         // Load group memberships using block-bounded latest trust state.
+        // Registration filter: member (trustee) must be a registered avatar (matches groupTrustQuery.sql).
         const string sql = @"
-            WITH latest_trust AS (
+            WITH " + RegisteredAvatarsCte + @",
+            latest_trust AS (
                 SELECT
                     ct.truster,
                     ct.trustee,
@@ -1313,14 +1362,11 @@ public class CacheWarmupService : BackgroundService
                 lt.trustee AS ""member"",
                 lt.""expiryTime""
             FROM latest_trust lt
+            INNER JOIN registered_avatars ra_member ON ra_member.avatar = lt.trustee
+            INNER JOIN registered_avatars ra_group ON ra_group.avatar = lt.truster
+            INNER JOIN ""CrcV2_RegisterGroup"" g ON g.""group"" = lt.truster AND g.""blockNumber"" <= @toBlock
             WHERE lt.rn = 1
-              AND lt.""expiryTime"" > @targetTimestamp
-              AND EXISTS (
-                  SELECT 1
-                  FROM ""CrcV2_RegisterGroup"" g
-                  WHERE g.""group"" = lt.truster
-                    AND g.""blockNumber"" <= @toBlock
-              )";
+              AND lt.""expiryTime"" > @targetTimestamp";
 
         var memberships = new Dictionary<string, (string Member, long ExpiryTime)>();
 
@@ -1394,8 +1440,10 @@ public class CacheWarmupService : BackgroundService
         _logger.LogInformation("Loaded {Count} V1 trust relations", v1TrustData.Count);
 
         // Load V2 trust relations using block-bounded latest trust state.
+        // Registration filter: both truster and trustee must be registered avatars (matches trustQuery.sql).
         const string v2Sql = @"
-            WITH latest_trust AS (
+            WITH " + RegisteredAvatarsCte + @",
+            latest_trust AS (
                 SELECT
                     ct.truster,
                     ct.trustee,
@@ -1407,10 +1455,12 @@ public class CacheWarmupService : BackgroundService
                 FROM ""CrcV2_Trust"" ct
                 WHERE ct.""blockNumber"" <= @toBlock
             )
-            SELECT truster, trustee, ""expiryTime""
-            FROM latest_trust
-            WHERE rn = 1
-              AND ""expiryTime"" > @targetTimestamp";
+            SELECT lt.truster, lt.trustee, lt.""expiryTime""
+            FROM latest_trust lt
+            INNER JOIN registered_avatars ra1 ON ra1.avatar = lt.truster
+            INNER JOIN registered_avatars ra2 ON ra2.avatar = lt.trustee
+            WHERE lt.rn = 1
+              AND lt.""expiryTime"" > @targetTimestamp";
 
         var v2TrustData = new Dictionary<string, long>();
 
@@ -1461,11 +1511,14 @@ public class CacheWarmupService : BackgroundService
     {
         _logger.LogInformation("Loading consented flow flags...");
 
+        // Registration filter: only load flags for registered avatars (matches consentedFlowQuery.sql).
         const string sql = @"
-            SELECT DISTINCT ON (avatar) avatar, flag
-            FROM ""CrcV2_SetAdvancedUsageFlag""
-            WHERE ""blockNumber"" <= @toBlock
-            ORDER BY avatar, ""blockNumber"" DESC, ""transactionIndex"" DESC, ""logIndex"" DESC";
+            WITH " + RegisteredAvatarsCte + @"
+            SELECT DISTINCT ON (f.avatar) f.avatar, f.flag
+            FROM ""CrcV2_SetAdvancedUsageFlag"" f
+            INNER JOIN registered_avatars ra ON ra.avatar = f.avatar
+            WHERE f.""blockNumber"" <= @toBlock
+            ORDER BY f.avatar, f.""blockNumber"" DESC, f.""transactionIndex"" DESC, f.""logIndex"" DESC";
 
         var flags = new Dictionary<string, byte[]>();
 

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -516,9 +516,8 @@ public class NotificationListenerService : BackgroundService
         // Process V2 RegisterGroup
         await ProcessV2RegisterGroupAsync(conn, fromBlock, toBlock, ct);
 
-        // Process V2 Stopped (remove deregistered avatars — must run before trust/transfers
-        // so downstream registration checks exclude stopped avatars)
-        await ProcessV2StoppedAsync(conn, fromBlock, toBlock, ct);
+        // Note: CrcV2_Stopped is NOT processed here — stop() only prevents minting,
+        // it does not deregister the avatar. Stopped avatars remain in V2Avatars/Groups.
 
         // Process V2 Trust (for group memberships)
         await ProcessV2TrustAsync(conn, fromBlock, toBlock, ct);
@@ -645,41 +644,6 @@ public class NotificationListenerService : BackgroundService
         if (count > 0)
         {
             _logger.LogDebug("Processed {Count} V2 group registrations", count);
-        }
-    }
-
-    private async Task ProcessV2StoppedAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
-    {
-        const string sql = @"
-            SELECT s.""blockNumber"", s.""avatar""
-            FROM ""CrcV2_Stopped"" s
-            WHERE s.""blockNumber"" >= @fromBlock AND s.""blockNumber"" <= @toBlock
-            ORDER BY s.""blockNumber"", s.""transactionIndex"", s.""logIndex""";
-
-        await using var cmd = new NpgsqlCommand(sql, conn);
-        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
-        cmd.Parameters.AddWithValue("toBlock", toBlock);
-
-        var count = 0;
-        await using (var reader = await cmd.ExecuteReaderAsync(ct))
-        {
-            while (await reader.ReadAsync(ct))
-            {
-                var blockNumber = reader.GetInt64(0);
-                var avatar = reader.GetString(1).ToLowerInvariant();
-
-                // Remove from V2Avatars AND Groups — downstream registration checks will
-                // auto-exclude this avatar's trust, balances, wrappers, and consent flags.
-                // Groups can also be stopped (Hub.sol stop() works for any registered avatar).
-                _caches.V2Avatars.Remove(blockNumber, avatar);
-                _caches.Groups.Remove(blockNumber, avatar);
-                count++;
-            }
-        }
-
-        if (count > 0)
-        {
-            _logger.LogInformation("Processed {Count} V2 stopped events (removed from V2Avatars)", count);
         }
     }
 

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -984,9 +984,9 @@ public class NotificationListenerService : BackgroundService
                 var fromLower = from.ToLowerInvariant();
                 var toLower = to.ToLowerInvariant();
 
-                // Update sender balance — account + token must be valid
+                // Update sender balance — token must be valid (account may be stopped but still holds tokens)
                 if (from != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(fromLower, tokenAddress, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenAddress, _registrations, _wrapperLookup))
                 {
                     var fromKey = $"{fromLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(fromKey))
@@ -998,9 +998,9 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance — account + token must be valid
+                // Update receiver balance — token must be valid
                 if (to != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(toLower, tokenAddress, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenAddress, _registrations, _wrapperLookup))
                 {
                     var toKey = $"{toLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(toKey))
@@ -1091,9 +1091,9 @@ public class NotificationListenerService : BackgroundService
                 var fromLower = from.ToLowerInvariant();
                 var toLower = to.ToLowerInvariant();
 
-                // Update sender balance — account + token must be valid
+                // Update sender balance — token must be valid (account may be stopped)
                 if (from != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(fromLower, tokenKey, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
                 {
                     var fromKey = $"{fromLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(fromKey))
@@ -1105,9 +1105,9 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance — account + token must be valid
+                // Update receiver balance — token must be valid
                 if (to != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidBalance(toLower, tokenKey, _registrations, _wrapperLookup))
+                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
                 {
                     var toKey = $"{toLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(toKey))

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -18,6 +18,8 @@ public class NotificationListenerService : BackgroundService
     private readonly CacheServiceState _state;
     private readonly CacheContainer _caches;
     private readonly NpgsqlDataSource _readonlyDataSource;
+    private readonly IRegistrationSet _registrations;
+    private readonly IWrapperLookup _wrapperLookup;
 
     // Serializes notification handling — Npgsql's conn.Notification callback is async void,
     // so overlapping notifications can fire concurrent HandleNotificationAsync calls. Without
@@ -42,6 +44,8 @@ public class NotificationListenerService : BackgroundService
         _state = state;
         _caches = caches;
         _readonlyDataSource = readonlyDataSource;
+        _registrations = new CacheRegistrationSet(caches);
+        _wrapperLookup = new CacheWrapperLookup(caches);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -512,6 +516,10 @@ public class NotificationListenerService : BackgroundService
         // Process V2 RegisterGroup
         await ProcessV2RegisterGroupAsync(conn, fromBlock, toBlock, ct);
 
+        // Process V2 Stopped (remove deregistered avatars — must run before trust/transfers
+        // so downstream registration checks exclude stopped avatars)
+        await ProcessV2StoppedAsync(conn, fromBlock, toBlock, ct);
+
         // Process V2 Trust (for group memberships)
         await ProcessV2TrustAsync(conn, fromBlock, toBlock, ct);
 
@@ -640,6 +648,41 @@ public class NotificationListenerService : BackgroundService
         }
     }
 
+    private async Task ProcessV2StoppedAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
+    {
+        const string sql = @"
+            SELECT s.""blockNumber"", s.""avatar""
+            FROM ""CrcV2_Stopped"" s
+            WHERE s.""blockNumber"" >= @fromBlock AND s.""blockNumber"" <= @toBlock
+            ORDER BY s.""blockNumber"", s.""transactionIndex"", s.""logIndex""";
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
+        cmd.Parameters.AddWithValue("toBlock", toBlock);
+
+        var count = 0;
+        await using (var reader = await cmd.ExecuteReaderAsync(ct))
+        {
+            while (await reader.ReadAsync(ct))
+            {
+                var blockNumber = reader.GetInt64(0);
+                var avatar = reader.GetString(1).ToLowerInvariant();
+
+                // Remove from V2Avatars AND Groups — downstream registration checks will
+                // auto-exclude this avatar's trust, balances, wrappers, and consent flags.
+                // Groups can also be stopped (Hub.sol stop() works for any registered avatar).
+                _caches.V2Avatars.Remove(blockNumber, avatar);
+                _caches.Groups.Remove(blockNumber, avatar);
+                count++;
+            }
+        }
+
+        if (count > 0)
+        {
+            _logger.LogInformation("Processed {Count} V2 stopped events (removed from V2Avatars)", count);
+        }
+    }
+
     private async Task ProcessV2TrustAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
     {
         // Process all V2 Trust events - update both V2TrustRelations cache and GroupMemberships (when truster is a group)
@@ -670,17 +713,20 @@ public class NotificationListenerService : BackgroundService
 
                 var trusterKey = truster.ToLowerInvariant();
                 var trusteeKey = trustee.ToLowerInvariant();
-                var trustKey = $"{trusterKey}:{trusteeKey}";
 
                 // Safely cast expiryTime to long
                 long expiryLong = expiryTimeBig > long.MaxValue ? long.MaxValue : (long)expiryTimeBig;
 
-                // Always update V2TrustRelations cache
+                // Registration check: both truster and trustee must be registered avatars.
+                // Removals (expiryTime == 0) always proceed — safe to remove non-existent entries.
+                var trusterRegistered = _registrations.IsRegistered(trusterKey);
+                var trusteeRegistered = _registrations.IsRegistered(trusteeKey);
+
                 if (expiryTimeBig == 0)
                 {
                     _caches.RemoveV2Trust(blockNumber, trusterKey, trusteeKey);
                 }
-                else
+                else if (trusterRegistered && trusteeRegistered)
                 {
                     _caches.UpsertV2Trust(blockNumber, trusterKey, trusteeKey, expiryLong);
                 }
@@ -689,14 +735,11 @@ public class NotificationListenerService : BackgroundService
                 // Also update GroupMemberships if truster is a group
                 if (_caches.Groups.ContainsKey(trusterKey))
                 {
-                    // Composite key: group:member
-                    var membershipKey = $"{trusterKey}:{trusteeKey}";
-
                     if (expiryTimeBig == 0)
                     {
                         _caches.RemoveGroupMembership(blockNumber, trusterKey, trusteeKey);
                     }
-                    else
+                    else if (trusteeRegistered)
                     {
                         _caches.UpsertGroupMembership(blockNumber, trusterKey, trusteeKey, expiryLong);
                     }
@@ -737,9 +780,14 @@ public class NotificationListenerService : BackgroundService
 
                     // Key by wrapper address (not avatar) to support avatars with multiple wrappers
                     var wrapperKey = erc20Wrapper.ToLowerInvariant();
+                    var avatarKey = avatar.ToLowerInvariant();
 
-                    _caches.UpsertWrapper(blockNumber, wrapperKey, avatar, circlesType);
-                    count++;
+                    // Registration check: underlying avatar must be registered
+                    if (_registrations.IsRegistered(avatarKey))
+                    {
+                        _caches.UpsertWrapper(blockNumber, wrapperKey, avatar, circlesType);
+                        count++;
+                    }
                 }
             }
 
@@ -933,11 +981,14 @@ public class NotificationListenerService : BackgroundService
                     currentBlock = blockNumber;
                 }
 
-                // Update sender balance and last activity
-                if (from != "0x0000000000000000000000000000000000000000")
+                var fromLower = from.ToLowerInvariant();
+                var toLower = to.ToLowerInvariant();
+
+                // Update sender balance — account + token must be valid
+                if (from != "0x0000000000000000000000000000000000000000"
+                    && CirclesInvariants.IsValidBalance(fromLower, tokenAddress, _registrations, _wrapperLookup))
                 {
-                    var fromKey = $"{from.ToLowerInvariant()}:{tokenAddress}";
-                    // Initialize from cache if we haven't seen this key yet in this block range
+                    var fromKey = $"{fromLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(fromKey))
                     {
                         _caches.V2BalancesByAccountAndToken.TryGetValue(fromKey, out var existingBalance);
@@ -947,11 +998,11 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance and last activity
-                if (to != "0x0000000000000000000000000000000000000000")
+                // Update receiver balance — account + token must be valid
+                if (to != "0x0000000000000000000000000000000000000000"
+                    && CirclesInvariants.IsValidBalance(toLower, tokenAddress, _registrations, _wrapperLookup))
                 {
-                    var toKey = $"{to.ToLowerInvariant()}:{tokenAddress}";
-                    // Initialize from cache if we haven't seen this key yet in this block range
+                    var toKey = $"{toLower}:{tokenAddress}";
                     if (!currentBalances.ContainsKey(toKey))
                     {
                         _caches.V2BalancesByAccountAndToken.TryGetValue(toKey, out var existingBalance);
@@ -1037,11 +1088,14 @@ public class NotificationListenerService : BackgroundService
                     currentBlock = blockNumber;
                 }
 
-                // Update sender balance and last activity
-                if (from != "0x0000000000000000000000000000000000000000")
+                var fromLower = from.ToLowerInvariant();
+                var toLower = to.ToLowerInvariant();
+
+                // Update sender balance — account + token must be valid
+                if (from != "0x0000000000000000000000000000000000000000"
+                    && CirclesInvariants.IsValidBalance(fromLower, tokenKey, _registrations, _wrapperLookup))
                 {
-                    var fromKey = $"{from.ToLowerInvariant()}:{tokenKey}";
-                    // Initialize from cache if we haven't seen this key yet in this block range
+                    var fromKey = $"{fromLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(fromKey))
                     {
                         _caches.V2BalancesByAccountAndToken.TryGetValue(fromKey, out var existingBalance);
@@ -1051,11 +1105,11 @@ public class NotificationListenerService : BackgroundService
                     _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
                 }
 
-                // Update receiver balance and last activity
-                if (to != "0x0000000000000000000000000000000000000000")
+                // Update receiver balance — account + token must be valid
+                if (to != "0x0000000000000000000000000000000000000000"
+                    && CirclesInvariants.IsValidBalance(toLower, tokenKey, _registrations, _wrapperLookup))
                 {
-                    var toKey = $"{to.ToLowerInvariant()}:{tokenKey}";
-                    // Initialize from cache if we haven't seen this key yet in this block range
+                    var toKey = $"{toLower}:{tokenKey}";
                     if (!currentBalances.ContainsKey(toKey))
                     {
                         _caches.V2BalancesByAccountAndToken.TryGetValue(toKey, out var existingBalance);
@@ -1266,8 +1320,12 @@ public class NotificationListenerService : BackgroundService
                 var avatar = reader.GetString(1).ToLowerInvariant();
                 var flag = (byte[])reader.GetValue(2);
 
-                _caches.ConsentedFlowFlags.Add(blockNumber, avatar, flag);
-                count++;
+                // Registration check: only store flags for registered avatars
+                if (_registrations.IsRegistered(avatar))
+                {
+                    _caches.ConsentedFlowFlags.Add(blockNumber, avatar, flag);
+                    count++;
+                }
             }
         }
 

--- a/src/Common/Circles.Common/CirclesInvariants.cs
+++ b/src/Common/Circles.Common/CirclesInvariants.cs
@@ -37,10 +37,9 @@ public static class CirclesInvariants
         long currentTimestamp,
         IRegistrationSet registrations)
     {
-        // Skip revoked/expired trust. In Hub.sol, expiryTime=0 is an explicit untrust —
-        // but the cache never stores 0 (incremental removes on 0, warmup SQL excludes 0).
-        // This predicate is unreachable with expiryTime=0 in practice.
-        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+        // expiryTime=0 is an explicit untrust in Hub.sol. The write path (NotificationListenerService)
+        // removes entries on 0, so this is defensive — aligns the predicate with the write semantics.
+        if (expiryTime == 0 || expiryTime <= currentTimestamp)
             return false;
 
         // Both must be registered (humans + orgs + groups)
@@ -76,7 +75,7 @@ public static class CirclesInvariants
             return false;
 
         // Skip revoked/expired trust
-        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+        if (expiryTime == 0 || expiryTime <= currentTimestamp)
             return false;
 
         // Trusted token must be a registered avatar (human, org, or group)
@@ -157,7 +156,7 @@ public static class CirclesInvariants
         IRegistrationSet registrations)
     {
         // Must not be expired
-        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+        if (expiryTime == 0 || expiryTime <= currentTimestamp)
             return false;
 
         // Group must be registered as a group

--- a/src/Common/Circles.Common/CirclesInvariants.cs
+++ b/src/Common/Circles.Common/CirclesInvariants.cs
@@ -103,16 +103,27 @@ public static class CirclesInvariants
         if (!registrations.IsRegistered(account))
             return false;
 
-        // Check token validity
+        return IsValidToken(tokenAddress, registrations, wrapperLookup);
+    }
+
+    /// <summary>
+    /// Checks whether a token is valid (owner is registered).
+    /// Does NOT check the holder — use this for informational endpoints where
+    /// stopped/unregistered avatars may still hold valid tokens.
+    /// Use <see cref="IsValidBalance"/> for pathfinder graph filtering (checks both).
+    /// </summary>
+    public static bool IsValidToken(
+        string tokenAddress,
+        IRegistrationSet registrations,
+        IWrapperLookup? wrapperLookup)
+    {
         if (wrapperLookup != null && wrapperLookup.TryGetUnderlyingAvatar(tokenAddress, out var underlyingAvatar))
         {
-            // Wrapper token: underlying avatar must be registered
             if (!registrations.IsRegistered(underlyingAvatar))
                 return false;
         }
         else
         {
-            // Native ERC1155: tokenAddress IS the token owner — must be registered
             if (!registrations.IsRegistered(tokenAddress))
                 return false;
         }

--- a/src/Common/Circles.Common/CirclesInvariants.cs
+++ b/src/Common/Circles.Common/CirclesInvariants.cs
@@ -1,0 +1,219 @@
+namespace Circles.Common;
+
+/// <summary>
+/// Single source of truth for Circles V2 validity predicates.
+/// Used by both the Cache Service (output filtering) and Pathfinder (graph construction)
+/// to ensure consistent trust, registration, and balance validation.
+///
+/// These predicates mirror the on-chain invariants enforced by Hub.sol:
+/// - All flow vertices must be registered avatars (humans, orgs, or groups)
+/// - Trust edges must connect registered avatars with valid expiry
+/// - Group trusters are handled separately from avatar trusters
+/// - ERC20 wrapper underlying avatars must be registered
+/// </summary>
+public static class CirclesInvariants
+{
+    /// <summary>
+    /// Checks whether an address is a registered V2 avatar (human, organization, or group).
+    /// Hub.sol reverts with CirclesAvatarMustBeRegistered if unregistered addresses
+    /// appear as flow vertices.
+    /// </summary>
+    public static bool IsRegisteredAvatar(string address, IRegistrationSet registrations)
+    {
+        return registrations.IsRegistered(address);
+    }
+
+    /// <summary>
+    /// Checks whether a trust edge is valid for pathfinder inclusion.
+    /// Implements the filtering logic from trustQuery.sql:
+    /// - Both truster and trustee must be registered
+    /// - Trust must not be expired
+    /// - Group trusters are excluded (handled separately as group trusts)
+    /// </summary>
+    public static bool IsValidTrustEdge(
+        string truster,
+        string trustee,
+        long expiryTime,
+        long currentTimestamp,
+        IRegistrationSet registrations)
+    {
+        // Skip revoked/expired trust. In Hub.sol, expiryTime=0 is an explicit untrust —
+        // but the cache never stores 0 (incremental removes on 0, warmup SQL excludes 0).
+        // This predicate is unreachable with expiryTime=0 in practice.
+        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+            return false;
+
+        // Both must be registered (humans + orgs + groups)
+        if (!registrations.IsRegistered(truster))
+            return false;
+        if (!registrations.IsRegistered(trustee))
+            return false;
+
+        // Group trusters are excluded — they're handled in group trust edges
+        if (registrations.IsGroup(truster))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether a group trust edge is valid for pathfinder inclusion.
+    /// Implements the filtering logic from groupTrustQuery.sql:
+    /// - Truster must be a registered group using the standard router
+    /// - Trusted token (trustee) must be a registered avatar
+    /// - Trust must not be expired
+    /// </summary>
+    public static bool IsValidGroupTrustEdge(
+        string groupAddress,
+        string trustedToken,
+        long expiryTime,
+        long currentTimestamp,
+        IRegistrationSet registrations,
+        IReadOnlySet<string> routerGroups)
+    {
+        // Truster must be a router-filtered group
+        if (!routerGroups.Contains(groupAddress))
+            return false;
+
+        // Skip revoked/expired trust
+        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+            return false;
+
+        // Trusted token must be a registered avatar (human, org, or group)
+        if (!registrations.IsRegistered(trustedToken))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether a V2 balance entry is valid for pathfinder inclusion.
+    /// Implements the filtering logic from balanceQuery.sql:
+    /// - Account must be a registered avatar
+    /// - For native ERC1155: tokenAddress (= token owner) must be registered
+    /// - For wrappers: underlying avatar must be registered
+    /// </summary>
+    public static bool IsValidBalance(
+        string account,
+        string tokenAddress,
+        IRegistrationSet registrations,
+        IWrapperLookup? wrapperLookup)
+    {
+        // Account must be a registered avatar
+        if (!registrations.IsRegistered(account))
+            return false;
+
+        // Check token validity
+        if (wrapperLookup != null && wrapperLookup.TryGetUnderlyingAvatar(tokenAddress, out var underlyingAvatar))
+        {
+            // Wrapper token: underlying avatar must be registered
+            if (!registrations.IsRegistered(underlyingAvatar))
+                return false;
+        }
+        else
+        {
+            // Native ERC1155: tokenAddress IS the token owner — must be registered
+            if (!registrations.IsRegistered(tokenAddress))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether a wrapper mapping is valid for pathfinder inclusion.
+    /// Implements the filtering logic from wrapperMappingQuery.sql:
+    /// - Underlying avatar must be registered
+    /// </summary>
+    public static bool IsValidWrapperMapping(
+        string underlyingAvatar,
+        IRegistrationSet registrations)
+    {
+        return registrations.IsRegistered(underlyingAvatar);
+    }
+
+    /// <summary>
+    /// Checks whether a group membership is valid.
+    /// - Group must be registered
+    /// - Member must be a registered avatar
+    /// - Membership must not be expired
+    /// </summary>
+    public static bool IsValidGroupMembership(
+        string groupAddress,
+        string member,
+        long expiryTime,
+        long currentTimestamp,
+        IRegistrationSet registrations)
+    {
+        // Must not be expired
+        if (expiryTime > 0 && expiryTime <= currentTimestamp)
+            return false;
+
+        // Group must be registered as a group
+        if (!registrations.IsGroup(groupAddress))
+            return false;
+
+        // Member must be a registered avatar
+        if (!registrations.IsRegistered(member))
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Checks whether a consented flow flag is valid for pathfinder inclusion.
+    /// - Avatar must be registered
+    /// </summary>
+    public static bool IsValidConsentedFlowFlag(
+        string avatar,
+        IRegistrationSet registrations)
+    {
+        return registrations.IsRegistered(avatar);
+    }
+}
+
+/// <summary>
+/// Abstraction for checking avatar registration status.
+/// Implemented by CacheRegistrationSet (cache service) and pathfinder's own set.
+/// </summary>
+public interface IRegistrationSet
+{
+    /// <summary>Returns true if the address is a registered V2 avatar (human, org, or group).</summary>
+    bool IsRegistered(string address);
+
+    /// <summary>Returns true if the address is a registered V2 group.</summary>
+    bool IsGroup(string address);
+}
+
+/// <summary>
+/// Abstraction for wrapper address → underlying avatar lookups.
+/// Implemented differently by cache (CacheContainer) and pathfinder (CapacityGraph).
+/// </summary>
+public interface IWrapperLookup
+{
+    /// <summary>
+    /// If tokenAddress is an ERC20 wrapper, returns the underlying avatar address.
+    /// Returns false for native ERC1155 token addresses.
+    /// </summary>
+    bool TryGetUnderlyingAvatar(string tokenAddress, out string underlyingAvatar);
+}
+
+/// <summary>
+/// Simple implementation of <see cref="IRegistrationSet"/> backed by two HashSets.
+/// </summary>
+public sealed class HashSetRegistrationSet : IRegistrationSet
+{
+    private readonly IReadOnlySet<string> _avatars;
+    private readonly IReadOnlySet<string> _groups;
+
+    /// <param name="avatars">All registered addresses (humans + orgs + groups).</param>
+    /// <param name="groups">Only group addresses (subset of avatars).</param>
+    public HashSetRegistrationSet(IReadOnlySet<string> avatars, IReadOnlySet<string> groups)
+    {
+        _avatars = avatars;
+        _groups = groups;
+    }
+
+    public bool IsRegistered(string address) => _avatars.Contains(address) || _groups.Contains(address);
+    public bool IsGroup(string address) => _groups.Contains(address);
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -507,8 +507,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void StoppedAvatar_ExcludedFromContains()
+    public void StoppedAvatar_StillInContains()
     {
+        // Hub.sol stop() only prevents minting — avatar remains registered
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -518,14 +519,16 @@ public class InMemoryAvatarStateTests
 
         state.InitializeStoppedAvatars(new[] { Alice });
 
-        Assert.That(state.Contains(Alice), Is.False);
+        Assert.That(state.Contains(Alice), Is.True, "Stopped avatars are still registered");
         Assert.That(state.Contains(Bob), Is.True);
         Assert.That(state.StoppedCount, Is.EqualTo(1));
+        Assert.That(state.IsStopped(Alice), Is.True);
     }
 
     [Test]
-    public void MarkStopped_ExcludesFromContains()
+    public void MarkStopped_StillInContains()
     {
+        // Hub.sol stop() only prevents minting — avatar remains registered
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
 
@@ -533,7 +536,8 @@ public class InMemoryAvatarStateTests
 
         state.MarkStopped(Alice);
 
-        Assert.That(state.Contains(Alice), Is.False);
+        Assert.That(state.Contains(Alice), Is.True, "Stopped avatars are still registered");
+        Assert.That(state.IsStopped(Alice), Is.True, "IsStopped tracks the stop event");
     }
 
     [Test]
@@ -544,8 +548,9 @@ public class InMemoryAvatarStateTests
         state.MarkStopped(Alice);
 
         var snapshot = state.Snapshot();
-        Assert.That(snapshot.Contains(Alice), Is.False);
+        Assert.That(snapshot.Contains(Alice), Is.True, "Stopped avatars remain in snapshot");
         Assert.That(snapshot.StoppedCount, Is.EqualTo(1));
+        Assert.That(snapshot.IsStopped(Alice), Is.True);
     }
 
     [Test]
@@ -580,8 +585,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void GetActiveAvatarSet_MarkStopped_InvalidatesCache()
+    public void GetActiveAvatarSet_MarkStopped_DoesNotExclude()
     {
+        // Hub.sol stop() only prevents minting — GetActiveAvatarSet includes stopped
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -595,12 +601,12 @@ public class InMemoryAvatarStateTests
         state.MarkStopped(Alice);
 
         var set2 = state.GetActiveAvatarSet();
-        Assert.That(set2, Has.Count.EqualTo(1));
-        Assert.That(set2.Contains(Alice), Is.False);
+        Assert.That(set2, Has.Count.EqualTo(2), "Stopped avatars remain in active set");
+        Assert.That(set2.Contains(Alice), Is.True);
     }
 
     [Test]
-    public void GetActiveAvatarSet_InitializeFromFullLoad_InvalidatesCache()
+    public void GetActiveAvatarSet_InitializeFromFullLoad_ReplacesSet()
     {
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[] { (Alice, "CrcV2_RegisterHuman") });
@@ -616,8 +622,9 @@ public class InMemoryAvatarStateTests
     }
 
     [Test]
-    public void GetActiveAvatarSet_InitializeStoppedAvatars_InvalidatesCache()
+    public void GetActiveAvatarSet_InitializeStoppedAvatars_DoesNotExclude()
     {
+        // Stopped avatars remain in active set — stop() only prevents minting
         var state = new InMemoryAvatarState();
         state.InitializeFromFullLoad(new[]
         {
@@ -631,8 +638,8 @@ public class InMemoryAvatarStateTests
         state.InitializeStoppedAvatars(new[] { Bob });
 
         var set2 = state.GetActiveAvatarSet();
-        Assert.That(set2, Has.Count.EqualTo(1));
-        Assert.That(set2.Contains(Bob), Is.False);
+        Assert.That(set2, Has.Count.EqualTo(2), "Stopped avatars remain in active set");
+        Assert.That(set2.Contains(Bob), Is.True);
     }
 }
 
@@ -831,8 +838,9 @@ public class IncrementalLoadGraphTests
     }
 
     [Test]
-    public void LoadRegisteredAvatars_ExcludesStoppedAvatars()
+    public void LoadRegisteredAvatars_IncludesStoppedAvatars()
     {
+        // Hub.sol stop() only prevents minting — stopped avatars remain registered
         var avatars = CreateAvatarState(
             (Alice, "CrcV2_RegisterHuman"),
             (Bob, "CrcV2_RegisterHuman"));
@@ -845,7 +853,7 @@ public class IncrementalLoadGraphTests
         var registered = incGraph.LoadRegisteredAvatars().ToHashSet();
 
         Assert.That(registered.Contains(Alice), Is.True);
-        Assert.That(registered.Contains(Bob), Is.False);
+        Assert.That(registered.Contains(Bob), Is.True, "Stopped avatars are still registered");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/InMemoryAvatarState.cs
@@ -3,39 +3,43 @@ namespace Circles.Pathfinder.Data;
 /// <summary>
 /// In-memory set of registered avatars and groups.
 /// Used to filter trust/balance edges to only include registered participants.
-/// Stopped avatars (D13) are excluded from Contains() checks.
+///
+/// Hub.sol stop() only prevents future minting — it does NOT deregister the avatar.
+/// Stopped avatars remain registered, can transfer, and can be flow vertices.
+/// The _stopped set is retained for informational/metric purposes only.
 /// </summary>
 public class InMemoryAvatarState
 {
     private readonly HashSet<string> _avatars = new();
     private readonly HashSet<string> _groups = new();
     private readonly HashSet<string> _stopped = new();
-    private HashSet<string>? _cachedActiveSet;
 
     /// <summary>Total number of registered avatars (including stopped).</summary>
     public int Count => _avatars.Count;
     /// <summary>Number of registered groups.</summary>
     public int GroupCount => _groups.Count;
-    /// <summary>Number of stopped avatars.</summary>
+    /// <summary>Number of stopped avatars (informational only — they're still registered).</summary>
     public int StoppedCount => _stopped.Count;
 
-    /// <summary>All registered avatars (including groups), excluding stopped.</summary>
+    /// <summary>All registered avatars (including groups and stopped).</summary>
     public HashSet<string> AvatarSet => _avatars;
 
     /// <summary>Only registered groups (subset of avatars).</summary>
     public HashSet<string> GetGroupSet() => _groups;
 
-    /// <summary>All registered avatars excluding stopped avatars. Cached until mutation.</summary>
-    public IReadOnlySet<string> GetActiveAvatarSet()
-    {
-        return _cachedActiveSet ??= _avatars.Where(a => !_stopped.Contains(a)).ToHashSet();
-    }
+    /// <summary>All registered avatars. Stopped avatars are included (still registered per Hub.sol).</summary>
+    public IReadOnlySet<string> GetActiveAvatarSet() => _avatars;
 
-    /// <summary>Returns true if address is a registered, non-stopped avatar.</summary>
+    /// <summary>Returns true if address is a registered avatar (including stopped).</summary>
     public bool Contains(string address)
     {
-        var lower = address.ToLowerInvariant();
-        return _avatars.Contains(lower) && !_stopped.Contains(lower);
+        return _avatars.Contains(address.ToLowerInvariant());
+    }
+
+    /// <summary>Returns true if address was ever registered (same as Contains — stopped are registered).</summary>
+    public bool IsRegistered(string address)
+    {
+        return _avatars.Contains(address.ToLowerInvariant());
     }
 
     /// <summary>Returns true if address is a registered group.</summary>
@@ -47,7 +51,6 @@ public class InMemoryAvatarState
     /// </summary>
     public void InitializeFromFullLoad(IEnumerable<(string Avatar, string Type)> rows)
     {
-        _cachedActiveSet = null;
         _avatars.Clear();
         _groups.Clear();
         foreach (var row in rows)
@@ -59,27 +62,27 @@ public class InMemoryAvatarState
     }
 
     /// <summary>
-    /// Load stopped avatars (full state). Clears and repopulates the stopped set.
+    /// Load stopped avatars (informational only — does not affect registration checks).
     /// </summary>
     public void InitializeStoppedAvatars(IEnumerable<string> stoppedAvatars)
     {
-        _cachedActiveSet = null;
         _stopped.Clear();
         foreach (var avatar in stoppedAvatars)
             _stopped.Add(avatar.ToLowerInvariant());
     }
 
-    /// <summary>Mark an avatar as stopped (incremental delta).</summary>
+    /// <summary>Mark an avatar as stopped (informational only).</summary>
     public void MarkStopped(string avatar)
     {
-        _cachedActiveSet = null;
         _stopped.Add(avatar.ToLowerInvariant());
     }
+
+    /// <summary>Returns true if the avatar has been stopped (informational — they're still registered).</summary>
+    public bool IsStopped(string address) => _stopped.Contains(address.ToLowerInvariant());
 
     /// <summary>Register a new avatar (incremental delta). Groups added to both sets.</summary>
     public void AddAvatar(string avatar, string type)
     {
-        _cachedActiveSet = null;
         avatar = avatar.ToLowerInvariant();
         _avatars.Add(avatar);
         if (type == "CrcV2_RegisterGroup")


### PR DESCRIPTION
## Summary

Single source of truth for Circles V2 trust/registration validation across cache and pathfinder.

### Core (#294)
- `CirclesInvariants` shared predicates in `Circles.Common` (`IsValidTrustEdge`, `IsValidBalance`, `IsValidToken`, etc.)
- `IRegistrationSet` / `IWrapperLookup` interfaces + cache adapters
- Registration filters in cache warmup SQL, incremental processing, all controller output
- `RegisteredAvatarsCte` shared SQL constant (eliminates 6x duplication)
- 52 new tests (36 predicate unit + 16 conformance)

### Balance API vs Pathfinder (#300, #301)
- `IsValidToken` (token-only) for balance API — stopped avatars can still hold valid tokens
- `IsValidBalance` (account + token) for pathfinder graph — Hub.sol requires registered flow vertices
- All 3 BalancesController endpoints + incremental writes use `IsValidToken`

### Stopped avatar fix (#302)
- Hub.sol `stop()` only prevents minting — does NOT deregister
- Removed all `CrcV2_Stopped` exclusions from cache warmup SQL and incremental processing
- Fixed pre-existing pathfinder bug: `InMemoryAvatarState.Contains()` no longer excludes stopped avatars

## Verified on staging
- Rolling deploy to staging1 + staging2, 15/15 smoke on both
- Stopped avatar balance visible (0.052 CRC)
- Pathfinder routes through stopped avatars (maxFlow returned)
- 221 cache + 904 pathfinder tests pass

## Test plan
- [x] All tests pass
- [x] Staging verified
- [ ] Production deploy (rolling, after dev merge)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralised validation for avatars, tokens, trusts, group memberships and wrapper mappings to standardise responses.
  * Stopped avatars are tracked separately but remain considered registered where applicable.

* **Bug Fixes**
  * Responses now consistently exclude unregistered or expired entries across balances, trusts, group trusts, wrapper mappings and consent flags.
  * Token/address casing and wrapper resolution issues addressed for balance listings.

* **Tests**
  * Extensive conformance and invariant tests added to validate end-to-end filtering and controller outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->