### PR TITLE
docs(rpc): comprehensive README rewrite covering all 45 methods

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -1324,6 +1324,12 @@ public static class OpenRpcGenerator
             new OpenRpcServer { Name = "Production", Url = "https://rpc.aboutcircles.com" }
         ];
 
+        doc.ExternalDocs = new OpenRpcExternalDocs
+        {
+            Description = "Circles RPC Host README — full method reference, filter predicates, WebSocket subscriptions, rate limiting, batch requests, and environment variables",
+            Url = "https://github.com/aboutcircles/circles-nethermind-plugin/blob/dev/src/Rpc/Circles.Rpc.Host/README.md"
+        };
+
         var interfaceType = typeof(ICirclesRpcModule);
 
         foreach (var (rpcName, csharpName, tag, summary, description) in MethodMappings)

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcModels.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcModels.cs
@@ -21,9 +21,23 @@ public class OpenRpcDocument
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<OpenRpcServer>? Servers { get; set; }
 
+    [JsonPropertyName("externalDocs")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public OpenRpcExternalDocs? ExternalDocs { get; set; }
+
     [JsonPropertyName("components")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public OpenRpcComponents? Components { get; set; }
+}
+
+public class OpenRpcExternalDocs
+{
+    [JsonPropertyName("description")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("url")]
+    public string Url { get; set; } = "";
 }
 
 public class OpenRpcServer

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -1,72 +1,76 @@
 # Circles RPC Host
 
-A JSON-RPC 2.0 service that exposes Circles protocol data and operations through a standardized HTTP API. This service acts as the primary interface for querying Circles blockchain events, user profiles, trust relationships, and pathfinding operations.
+JSON-RPC 2.0 service exposing Circles protocol data: balances, avatars, profiles, trust networks, events, groups, invitations, and transitive transfer paths.
 
-## Overview
+**45 Circles methods** + transparent proxy for standard Ethereum RPC (`eth_*`, `net_*`, `web3_*`).
 
-The RPC Host provides:
-
-- **Balance & Token Queries** - Check CRC holdings and token metadata
-- **Profile Management** - Retrieve and search user profiles from IPFS
-- **Trust Networks** - Query trust relationships and find common connections
-- **Event Indexing** - Access indexed blockchain events with advanced filtering
-- **Pathfinding** - Calculate transitive payment paths through the trust network
-- **System Health** - Monitor database and blockchain sync status
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /` | JSON-RPC 2.0 (single & batch) |
+| `GET /ws` or `GET /ws/subscribe` | WebSocket event subscriptions |
+| `GET /docs` | API documentation portal |
+| `GET /openrpc.json` | Machine-readable OpenRPC spec |
+| `GET /openrpc` | Interactive playground (CirclesTools) |
+| `GET /live` | Liveness probe |
+| `GET /ready` | Readiness probe (DB + Nethermind sync + Pathfinder + Indexer lag) |
+| `GET /health` | Nethermind connectivity check |
+| `GET /metrics` | Prometheus metrics |
 
 ## Quick Start
-
-### Running Locally
 
 ```bash
 # Using script (recommended)
 ./scripts/run-rpc.sh
 
-# Or directly with dotnet
-cd src/Rpc/Circles.Rpc.Host
-dotnet run
+# Or directly
+cd src/Rpc/Circles.Rpc.Host && dotnet run
 ```
 
-Default URL: `http://localhost:8081`
+Default: `http://localhost:8081`
 
-### Configuration
+## Configuration
 
-Set environment variables before starting:
+### Required Environment Variables
 
-```bash
-# Required
-export POSTGRES_READONLY_CONNECTION_STRING="Host=localhost;Port=5432;Database=postgres;Username=postgres;Password=postgres"
-export NETHERMIND_RPC_URL="http://localhost:8545"
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_READONLY_CONNECTION_STRING` | — | PostgreSQL connection string for indexed Circles data |
+| `NETHERMIND_RPC_URL` | `http://localhost:8545` | Nethermind JSON-RPC endpoint |
 
-# Optional
-export BALANCE_MODE="live"  # "live" (eth_call) or "database" (fast but stale)
-export DATABASE_QUERY_TIMEOUT_SECONDS=30
-export PROFILE_SEARCH_TIMEOUT_SECONDS=30
-export EXTERNAL_PATHFINDER_URL="http://localhost:8080"
+### Optional Environment Variables
 
-# Cache Service (optional — enables fast balance/avatar/profile queries)
-export USE_CACHE_SERVICE=true
-export CACHE_SERVICE_URL="http://cache-service:3001"
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BALANCE_MODE` | `live` | `"live"` (eth_call, accurate) or `"database"` (fast, may be stale) |
+| `DATABASE_QUERY_TIMEOUT_SECONDS` | `30` | Timeout for general DB queries |
+| `PROFILE_SEARCH_TIMEOUT_SECONDS` | `30` | Timeout for profile search queries |
+| `EXTERNAL_PATHFINDER_URL` | — | Pathfinder REST API URL (for `circlesV2_findPath`, `circles_getNetworkSnapshot`) |
+| `USE_CACHE_SERVICE` | `false` | Enable Cache Service for balance/avatar/profile queries |
+| `CACHE_SERVICE_URL` | — | Cache Service endpoint (required if `USE_CACHE_SERVICE=true`) |
+| `PROFILE_PINNING_SERVICE_URL` | — | Profile pinning service (fast profile search proxy, falls back to SQL) |
+| `CORS_ALLOWED_ORIGINS` | `*` | Comma-separated origins, or `*` for all |
+| `RPC_MAX_CONCURRENT_REQUESTS` | `max(CPU×4, 32)` | Concurrency semaphore limit; excess returns 503 |
+| `RPC_RATE_LIMIT_PER_SECOND` | `100` | Per-IP sustained rate (0 = disabled); batch items count individually |
+| `RPC_RATE_LIMIT_BURST` | `200` | Per-IP burst allowance before throttling kicks in |
+| `INDEXER_MAX_LAG_BLOCKS` | `100` | Max block lag before `/ready` returns 503 (0 = disabled) |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | — | OpenTelemetry OTLP endpoint (enables distributed tracing) |
 
-# Profile Pinning Service (optional — fast profile search proxy, falls back to SQL)
-export PROFILE_PINNING_SERVICE_URL="http://profile-pinning:3000"
+### Balance Modes
 
-# CORS
-export CORS_ALLOWED_ORIGINS="*"
-```
+| Mode | Accuracy | Speed | Requires |
+|------|----------|-------|----------|
+| `live` (default) | Current block state | Slower | Nethermind RPC |
+| `database` | Indexed (may lag) | Fast | PostgreSQL only |
 
-See `.env.example` for full configuration options.
-
-## JSON-RPC 2.0 API
+## JSON-RPC 2.0
 
 ### Request Format
-
-All requests must be valid JSON-RPC 2.0:
 
 ```json
 {
   "jsonrpc": "2.0",
   "method": "circles_getTotalBalance",
-  "params": ["0x1234..."],
+  "params": ["0xde374ece6fa50e781e81aac78e811b33d16912c7", true],
   "id": 1
 }
 ```
@@ -78,7 +82,7 @@ All requests must be valid JSON-RPC 2.0:
 ```json
 {
   "jsonrpc": "2.0",
-  "result": {...},
+  "result": "142.87",
   "id": 1
 }
 ```
@@ -88,22 +92,153 @@ All requests must be valid JSON-RPC 2.0:
 ```json
 {
   "jsonrpc": "2.0",
-  "error": {
-    "code": -32602,
-    "message": "Invalid params: Address parameter is required"
-  },
+  "error": { "code": -32602, "message": "Invalid params: Address parameter is required" },
   "id": 1
 }
 ```
 
-**Error Codes:**
+### Error Codes
 
-- `-32600` - Invalid Request
-- `-32601` - Method not found
-- `-32602` - Invalid params
-- `-32603` - Internal server error
+| Code | Meaning | HTTP Status |
+|------|---------|-------------|
+| `-32700` | Parse error (malformed JSON) | 400 |
+| `-32600` | Invalid Request (missing jsonrpc/method, batch too large/empty) | 400 |
+| `-32601` | Method not found | 200 |
+| `-32602` | Invalid params (wrong types, missing required) | 200 |
+| `-32603` | Internal server error / proxy error | 200/500 |
+| `-32000` | Server busy (concurrency limit) | 503 |
+| `-32000` | Rate limit exceeded | 429 |
 
-## Available RPC Methods
+### Batch Requests
+
+Send a JSON array of requests. All responses are returned in a single JSON array.
+
+**Limits:**
+- Max **50 items** per batch
+- Max **1 MB** request body
+- Empty arrays are rejected (JSON-RPC 2.0 spec)
+- Each item costs 1 rate-limit token (50-item batch = 50 tokens)
+
+**Routing:** Circles methods (`circles_*`, `circlesV2_*`) are handled locally; Ethereum methods (`eth_*`, `net_*`, `web3_*`) are batched and proxied to Nethermind in a single call. Unknown methods return `-32601`.
+
+```bash
+curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '[
+  {"jsonrpc":"2.0","method":"circles_getTotalBalance","params":["0xde374ece6fa50e781e81aac78e811b33d16912c7",true],"id":1},
+  {"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":2}
+]'
+```
+
+### Rate Limiting & Concurrency
+
+**Rate limiting** — per-IP token bucket:
+- Sustained: `RPC_RATE_LIMIT_PER_SECOND` tokens/sec (default 100)
+- Burst: `RPC_RATE_LIMIT_BURST` (default 200)
+- Batch items count individually
+- Returns HTTP 429 + `{"code": -32000, "message": "Rate limit exceeded"}`
+- Stale per-IP buckets evicted after 5 minutes of inactivity
+- Set `RPC_RATE_LIMIT_PER_SECOND=0` to disable
+
+**Concurrency** — semaphore guard:
+- Max `RPC_MAX_CONCURRENT_REQUESTS` in-flight Circles requests
+- Returns HTTP 503 + `{"code": -32000, "message": "Server busy"}`
+- Non-blocking: rejects immediately, no queuing
+
+### Ethereum Proxy
+
+Standard Ethereum JSON-RPC methods are transparently proxied to Nethermind:
+
+| Prefix | Example Methods |
+|--------|----------------|
+| `eth_*` | `eth_blockNumber`, `eth_getBalance`, `eth_call`, `eth_sendRawTransaction` |
+| `net_*` | `net_version`, `net_peerCount` |
+| `web3_*` | `web3_clientVersion` |
+
+Blocked: `admin_*`, `debug_*`, `personal_*`, `miner_*` (security).
+
+---
+
+## WebSocket Subscriptions
+
+Real-time event streaming via WebSocket. The server listens on PostgreSQL `circles_events` NOTIFY channel and pushes matching events to connected clients.
+
+### Endpoints
+
+- `ws://localhost:8081/ws`
+- `ws://localhost:8081/ws/subscribe`
+
+### Subscribe
+
+Send a JSON-RPC 2.0 message after connecting:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "circles_subscribe",
+  "params": { "address": "0xde374ece6fa50e781e81aac78e811b33d16912c7" },
+  "id": 1
+}
+```
+
+- `params.address` (optional): filter events containing this address. Omit or `null` for all events.
+- Also accepts `"method": "eth_subscribe"` for compatibility (mapped internally to `circles_subscribe`).
+
+### Acknowledgement
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": { "subscriptionId": "a1b2c3..." },
+  "id": 1
+}
+```
+
+### Event Push
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "circles_subscription",
+  "params": { "result": [ ...events... ] }
+}
+```
+
+Events are the same format as `circles_events` responses. Pushes occur per block range as the indexer processes new blocks.
+
+### JavaScript Example
+
+```javascript
+const ws = new WebSocket("ws://localhost:8081/ws");
+ws.onopen = () => {
+  ws.send(JSON.stringify({
+    jsonrpc: "2.0",
+    method: "circles_subscribe",
+    params: { address: "0xde374ece6fa50e781e81aac78e811b33d16912c7" },
+    id: 1
+  }));
+};
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  if (data.method === "circles_subscription") {
+    console.log("New events:", data.params.result);
+  }
+};
+```
+
+---
+
+## RPC Methods Reference
+
+### Discovery
+
+#### `rpc.discover`
+
+Returns the OpenRPC 1.3.2 specification document describing all available methods, parameters, and schemas.
+
+**Parameters:** None
+
+**Returns:** OpenRPC document (JSON object)
+
+---
 
 ### Balance & Token Methods
 
@@ -113,58 +248,59 @@ Get total V1 Circles balance for an address.
 
 **Parameters:**
 
-- `address` (string) - Ethereum address
-- `asTimeCircles` (boolean, optional) - Format as TimeCircles (default: true)
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | address | string | yes | — | Ethereum address |
+| 1 | asTimeCircles | boolean | no | true | Format as TimeCircles (adjusts for inflation) |
 
-**Returns:** `string` - Total balance
-
-**Example:**
+**Returns:** `string` — total balance
 
 ```bash
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
+  "jsonrpc": "2.0", "id": 1,
   "method": "circles_getTotalBalance",
