### PR TITLE
fix(pathfinder): use BaseMintPolicy address for group SQL filter

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -97,7 +97,7 @@ public class ProxyLoadGraph : ILoadGraph
         WHERE t2."group" IS NULL
         """;
 
-    // Group query with temporal filter — {1} = router address from Settings.GroupRouterAddress
+    // Group query with temporal filter — {1} = mint policy address from Settings.StandardMintPolicyAddress
     private const string GroupQueryTemplate = """
         SELECT "group" AS group_address
         FROM "CrcV2_RegisterGroup"
@@ -105,7 +105,7 @@ public class ProxyLoadGraph : ILoadGraph
           AND "blockNumber" <= {0}
         """;
 
-    // Group trust query with temporal filter: uses same trust_state CTE — {1} = router address
+    // Group trust query with temporal filter — {1} = mint policy address
     private const string GroupTrustQueryTemplate = """
         WITH trust_state AS (
             SELECT truster, trustee, "expiryTime",
@@ -226,7 +226,7 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<string> LoadGroups()
     {
-        var query = string.Format(GroupQueryTemplate, _client.BlockNumber, _settings.GroupRouterAddress);
+        var query = string.Format(GroupQueryTemplate, _client.BlockNumber, _settings.StandardMintPolicyAddress);
         var response = _client.ExecuteQueryAsync(query, maxRows: 10000).GetAwaiter().GetResult();
         var results = new List<string>();
 
@@ -241,7 +241,7 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber, _settings.GroupRouterAddress);
+        var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber, _settings.StandardMintPolicyAddress);
         var response = _client.ExecuteQueryAsync(query, maxRows: 100000).GetAwaiter().GetResult();
         var results = new List<(string GroupAddress, string TrustedToken)>();
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -128,7 +128,7 @@ public class IncrementalLoadGraph : ILoadGraph
     /// </summary>
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        // Use router-filtered groups from DB (matches groupQuery.sql parameterized by GroupRouterAddress)
+        // Groups filtered by standard mint policy from DB (matches groupQuery.sql parameterized by StandardMintPolicyAddress)
         var routerGroups = new HashSet<string>(_inner.LoadGroups().Select(g => g.ToLowerInvariant()));
         return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp);
     }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -215,7 +215,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -240,7 +240,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -353,7 +353,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -376,7 +376,7 @@ namespace Circles.Pathfinder.Data
 
             using var command = new NpgsqlCommand(groupTrustQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
-            command.Parameters.AddWithValue("router", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.sql
@@ -1,4 +1,4 @@
 SELECT
     "group" as group_address
 FROM "CrcV2_RegisterGroup"
-WHERE "mint" = LOWER(@router);
+WHERE "mint" = LOWER(@mintPolicy);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -3,4 +3,4 @@ SELECT
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
 INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
-WHERE g."mint" = LOWER(@router);
+WHERE g."mint" = LOWER(@mintPolicy);

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -109,12 +109,22 @@ public class Settings
     }
 
     /// <summary>
-    /// Address of the V2 base group router contract used to filter groups and group trusts.
-    /// Previously hardcoded in SQL; now parameterized to avoid silent data loss if the router changes.
+    /// Address of the V2 base group router contract. Used by GraphFactory to track
+    /// the router node and filter group collateral edges (AddTokenPoolOutEdges router
+    /// trust check). NOT used for SQL group filtering — see StandardMintPolicyAddress.
     /// Reads V2_BASE_GROUP_ROUTER env var (same as Common.Settings.BaseGroupRouter).
     /// </summary>
     public string GroupRouterAddress { get; set; } =
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.ToLowerInvariant()
         ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    /// <summary>
+    /// Address of the standard group mint policy contract. Used to filter which groups
+    /// participate in pathfinding (only groups registered with this mint policy are included).
+    /// Must match the Cache Service's StandardTreasuryMint constant.
+    /// </summary>
+    public string StandardMintPolicyAddress { get; set; } =
+        Environment.GetEnvironmentVariable("V2_STANDARD_MINT_POLICY")?.ToLowerInvariant()
+        ?? "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
 
 }

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -157,6 +157,12 @@ public class V2Pathfinder
         _logger.LogInformation("[{ReqId}] Graph: avatars={Avatars}, groups={Groups}, edges={Edges}",
             reqId, capacityGraph.AvatarNodes.Count, capacityGraph.GroupNodes.Count, capacityGraph.Edges.Count);
 
+        if (capacityGraph.GroupNodes.Count == 0)
+        {
+            _logger.LogWarning("[{ReqId}] Graph has 0 groups — group minting paths will be unavailable. " +
+                "Check group loading (SQL fallback may have broken filter, or Cache Service not returning groups).", reqId);
+        }
+
         return new PipelineContext
         {
             Graph = capacityGraph,

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -449,7 +449,7 @@ public class V2Pathfinder
         }
 
         // Debug: compact transfer summary for replay analysis
-        if (ctx.Transfers.Count > 0 && _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+        if (ctx.Transfers?.Count > 0 && _logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
         {
             static string Trunc(string s) => s[..Math.Min(10, s.Length)];
             var summary = string.Join(" | ", ctx.Transfers.Select(t =>


### PR DESCRIPTION
## Summary

PR #282 parameterized the group SQL queries but passed the Router address (`0xdc2874...`) instead of the BaseMintPolicy address (`0xcdfc5135...`). The `CrcV2_RegisterGroup.mint` column stores the mint policy contract, not the Router — so the filter matched 0 groups on the SQL/DB fallback path.

Production was unaffected (uses Cache path which has the correct address hardcoded as `StandardTreasuryMint`), but the DB fallback path (`CACHE_GRAPH_FALLBACK_TO_DB`) silently returned 0 groups, disabling group minting if the Cache Service was down.

## Changes

- `groupQuery.sql`, `groupTrustQuery.sql`: `@router` → `@mintPolicy`
- `Settings.cs`: new `StandardMintPolicyAddress` (env `V2_STANDARD_MINT_POLICY`, default `0xcdfc5135...` = verified `BaseMintPolicy` contract on Gnosis Chain)
- `LoadGraph.cs`: all 4 call sites pass `StandardMintPolicyAddress`
- `ProxyLoadGraph.cs`: test helper updated
- `IncrementalLoadGraph.cs`: fix stale comment
- `V2Pathfinder.cs`: add `groups=0` warning log
- `Settings.cs`: fix `GroupRouterAddress` doc comment (not used for SQL filtering)

## Verification

- `BaseMintPolicy` at `0xcdfc5135...` verified on Blockscout (source verified, 337 groups match)
- Matches Cache Service's `StandardTreasuryMint` constant
- 3 independent audit agents confirmed no regressions
- 904 tests pass, 0 fail

## Test plan

- [x] `dotnet test` — 904 passed, 0 failed
- [x] Verified on prod DB: `SELECT count(*) FROM "CrcV2_RegisterGroup" WHERE "mint" = LOWER('0xcdfc5135...')` → 337
- [ ] Deploy to staging, verify pathfinder loads 337 groups via SQL path
- [ ] Verify `CACHE_GRAPH_FALLBACK_TO_DB` correctly loads groups when cache is unavailable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added a new configuration setting (StandardMintPolicyAddress) to control which groups are included in pathfinding.
  - Added a warning when no groups are found during pathfinding to surface potential configuration or data issues.

* **Documentation**
  - Clarified configuration docs to explain the roles of group-related settings and when each is applied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->