### PR TITLE
feat(pathfinder): structured request logging for all endpoints

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -135,6 +135,9 @@ internal sealed class FindPathHandler(
             return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
 
+        var sw = Stopwatch.StartNew();
+        var graphBlock = state.LastKnownBlockNumber;
+
         FindPathMetrics.InFlightRequestsGauge.Inc();
         try
         {
@@ -177,8 +180,6 @@ internal sealed class FindPathHandler(
                 }
 
                 // Simulation canary: enqueue for async eth_call validation.
-                // Skip when request has simulated inputs — those paths depend on
-                // state that doesn't exist on-chain, so eth_call would always revert.
                 bool hasSimulated = (request.SimulatedBalances?.Count > 0)
                                     || (request.SimulatedTrusts?.Count > 0);
 
@@ -188,9 +189,6 @@ internal sealed class FindPathHandler(
                     && !string.IsNullOrEmpty(request.Sink)
                     && !hasSimulated)
                 {
-                    // Build wrapper→avatar string mapping for the canary to resolve
-                    // wrapper contract addresses back to avatar addresses before eth_call.
-                    // Wrapped in try-catch: canary is best-effort and must never affect the response.
                     Dictionary<string, string>? wrapperMap = null;
                     try
                     {
@@ -215,9 +213,25 @@ internal sealed class FindPathHandler(
                         Source: request.Source,
                         Sink: request.Sink,
                         GraphBlock: mfr.GraphBlock,
-                        Transfers: new List<TransferPathStep>(mfr.Transfers), // defensive copy
+                        Transfers: new List<TransferPathStep>(mfr.Transfers),
                         WrapperToAvatar: wrapperMap));
                 }
+
+                log.LogInformation(
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
+                    route, request.Source, request.Sink, request.TargetFlow,
+                    mfr.MaxFlow, mfr.Transfers?.Count ?? 0, request.MaxTransfers ?? -1,
+                    h.Graph.Block, sw.ElapsedMilliseconds, 200,
+                    request.WithWrap ?? false, request.QuantizedMode ?? false);
+            }
+            else
+            {
+                log.LogInformation(
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers=0 maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
+                    route, request.Source, request.Sink, request.TargetFlow,
+                    result, request.MaxTransfers ?? -1,
+                    graphBlock, sw.ElapsedMilliseconds, 200,
+                    request.WithWrap ?? false, request.QuantizedMode ?? false);
             }
 
             return Results.Ok(result);
@@ -225,21 +239,28 @@ internal sealed class FindPathHandler(
         catch (TimeoutException)
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("timeout").Inc();
-            log.LogError("{Route} solver timed out after {Timeout}s for request: from={From}, to={To}, amount={Amount}",
-                route, settings.SolverTimeoutSeconds, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow);
+            log.LogError(
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=timeout",
+                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow,
+                graphBlock, sw.ElapsedMilliseconds, 504);
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
         catch (ArgumentException ex)
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("bad_request").Inc();
-            log.LogWarning(ex, "{Route} validation error: {Message}", route, ex.Message);
+            log.LogWarning(ex,
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=bad_request",
+                route, request.Source, request.Sink, request.TargetFlow,
+                graphBlock, sw.ElapsedMilliseconds, 400);
             return Results.BadRequest(ex.Message);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("error").Inc();
-            log.LogError(ex, "{Route} threw exception for request: from={From}, to={To}, amount={Amount}",
-                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow);
+            log.LogError(ex,
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=exception",
+                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow,
+                graphBlock, sw.ElapsedMilliseconds, 500);
             return Results.StatusCode(StatusCodes.Status500InternalServerError);
         }
         finally

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -138,6 +138,11 @@ internal sealed class FindPathHandler(
         var sw = Stopwatch.StartNew();
         var graphBlock = state.LastKnownBlockNumber;
 
+        // Sanitize once for all log branches (prevents log forging via CR/LF in user input)
+        var safeSource = SanitizeForLog(request.Source);
+        var safeSink = SanitizeForLog(request.Sink);
+        var safeTargetFlow = SanitizeForLog(request.TargetFlow);
+
         FindPathMetrics.InFlightRequestsGauge.Inc();
         try
         {
@@ -151,6 +156,8 @@ internal sealed class FindPathHandler(
             }
 
             using var h = await pool.Rent(request, balanceGraph, trustGraph);
+            graphBlock = h.Graph.Block; // use the rented graph's actual block
+
             var solverTimeout = TimeSpan.FromSeconds(settings.SolverTimeoutSeconds);
             var result = await Task.Run(() => solve(h.Graph)).WaitAsync(solverTimeout);
 
@@ -159,9 +166,8 @@ internal sealed class FindPathHandler(
             // Record consent + canary metrics if applicable
             if (result is MaxFlowResponse mfr)
             {
-                // Stamp graph block for staleness detection (use graph's own block, not
-                // state.Current.Block which may have advanced during solving)
-                mfr.GraphBlock = h.Graph.Block;
+                // Stamp graph block for staleness detection
+                mfr.GraphBlock = graphBlock;
 
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
@@ -219,17 +225,18 @@ internal sealed class FindPathHandler(
 
                 log.LogInformation(
                     "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
-                    route, request.Source, request.Sink, request.TargetFlow,
+                    route, safeSource, safeSink, safeTargetFlow,
                     mfr.MaxFlow, mfr.Transfers?.Count ?? 0, request.MaxTransfers ?? -1,
-                    h.Graph.Block, sw.ElapsedMilliseconds, 200,
+                    graphBlock, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false);
             }
             else
             {
+                // /findMaxFlow returns long, not MaxFlowResponse
                 log.LogInformation(
-                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers=0 maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
-                    route, request.Source, request.Sink, request.TargetFlow,
-                    result, request.MaxTransfers ?? -1,
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
+                    route, safeSource, safeSink, safeTargetFlow,
+                    result, 0, request.MaxTransfers ?? -1,
                     graphBlock, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false);
             }
@@ -240,27 +247,33 @@ internal sealed class FindPathHandler(
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("timeout").Inc();
             log.LogError(
-                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=timeout",
-                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow,
-                graphBlock, sw.ElapsedMilliseconds, 504);
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} error={Error}",
+                route, safeSource, safeSink, safeTargetFlow,
+                "", 0, request.MaxTransfers ?? -1,
+                graphBlock, sw.ElapsedMilliseconds, 504,
+                request.WithWrap ?? false, request.QuantizedMode ?? false, "timeout");
             return Results.StatusCode(StatusCodes.Status504GatewayTimeout);
         }
         catch (ArgumentException ex)
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("bad_request").Inc();
             log.LogWarning(ex,
-                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=bad_request",
-                route, request.Source, request.Sink, request.TargetFlow,
-                graphBlock, sw.ElapsedMilliseconds, 400);
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} error={Error}",
+                route, safeSource, safeSink, safeTargetFlow,
+                "", 0, request.MaxTransfers ?? -1,
+                graphBlock, sw.ElapsedMilliseconds, 400,
+                request.WithWrap ?? false, request.QuantizedMode ?? false, "bad_request");
             return Results.BadRequest(ex.Message);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
             FindPathMetrics.SolverStatusTotal.WithLabels("error").Inc();
             log.LogError(ex,
-                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow= transfers=0 graphBlock={GraphBlock} durationMs={DurationMs} status={Status} error=exception",
-                route, SanitizeForLog(request.Source), SanitizeForLog(request.Sink), request.TargetFlow,
-                graphBlock, sw.ElapsedMilliseconds, 500);
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} error={Error}",
+                route, safeSource, safeSink, safeTargetFlow,
+                "", 0, request.MaxTransfers ?? -1,
+                graphBlock, sw.ElapsedMilliseconds, 500,
+                request.WithWrap ?? false, request.QuantizedMode ?? false, "exception");
             return Results.StatusCode(StatusCodes.Status500InternalServerError);
         }
         finally

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -382,8 +382,6 @@ app.MapPost("/findPath", async (
     request.Sink = request.Sink?.Replace("\r", "").Replace("\n", "").ToLowerInvariant();
     request.TargetFlow = request.TargetFlow?.Replace("\r", "").Replace("\n", "");
 
-    log.LogInformation("Deserialized request - Source: {Source}, Sink: {Sink}, TargetFlow: {TargetFlow}",
-        request.Source, request.Sink, request.TargetFlow);
 
     using var act = Source.StartActivity("findPath", ActivityKind.Server);
     act?.SetTag("http.route", "/findPath");


### PR DESCRIPTION
## Summary
- Unified structured log line per request in `FindPathHandler.ExecuteWithGuard` — covers all 3 endpoints (GET /findMaxFlow, GET /findPath, POST /findPath)
- Fields: `route, source, sink, targetFlow, maxFlow, transfers, maxTransfers, graphBlock, durationMs, status, withWrap, quantizedMode`
- Error paths (timeout, bad_request, exception) use the same structured format
- Removes redundant POST-only `Deserialized request` log from Program.cs

## Why
- GET /findPath and GET /findMaxFlow had **no request parameter logging** at Info level — impossible to trace which addresses were queried
- Error logs used inconsistent formats across timeout/bad_request/exception paths
- Enables Loki querying by source/sink/status, Tempo trace correlation
- Foundation for the canary replay script that detects pathfinder results which revert on-chain

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `./scripts/test.sh pathfinder` — all tests pass
- [ ] Deploy to staging → verify log lines appear in `docker logs pathfinder`
- [ ] Verify Loki can parse structured fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Enhanced structured logging for pathfinding requests, including request timing and graph context information to improve system monitoring and observability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->