-  "params": ["0xde374ece6fa50e781e81aac78e811b33d16912c7", true],
-  "id": 1
+  "params": ["0xde374ece6fa50e781e81aac78e811b33d16912c7", true]
 }'
 ```
 
 #### `circlesV2_getTotalBalance`
 
-Get total V2 Circles balance for an address.
+Get total V2 Circles balance for an address. V2 uses ERC-1155 tokens with ~7%/year demurrage.
 
-**Parameters:** Same as `circles_getTotalBalance`
+**Parameters:** Same as `circles_getTotalBalance`.
+
+**Returns:** `string` — total V2 balance
 
 #### `circles_getTokenBalances`
 
-Get detailed token balances for all tokens held by an address.
+Get all individual token balances for an address (V1 + V2, personal + group + wrapped).
 
 **Parameters:**
 
-- `address` (string) - Ethereum address
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | address | string | yes |
 
-**Returns:** `CirclesTokenBalance[]` - Array of token balances with metadata
-
-**Response Schema:**
+**Returns:** `CirclesTokenBalance[]`
 
 ```typescript
-{
-  tokenAddress: string
-  tokenId: string
-  tokenOwner: string
-  tokenType: string
-  version: number
-  attoCircles: string
-  circles: number
-  staticAttoCircles: string
-  staticCircles: number
-  attoCrc: string
-  crc: number
-  isErc20: boolean
-  isErc1155: boolean
-  isWrapped: boolean
-  isInflationary: boolean
-  isGroup: boolean
+interface CirclesTokenBalance {
+  tokenAddress: string;
+  tokenId: string;
+  tokenOwner: string;
+  tokenType: string;     // "CrcV1_Signup" | "CrcV2_RegisterHuman" | "CrcV2_RegisterGroup" | ...
+  version: number;       // 1 or 2
+  attoCircles: string;   // Demurraged balance in atto (10^-18)
+  circles: number;       // Demurraged balance in Circles
+  staticAttoCircles: string; // Static (non-demurraged) atto
+  staticCircles: number;
+  attoCrc: string;       // CRC units (legacy)
+  crc: number;
+  isErc20: boolean;
+  isErc1155: boolean;
+  isWrapped: boolean;    // ERC-20 wrapper around ERC-1155
+  isInflationary: boolean;
+  isGroup: boolean;
 }
 ```
 
@@ -174,9 +310,25 @@ Get metadata for a specific token.
 
 **Parameters:**
 
-- `tokenAddress` (string) - Token address
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | tokenAddress | string | yes |
 
-**Returns:** `TokenInfo`
+**Returns:** `TokenInfo | null`
+
+```typescript
+interface TokenInfo {
+  tokenAddress: string;
+  tokenOwner: string;
+  tokenType: string;
+  version: number;
+  isErc20: boolean;
+  isErc1155: boolean;
+  isWrapped: boolean;
+  isInflationary: boolean;
+  isGroup: boolean;
+}
+```
 
 #### `circles_getTokenInfoBatch`
 
@@ -184,162 +336,187 @@ Get metadata for multiple tokens.
 
 **Parameters:**
 
-- `tokenAddresses` (string[]) - Array of token addresses
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | tokenAddresses | string[] | yes |
 
-**Returns:** `TokenInfo?[]` - Array with nulls for non-existent tokens
+**Returns:** `(TokenInfo | null)[]` — same length as input, null for unknown tokens
+
+#### `circles_getTokenHolders`
+
+Get all holders of a specific token with cursor-based pagination.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | tokenAddress | string | yes | — |
+| 1 | limit | number | no | 100 |
+| 2 | cursor | string | no | null |
+
+**Returns:** `PagedResponse<TokenHolderRow>`
+
+```typescript
+interface TokenHolderRow {
+  account: string;
+  balance: string;
+  tokenAddress: string;
+  version: number;
+}
+```
+
+---
 
 ### Avatar & Profile Methods
 
 #### `circles_getAvatarInfo`
 
-Get avatar information for an address (V1 and V2 merged).
+Get avatar information (V1 + V2 merged).
 
 **Parameters:**
 
-- `address` (string) - Avatar address
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | address | string | yes |
 
 **Returns:** `AvatarInfo`
 
-**Response Schema:**
-
 ```typescript
-{
-  version: number
-  type: string
-  avatar: string
-  tokenId: string
-  hasV1: boolean
-  v1Token: string | null
-  cidV0Digest: string
-  cidV0: string | null
-  isHuman: boolean
-  name: string | null
-  symbol: string
+interface AvatarInfo {
+  version: number;
+  type: string;        // "CrcV2_RegisterHuman" | "CrcV2_RegisterGroup" | "CrcV2_RegisterOrganization" | "CrcV1_Signup" | ...
+  avatar: string;
+  tokenId: string;
+  hasV1: boolean;
+  v1Token: string | null;
+  cidV0Digest: string;
+  cidV0: string | null;
+  isHuman: boolean;
+  name: string | null;
+  symbol: string;
 }
 ```
 
 #### `circles_getAvatarInfoBatch`
 
-Get avatar information for multiple addresses.
-
-**Parameters:**
-
-- `addresses` (string[])
+**Parameters:** `[string[]]` — array of addresses
 
 **Returns:** `AvatarInfo[]`
 
 #### `circles_getProfileCid`
 
-Get the IPFS CID for an avatar's profile.
+Get IPFS CID for an avatar's profile.
 
-**Parameters:**
+**Parameters:** `[string]` — address
 
-- `address` (string)
-
-**Returns:** `string | null` - CIDv0 string
+**Returns:** `string | null` — CIDv0 string
 
 #### `circles_getProfileCidBatch`
 
-Get profile CIDs for multiple addresses.
-
-**Parameters:**
-
-- `addresses` (string[])
+**Parameters:** `[string[]]` — addresses
 
 **Returns:** `{ [address: string]: string | null }`
 
 #### `circles_getProfileByCid`
 
-Retrieve a profile from IPFS by its CID.
+Retrieve profile data from IPFS by CID.
 
-**Parameters:**
+**Parameters:** `[string]` — CIDv0
 
-- `cid` (string) - CIDv0 string
-
-**Returns:** `JsonElement | null` - Profile data from IPFS
+**Returns:** `object | null` — profile JSON from IPFS
 
 #### `circles_getProfileByCidBatch`
 
-Retrieve multiple profiles by their CIDs.
+**Parameters:** `[string[]]` — CIDs
 
-**Parameters:**
-
-- `cids` (string[])
-
-**Returns:** `{ [cid: string]: JsonElement | null }`
+**Returns:** `{ [cid: string]: object | null }`
 
 #### `circles_getProfileByAddress`
 
-Get profile data for an avatar address (CID lookup + IPFS fetch).
+Get profile for an address (CID lookup → IPFS fetch, enriched with avatar type).
 
-**Parameters:**
+**Parameters:** `[string]` — address
 
-- `address` (string)
-
-**Returns:** `JsonElement | null` - Profile enriched with avatar type and short name
+**Returns:** `object | null` — profile JSON enriched with avatar type and short name
 
 #### `circles_getProfileByAddressBatch`
 
-Get profiles for multiple addresses.
+**Parameters:** `[string[]]` — addresses
 
-**Parameters:**
-
-- `addresses` (string[])
-
-**Returns:** `{ [address: string]: JsonElement | null }`
+**Returns:** `{ [address: string]: object | null }`
 
 #### `circles_searchProfiles`
 
-Full-text search for profiles.
+Full-text search across profiles.
 
 **Parameters:**
 
-- `text` (string) - Search query (max 3 tokens, each > 1 char)
-- `limit` (number, optional) - Max results (default: 20, max: 100)
-- `offset` (number, optional) - Pagination offset (default: 0)
-- `types` (string[], optional) - Filter by avatar types
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | text | string | yes | — | Search query (max 3 tokens, each > 1 char) |
+| 1 | limit | number | no | 20 | Max results (max 100) |
+| 2 | offset | number | no | 0 | Pagination offset |
+| 3 | types | string[] | no | null | Filter by avatar types |
 
 **Returns:**
 
 ```typescript
 {
-  total: number
+  total: number;
   results: Array<{
-    avatar: string
-    avatarInfo: AvatarInfo
-    profile: JsonElement | null
-  }>
+    avatar: string;
+    avatarInfo: AvatarInfo;
+    profile: object | null;
+  }>;
 }
 ```
 
-**Example:**
-
 ```bash
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
+  "jsonrpc": "2.0", "id": 1,
   "method": "circles_searchProfiles",
-  "params": ["berlin", 10, 0, ["CrcV2_RegisterHuman"]],
-  "id": 1
+  "params": ["berlin", 10, 0, ["CrcV2_RegisterHuman"]]
 }'
 ```
+
+---
 
 ### Trust & Network Methods
 
 #### `circles_getTrustRelations`
 
-Get trust relationships for an address.
+Get V1 trust relationships for an address.
 
-**Parameters:**
+> **Note:** V1 only. For V2 trust, use `circles_getAggregatedTrustRelations` or query `V_CrcV2_TrustRelations` via `circles_query`.
 
-- `address` (string)
+**Parameters:** `[string]` — address
 
 **Returns:**
 
 ```typescript
 {
-  user: string
-  trusts: Array<{ user: string; limit: number }>
-  trustedBy: Array<{ user: string; limit: number }>
+  user: string;
+  trusts: Array<{ user: string; limit: number }>;
+  trustedBy: Array<{ user: string; limit: number }>;
+}
+```
+
+#### `circles_getAggregatedTrustRelations`
+
+Get V2 trust relations in SDK-compatible format with relation types.
+
+**Parameters:** `[string]` — avatar address
+
+**Returns:** `AggregatedTrustRelation[]`
+
+```typescript
+interface AggregatedTrustRelation {
+  subjectAvatar: string;
+  relation: "mutuallyTrusts" | "trusts" | "trustedBy";
+  objectAvatar: string;
+  timestamp: number;
+  expiryTime: number;
+  objectAvatarType: string | null;  // "CrcV2_RegisterHuman" | "CrcV2_RegisterGroup" | ...
 }
 ```
 
@@ -349,127 +526,211 @@ Find addresses that two users both trust.
 
 **Parameters:**
 
-- `address1` (string)
-- `address2` (string)
-- `version` (number, optional) - Filter by Circles version (1, 2, or null for both)
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address1 | string | yes | — |
+| 1 | address2 | string | yes | — |
+| 2 | version | number | no | null (both V1+V2) |
 
-**Returns:** `string[]` - Array of commonly trusted addresses
-
-**Example:**
+**Returns:** `{ address1: string; address2: string; commonTrusts: string[] }`
 
 ```bash
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
+  "jsonrpc": "2.0", "id": 1,
   "method": "circles_getCommonTrust",
