### PR TITLE
fix(security): sanitize user input in log entries

### DIFF
--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -160,116 +160,116 @@ public class NotificationListenerService : BackgroundService
         await _notificationGate.WaitAsync(ct);
         try
         {
-        _logger.LogDebug("Received notification ping");
+            _logger.LogDebug("Received notification ping");
 
-        // Treat the notification as a ping - don't trust the payload content
-        // Instead, query the database for the actual latest blocks
-        List<(long BlockNumber, string BlockHash)> recentBlocks = new();
+            // Treat the notification as a ping - don't trust the payload content
+            // Instead, query the database for the actual latest blocks
+            List<(long BlockNumber, string BlockHash)> recentBlocks = new();
 
-        await WithReadonlyConnectionAsync(async (conn, token) =>
-        {
-            recentBlocks = await GetRecentBlocksAsync(conn, _settings.RollbackCapacity, token);
-        }, ct);
-
-        if (recentBlocks.Count == 0)
-        {
-            _logger.LogWarning("No blocks found in System_Block table");
-            return;
-        }
-
-        // Update the block ring buffer and detect any reorgs
-        var reorgPoint = _state.BlockRingBuffer.UpdateFromBlocks(recentBlocks);
-
-        if (reorgPoint.HasValue)
-        {
-            if (reorgPoint.Value <= _state.WarmupTargetBlock)
+            await WithReadonlyConnectionAsync(async (conn, token) =>
             {
+                recentBlocks = await GetRecentBlocksAsync(conn, _settings.RollbackCapacity, token);
+            }, ct);
+
+            if (recentBlocks.Count == 0)
+            {
+                _logger.LogWarning("No blocks found in System_Block table");
+                return;
+            }
+
+            // Update the block ring buffer and detect any reorgs
+            var reorgPoint = _state.BlockRingBuffer.UpdateFromBlocks(recentBlocks);
+
+            if (reorgPoint.HasValue)
+            {
+                if (reorgPoint.Value <= _state.WarmupTargetBlock)
+                {
+                    _logger.LogWarning(
+                        "Detected reorg at block {ReorgBlock} crossing warmup seed boundary {WarmupTarget}. Triggering full re-warmup.",
+                        reorgPoint.Value,
+                        _state.WarmupTargetBlock);
+
+                    CacheMetrics.ReorgsDetected.Inc();
+                    TriggerFullRewarmup();
+                    return;
+                }
+
                 _logger.LogWarning(
-                    "Detected reorg at block {ReorgBlock} crossing warmup seed boundary {WarmupTarget}. Triggering full re-warmup.",
-                    reorgPoint.Value,
-                    _state.WarmupTargetBlock);
+                    "Detected reorg at block {ReorgBlock}! Rolling back caches from block {RollbackBlock}...",
+                    reorgPoint.Value, reorgPoint.Value);
 
+                // Track reorg in metrics
                 CacheMetrics.ReorgsDetected.Inc();
-                TriggerFullRewarmup();
-                return;
+
+                // Rollback all caches to the reorg point. If the reorg is deeper than
+                // RollbackCapacity, RollbackAll throws InvalidOperationException — in that
+                // case the only safe recovery is a full re-warmup.
+                try
+                {
+                    _caches.RollbackAll(reorgPoint.Value);
+
+                    // Rebuild secondary indexes after rollback
+                    _logger.LogInformation("Rebuilding secondary indexes after rollback...");
+                    _caches.RebuildSecondaryIndexes();
+
+                    // Update state
+                    _state.LastProcessedBlock = Math.Min(_state.LastProcessedBlock, reorgPoint.Value - 1);
+
+                    _logger.LogInformation("Rollback completed. Will reprocess from block {FromBlock}",
+                        reorgPoint.Value);
+                }
+                catch (InvalidOperationException rollbackEx)
+                {
+                    _logger.LogError(rollbackEx,
+                        "Reorg at block {ReorgBlock} exceeds rollback capacity. Triggering full re-warmup.",
+                        reorgPoint.Value);
+
+                    TriggerFullRewarmup();
+                    return;
+                }
             }
 
-            _logger.LogWarning(
-                "Detected reorg at block {ReorgBlock}! Rolling back caches from block {RollbackBlock}...",
-                reorgPoint.Value, reorgPoint.Value);
+            // Process any new blocks that we haven't processed yet
+            var latestBlock = recentBlocks.Max(b => b.BlockNumber);
+            var fromBlock = _state.LastProcessedBlock + 1;
 
-            // Track reorg in metrics
-            CacheMetrics.ReorgsDetected.Inc();
-
-            // Rollback all caches to the reorg point. If the reorg is deeper than
-            // RollbackCapacity, RollbackAll throws InvalidOperationException — in that
-            // case the only safe recovery is a full re-warmup.
-            try
+            if (fromBlock <= latestBlock)
             {
-                _caches.RollbackAll(reorgPoint.Value);
+                var blocksProcessed = latestBlock - fromBlock + 1;
+                _logger.LogInformation("Processing block range {FromBlock} → {ToBlock} ({Count} blocks)",
+                    fromBlock, latestBlock, blocksProcessed);
 
-                // Rebuild secondary indexes after rollback
-                _logger.LogInformation("Rebuilding secondary indexes after rollback...");
-                _caches.RebuildSecondaryIndexes();
+                try
+                {
+                    // Process new blocks
+                    await ProcessBlockRangeAsync(fromBlock, latestBlock, ct);
 
-                // Update state
-                _state.LastProcessedBlock = Math.Min(_state.LastProcessedBlock, reorgPoint.Value - 1);
+                    _state.LastProcessedBlock = latestBlock;
+                    _state.CurrentBlockTimestamp = await GetBlockTimestampAsync(latestBlock, ct);
 
-                _logger.LogInformation("Rollback completed. Will reprocess from block {FromBlock}",
-                    reorgPoint.Value);
+                    // Track blocks processed
+                    CacheMetrics.BlocksProcessed.Inc(blocksProcessed);
+
+                    _logger.LogInformation("Completed processing blocks {FromBlock} → {ToBlock}. Cache now at block {CurrentBlock}",
+                        fromBlock, latestBlock, _state.LastProcessedBlock);
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    _logger.LogError(ex, "Failed to process block range {FromBlock} → {ToBlock}", fromBlock, latestBlock);
+
+                    // Attempt to rollback caches to restore consistency with _state.LastProcessedBlock
+                    // The rollback target is fromBlock (first unprocessed block), which restores state to
+                    // what it was after processing (LastProcessedBlock = fromBlock - 1)
+                    await AttemptRecoveryRollbackAsync(fromBlock, ct);
+
+                    throw;
+                }
             }
-            catch (InvalidOperationException rollbackEx)
+            else
             {
-                _logger.LogError(rollbackEx,
-                    "Reorg at block {ReorgBlock} exceeds rollback capacity. Triggering full re-warmup.",
-                    reorgPoint.Value);
-
-                TriggerFullRewarmup();
-                return;
+                _logger.LogDebug("No new blocks to process (last processed: {LastProcessed}, latest: {Latest})",
+                    _state.LastProcessedBlock, latestBlock);
             }
-        }
-
-        // Process any new blocks that we haven't processed yet
-        var latestBlock = recentBlocks.Max(b => b.BlockNumber);
-        var fromBlock = _state.LastProcessedBlock + 1;
-
-        if (fromBlock <= latestBlock)
-        {
-            var blocksProcessed = latestBlock - fromBlock + 1;
-            _logger.LogInformation("Processing block range {FromBlock} → {ToBlock} ({Count} blocks)",
-                fromBlock, latestBlock, blocksProcessed);
-
-            try
-            {
-                // Process new blocks
-                await ProcessBlockRangeAsync(fromBlock, latestBlock, ct);
-
-                _state.LastProcessedBlock = latestBlock;
-                _state.CurrentBlockTimestamp = await GetBlockTimestampAsync(latestBlock, ct);
-
-                // Track blocks processed
-                CacheMetrics.BlocksProcessed.Inc(blocksProcessed);
-
-                _logger.LogInformation("Completed processing blocks {FromBlock} → {ToBlock}. Cache now at block {CurrentBlock}",
-                    fromBlock, latestBlock, _state.LastProcessedBlock);
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                _logger.LogError(ex, "Failed to process block range {FromBlock} → {ToBlock}", fromBlock, latestBlock);
-
-                // Attempt to rollback caches to restore consistency with _state.LastProcessedBlock
-                // The rollback target is fromBlock (first unprocessed block), which restores state to
-                // what it was after processing (LastProcessedBlock = fromBlock - 1)
-                await AttemptRecoveryRollbackAsync(fromBlock, ct);
-
-                throw;
-            }
-        }
-        else
-        {
-            _logger.LogDebug("No new blocks to process (last processed: {LastProcessed}, latest: {Latest})",
-                _state.LastProcessedBlock, latestBlock);
-        }
         }
         finally
         {

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -115,6 +115,12 @@ internal sealed class FindPathHandler(
     /// Execute a solver call with semaphore guarding, graph rent, timeout, metrics, and exception handling.
     /// The <paramref name="solve"/> delegate receives the rented capacity graph and returns the result to serialize.
     /// </summary>
+    /// <summary>
+    /// Strip CR/LF from user-supplied values before logging (prevents log forging).
+    /// </summary>
+    private static string? SanitizeForLog(string? value) =>
+        value?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
     internal async Task<IResult> ExecuteWithGuard(
         string route,
         FlowRequest request,
@@ -220,7 +226,7 @@ internal sealed class FindPathHandler(
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("timeout").Inc();
             log.LogError("{Route} solver timed out after {Timeout}s for request: from={From}, to={To}, amount={Amount}",
-                route, settings.SolverTimeoutSeconds, request.Source, request.Sink, request.TargetFlow);
+                route, settings.SolverTimeoutSeconds, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow);
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
         catch (ArgumentException ex)
@@ -233,7 +239,7 @@ internal sealed class FindPathHandler(
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("error").Inc();
             log.LogError(ex, "{Route} threw exception for request: from={From}, to={To}, amount={Amount}",
-                route, request.Source, request.Sink, request.TargetFlow);
+                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow);
             return Results.StatusCode(StatusCodes.Status500InternalServerError);
         }
         finally

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -88,10 +88,15 @@ internal sealed class FindPathHandler(
         int? maxTransfers = null, bool? quantizedMode = null,
         bool? debugShowIntermediateSteps = null)
     {
+        // Normalize and sanitize addresses once so all downstream logging is safe
+        // (prevents log forging via embedded \r\n in user-supplied addresses).
+        var normalizedFrom = from.ToLowerInvariant().Replace("\r", string.Empty).Replace("\n", string.Empty);
+        var normalizedTo = to.ToLowerInvariant().Replace("\r", string.Empty).Replace("\n", string.Empty);
+
         return new FlowRequest
         {
-            Source = from.ToLowerInvariant(),
-            Sink = to.ToLowerInvariant(),
+            Source = normalizedFrom,
+            Sink = normalizedTo,
             TargetFlow = amount,
             FromTokens = fromTokens?.ToList(),
             ToTokens = toTokens?.ToList(),

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -377,6 +377,11 @@ app.MapPost("/findPath", async (
     var arraySizeErr = FindPathHandler.ValidateArraySizes(request);
     if (arraySizeErr != null) return arraySizeErr;
 
+    // Sanitize user input early: strip CR/LF to prevent log forging, then lowercase.
+    request.Source = request.Source?.Replace("\r", "").Replace("\n", "").ToLowerInvariant();
+    request.Sink = request.Sink?.Replace("\r", "").Replace("\n", "").ToLowerInvariant();
+    request.TargetFlow = request.TargetFlow?.Replace("\r", "").Replace("\n", "");
+
     log.LogInformation("Deserialized request - Source: {Source}, Sink: {Sink}, TargetFlow: {TargetFlow}",
         request.Source, request.Sink, request.TargetFlow);
 
@@ -386,9 +391,6 @@ app.MapPost("/findPath", async (
     act?.SetTag("to", request.Sink);
     act?.SetTag("amount", request.TargetFlow);
     using var scope = log.BeginScope("traceId:{TraceId}", act?.TraceId.ToString());
-
-    request.Source = request.Source?.ToLowerInvariant();
-    request.Sink = request.Sink?.ToLowerInvariant();
 
     if (settings.ExcludeConsentedIntermediaries)
         request.SimulatedConsentedAvatars = null;

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -296,27 +296,33 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         int? sourceId = !string.IsNullOrWhiteSpace(request?.Source) ? AddressIdPool.IdOf(request.Source) : null;
         int? sinkId = !string.IsNullOrWhiteSpace(request?.Sink) ? AddressIdPool.IdOf(request.Sink) : null;
 
+        // Defense-in-depth: sanitize for logging to prevent log forging via embedded newlines.
+        // FlowRequest.Source/Sink are already sanitized at construction in FindPathHandler.BuildRequest,
+        // but guard here too since GraphFactory is a public API.
+        var logSource = request?.Source?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+        var logSink = request?.Sink?.Replace("\r", string.Empty).Replace("\n", string.Empty);
+
         if (sourceId != null && capacityGraph.IsGroup(sourceId.Value))
         {
-            _logger.LogWarning("Rejected source '{Source}': address is a group", request!.Source);
+            _logger.LogWarning("Rejected source '{Source}': address is a group", logSource);
             throw new ArgumentException("Invalid source address.");
         }
 
         if (sinkId != null && capacityGraph.IsGroup(sinkId.Value))
         {
-            _logger.LogWarning("Rejected sink '{Sink}': address is a group", request!.Sink);
+            _logger.LogWarning("Rejected sink '{Sink}': address is a group", logSink);
             throw new ArgumentException("Invalid sink address.");
         }
 
         if (sourceId != null && capacityGraph.IsRouter(sourceId.Value))
         {
-            _logger.LogWarning("Rejected source '{Source}': address is the router", request!.Source);
+            _logger.LogWarning("Rejected source '{Source}': address is the router", logSource);
             throw new ArgumentException("Invalid source address.");
         }
 
         if (sinkId != null && capacityGraph.IsRouter(sinkId.Value))
         {
-            _logger.LogWarning("Rejected sink '{Sink}': address is the router", request!.Sink);
+            _logger.LogWarning("Rejected sink '{Sink}': address is the router", logSink);
             throw new ArgumentException("Invalid sink address.");
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -16,6 +16,9 @@ public class V2Pathfinder
     private readonly ILogger _logger;
     private readonly Settings _settings;
 
+    /// <summary>Strip CR/LF from values before logging (defense-in-depth against log forging).</summary>
+    private static string? Sanitize(string? v) => v?.Replace("\r", "").Replace("\n", "");
+
     public V2Pathfinder(ILogger<V2Pathfinder>? logger = null, Settings? settings = null)
     {
         _logger = logger ?? NullLogger<V2Pathfinder>.Instance;
@@ -150,13 +153,13 @@ public class V2Pathfinder
         if (!capacityGraph.AvatarNodes.ContainsKey(sourceId))
         {
             _logger.LogWarning("[{ReqId}] Source '{Source}' not in graph snapshot (block={Block}) — returning zero flow",
-                reqId, request.Source, capacityGraph.Block);
+                reqId, Sanitize(request.Source), capacityGraph.Block);
             return null;
         }
         if (!capacityGraph.AvatarNodes.ContainsKey(effSink))
         {
             _logger.LogWarning("[{ReqId}] Sink '{Sink}' not in graph snapshot (block={Block}) — returning zero flow",
-                reqId, request.Sink, capacityGraph.Block);
+                reqId, Sanitize(request.Sink), capacityGraph.Block);
             return null;
         }
 
@@ -175,7 +178,7 @@ public class V2Pathfinder
 
             _logger.LogInformation(
                 "[{ReqId}] Request: from={Source} to={Sink} amount={Amount} block={Block} flags=[{Flags}]",
-                reqId, request.Source, request.Sink, targetFlow, capacityGraph.Block,
+                reqId, Sanitize(request.Source), Sanitize(request.Sink), targetFlow, capacityGraph.Block,
                 flags.Count > 0 ? string.Join(",", flags) : "none");
         }
 

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -1020,28 +1020,28 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 return $"{column} NOT LIKE {paramName}";
 
             case FilterType.In:
-            {
-                var inValues = TryExtractEnumerableFilterValues(predicate.Value);
-                if (inValues == null)
-                    throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
-                if (inValues.Count == 0)
-                    return "1=0"; // empty IN matches nothing
-                if (inValues.Count > MaxInFilterElements)
-                    throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
-                return BuildInClause(column, paramName, inValues, parameters, negate: false);
-            }
+                {
+                    var inValues = TryExtractEnumerableFilterValues(predicate.Value);
+                    if (inValues == null)
+                        throw new ArgumentException($"Value for 'In' filter on column '{predicate.Column}' must be an array.");
+                    if (inValues.Count == 0)
+                        return "1=0"; // empty IN matches nothing
+                    if (inValues.Count > MaxInFilterElements)
+                        throw new ArgumentException($"In filter exceeds maximum of {MaxInFilterElements} elements.");
+                    return BuildInClause(column, paramName, inValues, parameters, negate: false);
+                }
 
             case FilterType.NotIn:
-            {
-                var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
-                if (notInValues == null)
-                    throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
-                if (notInValues.Count == 0)
-                    return "1=1"; // empty NOT IN excludes nothing
-                if (notInValues.Count > MaxInFilterElements)
-                    throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
-                return BuildInClause(column, paramName, notInValues, parameters, negate: true);
-            }
+                {
+                    var notInValues = TryExtractEnumerableFilterValues(predicate.Value);
+                    if (notInValues == null)
+                        throw new ArgumentException($"Value for 'NotIn' filter on column '{predicate.Column}' must be an array.");
+                    if (notInValues.Count == 0)
+                        return "1=1"; // empty NOT IN excludes nothing
+                    if (notInValues.Count > MaxInFilterElements)
+                        throw new ArgumentException($"NotIn filter exceeds maximum of {MaxInFilterElements} elements.");
+                    return BuildInClause(column, paramName, notInValues, parameters, negate: true);
+                }
 
             case FilterType.IsNull:
                 return $"{column} IS NULL";


### PR DESCRIPTION
## Summary

Addresses 4 CodeQL log forging alerts (code-scanning/98-101) from PR #304.

- **`FindPathHandler.BuildRequest`**: Strip `\r\n` from `source`/`sink` at `FlowRequest` construction — all downstream logging of these fields is safe by default
- **`GraphFactory.CreateCapacityGraph`**: Belt-and-suspenders sanitization at the log sink via `logSource`/`logSink` local variables — guards against direct `GraphFactory` usage bypassing `FindPathHandler`

## Test plan

- [x] 917 pathfinder tests pass, 0 regressions
- [x] Non-malicious input unaffected (Ethereum addresses contain no control chars)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Input fields for route/source and destination are now normalised (lowercased where applicable) and CR/LF control characters are stripped early in request handling, reducing errors from malformed values.
  * Logging and tracing now record sanitized endpoint values so logs no longer include raw control characters, improving readability and diagnostic reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->