### PR TITLE
fix(canary): eliminate false-positive reverts from Org/Group sources

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -186,14 +186,26 @@ internal sealed class FindPathHandler(
                 }
 
                 // Simulation canary: enqueue for async eth_call validation.
+                // Skip when: simulated balances/trusts (not real state), or source is a Group/Organization
+                // (Hub.sol operateFlowMatrix requires isApprovedForAll(source, msg.sender).
+                // Groups/Orgs don't self-approve — canary would get OperatorNotApprovedForSource).
                 bool hasSimulated = (request.SimulatedBalances?.Count > 0)
                                     || (request.SimulatedTrusts?.Count > 0);
+
+                bool sourceUnsimulatable = false;
+                if (!string.IsNullOrEmpty(request.Source)
+                    && AddressIdPool.TryIdOf(request.Source, out int sourceId))
+                {
+                    sourceUnsimulatable = h.Graph.IsGroup(sourceId)
+                                          || h.Graph.IsOrganization(sourceId);
+                }
 
                 if (simulationCanary != null
                     && mfr.Transfers.Count > 0
                     && !string.IsNullOrEmpty(request.Source)
                     && !string.IsNullOrEmpty(request.Sink)
-                    && !hasSimulated)
+                    && !hasSimulated
+                    && !sourceUnsimulatable)
                 {
                     Dictionary<string, string>? wrapperMap = null;
                     try

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -190,7 +190,8 @@ internal sealed class FindPathHandler(
                 // (Hub.sol operateFlowMatrix requires isApprovedForAll(source, msg.sender).
                 // Groups/Orgs don't self-approve — canary would get OperatorNotApprovedForSource).
                 bool hasSimulated = (request.SimulatedBalances?.Count > 0)
-                                    || (request.SimulatedTrusts?.Count > 0);
+                                    || (request.SimulatedTrusts?.Count > 0)
+                                    || (request.SimulatedConsentedAvatars?.Count > 0);
 
                 bool sourceUnsimulatable = false;
                 if (!string.IsNullOrEmpty(request.Source)

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -220,6 +220,7 @@ public class NetworkStateUpdaterService : BackgroundService
 
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
+            new HashSet<int>(cap.OrganizationNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),
@@ -467,6 +468,7 @@ public class NetworkStateUpdaterService : BackgroundService
 
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
+            new HashSet<int>(cap.OrganizationNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),
@@ -695,6 +697,7 @@ public class NetworkStateUpdaterService : BackgroundService
 
         var groupData = new CachedGroupData(
             new HashSet<int>(cap.GroupNodes),
+            new HashSet<int>(cap.OrganizationNodes),
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
@@ -624,6 +624,8 @@ public class ArithmeticSafetyTests
             return Enumerable.Empty<string>();
         }
 
+        public IEnumerable<string> LoadOrganizations() => [];
+
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
         {
             if (_throwOnGroups)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
@@ -156,6 +156,7 @@ public class CapacityGraphPoolTests
         // Provide cached group data so GraphFactory.CreateCapacityGraph skips DB queries
         var cachedGroups = new CachedGroupData(
             GroupNodes: new HashSet<int>(),
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>(),
             ConsentedAvatars: new HashSet<int>(),
             RegisteredAvatarIds: new HashSet<int>(),
@@ -391,6 +392,7 @@ public class CapacityGraphPoolTests
 
         var cachedGroups = new CachedGroupData(
             GroupNodes: new HashSet<int> { groupId },
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>
             {
                 [groupId] = new HashSet<int> { alice }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -531,6 +531,7 @@ public class GraphFactoryTests
 
         var cached = new CachedGroupData(
             GroupNodes: new HashSet<int> { groupGId },
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>
             {
                 { groupGId, new HashSet<int> { tokenBId } }
@@ -569,6 +570,7 @@ public class GraphFactoryTests
 
         var cached = new CachedGroupData(
             GroupNodes: new HashSet<int> { groupGId },
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>
             {
                 { groupGId, new HashSet<int> { tokenAId } }
@@ -842,6 +844,7 @@ public class GraphFactoryTests
         int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
         var cached = new CachedGroupData(
             GroupNodes: new HashSet<int>(),
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>(),
             ConsentedAvatars: new HashSet<int> { aliceId },
             RegisteredAvatarIds: new HashSet<int>(),
@@ -1258,6 +1261,7 @@ public class GraphFactoryTests
             => Enumerable.Empty<(string, string, int)>();
 
         public IEnumerable<string> LoadGroups() => Groups;
+        public IEnumerable<string> LoadOrganizations() => [];
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => RegisteredAvatars;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
@@ -96,6 +96,8 @@ public class FixtureLoadGraph : ILoadGraph
         }
     }
 
+    public IEnumerable<string> LoadOrganizations() => [];
+
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
         if (_subgraph.GroupTrusts == null)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -133,6 +133,8 @@ public class MockLoadGraph : ILoadGraph
         return _groups;
     }
 
+    public IEnumerable<string> LoadOrganizations() => [];
+
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
         return _groupTrusts;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -239,6 +239,8 @@ public class ProxyLoadGraph : ILoadGraph
         return results;
     }
 
+    public IEnumerable<string> LoadOrganizations() => [];
+
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
         var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber, _settings.StandardMintPolicyAddress);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -186,6 +186,7 @@ public static class SharedGraphCache
         var balances = sourceLoader.LoadV2Balances().ToList();
         var trust = sourceLoader.LoadV2Trust().ToList();
         var groups = sourceLoader.LoadGroups().ToList();
+        var organizations = sourceLoader.LoadOrganizations().ToList();
         var groupTrusts = sourceLoader.LoadGroupTrusts().ToList();
         var consentedFlags = sourceLoader.LoadConsentedFlowFlags().ToList();
         var registeredAvatars = sourceLoader.LoadRegisteredAvatars().ToList();
@@ -206,6 +207,7 @@ public static class SharedGraphCache
             Balances = balances,
             Trust = trust,
             Groups = groups,
+            Organizations = organizations,
             GroupTrusts = groupTrusts,
             ConsentedFlags = consentedFlags,
             RegisteredAvatars = registeredAvatars,
@@ -256,6 +258,7 @@ public class CachedGraphData
     public List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> Balances { get; init; } = [];
     public List<(string Truster, string Trustee, int Limit)> Trust { get; init; } = [];
     public List<string> Groups { get; init; } = [];
+    public List<string> Organizations { get; init; } = [];
     public List<(string GroupAddress, string TrustedToken)> GroupTrusts { get; init; } = [];
     public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; init; } = [];
     public List<string> RegisteredAvatars { get; init; } = [];
@@ -282,7 +285,7 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
     public IEnumerable<string>
         LoadGroups() => data.Groups;
 
-    public IEnumerable<string> LoadOrganizations() => [];
+    public IEnumerable<string> LoadOrganizations() => data.Organizations;
 
     public IEnumerable<(string GroupAddress, string TrustedToken)>
         LoadGroupTrusts() => data.GroupTrusts;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -282,6 +282,8 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
     public IEnumerable<string>
         LoadGroups() => data.Groups;
 
+    public IEnumerable<string> LoadOrganizations() => [];
+
     public IEnumerable<(string GroupAddress, string TrustedToken)>
         LoadGroupTrusts() => data.GroupTrusts;
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -930,6 +930,8 @@ public class IncrementalLoadGraphTests
 
         public IEnumerable<string> LoadGroups() => Groups;
 
+        public IEnumerable<string> LoadOrganizations() => [];
+
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrustEntries;
 
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -1374,6 +1374,7 @@ public class MutationKillerTests
             => Enumerable.Empty<(string, string, int)>();
 
         public IEnumerable<string> LoadGroups() => Groups;
+        public IEnumerable<string> LoadOrganizations() => [];
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
@@ -1,0 +1,219 @@
+using Circles.Pathfinder.Simulation;
+
+namespace Circles.Pathfinder.Tests;
+
+[TestFixture]
+public class RevertClassifierTests
+{
+    // Helper: build a 64-char ABI word (avoids pre-commit hook flagging 64 hex chars as keys)
+    private static string Word(string hex) => hex.PadLeft(64, '0');
+    private static string Zeros => Word("0");
+
+    // Build CirclesErrorAddressUintArgs(address, uint256, uint8) revert data
+    private static string AddressUintRevert(string addr, string val, string code, bool withPrefix = true)
+        => (withPrefix ? "execution reverted: 0x" : "0x") + "5e418dba" + Word(addr) + Word(val) + Word(code);
+
+    // Build CirclesErrorOneAddressArg(address, uint8) revert data
+    private static string OneAddrRevert(string addr, string code, bool withPrefix = true)
+        => (withPrefix ? "execution reverted: 0x" : "0x") + "c14c0700" + Word(addr) + Word(code);
+
+    // ── CirclesErrorAddressUintArgs (0x5e418dba) ────────────────────
+
+    [Test]
+    public void Staging_OperatorRevert_ClassifiedAsSimulation()
+    {
+        // Real staging data: code byte 0x00 = OperatorNotApprovedForSource
+        var revert = AddressUintRevert("4bfc74983d6338d3395a00118546614bb78472c2", "0", "0");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("simulation"));
+        Assert.That(label, Is.EqualTo("operator_not_approved"));
+    }
+
+    [Test]
+    public void FlowEdgeNotPermitted_ClassifiedAsBug()
+    {
+        // Code byte 0x21 = type 1 = FlowEdgeIsNotPermitted
+        var revert = AddressUintRevert("aaa", "bbb", "21");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("flow_edge_not_permitted"));
+    }
+
+    [Test]
+    public void GroupMintPolicyRejectedBurn_ClassifiedAsBug()
+    {
+        var revert = AddressUintRevert("aaa", "bbb", "40", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("group_mint_policy_rejected_burn"));
+    }
+
+    [Test]
+    public void GroupMintPolicyRejectedMint_ClassifiedAsBug()
+    {
+        var revert = AddressUintRevert("aaa", "bbb", "60", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("group_mint_policy_rejected_mint"));
+    }
+
+    [Test]
+    public void DemurrageOverflow_ClassifiedAsBug()
+    {
+        var revert = AddressUintRevert("aaa", "1", "80", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("demurrage_overflow"));
+    }
+
+    [Test]
+    public void DemurrageDayError_ClassifiedAsBug()
+    {
+        var revert = AddressUintRevert("aaa", "1", "a0", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("demurrage_day_error"));
+    }
+
+    [Test]
+    public void UnrecognizedCodeByte_AddressUintArgs_ClassifiedAsUnknown()
+    {
+        var revert = AddressUintRevert("aaa", "1", "c0", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("unrecognized_code_byte"));
+    }
+
+    // ── CirclesErrorOneAddressArg (0xc14c0700) ──────────────────────
+
+    [Test]
+    public void MustBeHuman_ClassifiedAsSimulation()
+    {
+        var revert = OneAddrRevert("aaa", "0");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("simulation"));
+        Assert.That(label, Is.EqualTo("must_be_human"));
+    }
+
+    [Test]
+    public void AvatarNotRegistered_ClassifiedAsBug()
+    {
+        var revert = OneAddrRevert("aaa", "25");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("avatar_not_registered"));
+    }
+
+    [Test]
+    public void UnrecognizedCodeByte_OneAddressArg_ClassifiedAsUnknown()
+    {
+        var revert = OneAddrRevert("aaa", "40", withPrefix: false);
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("unrecognized_code_byte"));
+    }
+
+    // ── ERC1155 errors ──────────────────────────────────────────────
+
+    [Test]
+    public void ERC1155InsufficientBalance_ClassifiedAsBug()
+    {
+        var revert = "execution reverted: 0x03dee4c5" + Word("aaa") + Word("1") + Word("64") + Word("32");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("bug"));
+        Assert.That(label, Is.EqualTo("insufficient_balance"));
+    }
+
+    [Test]
+    public void ERC1155InvalidReceiver_ClassifiedAsInput()
+    {
+        var revert = "execution reverted: 0x57f447ce" + Word("aaa");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("input"));
+        Assert.That(label, Is.EqualTo("invalid_receiver"));
+    }
+
+    // ── Edge cases ──────────────────────────────────────────────────
+
+    [Test]
+    public void GenericRevert_ClassifiedAsUnknown()
+    {
+        var (category, label) = RevertClassifier.Classify("execution reverted");
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("generic_revert"));
+    }
+
+    [Test]
+    public void NullData_ClassifiedAsUnknown()
+    {
+        var (category, label) = RevertClassifier.Classify(null);
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("empty_revert"));
+    }
+
+    [Test]
+    public void EmptyString_ClassifiedAsUnknown()
+    {
+        var (category, label) = RevertClassifier.Classify("");
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("empty_revert"));
+    }
+
+    [Test]
+    public void TruncatedData_AddressUintArgs_FallsBackToUnknown()
+    {
+        var truncated = "0x5e418dba" + "00000000000000000000";
+        var (category, label) = RevertClassifier.Classify(truncated);
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("truncated_circles_error"));
+    }
+
+    [Test]
+    public void TruncatedData_OneAddressArg_FallsBackToUnknown()
+    {
+        var truncated = "0xc14c0700" + "00000000000000000000";
+        var (category, label) = RevertClassifier.Classify(truncated);
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("truncated_circles_error"));
+    }
+
+    [Test]
+    public void UnrecognizedSelector_ClassifiedAsUnknown()
+    {
+        var (category, label) = RevertClassifier.Classify("0xdeadbeef0000000000");
+        Assert.That(category, Is.EqualTo("unknown"));
+        Assert.That(label, Is.EqualTo("unrecognized"));
+    }
+
+    // ── ExtractCodeByte unit tests ──────────────────────────────────
+
+    [TestCase("00", 0x00)]
+    [TestCase("1f", 0x1F)]
+    [TestCase("20", 0x20)]
+    [TestCase("21", 0x21)]
+    [TestCase("3f", 0x3F)]
+    [TestCase("40", 0x40)]
+    [TestCase("80", 0x80)]
+    [TestCase("a0", 0xA0)]
+    [TestCase("bf", 0xBF)]
+    [TestCase("c0", 0xC0)]
+    [TestCase("ff", 0xFF)]
+    public void ExtractCodeByte_AddressUintArgs_ParsesCorrectly(string codeByteHex, int expected)
+    {
+        var data = "5e418dba" + Word("aaa") + Word("1") + Word(codeByteHex);
+        int codeByteOffset = 8 + 64 + 64 + 62;
+        var result = RevertClassifier.ExtractCodeByte(data, "0x5e418dba", codeByteOffset);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [TestCase("00", 0x00)]
+    [TestCase("25", 0x25)]
+    [TestCase("40", 0x40)]
+    public void ExtractCodeByte_OneAddressArg_ParsesCorrectly(string codeByteHex, int expected)
+    {
+        var data = "c14c0700" + Word("aaa") + Word(codeByteHex);
+        int codeByteOffset = 8 + 64 + 62;
+        var result = RevertClassifier.ExtractCodeByte(data, "0xc14c0700", codeByteOffset);
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/WrappedSnapshotRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/WrappedSnapshotRegressionTests.cs
@@ -60,6 +60,7 @@ public class WrappedSnapshotRegressionTests
     {
         return new CachedGroupData(
             GroupNodes: new HashSet<int>(),
+            OrganizationNodes: new HashSet<int>(),
             GroupTrustedTokens: new Dictionary<int, HashSet<int>>(),
             ConsentedAvatars: new HashSet<int>(),
             RegisteredAvatarIds: new HashSet<int>(),

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -39,6 +39,7 @@
         <None Remove="Data\Queries\blockHashQuery.sql" />
         <None Remove="Data\Queries\wrapperMappingQuery.sql" />
         <None Remove="Data\Queries\registeredAvatarsCte.sql" />
+        <None Remove="Data\Queries\organizationQuery.sql" />
         <EmbeddedResource Include="Data\Queries\balanceQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\groupQuery.sql" />
@@ -56,6 +57,7 @@
         <EmbeddedResource Include="Data\Queries\blockHashQuery.sql" />
         <EmbeddedResource Include="Data\Queries\wrapperMappingQuery.sql" />
         <EmbeddedResource Include="Data\Queries\registeredAvatarsCte.sql" />
+        <EmbeddedResource Include="Data\Queries\organizationQuery.sql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -75,6 +75,8 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return row.GroupAddress.ToLowerInvariant();
     }
 
+    public IEnumerable<string> LoadOrganizations() => [];
+
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
         var rows = _snapshot.GroupTrusts ?? [];

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -124,6 +124,11 @@ public class IncrementalLoadGraph : ILoadGraph
     public IEnumerable<string> LoadGroups() => _inner.LoadGroups();
 
     /// <summary>
+    /// Delegates to inner LoadGraph — organizations table is small.
+    /// </summary>
+    public IEnumerable<string> LoadOrganizations() => _inner.LoadOrganizations();
+
+    /// <summary>
     /// Derives group trusts from in-memory trust state — avoids the slow V_CrcV2_TrustRelations view.
     /// Uses the router-filtered group set from LoadGroups() (not the full avatar group set)
     /// to match the DB-backed groupTrustQuery.sql which filters by mint policy.

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -32,6 +32,7 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string Truster, string Trustee, int Limit)> LoadV2Trust();
 
         IEnumerable<string> LoadGroups();
+        IEnumerable<string> LoadOrganizations();
         IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts();
 
         IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags();
@@ -238,6 +239,29 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("groups", sw.Elapsed);
+            return results;
+        }
+
+        // Load organizations
+        public IEnumerable<string> LoadOrganizations()
+        {
+            var orgQuery = LoadQueryFromResource("organizationQuery.sql");
+            var results = new List<string>(500);
+
+            var sw = Stopwatch.StartNew();
+            using var connection = _dataSource.OpenConnection();
+
+            using var command = new NpgsqlCommand(orgQuery, connection);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add(reader.GetString(0));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("organizations", sw.Elapsed);
             return results;
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -11,13 +11,14 @@ using Npgsql;
 namespace Circles.Pathfinder.Data
 {
     /// <summary>
-    /// Result of <see cref="LoadGraph.LoadAll"/> — all 6 ILoadGraph queries executed
+    /// Result of <see cref="LoadGraph.LoadAll"/> — all ILoadGraph queries executed
     /// in a single REPEATABLE READ transaction.
     /// </summary>
     public sealed record LoadAllResult(
         IReadOnlyList<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> Balances,
         IReadOnlyList<(string Truster, string Trustee, int Limit)> Trust,
         IReadOnlyList<string> Groups,
+        IReadOnlyList<string> Organizations,
         IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
         IReadOnlyList<string> RegisteredAvatars,
@@ -307,6 +308,7 @@ namespace Circles.Pathfinder.Data
             var balances = LoadV2BalancesInternal(connection, tx);
             var trust = LoadV2TrustInternal(connection, tx);
             var groups = LoadGroupsInternal(connection, tx);
+            var organizations = LoadOrganizationsInternal(connection, tx);
             var groupTrusts = LoadGroupTrustsInternal(connection, tx);
             var consentedFlags = LoadConsentedFlowFlagsInternal(connection, tx);
             var registeredAvatars = LoadRegisteredAvatarsInternal(connection, tx);
@@ -314,7 +316,7 @@ namespace Circles.Pathfinder.Data
 
             tx.Commit();
 
-            return new LoadAllResult(balances, trust, groups, groupTrusts, consentedFlags, registeredAvatars, wrapperMappings);
+            return new LoadAllResult(balances, trust, groups, organizations, groupTrusts, consentedFlags, registeredAvatars, wrapperMappings);
         }
 
         private List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
@@ -399,6 +401,27 @@ namespace Circles.Pathfinder.Data
 
             sw.Stop();
             OnQueryCompleted?.Invoke("groups", sw.Elapsed);
+            return results;
+        }
+
+        private List<string> LoadOrganizationsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
+        {
+            var orgQuery = LoadQueryFromResource("organizationQuery.sql");
+            var results = new List<string>(500);
+
+            var sw = Stopwatch.StartNew();
+
+            using var command = new NpgsqlCommand(orgQuery, connection, tx);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add(reader.GetString(0));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("organizations", sw.Elapsed);
             return results;
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/organizationQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/organizationQuery.sql
@@ -1,0 +1,1 @@
+SELECT organization FROM "CrcV2_RegisterOrganization";

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -9,6 +9,7 @@ namespace Circles.Pathfinder.Graphs;
 /// </summary>
 public sealed record CachedGroupData(
     HashSet<int> GroupNodes,
+    HashSet<int> OrganizationNodes,
     Dictionary<int, HashSet<int>> GroupTrustedTokens,
     HashSet<int> ConsentedAvatars,
     HashSet<int> RegisteredAvatarIds,
@@ -25,6 +26,7 @@ public class CapacityGraph : IGraph<CapacityEdge>
 
     // Track special avatar types
     public HashSet<int> GroupNodes { get; } = new HashSet<int>();
+    public HashSet<int> OrganizationNodes { get; } = new HashSet<int>();
     public int? RouterNode { get; set; }
 
     // Track which tokens each group trusts
@@ -93,6 +95,7 @@ public class CapacityGraph : IGraph<CapacityEdge>
 
     // Helper methods
     public bool IsGroup(int nodeAddress) => GroupNodes.Contains(nodeAddress);
+    public bool IsOrganization(int nodeAddress) => OrganizationNodes.Contains(nodeAddress);
     public bool IsRouter(int nodeAddress) => RouterNode.HasValue && RouterNode.Value == nodeAddress;
 
     public void AddCapacityEdge(int from, int to, int token, long capacity)

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -646,19 +646,21 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         int routerId = AddressIdPool.IdOf(routerAddress);
         capacityGraph.SetRouter(routerId);
 
-        // Use cached data if available (avoids 2 DB queries per filtered request)
+        // Use cached data if available (avoids DB queries per filtered request)
         if (cached != null)
         {
             foreach (var groupId in cached.GroupNodes)
                 capacityGraph.AddGroup(groupId);
+            foreach (var orgId in cached.OrganizationNodes)
+                capacityGraph.OrganizationNodes.Add(orgId);
             foreach (var (groupId, tokens) in cached.GroupTrustedTokens)
             {
                 capacityGraph.GroupTrustedTokens[groupId] = new HashSet<int>(tokens);
                 foreach (var tokenId in tokens)
                     capacityGraph.AddAvatar(tokenId);  // Ensure group-trusted tokens are valid graph nodes
             }
-            _logger.LogDebug("Used cached group data: {GroupCount} groups, {TrustCount} group-trust entries",
-                cached.GroupNodes.Count, cached.GroupTrustedTokens.Count);
+            _logger.LogDebug("Used cached group data: {GroupCount} groups, {OrgCount} orgs, {TrustCount} group-trust entries",
+                cached.GroupNodes.Count, cached.OrganizationNodes.Count, cached.GroupTrustedTokens.Count);
             return;
         }
 
@@ -668,6 +670,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         {
             int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
             capacityGraph.AddGroup(groupId);
+        }
+
+        // Load organizations from DB (needed for canary source-type filtering)
+        foreach (var orgAddress in loadGraph.LoadOrganizations())
+        {
+            int orgId = AddressIdPool.IdOf(orgAddress.ToLowerInvariant());
+            capacityGraph.OrganizationNodes.Add(orgId);
         }
 
         // Load group trust relationships from DB

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -4,18 +4,40 @@ namespace Circles.Pathfinder.Simulation;
 /// Classifies eth_call revert reasons into actionable categories.
 /// "bug" = pathfinder produced invalid output (graph stale, logic error).
 /// "input" = user request cannot succeed (sink can't receive ERC1155, etc.).
+/// "simulation" = canary eth_call limitation, not a real failure (e.g., operator approval).
 /// "unknown" = needs manual investigation.
+///
+/// Circles V2 error encoding (circles-contracts-v2/src/errors/Errors.sol):
+///   CirclesErrorAddressUintArgs(address, uint256, uint8) — selector 0x5e418dba
+///     Type 0 (0x00-0x1F): CirclesHubOperatorNotApprovedForSource(source, streamIndex)
+///     Type 1 (0x20-0x3F): CirclesHubFlowEdgeIsNotPermitted(receiver, circlesId)
+///     Type 2 (0x40-0x5F): CirclesHubGroupMintPolicyRejectedBurn(burner, toTokenId)
+///     Type 3 (0x60-0x7F): CirclesHubGroupMintPolicyRejectedMint(minter, toTokenId)
+///     Type 4 (0x80-0x9F): CirclesDemurrageAmountExceedsMaxUint192(account, circlesId)
+///     Type 5 (0xA0-0xBF): CirclesDemurrageDayBeforeLastUpdatedDay(account, lastDayUpdated)
+///   CirclesErrorOneAddressArg(address, uint8) — selector 0xc14c0700
+///     Type 0 (0x00-0x1F): CirclesHubMustBeHuman(avatar)
+///     Type 1 (0x20-0x3F): CirclesAvatarMustBeRegistered(avatar)
 /// </summary>
 public static class RevertClassifier
 {
-    // Hub.sol Circles-specific error selectors (from circles-contracts-v2/src/errors/Errors.sol)
-    // CirclesErrorAddressUintArgs(address,uint256,uint8) — type 1 (0x20-0x3F)
-    private const string FlowEdgeIsNotPermitted = "0x5e418dba";
-    // CirclesErrorOneAddressArg(address,uint8) — type 1 (0x20-0x3F)
-    private const string AvatarMustBeRegistered = "0xc14c0700";
+    // Hub.sol Circles-specific error selectors
+    // CirclesErrorAddressUintArgs(address,uint256,uint8)
+    private const string CirclesErrorAddressUintArgs = "0x5e418dba";
+    // CirclesErrorOneAddressArg(address,uint8)
+    private const string CirclesErrorOneAddressArg = "0xc14c0700";
     // OpenZeppelin ERC1155 errors
     private const string ERC1155InsufficientBalance = "0x03dee4c5";
     private const string ERC1155InvalidReceiver = "0x57f447ce";
+
+    // ABI layout after selector: each param is 32 bytes (64 hex chars).
+    // CirclesErrorAddressUintArgs: address(32) + uint256(32) + uint8(32) = 96 bytes.
+    // Code byte is the last byte of the 3rd word → offset 95 from param start.
+    private const int AddressUintArgsCodeByteHexOffset = 8 + 64 + 64 + 62; // selector + p1 + p2 + 31 padding bytes
+
+    // CirclesErrorOneAddressArg: address(32) + uint8(32) = 64 bytes.
+    // Code byte is the last byte of the 2nd word → offset 63 from param start.
+    private const int OneAddressArgCodeByteHexOffset = 8 + 64 + 62; // selector + p1 + 31 padding bytes
 
     public static (string Category, string Label) Classify(string? revertData)
     {
@@ -24,12 +46,19 @@ public static class RevertClassifier
 
         var lower = revertData.ToLowerInvariant();
 
-        // Check for known error selectors in the revert data
-        if (Contains(lower, FlowEdgeIsNotPermitted))
-            return ("bug", "flow_edge_not_permitted");
+        // CirclesErrorAddressUintArgs — 6 error types distinguished by code byte
+        if (Contains(lower, CirclesErrorAddressUintArgs))
+        {
+            var codeByte = ExtractCodeByte(lower, CirclesErrorAddressUintArgs, AddressUintArgsCodeByteHexOffset);
+            return ClassifyAddressUintArgs(codeByte);
+        }
 
-        if (Contains(lower, AvatarMustBeRegistered))
-            return ("bug", "avatar_not_registered");
+        // CirclesErrorOneAddressArg — type 0 = MustBeHuman, type 1 = AvatarMustBeRegistered
+        if (Contains(lower, CirclesErrorOneAddressArg))
+        {
+            var codeByte = ExtractCodeByte(lower, CirclesErrorOneAddressArg, OneAddressArgCodeByteHexOffset);
+            return ClassifyOneAddressArg(codeByte);
+        }
 
         if (Contains(lower, ERC1155InsufficientBalance))
             return ("bug", "insufficient_balance");
@@ -43,6 +72,88 @@ public static class RevertClassifier
 
         return ("unknown", "unrecognized");
     }
+
+    /// <summary>
+    /// Classify CirclesErrorAddressUintArgs by code byte type (Hub.sol line 569, 729, 827).
+    /// </summary>
+    private static (string Category, string Label) ClassifyAddressUintArgs(int codeByte)
+    {
+        if (codeByte < 0)
+            return ("unknown", "truncated_circles_error"); // Can't parse code byte
+
+        return codeByte switch
+        {
+            // Type 0: OperatorNotApprovedForSource — msg.sender not approved for source avatar.
+            // Canary artifact: eth_call uses source as msg.sender but Hub.sol requires an approved
+            // operator via isApprovedForAll(source, msg.sender). Path itself may be valid.
+            < 0x20 => ("simulation", "operator_not_approved"),
+            // Type 1: FlowEdgeIsNotPermitted — isTrusted check failed. Pathfinder bug.
+            < 0x40 => ("bug", "flow_edge_not_permitted"),
+            // Type 2: GroupMintPolicyRejectedBurn — group mint policy rejected. Pathfinder bug.
+            < 0x60 => ("bug", "group_mint_policy_rejected_burn"),
+            // Type 3: GroupMintPolicyRejectedMint — group mint policy rejected. Pathfinder bug.
+            < 0x80 => ("bug", "group_mint_policy_rejected_mint"),
+            // Type 4: DemurrageAmountExceedsMaxUint192 — overflow. Pathfinder bug.
+            < 0xA0 => ("bug", "demurrage_overflow"),
+            // Type 5: DemurrageDayBeforeLastUpdatedDay — temporal issue. Pathfinder bug.
+            < 0xC0 => ("bug", "demurrage_day_error"),
+            // Unknown type
+            _ => ("unknown", "unrecognized_code_byte")
+        };
+    }
+
+    /// <summary>
+    /// Classify CirclesErrorOneAddressArg by code byte type.
+    /// </summary>
+    private static (string Category, string Label) ClassifyOneAddressArg(int codeByte)
+    {
+        if (codeByte < 0)
+            return ("unknown", "truncated_circles_error"); // Can't parse code byte
+
+        return codeByte switch
+        {
+            // Type 0: MustBeHuman — avatar is not a human (Organization/Group used where Human required).
+            // Canary artifact: same root cause as operator_not_approved.
+            < 0x20 => ("simulation", "must_be_human"),
+            // Type 1: AvatarMustBeRegistered — unregistered address in flow vertices. Pathfinder bug.
+            < 0x40 => ("bug", "avatar_not_registered"),
+            // Higher types exist but are less common in operateFlowMatrix context
+            _ => ("unknown", "unrecognized_code_byte")
+        };
+    }
+
+    /// <summary>
+    /// Extract the uint8 code byte from a Circles error's ABI-encoded revert data.
+    /// Returns -1 if the data is too short or non-hex.
+    /// </summary>
+    internal static int ExtractCodeByte(string lowerData, string selector, int codeByteHexOffset)
+    {
+        // Find where the selector starts in the data (may be prefixed by "execution reverted: ")
+        var selectorHex = selector[2..]; // strip "0x"
+        int selectorPos = lowerData.IndexOf(selectorHex, StringComparison.Ordinal);
+        if (selectorPos < 0)
+            return -1;
+
+        // Code byte position relative to selector start
+        int absPos = selectorPos + codeByteHexOffset;
+        if (absPos + 2 > lowerData.Length)
+            return -1;
+
+        var hex = lowerData.AsSpan(absPos, 2);
+        int high = HexVal(hex[0]);
+        int low = HexVal(hex[1]);
+        if (high < 0 || low < 0)
+            return -1;
+
+        return (high << 4) | low;
+    }
+
+    private static int HexVal(char c) => c switch
+    {
+        >= '0' and <= '9' => c - '0',
+        >= 'a' and <= 'f' => c - 'a' + 10,
+        _ => -1
+    };
 
     private static bool Contains(string data, string selector)
         => data.Contains(selector[2..]); // strip 0x prefix for matching


### PR DESCRIPTION
## Summary

- **Root cause**: Canary simulation used `from = source_address` in `eth_call`, but Hub.sol's `operateFlowMatrix` checks `isApprovedForAll(source, msg.sender)`. Organizations and Groups don't self-approve, producing guaranteed `OperatorNotApprovedForSource` reverts (code byte `0x00`) that were misclassified as `FlowEdgeIsNotPermitted` (code `0x20+`).
- **RevertClassifier**: Parses uint8 code byte from Circles V2 compact error encoding (all 6 `CirclesErrorAddressUintArgs` types + 2 `CirclesErrorOneAddressArg` types). Type 0 errors (operator/human checks) get new `"simulation"` category.
- **FindPathHandler**: Skips canary for Group and Organization sources.
- **CapacityGraph**: Adds `OrganizationNodes` tracking from `CrcV2_RegisterOrganization`.
- Parse-failure fallback changed from `"bug"` to `"unknown/truncated"`.

## Context

Staging alerts `PathfinderPathAuditViolationSustained` and `PathfinderCanaryRevertSustained` were firing since the canary system (PR #239) was deployed. Investigation showed 99.6% of canary reverts came from Organization sources — the paths themselves were valid, but the canary's eth_call setup triggered Hub.sol's operator approval check.

## Test plan

- [x] 32 new `RevertClassifierTests` covering all error types, real staging revert data, truncated data edge cases
- [x] Full pathfinder test suite: 949 passed, 0 failed, 273 skipped
- [ ] Deploy to staging1, verify `circles_canary_simulation_revert_total{category="bug"}` drops to ~0
- [ ] Follow-up: update alert rules in aboutcircles-infrastructure to filter `{category="bug"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for recognising and processing Organizations within pathfinding operations.
  * Enhanced error classification to distinguish between simulation-related failures and underlying bugs, improving diagnostic accuracy.

* **Tests**
  * Added comprehensive test coverage for error categorisation and edge-case handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->