-  "params": ["0xaddr1...", "0xaddr2...", 2],
-  "id": 1
+  "params": ["0xaddr1...", "0xaddr2...", 2]
 }'
 ```
 
 #### `circles_getNetworkSnapshot`
 
-Get a complete snapshot of the Circles trust network.
+Get a complete snapshot of the trust network. Proxied to Pathfinder service.
 
 **Parameters:** None
 
-**Returns:** `NetworkSnapshotResponse` (proxied from Pathfinder service)
+**Returns:** Network snapshot (raw Pathfinder response)
 
-#### `circlesV2_findPath`
+---
 
-Calculate a transitive payment path through the trust network.
+### Group Methods
+
+#### `circles_findGroups`
+
+Find groups with optional filters and cursor-based pagination.
 
 **Parameters:**
 
-- `flowRequest` (FlowRequest object):
-  ```typescript
-  {
-    source: string;
-    sink: string;
-    targetFlow: string;
-    fromTokens?: string[];  // Source token filter
-    toTokens?: string[];    // Destination token filter
-    withWrap?: boolean;     // Enable ERC20 wrapping
-  }
-  ```
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | limit | number | no | 50 |
+| 1 | queryParams | object | no | null |
+| 2 | cursor | string | no | null |
 
-**Returns:** `JsonElement` - Path response from Pathfinder
+**queryParams:**
 
-**Example:**
-
-```bash
-curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
-  "method": "circlesV2_findPath",
-  "params": [{
-    "source": "0xsource...",
-    "sink": "0xsink...",
-    "targetFlow": "1000000000000000000"
-  }],
-  "id": 1
-}'
+```typescript
+{
+  nameStartsWith?: string;
+  symbolStartsWith?: string;
+  ownerIn?: string[];  // Filter by group owner addresses
+}
 ```
