### PR TITLE
fix(cache,pathfinder): address 4 audit findings (C1, H1, H2, H3)

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -23,8 +23,11 @@ public class PathfinderGraphController : ControllerBase
     /// <summary>
     /// Standard treasury mint address — only groups with this mint policy
     /// participate in the pathfinder's transitive transfer routing.
+    /// Reads V2_STANDARD_MINT_POLICY env var (same as Pathfinder Settings.StandardMintPolicyAddress).
     /// </summary>
-    private const string StandardTreasuryMint = "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
+    private static readonly string StandardTreasuryMint =
+        Environment.GetEnvironmentVariable("V2_STANDARD_MINT_POLICY")?.Trim().ToLowerInvariant()
+        ?? "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
 
     private const int SchemaVersion = 1;
 
@@ -168,15 +171,23 @@ public class PathfinderGraphController : ControllerBase
             if (attoBalance == BigInteger.Zero)
                 continue;
 
-            // Get last activity timestamp
-            _caches.V2LastActivity.TryGetValue(kvp.Key, out var lastActivity);
+            // Get last activity timestamp.
+            // Defensive: warmup and incremental paths always write lastActivity alongside
+            // balance from the same source. This guard protects against hypothetical cache
+            // inconsistency — skip rather than emit an undecayed balance.
+            var hasLastActivity = _caches.V2LastActivity.TryGetValue(kvp.Key, out var lastActivity);
 
             if (isStatic)
             {
                 // Static (inflationary) → convert to demurraged equivalent at target day
                 attoBalance = CirclesConverter.InflationaryToDemurrage(attoBalance, targetDay);
             }
-            else if (lastActivity >= V2InflationDayZero)
+            else if (!hasLastActivity || lastActivity < V2InflationDayZero)
+            {
+                // Missing or pre-epoch timestamp → cannot compute demurrage → skip
+                continue;
+            }
+            else
             {
                 // Demurraged: apply demurrage from lastActivity → now
                 var lastActivityDay = (ulong)(lastActivity - V2InflationDayZero) / (ulong)SecondsPerDay;

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -6,16 +6,21 @@ namespace Circles.Pathfinder.Graphs;
 
 public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph, ILogger<GraphFactory>? graphFactoryLogger = null)
 {
-    private volatile CapacityGraphSnapshot? _current;
+    private volatile SnapshotState? _state;
     private volatile CapacityGraphSnapshot? _currentWrapped;
-    private volatile CachedGroupData? _cachedGroupData;
     private readonly GraphFactory _gf = new(routerAddress, loadGraph, graphFactoryLogger);
 
+    /// <summary>
+    /// Packs snapshot + cachedGroupData into a single reference so readers
+    /// always see a consistent pair (no torn read between two volatile fields).
+    /// </summary>
+    private sealed record SnapshotState(CapacityGraphSnapshot Snapshot, CachedGroupData? GroupData);
+
     /// <summary>Whether a snapshot has been loaded (used by health checks).</summary>
-    public bool HasCurrentSnapshot => _current is not null;
+    public bool HasCurrentSnapshot => _state is not null;
 
     /// <summary>Current snapshot (for metrics). May be null before first load.</summary>
-    public CapacityGraphSnapshot? CurrentSnapshot => _current;
+    public CapacityGraphSnapshot? CurrentSnapshot => _state?.Snapshot;
 
     /// <summary>Current wrapped snapshot (for metrics). May be null before first load.</summary>
     public CapacityGraphSnapshot? CurrentWrappedSnapshot => _currentWrapped;
@@ -26,11 +31,9 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
 
     public void UpdateSnapshot(CapacityGraphSnapshot snap, CachedGroupData? groupData = null)
     {
-        // Store cached group data before snapshot so readers see it when they see the new snapshot
-        _cachedGroupData = groupData;
-        // Volatile write (field is already volatile) — old snapshot becomes
-        // eligible for GC once all in-flight requests release their references.
-        _current = snap;
+        // Single volatile write — readers always see consistent snapshot+groupData pair.
+        // Old state becomes eligible for GC once all in-flight requests release their references.
+        _state = new SnapshotState(snap, groupData);
     }
 
     /// <summary>
@@ -50,8 +53,9 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
         BalanceGraph balances,
         IReadOnlyDictionary<int, HashSet<int>> trust)
     {
-        var snap = _current;
-        if (snap == null)
+        // Single volatile read — snapshot and groupData are always consistent.
+        var state = _state;
+        if (state == null)
             throw new InvalidOperationException("No capacity graph available yet.");
 
         if (RequestNeedsFiltering(r))
@@ -68,13 +72,13 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
             }
 
             // build ad-hoc filtered graph, using cached group/consent data to skip DB queries
-            var g = _gf.CreateCapacityGraph(balances, trust, r, _cachedGroupData);
-            g.Block = snap.Block; // propagate block for replay logging
+            var g = _gf.CreateCapacityGraph(balances, trust, r, state.GroupData);
+            g.Block = state.Snapshot.Block; // propagate block for replay logging
             return Task.FromResult(new CapacityGraphHandle(g));
         }
 
         // Return the shared snapshot — GC keeps it alive while referenced
