### PR TITLE
fix: rawBatch path — no /api prefix

### DIFF
--- a/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
+++ b/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
@@ -326,7 +326,7 @@ public class CacheServiceClient
     {
         try
         {
-            var url = $"{_profileContentBaseUrl}/api/rawBatch";
+            var url = $"{_profileContentBaseUrl}/rawBatch";
             var request = new ProfileContentBatchRequest(cids);
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();


### PR DESCRIPTION
## Summary
- Pinning service routes are mounted at `/` (Caddy strips `/profiles` prefix)
- Internal path is `/rawBatch`, not `/api/rawBatch`
- One-line fix: remove `/api` from the URL

## Test plan
- Deploy to staging, verify `circles_getProfileByAddress` returns profile content (name, description, etc.)
- Compare against production baseline