+
+**Returns:** `PagedResponse<GroupRow>`
+
+```typescript
+interface GroupRow {
+  group: string;
+  name: string;
+  symbol: string;
+  mint: string;       // Mint policy address
+  treasury: string;   // Treasury address
+  blockNumber: number;
+  timestamp: number;
+}
+```
+
+#### `circles_getGroupMembers`
+
+Get members of a group with cursor-based pagination.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | groupAddress | string | yes | — |
+| 1 | limit | number | no | 100 |
+| 2 | cursor | string | no | null |
+
+**Returns:** `PagedResponse<GroupMembershipRow>`
+
+```typescript
+interface GroupMembershipRow {
+  blockNumber: number;
+  timestamp: number;
+  transactionIndex: number;
+  logIndex: number;
+  transactionHash: string;
+  group: string;
+  member: string;
+  expiryTime: number;
+}
+```
+
+#### `circles_getGroupMemberships`
+
+Get groups that an address is a member of (inverse of `circles_getGroupMembers`).
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | memberAddress | string | yes | — |
+| 1 | limit | number | no | 50 |
+| 2 | cursor | string | no | null |
+
+**Returns:** `PagedResponse<GroupMembershipRow>`
+
+---
+
+### Transaction & Transfer Methods
+
+#### `circles_getTransactionHistory`
+
+Get transaction history for an avatar with all circle amount formats.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | avatarAddress | string | yes | — | |
+| 1 | limit | number | no | 50 | |
+| 2 | cursor | string | no | null | base64-encoded `block:tx:log` |
+| 3 | version | number | no | null | null=both, 1=V1, 2=V2 |
+| 4 | excludeIntermediary | boolean | no | true | If true, uses TransferSummary (excludes hop transfers) |
+
+**Returns:** `PagedResponse<TransactionHistoryRow>`
+
+```typescript
+interface TransactionHistoryRow {
+  blockNumber: number;
+  timestamp: number;
+  transactionIndex: number;
+  logIndex: number;
+  transactionHash: string;
+  version: number;
+  from: string;
+  to: string;
+  operator: string | null;
+  id: string | null;           // Token ID
+  value: string;               // Raw demurraged attoCircles
+  circles: string;             // Demurraged Circles
+  attoCircles: string;
+  crc: string;                 // CRC units
+  attoCrc: string;
+  staticCircles: string;       // Non-demurraged
+  staticAttoCircles: string;
+}
+```
+
+#### `circles_getTransferData`
+
+Get ERC-1155 transfer calldata bytes for an address. Convenience method without raw `filterPredicates`.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | address | string | yes | — | Primary address |
+| 1 | direction | string | no | null | `"sent"` (from=addr), `"received"` (to=addr), null=both |
+| 2 | counterparty | string | no | null | AND with specific counterparty |
+| 3 | fromBlock | number | no | null | Start block (inclusive) |
+| 4 | toBlock | number | no | null | End block (inclusive) |
+| 5 | limit | number | no | 50 | Max results (max 1000) |
+| 6 | cursor | string | no | null | base64-encoded `block:tx:log` |
+
+**Returns:** `PagedResponse<TransferDataRow>`
+
+```typescript
+interface TransferDataRow {
+  blockNumber: number;
+  timestamp: number;
+  transactionIndex: number;
+  logIndex: number;
+  transactionHash: string;
+  from: string;
+  to: string;
+  data: string;   // Hex-encoded bytes
+}
+```
+
+---
 
 ### Event & Query Methods
 
 #### `circles_events`
 
-Query indexed blockchain events with advanced filtering. Returns a flat array (backwards compatible).
+Query indexed blockchain events with advanced filtering. Returns a **flat array** (backwards compatible).
 
-**Positional Parameters (JSON-RPC `params` array):**
+**Parameters (positional):**
 
 | Index | Name | Type | Default | Description |
 |-------|------|------|---------|-------------|
-| 0 | address | string\|null | null (all) | Filter by address |
+| 0 | address | string\|null | null | Filter by address (null = all) |
 | 1 | fromBlock | number\|null | null | Start block (inclusive) |
 | 2 | toBlock | number\|null | null | End block (inclusive) |
