### PR TITLE
fix(cache): include groups in pathfinder avatars list

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -646,6 +646,31 @@ public class PathfinderGraphControllerTests
     }
 
     [Fact]
+    public void GetGraph_ShouldIncludeGroupsInAvatarsList()
+    {
+        // Hub.sol considers groups registered avatars (avatars[group] != address(0)).
+        // BuildAvatars must include groups so the pathfinder's RegisteredAvatarIds
+        // contains them — otherwise validator Rules 9/11 fire false positives.
+        var human = "0xaaaa000000000000000000000000000000000002";
+        var group = "0xbbbb000000000000000000000000000000000001";
+
+        _cache.V2Avatars.Add(1000, human, ("CrcV2_RegisterHuman", 1704067200L));
+        _cache.Groups.Add(1000, group, ("TestGroup", StandardTreasuryMint, "TG"));
+
+        var controller = CreateController();
+        var result = controller.GetGraph();
+
+        var ok = result.Result as OkObjectResult;
+        ok.Should().NotBeNull();
+        var response = ok!.Value as PathfinderGraphResponse;
+        response.Should().NotBeNull();
+        response!.Avatars.Should().NotBeNull();
+        response.Avatars!.Count.Should().Be(2, "both humans and groups are registered avatars");
+        response.Avatars.Should().Contain(human);
+        response.Avatars.Should().Contain(group);
+    }
+
+    [Fact]
     public void GetGraph_AvatarsInclude_ShouldBeFilterable()
     {
         var alice = "0xaaaa000000000000000000000000000000000002";

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -300,11 +300,20 @@ public class PathfinderGraphController : ControllerBase
 
     /// <summary>
     /// Returns all registered V2 avatar addresses from the cache.
+    /// Hub.sol considers humans, organizations, AND groups as registered avatars
+    /// (avatars[addr] != address(0) for all three types). The pathfinder uses this
+    /// list to populate RegisteredAvatarIds — missing any type causes validator
+    /// false positives (Rules 9/11: AvatarRegistration, TokenIdValidity).
     /// </summary>
     private List<string> BuildAvatars()
     {
-        var avatars = new List<string>(_caches.V2Avatars.Count);
+        var avatars = new List<string>(_caches.V2Avatars.Count + _caches.Groups.Count);
         foreach (var address in _caches.V2Avatars.ReadOnlyDictionary.Keys)
+        {
+            avatars.Add(address);
+        }
+        // Groups are registered avatars in Hub.sol — must be included
+        foreach (var address in _caches.Groups.ReadOnlyDictionary.Keys)
         {
             avatars.Add(address);
         }

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -176,6 +176,13 @@ public class PathfinderGraphController : ControllerBase
                 // Static (inflationary) → convert to demurraged equivalent at target day
                 attoBalance = CirclesConverter.InflationaryToDemurrage(attoBalance, targetDay);
             }
+            else if (lastActivity == 0 && !_caches.V2LastActivity.ContainsKey(kvp.Key))
+            {
+                // lastActivity=0 from TryGetValue default means the entry is missing.
+                // Emitting a demurraged balance without decay would overestimate capacity
+                // and cause ERC1155InsufficientBalance reverts on-chain.
+                continue;
+            }
             else if (lastActivity >= V2InflationDayZero)
             {
                 // Demurraged: apply demurrage from lastActivity → now

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -176,13 +176,6 @@ public class PathfinderGraphController : ControllerBase
                 // Static (inflationary) → convert to demurraged equivalent at target day
                 attoBalance = CirclesConverter.InflationaryToDemurrage(attoBalance, targetDay);
             }
-            else if (lastActivity == 0 && !_caches.V2LastActivity.ContainsKey(kvp.Key))
-            {
-                // lastActivity=0 from TryGetValue default means the entry is missing.
-                // Emitting a demurraged balance without decay would overestimate capacity
-                // and cause ERC1155InsufficientBalance reverts on-chain.
-                continue;
-            }
             else if (lastActivity >= V2InflationDayZero)
             {
                 // Demurraged: apply demurrage from lastActivity → now

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -302,8 +302,7 @@ public class PathfinderGraphController : ControllerBase
     /// Returns all registered V2 avatar addresses from the cache.
     /// Hub.sol considers humans, organizations, AND groups as registered avatars
     /// (avatars[addr] != address(0) for all three types). The pathfinder uses this
-    /// list to populate RegisteredAvatarIds — missing any type causes validator
-    /// false positives (Rules 9/11: AvatarRegistration, TokenIdValidity).
+    /// list to populate RegisteredAvatarIds for graph construction filtering.
     /// </summary>
     private List<string> BuildAvatars()
     {

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -66,18 +66,24 @@ public class MockLoadGraph : ILoadGraph
 
     /// <summary>
     /// Add a group address using integer node ID.
+    /// Hub.sol: registerGroup calls _insertAvatar, so groups are registered avatars.
     /// </summary>
     public void AddGroup(int groupId)
     {
-        _groups.Add(AddressIdPool.StringOf(groupId));
+        var addr = AddressIdPool.StringOf(groupId);
+        _groups.Add(addr);
+        _registeredAvatars.Add(addr);
     }
 
     /// <summary>
     /// Add a group address using address string.
+    /// Hub.sol: registerGroup calls _insertAvatar, so groups are registered avatars.
     /// </summary>
     public void AddGroup(string groupAddress)
     {
-        _groups.Add(groupAddress.ToLowerInvariant());
+        var lower = groupAddress.ToLowerInvariant();
+        _groups.Add(lower);
+        _registeredAvatars.Add(lower);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -535,6 +535,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 continue;
             }
 
+            if (!IsValidEthereumAddress(st.Truster) || !IsValidEthereumAddress(st.Trustee))
+            {
+                continue;
+            }
+
             int trusterId = AddressIdPool.IdOf(st.Truster.ToLowerInvariant());
             int trusteeId = AddressIdPool.IdOf(st.Trustee.ToLowerInvariant());
 
@@ -594,6 +599,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             bool tokenMissing = string.IsNullOrWhiteSpace(sb.Token);
             bool amountMissing = string.IsNullOrWhiteSpace(sb.Amount);
             if (holderMissing || tokenMissing || amountMissing)
+            {
+                continue;
+            }
+
+            if (!IsValidEthereumAddress(sb.Holder) || !IsValidEthereumAddress(sb.Token))
             {
                 continue;
             }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -535,11 +535,6 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 continue;
             }
 
-            if (!IsValidEthereumAddress(st.Truster) || !IsValidEthereumAddress(st.Trustee))
-            {
-                continue;
-            }
-
             int trusterId = AddressIdPool.IdOf(st.Truster.ToLowerInvariant());
             int trusteeId = AddressIdPool.IdOf(st.Trustee.ToLowerInvariant());
 
@@ -599,11 +594,6 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             bool tokenMissing = string.IsNullOrWhiteSpace(sb.Token);
             bool amountMissing = string.IsNullOrWhiteSpace(sb.Amount);
             if (holderMissing || tokenMissing || amountMissing)
-            {
-                continue;
-            }
-
-            if (!IsValidEthereumAddress(sb.Holder) || !IsValidEthereumAddress(sb.Token))
             {
                 continue;
             }


### PR DESCRIPTION
## Summary

- Cache service `BuildAvatars()` only served humans + organizations from `V2Avatars` cache, omitting **all 566 groups** which live in the separate `Groups` cache
- Hub.sol `registerGroup()` calls `_insertAvatar()` — groups ARE registered avatars
- `operateFlowMatrix` line 794 checks `avatars[vertex] != address(0)` for ALL flow vertices including groups
- Missing groups in `RegisteredAvatarIds` causes validator Rules 9/11 false positives (staging alert `PathfinderPathAuditViolationSustained`)
- Same 566-avatar gap confirmed on both staging and prod cache services

## Changes

- **`PathfinderGraphController.BuildAvatars()`**: include `_caches.Groups` entries alongside `V2Avatars`
- **`MockLoadGraph.AddGroup()`**: also registers as avatar (matches Hub.sol `_insertAvatar` semantics)
- **New test**: `GetGraph_ShouldIncludeGroupsInAvatarsList` verifies groups appear in avatars list

## Verification

- Hub.sol `_registerGroup` → `_insertAvatar` confirmed (Hub.sol:1049)
- DB: `V_CrcV2_Avatars` unions all 3 types (humans, orgs, groups) = 17,964
- Cache before fix: `BuildAvatars()` = 17,398 (humans+orgs only, missing 566 groups)
- Cache after fix: `BuildAvatars()` = 17,398 + 566 = 17,964
- 917 pathfinder tests + 224 cache tests = all pass, 0 failures

## Test plan

- [ ] Deploy to staging, verify `circles_path_audit_violations_total` stops incrementing
- [ ] Verify cache endpoint returns correct avatar count (should match DB)
- [ ] Verify `PathfinderPathAuditViolationSustained` alert resolves
- [ ] After staging verification, merge to dev for prod deployment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Group registrations are now correctly included in the avatars list returned by the graph retrieval function.

* **Tests**
  * Added test coverage to verify that both human and group registrations appear in the avatars list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->