-        return Task.FromResult(new CapacityGraphHandle(snap.Base));
+        return Task.FromResult(new CapacityGraphHandle(state.Snapshot.Base));
     }
 
     /* ------------------------------------------------------------------ */

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -535,8 +535,16 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 continue;
             }
 
-            int trusterId = AddressIdPool.IdOf(st.Truster.ToLowerInvariant());
-            int trusteeId = AddressIdPool.IdOf(st.Trustee.ToLowerInvariant());
+            var trusterNorm = st.Truster.Trim().ToLowerInvariant();
+            var trusteeNorm = st.Trustee.Trim().ToLowerInvariant();
+            if (!IsValidEthereumAddress(trusterNorm) || !IsValidEthereumAddress(trusteeNorm))
+            {
+                _logger.LogWarning("Invalid address in simulated trust: truster='{Truster}' trustee='{Trustee}' (skipped)", st.Truster, st.Trustee);
+                continue;
+            }
+
+            int trusterId = AddressIdPool.IdOf(trusterNorm);
+            int trusteeId = AddressIdPool.IdOf(trusteeNorm);
 
             if (!result.TryGetValue(trusterId, out var set))
             {
@@ -598,10 +606,23 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 continue;
             }
 
-            int holderId = AddressIdPool.IdOf(sb.Holder.ToLowerInvariant());
-            int tokenId = AddressIdPool.IdOf(sb.Token.ToLowerInvariant());
+            var holderNorm = sb.Holder.Trim().ToLowerInvariant();
+            var tokenNorm = sb.Token.Trim().ToLowerInvariant();
+            if (!IsValidEthereumAddress(holderNorm) || !IsValidEthereumAddress(tokenNorm))
+            {
+                _logger.LogWarning("Invalid address in simulated balance: holder='{Holder}' token='{Token}' (skipped)", sb.Holder, sb.Token);
+                continue;
+            }
 
-            var amt = CirclesConverter.TruncateToInt64(UInt256.Parse(sb.Amount));
+            int holderId = AddressIdPool.IdOf(holderNorm);
+            int tokenId = AddressIdPool.IdOf(tokenNorm);
+
+            if (!UInt256.TryParse(sb.Amount, out var parsedAmount))
+            {
+                _logger.LogWarning("Invalid amount in simulated balance: '{Amount}' (skipped)", sb.Amount);
+                continue;
+            }
+            var amt = CirclesConverter.TruncateToInt64(parsedAmount);
             if (amt <= 0)
             {
                 continue;


### PR DESCRIPTION
## Summary

Consolidated fixes for 4 findings from the 6-agent multi-angle audit.

### C1 — Missing lastActivity demurrage bypass (Critical)
- **File**: `PathfinderGraphController.cs:172`
- **Bug**: `V2LastActivity.TryGetValue` defaults `lastActivity` to 0 when entry is missing → demurrage guard `lastActivity >= V2InflationDayZero` evaluates false → undecayed balance emitted → overestimates on-chain capacity
- **Fix**: Check `TryGetValue` return value; skip non-static balances with no activity record

### H1 — Non-atomic CapacityGraphPool swap (High)
- **File**: `CapacityGraphPool.cs:27-34`
- **Bug**: `_cachedGroupData` written before `_current` as two separate volatile fields → filtered requests briefly see mismatched snapshot+groupData pair
- **Fix**: Pack both into single `SnapshotState` record — one volatile reference, no torn reads

### H2 — StandardTreasuryMint config coupling (High)
- **File**: `PathfinderGraphController.cs:27`
- **Bug**: Cache hardcoded `0xcdfc...` while Pathfinder read `V2_STANDARD_MINT_POLICY` env var → if env overridden, groups silently disappear from cache path
- **Fix**: Cache now reads same `V2_STANDARD_MINT_POLICY` env var with identical default

### H3 — AddressIdPool DoS via simulated addresses (High)
- **File**: `GraphFactory.cs:538,601`
- **Bug**: `NormalizeSimulatedTrusts` and `NormalizeSimulatedBalances` passed unvalidated user-supplied strings to `AddressIdPool.IdOf` → permanent memory growth from arbitrary input
- **Fix**: Add `IsValidEthereumAddress` guard before `IdOf` (matches existing `SimulatedConsentedAvatars` pattern)

## Not addressed (architectural / lower priority)
- **C2** — FlowMatrixEncoder wrapper TokenOwner (canary-only, needs separate wrapper→avatar resolution refactor)
- **H4** — Zombie solver threads (OR-Tools architectural limitation, no clean cancellation path)
- Medium items (decompression bomb, TruncateToInt64 saturation, NetworkState atomicity, etc.)

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 5/5 projects pass
- [ ] Deploy to staging, verify no regressions
- [ ] Monitor `circles_path_audit_violations_total` stays at 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation: invalid Ethereum addresses and malformed amounts in ingested data are now rejected and logged; bad entries are skipped.
  * Balance handling updated to skip records lacking complete activity history, preventing incorrect demurrage calculations.
  * Snapshot reads made atomic/consistent to avoid intermittent inconsistencies when producing capacity data.

* **Configuration**
  * Treasury mint address now read from an environment setting with automatic fallback to the previous default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->