-| 3 | eventTypes | string[]\|null | null (all) | Filter by event types |
-| 4 | filterPredicates | object[]\|null | null | Advanced filters (see below) |
-| 5 | sortAscending | bool\|null | false | Sort order |
-| 6 | limit | number\|null | 100 (max 1000) | Max events to return |
-| 7 | cursor | string\|null | null | Pagination cursor (use with `circles_events_paginated`) |
+| 3 | eventTypes | string[]\|null | null | Filter by event types (null = all) |
+| 4 | filterPredicates | object[]\|null | null | Advanced filters (see [Filter Predicates](#filter-predicates)) |
+| 5 | sortAscending | boolean\|null | false | Sort order |
+| 6 | limit | number\|null | 100 | Max events (max 1000) |
+| 7 | cursor | string\|null | null | Pagination cursor |
 
-> **Note:** Parameters are positional. To set `limit` (index 6), you must pass all preceding params — use `null` or `false` for unused slots.
+> Parameters are positional. To set `limit` (index 6), pass `null` for unused preceding slots.
 
-**Returns:** `EventsResponse` — flat array of events. For paginated results with `hasMore`/`nextCursor`, use `circles_events_paginated`.
-
-**Filter Predicates:**
-
-Each filter predicate object has the following structure:
-
-```typescript
-{
-  Type: "FilterPredicate",
-  FilterType: string,   // comparison operator (see table below)
-  Column: string,       // column name to filter on
-  Value: any            // value to compare — type depends on FilterType
-}
-```
-
-**FilterType operators and their Value types:**
-
-| FilterType | Value type | Description |
-|------------|-----------|-------------|
-| `Equals` | scalar (string\|number) | Exact match |
-| `NotEquals` | scalar (string\|number) | Not equal |
-| `GreaterThan` | scalar (string\|number) | Greater than |
-| `GreaterThanOrEquals` | scalar (string\|number) | Greater than or equal |
-| `LessThan` | scalar (string\|number) | Less than |
-| `LessThanOrEquals` | scalar (string\|number) | Less than or equal |
-| `Like` | string (with `%` wildcards) | SQL LIKE pattern |
-| `ILike` | string (with `%` wildcards) | Case-insensitive LIKE |
-| `NotLike` | string (with `%` wildcards) | SQL NOT LIKE |
-| `In` | **array** (string[]\|number[]) | Match any value in array |
-| `NotIn` | **array** (string[]\|number[]) | Exclude values in array |
-| `IsNull` | *(ignored)* | Column is NULL |
-| `IsNotNull` | *(ignored)* | Column is not NULL |
-
-> **Important:** `In` and `NotIn` require `Value` to be an **array** (e.g., `["0xabc...", "0xdef..."]`), not a single string. Max 1000 elements per array.
-
-**Examples:**
-
-Get all events for a specific transaction (up to 1000):
+**Returns:** Flat event array (for paginated results with `hasMore`/`nextCursor`, use `circles_events_paginated`)
 
 ```bash
+# All events for a specific transaction
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
   "jsonrpc": "2.0", "id": 1,
   "method": "circles_events",
@@ -479,76 +740,83 @@ curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
       "Value": ["0xfc98cb9fbb96c19043c73214570660a04de9bbd78eb0ea127ce4371f4bbf0c5a"]}],
     false, 1000]
 }'
-```
 
-Get CrcV2_Transfer events for an address (default limit 100):
-
-```bash
+# V2 transfer events for an address
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
   "jsonrpc": "2.0", "id": 1,
   "method": "circles_events",
-  "params": ["0xaddr...", 30282299, null, ["CrcV2_Transfer"]]
+  "params": ["0xde374ece6fa50e781e81aac78e811b33d16912c7", 30282299, null, ["CrcV2_Transfer"]]
 }'
 ```
 
 #### `circles_events_paginated`
 
-Same parameters as `circles_events` but returns `{events, hasMore, nextCursor}` for cursor-based pagination.
-
-**Returns:** `PagedEventsResponse` — `{events: [...], hasMore: boolean, nextCursor: string | null}`
-
-To paginate, pass the `nextCursor` from the previous response as param index 7:
-
-```bash
-# First page
-curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0", "id": 1,
-  "method": "circles_events_paginated",
-  "params": [null, 0, null, null, null, false, 500]
-}'
-# → {"events": [...], "hasMore": true, "nextCursor": "abc123..."}
-
-# Next page — pass cursor as param index 7
-curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0", "id": 2,
-  "method": "circles_events_paginated",
-  "params": [null, 0, null, null, null, false, 500, "abc123..."]
-}'
-```
-
-#### `circles_query`
-
-Generic database query interface using structured DTOs.
-
-**Parameters:**
-
-- `query` (SelectDto):
-  ```typescript
-  {
-    namespace: string;
-    table: string;
-    columns?: string[];
-    filter?: FilterPredicate[];
-    order?: Array<{ column: string; sortOrder: "ASC" | "DESC" }>;
-    limit?: number;
-    distinct?: boolean;
-  }
-  ```
+Same parameters as `circles_events`. Returns `{ events, hasMore, nextCursor }` for cursor-based pagination.
 
 **Returns:**
 
 ```typescript
 {
-  columns: string[];
-  rows: Array<{ [key: string]: any }>;
+  events: object[];
+  hasMore: boolean;
+  nextCursor: string | null;
 }
 ```
 
-**Example:**
+Pass `nextCursor` from the previous response as param index 7 to get the next page.
+
+#### `circles_getBlockByTimestamp`
+
+Convert a Unix timestamp to the nearest block number. Useful for building block ranges for event queries.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | timestamp | number | yes | — | Unix timestamp (seconds since epoch) |
+| 1 | direction | string | no | `"before"` | `"before"` = at or before, `"after"` = at or after |
+
+**Returns:**
+
+```typescript
+{ blockNumber: number; timestamp: number }
+```
+
+#### `circles_query`
+
+Generic database query interface. Query any indexed table with structured filters.
+
+**Parameters:**
+
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | query | SelectDto | yes |
+
+**SelectDto:**
+
+```typescript
+{
+  namespace: string;      // e.g., "V_Crc", "CrcV2", "CrcV1"
+  table: string;          // e.g., "Avatars", "TrustRelations"
+  columns?: string[];     // Empty = all columns
+  filter?: FilterPredicate[];
+  order?: Array<{ column: string; sortOrder: "ASC" | "DESC" }>;
+  limit?: number;
+  distinct?: boolean;
+}
+```
+
+**Returns:**
+
+```typescript
+{ columns: string[]; rows: object[][] }
+```
+
+Use `circles_tables` to discover available namespaces, tables, and columns.
 
 ```bash
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
+  "jsonrpc": "2.0", "id": 1,
   "method": "circles_query",
   "params": [{
     "namespace": "V_Crc",
@@ -556,30 +824,95 @@ curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
     "columns": [],
     "limit": 10,
     "order": [{"column": "blockNumber", "sortOrder": "DESC"}]
-  }],
-  "id": 1
+  }]
 }'
 ```
+
+#### `circles_paginated_query`
+
+Same as `circles_query` but returns cursor-based pagination for tables with event columns.
+
+**Parameters:**
+
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | query | SelectDto | yes |
+| 1 | cursor | string | no |
+
+**Returns:**
+
+```typescript
+{
+  columns: string[];
+  rows: object[][];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+```
+
+### Filter Predicates
+
+Used by `circles_events`, `circles_events_paginated`, `circles_query`, and `circles_paginated_query`.
+
+```typescript
+{
+  Type: "FilterPredicate";
+  FilterType: string;   // Operator (see table)
+  Column: string;       // Column name
+  Value: any;           // Type depends on FilterType
+}
+```
+
+**Operators:**
+
+| FilterType | Value Type | Description |
+|------------|-----------|-------------|
+| `Equals` | scalar (string\|number) | Exact match |
+| `NotEquals` | scalar (string\|number) | Not equal |
+| `GreaterThan` | scalar (string\|number) | Greater than |
+| `GreaterThanOrEquals` | scalar (string\|number) | ≥ |
+| `LessThan` | scalar (string\|number) | Less than |
+| `LessThanOrEquals` | scalar (string\|number) | ≤ |
+| `Like` | string (with `%` wildcards) | SQL LIKE |
+| `ILike` | string (with `%` wildcards) | Case-insensitive LIKE |
+| `NotLike` | string (with `%` wildcards) | SQL NOT LIKE |
+| `In` | **array** (string[]\|number[]) | Match any in array (max 1000 elements) |
+| `NotIn` | **array** (string[]\|number[]) | Exclude values in array (max 1000 elements) |
+| `IsNull` | *(ignored)* | Column IS NULL |
+| `IsNotNull` | *(ignored)* | Column IS NOT NULL |
+
+> **Important:** `In` and `NotIn` require `Value` to be an **array**, not a single string.
+
+**Conjunction (AND/OR nesting):**
+
+Multiple predicates in the `filterPredicates` array are AND-ed together. For OR logic, use Conjunction:
+
+```json
+{
+  "Type": "Conjunction",
+  "ConjunctionType": "Or",
+  "Predicates": [
+    {"Type": "FilterPredicate", "FilterType": "Equals", "Column": "from", "Value": "0xabc..."},
+    {"Type": "FilterPredicate", "FilterType": "Equals", "Column": "to", "Value": "0xabc..."}
+  ]
+}
+```
+
+---
 
 ### System Methods
 
 #### `circles_health`
 
-Check service health status.
+Check service health.
 
 **Parameters:** None
 
-**Returns:** `string` - "Healthy" or error message
-
-**Health Checks:**
-
-- Database connectivity
-- Blockchain sync status (when `BALANCE_MODE=live`)
-- Pathfinder connectivity
+**Returns:** `{ status: string; timestamp: number; database: string; index: string }`
 
 #### `circles_tables`
 
-Get available database tables and schemas.
+List available database tables and their schemas. Use this to discover what's queryable via `circles_query`.
 
 **Parameters:** None
 
@@ -587,94 +920,486 @@ Get available database tables and schemas.
 
 ```typescript
 Array<{
-  namespace: string
+  namespace: string;
   tables: Array<{
-    table: string
-    topic: string
-    columns: Array<{ column: string; type: string }>
-  }>
+    table: string;
+    topic: string;
+    columns: Array<{ column: string; type: string }>;
+  }>;
 }>
 ```
 
-## Health Check Endpoints
+---
 
-- **`GET /live`** - Liveness probe (service is running)
-- **`GET /ready`** - Readiness probe (service is ready to accept traffic)
-  - Checks: Nethermind sync status, Pathfinder connectivity
-- **`GET /health`** - Nethermind connectivity check
-- **`GET /metrics`** - Prometheus metrics (if enabled)
+### Pathfinder Methods
 
-## Balance Modes
+#### `circlesV2_findPath`
 
-The service supports two balance query modes:
+Calculate a transitive payment path through the V2 trust network. Proxied to Pathfinder service.
 
-### Live Mode (default)
+**Parameters:**
 
-```bash
-export BALANCE_MODE="live"
+| Index | Name | Type | Required |
+|-------|------|------|----------|
+| 0 | flowRequest | FlowRequest | yes |
+
+**FlowRequest:**
+
+```typescript
+{
+  source: string;         // Sender address
+  sink: string;           // Receiver address
+  targetFlow: string;     // Amount in atto-circles (wei)
+  fromTokens?: string[];  // Source token filter
+  toTokens?: string[];    // Destination token filter
+  withWrap?: boolean;     // Enable ERC-20 wrapping
+}
 ```
 
-- Uses `eth_call` to query live blockchain state
-- Accurate, current balances
-- Slower, requires Nethermind RPC connection
-- Recommended for production
-
-### Database Mode
+**Returns:** Pathfinder response (JSON object with transfer steps, max flow, etc.)
 
 ```bash
-export BALANCE_MODE="database"
+curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
+  "jsonrpc": "2.0", "id": 1,
+  "method": "circlesV2_findPath",
+  "params": [{
+    "source": "0xde374ece6fa50e781e81aac78e811b33d16912c7",
+    "sink": "0x42cEDde51198D1773590311E2A340DC06B24cB37",
+    "targetFlow": "1000000000000000000"
+  }]
+}'
 ```
 
-- Queries indexed database
-- Fast responses
-- May be slightly stale (depends on indexer sync)
-- Good for development/testing
+---
+
+### SDK Enablement Methods
+
+Composite methods that replace multiple RPC round-trips. Reduce SDK calls by 60-80%.
+
+#### `circles_getProfileView`
+
+Complete profile view: avatar + profile + trust stats + balances in one call.
+
+**Parameters:** `[string]` — address
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  avatarInfo: AvatarInfo | null;
+  profile: object | null;
+  trustStats: { trustsCount: number; trustedByCount: number };
+  v1Balance: string | null;
+  v2Balance: string | null;
+}
+```
+
+#### `circles_getTrustNetworkSummary`
+
+Aggregated trust network statistics.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address | string | yes | — |
+| 1 | maxDepth | number | no | null |
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  directTrustsCount: number;
+  directTrustedByCount: number;
+  mutualTrustsCount: number;
+  mutualTrusts: string[];
+  networkReach: number;
+}
+```
+
+#### `circles_getAggregatedTrustRelationsEnriched`
+
+Trust relations categorized by type with enriched avatar info. Paginated.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address | string | yes | — |
+| 1 | limit | number | no | 50 (max 200) |
+| 2 | cursor | string | no | null |
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  results: TrustRelationInfo[];  // { address, avatarInfo, relationType }
+  counts: { mutual: number; trusts: number; trustedBy: number; total: number };
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+```
+
+#### `circles_getValidInviters`
+
+Addresses that trust the given address AND have sufficient balance to invite.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address | string | yes | — |
+| 1 | minimumBalance | string | no | null |
+| 2 | limit | number | no | 50 (max 200) |
+| 3 | cursor | string | no | null |
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  results: InviterInfo[];  // { address, balance, avatarInfo }
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+```
+
+#### `circles_getTransactionHistoryEnriched`
+
+Transaction history with participant profiles attached.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | address | string | yes | — | |
+| 1 | fromBlock | number | yes | — | |
+| 2 | toBlock | number | no | null | |
+| 3 | limit | number | no | 20 | |
+| 4 | cursor | string | no | null | |
+| 5 | version | number | no | null | null=V2, 1=V1, 2=V2 |
+| 6 | excludeIntermediary | boolean | no | true | Exclude hop transfers |
+
+**Returns:** `PagedResponse<EnrichedTransaction>`
+
+```typescript
+interface EnrichedTransaction {
+  blockNumber: number;
+  timestamp: number;
+  transactionIndex: number;
+  logIndex: number;
+  transactionHash: string;
+  version: number;
+  from: string;
+  to: string;
+  operator: string | null;
+  id: string | null;
+  value: string;
+  circles: string;
+  attoCircles: string;
+  crc: string;
+  attoCrc: string;
+  staticCircles: string;
+  staticAttoCircles: string;
+  fromProfile: object | null;
+  toProfile: object | null;
+}
+```
+
+#### `circles_searchProfileByAddressOrName`
+
+Unified search: auto-detects address prefix (`0x`) vs text search.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | query | string | yes | — |
+| 1 | limit | number | no | 20 (max 100) |
+| 2 | cursor | string | no | null |
+| 3 | types | string[] | no | null |
+
+**Returns:**
+
+```typescript
+{
+  query: string;
+  searchType: "address" | "text";
+  results: object[];
+  hasMore: boolean;
+  nextCursor: string | null;
+}
+```
+
+---
+
+### Invitation Methods
+
+#### `circles_getInvitationOrigin`
+
+Reconstruct how a user was invited to Circles. Supports V1 Signup, V2 Standard, V2 Escrow, and V2 At Scale.
+
+**Parameters:** `[string]` — address
+
+**Returns:** `InvitationOriginResponse | null`
+
+```typescript
+{
+  address: string;
+  invitationType: "v1_signup" | "v2_standard" | "v2_escrow" | "v2_at_scale";
+  inviter: string | null;        // null for v1_signup
+  proxyInviter: string | null;   // Only for v2_at_scale
+  escrowAmount: string | null;   // Only for v2_escrow (atto-circles)
+  blockNumber: number;
+  timestamp: number;
+  transactionHash: string;
+  version: number;               // 1 or 2
+}
+```
+
+#### `circles_getAllInvitations`
+
+Get all available invitations from all sources (trust, escrow, at-scale) in one call.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address | string | yes | — |
+| 1 | minimumBalance | string | no | null |
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  trustInvitations: TrustInvitation[];
+  escrowInvitations: EscrowInvitation[];
+  atScaleInvitations: AtScaleInvitation[];
+}
+```
+
+#### `circles_getTrustInvitations`
+
+Get trust-based invitations only (subset of `circles_getAllInvitations`).
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default |
+|-------|------|------|----------|---------|
+| 0 | address | string | yes | — |
+| 1 | minimumBalance | string | no | null |
+
+**Returns:** `TrustInvitation[]`
+
+```typescript
+interface TrustInvitation {
+  address: string;
+  source: "trust";
+  balance: string;
+  avatarInfo: AvatarInfo | null;
+}
+```
+
+#### `circles_getEscrowInvitations`
+
+Get escrow-based invitations (CRC escrowed for the address). Filters out redeemed/revoked/refunded.
+
+**Parameters:** `[string]` — address
+
+**Returns:** `EscrowInvitation[]`
+
+```typescript
+interface EscrowInvitation {
+  address: string;
+  source: "escrow";
+  escrowedAmount: string;
+  escrowDays: number;
+  blockNumber: number;
+  timestamp: number;
+  avatarInfo: AvatarInfo | null;
+}
+```
+
+#### `circles_getAtScaleInvitations`
+
+Get at-scale invitations (pre-created accounts not yet claimed).
+
+**Parameters:** `[string]` — address
+
+**Returns:** `AtScaleInvitation[]`
+
+```typescript
+interface AtScaleInvitation {
+  address: string;
+  source: "atScale";
+  blockNumber: number;
+  timestamp: number;
+  originInviter: string | null;
+}
+```
+
+#### `circles_getInvitationsFrom`
+
+Get accounts invited by a specific avatar.
+
+**Parameters:**
+
+| Index | Name | Type | Required | Default | Description |
+|-------|------|------|----------|---------|-------------|
+| 0 | address | string | yes | — | Inviter address |
+| 1 | accepted | boolean | no | false | `true`=registered, `false`=pending (trusted but not registered) |
+
+**Returns:**
+
+```typescript
+{
+  address: string;
+  accepted: boolean;
+  results: Array<{
+    address: string;
+    status: string;
+    blockNumber: number;
+    timestamp: number;
+    avatarInfo: AvatarInfo | null;
+  }>;
+}
+```
+
+---
+
+## Cursor-Based Pagination
+
+Methods returning `PagedResponse<T>` use cursor-based pagination:
+
+```typescript
+{
+  results: T[];
+  hasMore: boolean;
+  nextCursor: string | null;  // Pass as cursor param to get next page
+}
+```
+
+Cursors are opaque base64 strings (typically encoding `block:transactionIndex:logIndex`). Do not parse or construct them manually.
+
+---
+
+## Method Summary
+
+| # | Method | Category | Paginated | Cache |
+|---|--------|----------|-----------|-------|
+| 1 | `rpc.discover` | Discovery | — | — |
+| 2 | `circles_getTotalBalance` | Balance | — | Yes |
+| 3 | `circlesV2_getTotalBalance` | Balance | — | Yes |
+| 4 | `circles_getTokenBalances` | Balance | — | Yes |
+| 5 | `circles_getTokenInfo` | Token | — | — |
+| 6 | `circles_getTokenInfoBatch` | Token | — | — |
+| 7 | `circles_getTokenHolders` | Token | Cursor | — |
+| 8 | `circles_getAvatarInfo` | Avatar | — | Yes |
+| 9 | `circles_getAvatarInfoBatch` | Avatar | — | Yes |
+| 10 | `circles_getProfileCid` | Profile | — | — |
+| 11 | `circles_getProfileCidBatch` | Profile | — | — |
+| 12 | `circles_getProfileByCid` | Profile | — | — |
+| 13 | `circles_getProfileByCidBatch` | Profile | — | — |
+| 14 | `circles_getProfileByAddress` | Profile | — | Yes |
+| 15 | `circles_getProfileByAddressBatch` | Profile | — | Yes |
+| 16 | `circles_searchProfiles` | Profile | Offset | — |
+| 17 | `circles_getTrustRelations` | Trust | — | — |
+| 18 | `circles_getAggregatedTrustRelations` | Trust | — | — |
+| 19 | `circles_getCommonTrust` | Trust | — | — |
+| 20 | `circles_getNetworkSnapshot` | Network | — | — |
+| 21 | `circles_findGroups` | Group | Cursor | — |
+| 22 | `circles_getGroupMembers` | Group | Cursor | — |
+| 23 | `circles_getGroupMemberships` | Group | Cursor | — |
+| 24 | `circles_getTransactionHistory` | Transaction | Cursor | — |
+| 25 | `circles_getTransferData` | Transaction | Cursor | — |
+| 26 | `circles_getBlockByTimestamp` | Block | — | — |
+| 27 | `circles_events` | Events | — | — |
+| 28 | `circles_events_paginated` | Events | Cursor | — |
+| 29 | `circles_query` | Query | — | — |
+| 30 | `circles_paginated_query` | Query | Cursor | — |
+| 31 | `circles_health` | System | — | — |
+| 32 | `circles_tables` | System | — | — |
+| 33 | `circlesV2_findPath` | Pathfinder | — | — |
+| 34 | `circles_getProfileView` | SDK | — | — |
+| 35 | `circles_getTrustNetworkSummary` | SDK | — | — |
+| 36 | `circles_getAggregatedTrustRelationsEnriched` | SDK | Cursor | — |
+| 37 | `circles_getValidInviters` | SDK | Cursor | — |
+| 38 | `circles_getTransactionHistoryEnriched` | SDK | Cursor | — |
+| 39 | `circles_searchProfileByAddressOrName` | SDK | Cursor | — |
+| 40 | `circles_getInvitationOrigin` | Invitation | — | — |
+| 41 | `circles_getAllInvitations` | Invitation | — | — |
+| 42 | `circles_getTrustInvitations` | Invitation | — | — |
+| 43 | `circles_getEscrowInvitations` | Invitation | — | — |
+| 44 | `circles_getAtScaleInvitations` | Invitation | — | — |
+| 45 | `circles_getInvitationsFrom` | Invitation | — | — |
+
+---
 
 ## Architecture
 
-### Components
-
-1. **CirclesRpcModule** - Core business logic for all RPC methods, split into partial classes:
-   - `CirclesRpcModule.cs` - Transaction history, Events, Pathfinder, SDK endpoints, Query
-   - `RpcModule/CirclesRpcModule.Core.cs` - Constructor, fields, connection management
-   - `RpcModule/CirclesRpcModule.Balances.cs` - Token balance queries
-   - `RpcModule/CirclesRpcModule.Tokens.cs` - Token info and holders
-   - `RpcModule/CirclesRpcModule.Avatars.cs` - Avatar information
-   - `RpcModule/CirclesRpcModule.Profiles.cs` - Profile CID and content operations
-   - `RpcModule/CirclesRpcModule.Trust.cs` - Trust relations
-   - `RpcModule/CirclesRpcModule.Groups.cs` - Group operations
-   - `RpcModule/CirclesRpcModule.Helpers.cs` - Health and table utilities
-2. **CursorUtils.cs** - Cursor-based pagination utilities
-3. **Program.cs** - ASP.NET Core app, routes requests to handlers
-4. **Settings** - Environment-based configuration
-5. **DatabaseSchemaMap** - Maps database schemas for query operations
-6. **NethermindRpcClient** - Live balance queries via eth_call
-7. **AbiEncoder** - Ethereum ABI encoding for contract calls
-
-### Dependencies
-
-- **Circles.Index.Postgres** - Database access layer
-- **Circles.Index.Query** - Query abstractions and DTOs
-- **Circles.Pathfinder.DTOs** - Pathfinding request/response types
-- **Nethermind RPC** - Live blockchain queries (optional, for balance mode)
-- **External Pathfinder** - Pathfinding service (for `circlesV2_findPath`)
-
-### Data Flow
-
 ```
 Client Request
-    ↓
-JSON-RPC 2.0 Parser
-    ↓
-CirclesRpcModule
-    ↓
-┌─────────────┬───────────────┬──────────────┐
-│  Postgres   │  Nethermind   │  Pathfinder  │
-│  (Index DB) │  (eth_call)   │  (External)  │
-└─────────────┴───────────────┴──────────────┘
-    ↓
-JSON-RPC 2.0 Response
+    │
+    ▼
+┌─────────────────────────────────────────────┐
+│  ASP.NET Core (Kestrel)                     │
+│  ├─ Rate Limiter (per-IP token bucket)      │
+│  ├─ Batch Middleware (array detect, split)   │
+│  └─ Concurrency Semaphore                   │
+└─────────────┬───────────────────────────────┘
+              │
+    ┌─────────┴─────────┐
+    ▼                   ▼
+circles_*           eth_*/net_*/web3_*
+    │                   │
+    ▼                   ▼
+CirclesRpcModule    NethermindRpcClient
+    │                   │
+    ▼                   ▼
+┌──────────┬────────┬──────────────┐
+│ Postgres │ IPFS   │ Pathfinder   │
+│ (Index)  │(Profiles)│(Max Flow)  │
+└──────────┴────────┴──────────────┘
+    │
+    ▼ (optional)
+CacheServiceClient
 ```
+
+### Key Components
+
+| File | Purpose |
+|------|---------|
+| `Program.cs` | App setup, batch middleware, WebSocket handler, method dispatch switch |
+| `CirclesRpcModule.cs` + `RpcModule/*.cs` | Business logic (partial classes by domain) |
+| `ICirclesRpcModule.cs` | Interface + all DTO record definitions |
+| `RpcRateLimiter.cs` | Per-IP token bucket rate limiter |
+| `RpcMethodClassifier.cs` | Method routing (circles vs proxy vs reject) |
+| `RpcMetrics.cs` | Prometheus counters/histograms/gauges |
+| `CirclesSubscriptionService.cs` | WebSocket subscription via PostgreSQL LISTEN/NOTIFY |
+| `NethermindRpcClient.cs` | HTTP client for Nethermind proxy + balance eth_calls |
+| `Settings.cs` | Environment variable configuration |
+| `BuilderSetup.cs` | DI container, health checks, OpenTelemetry |
+| `OpenRpc/OpenRpcGenerator.cs` | Auto-generated OpenRPC 1.3.2 spec from reflection |
+
+## Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `circles_rpc_requests_total` | Counter | method | Total requests |
+| `circles_rpc_request_duration_seconds` | Histogram | method | Request duration |
+| `circles_rpc_errors_total` | Counter | method, error_type | Errors by type |
+| `circles_rpc_inflight_requests` | Gauge | method | Currently in-flight |
+| `circles_rpc_active_subscriptions` | Gauge | — | Active WebSocket subscriptions |
+| `circles_rpc_rejected_total` | Counter | — | Rejected by concurrency limit |
+| `circles_rpc_proxied_total` | Counter | method | Proxied to Nethermind |
+| `circles_rpc_proxy_duration_seconds` | Histogram | method | Proxy request duration |
+| `circles_rpc_rate_limited_total` | Counter | — | Rejected by rate limiter |
+| `circles_rpc_batch_total` | Counter | — | Batch requests received |
+| `circles_rpc_batch_size` | Histogram | — | Items per batch |
 
 ## Development
 
@@ -682,167 +1407,40 @@ JSON-RPC 2.0 Response
 
 - .NET 10.0 SDK
 - PostgreSQL 15+ (with indexed Circles data)
-- Nethermind RPC endpoint (optional, for live mode)
-- Pathfinder service (optional, for pathfinding methods)
+- Nethermind RPC endpoint (optional, for live balance mode)
+- Pathfinder service (optional, for `circlesV2_findPath` and `circles_getNetworkSnapshot`)
 
 ### Testing
 
 ```bash
-# Run tests
-cd src/Rpc/Circles.Rpc.Host.Tests
-dotnet test
+# Run unit tests
+./scripts/test.sh Circles.Rpc.Host.Tests
 
-# Test specific endpoint
-curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{
-  "jsonrpc": "2.0",
-  "method": "circles_health",
-  "params": [],
-  "id": 1
-}'
+# Test a live endpoint
+./scripts/test-rpc.sh                               # localhost:8081
+./scripts/test-rpc.sh https://rpc.aboutcircles.com  # production
+make test-rpc-regression                             # compare local vs production
 ```
 
 ### Adding New RPC Methods
 
 1. Add method signature to `ICirclesRpcModule.cs`
-2. Implement method in the appropriate partial class file:
-   - Balance/Token queries → `RpcModule/CirclesRpcModule.Balances.cs` or `Tokens.cs`
-   - Avatar queries → `RpcModule/CirclesRpcModule.Avatars.cs`
-   - Profile queries → `RpcModule/CirclesRpcModule.Profiles.cs`
-   - Trust queries → `RpcModule/CirclesRpcModule.Trust.cs`
-   - Group queries → `RpcModule/CirclesRpcModule.Groups.cs`
-   - System/health → `RpcModule/CirclesRpcModule.Helpers.cs`
-   - Transaction/Event/SDK → `CirclesRpcModule.cs` (main file)
-3. Add handler function in `Program.cs`
-4. Add route mapping in the method switch statement
-5. Update this README with method documentation
+2. Implement in the appropriate `RpcModule/CirclesRpcModule.*.cs` partial class
+3. Add handler function in `Program.cs` (or use `ReflectionHandler` for convention-based routing)
+4. Add case to the dispatch switch in `Program.cs`
+5. Add method name to `RpcMethodClassifier.KnownCirclesMethods`
+6. Update this README
 
 ## Troubleshooting
 
-### Common Issues
+**Port in use:** `ASPNETCORE_URLS="http://localhost:8082" ./scripts/run-rpc.sh`
 
-**Port 8081 already in use:**
+**DB connection errors:** Check `docker ps | grep postgres` and test with `psql`.
 
-```bash
-ASPNETCORE_URLS="http://localhost:8082" ./scripts/run-rpc.sh
-```
+**Pathfinder fails:** Ensure `curl http://localhost:8080/health` returns 200 and `EXTERNAL_PATHFINDER_URL` is set.
 
-**Database connection errors:**
+**Balance timeouts:** Increase `DATABASE_QUERY_TIMEOUT_SECONDS` or switch to `BALANCE_MODE=database`.
 
-```bash
-# Check Postgres is running
-docker ps | grep postgres
+**429 Too Many Requests:** Reduce request rate or increase `RPC_RATE_LIMIT_PER_SECOND` / `RPC_RATE_LIMIT_BURST`.
 
-# Test connection
-psql -h localhost -U postgres -d postgres -c "SELECT 1"
-```
-
-**Pathfinder methods fail:**
-
-```bash
-# Ensure pathfinder is running
-curl http://localhost:8080/health
-
-# Set pathfinder URL
-export EXTERNAL_PATHFINDER_URL="http://localhost:8080"
-```
-
-**Balance queries timeout:**
-
-```bash
-# Increase timeout
-export DATABASE_QUERY_TIMEOUT_SECONDS=60
-
-# Or switch to database mode
-export BALANCE_MODE="database"
-```
-
-## Performance Tuning
-
-- **Database queries:** Adjust `DATABASE_QUERY_TIMEOUT_SECONDS` (default: 30)
-- **Profile search:** Adjust `PROFILE_SEARCH_TIMEOUT_SECONDS` (default: 30)
-- **Balance mode:** Use `database` mode for faster responses
-- **Connection pooling:** Postgres connection string supports pooling parameters
-
-## Related Documentation
-
-- [Main README](../../../README.md) - Full API documentation with examples
-- [DEVELOPMENT.md](../../../DEVELOPMENT.md) - Build and deployment guide
-- [scripts/README.md](../../../scripts/README.md) - Script documentation
-- [Circles.Pathfinder](../../Pathfinder/Circles.Pathfinder/README.md) - Pathfinding service
-
-## RPC Method Status
-
-This section provides an overview of all available RPC methods, their cache support, and implementation status.
-
-### Core RPC Methods
-
-All 15 core methods are implemented and accessible via RPC:
-
-| Method                                | Status     | Cache Support | Notes               |
-| ------------------------------------- | ---------- | ------------- | ------------------- |
-| `circles_getTotalBalance`             | ✅ Working | ✅            | Cache + DB fallback |
-| `circles_getTokenBalances`            | ✅ Working | ✅            | V1 & V2 tokens      |
-| `circles_getAvatarInfo`               | ✅ Working | ✅            | Batch support       |
-| `circles_getProfileByAddress`         | ✅ Working | ✅            | IPFS + cache        |
-| `circles_getTrustRelations`           | ✅ Working | ❌            | V1 only, no cache   |
-| `circles_getAggregatedTrustRelations` | ✅ Working | ❌            | SDK format          |
-| `circles_findGroups`                  | ✅ Working | ❌            | Cursor pagination   |
-| `circles_getGroupMembers`             | ✅ Working | ❌            | Cursor pagination   |
-| `circles_getGroupMemberships`         | ✅ Working | ❌            | Cursor pagination   |
-| `circles_getTransactionHistory`       | ✅ Working | ❌            | With circle amounts |
-| `circles_getTokenHolders`             | ✅ Working | ❌            | Token distribution  |
-| `circles_getCommonTrust`              | ✅ Working | ❌            | V1/V2 support       |
-| `circles_events`                      | ✅ Working | ❌            | Flat array (compat) |
-| `circles_events_paginated`            | ✅ Working | ❌            | Cursor pagination   |
-| `circles_query`                       | ✅ Working | ❌            | Generic DB query    |
-| `circlesV2_findPath`                  | ✅ Working | ❌            | Pathfinder proxy    |
-
-**Count**: 15/15 core methods ✅
-
-### SDK Enablement Methods (✅ Now Fully Implemented & Exposed)
-
-✅ **Complete**: All 8 methods are now implemented in the backend AND exposed via RPC routing in `Program.cs`.
-
-| Method                                        | Purpose                                                      | Replaces  | Status     |
-| --------------------------------------------- | ------------------------------------------------------------ | --------- | ---------- |
-| `circles_getProfileView`                      | Complete profile (avatar + profile + balances + trust stats) | 6-7 calls | ✅ WORKING |
-| `circles_getTrustNetworkSummary`              | Aggregated trust network statistics                          | 3-4 calls | ✅ WORKING |
-| `circles_getAggregatedTrustRelationsEnriched` | Trust relations categorized by type + avatar info            | 2-3 calls | ✅ WORKING |
-| `circles_getValidInviters`                    | Inviters with sufficient balance                             | 3-4 calls | ✅ WORKING |
-| `circles_getTransactionHistoryEnriched`       | Transactions with participant profiles                       | 2-3 calls | ✅ WORKING |
-| `circles_searchProfileByAddressOrName`        | Unified search (address or text)                             | 2 calls   | ✅ WORKING |
-| `circles_getInvitationOrigin`                 | Reconstructs how user was invited (V1/V2/Escrow/AtScale)     | 4+ calls  | ✅ WORKING |
-| `circles_getAllInvitations`                   | All available invitations (trust, escrow, at-scale)          | 6-8 calls | ✅ WORKING |
-
-**Count**: 8/8 Phase 3 methods ✅ (23/23 total methods)
-
-#### Performance Impact
-
-These 7 endpoints reduce SDK round-trips by 60-80% for common operations.
-
-
-### Cache Support Status
-
-- **Balance methods** (`circles_getTotalBalance`, `circles_getTokenBalances`): ✅ Full cache support with DB fallback
-- **Avatar methods** (`circles_getAvatarInfo`): ✅ Full cache support with DB fallback
-- **Profile methods** (`circles_getProfileByAddress`): ✅ Full cache support with DB fallback
-- **Trust/Query methods**: ❌ No cache support, direct database queries only
-
-#### Cache Architecture
-
-The service supports both cache-enabled and direct database modes:
-
-```mermaid
-graph TD
-    A[RPC Request] --> B{Cache Enabled?}
-    B -->|Yes| C[Try Cache Service]
-    B -->|No| F[Direct Database]
-    C --> D{Cache Available?}
-    D -->|Yes| E[Return Cached Data]
-    D -->|No| F[Direct Database]
-    F --> G[Query Database]
-    G --> H[Return Fresh Data]
-```
-
-**Cache benefits**: 2-3x performance improvement for cached endpoints
-**Database benefits**: Always fresh data, no cache invalidation concerns
+**503 Server Busy:** Increase `RPC_MAX_CONCURRENT_REQUESTS` or investigate slow queries.


### PR DESCRIPTION
## Summary

- Rewrites RPC Host README from ~24 documented methods to **all 45**, with full parameter tables, return type schemas, and curl examples
- Adds missing sections: **WebSocket subscriptions**, **rate limiting** (per-IP token bucket), **batch requests** (50 items/1MB), **concurrency control** (503), **Ethereum proxy routing**, **Prometheus metrics** (11 metrics), **Conjunction/AND-OR filter nesting**
- Documents all 14 environment variables with defaults and descriptions
- Adds method summary table with category, pagination type, and cache support
- Adds `externalDocs` link to the OpenRPC 1.3.2 spec pointing to the README

**Motivation:** Audit found 21 of 45 methods undocumented, causing real bugs (devs' AI generated broken filter predicates because docs said `value: any`). Missing WebSocket/rate-limit/batch docs meant SDK consumers had to read source code.

## Test plan

- [x] `dotnet build` — 0 errors (58 pre-existing warnings)
- [x] `dotnet test Circles.Rpc.Host.Tests` — 137 passed, 0 failed
- [ ] Verify `/openrpc.json` includes `externalDocs` field on staging
- [ ] Spot-check README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Substantially updated service documentation with comprehensive endpoint reference, configuration guide, and method specifications.
  * Added external documentation links to API metadata for better discoverability.
  * Enhanced with error codes, rate-limiting behaviour, WebSocket subscription details, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->