### PR TITLE
fix(pathfinder): disable demurrage safety margin (default 1.0)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder/README.md
+++ b/src/Pathfinder/Circles.Pathfinder/README.md
@@ -209,7 +209,7 @@ The pathfinder can load its trust graph from the **Cache Service** (recommended)
 |----------|---------|-------------|
 | `MAX_CONCURRENT_REQUESTS` | `max(CPUCount × 2, 8)` | Max concurrent pathfinder requests |
 | `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | `10` | MaxFlow solver timeout per request |
-| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `0.9995` | 0.05% haircut on demurraged balances to avoid rounding reverts |
+| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `1.0` | Multiplicative factor on demurraged balances (1.0 = disabled, <1.0 = haircut) |
 | `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | `true` | Exclude consented avatars from intermediary positions in paths |
 
 ### Materialized View Refresh

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -39,13 +39,17 @@ public class Settings
 
     /// <summary>
     /// Safety margin factor applied to demurraged balances to account for the delay
-    /// between graph-build time and on-chain execution. Default 0.9995 (0.05% haircut).
-    /// Set to 1.0 to disable. Only applies when TargetDemurrageTimestamp is null (live mode).
+    /// between graph-build time and on-chain execution. Default 1.0 (disabled).
+    /// The previous default of 0.9995 (0.05% haircut) blocked exact-amount transfers
+    /// when the sender held precisely the required balance (e.g. organization refunds).
+    /// Demurrage drift over a realistic 60s delay is ~0.000014%, making even 0.9995
+    /// orders of magnitude too aggressive. Override via PATHFINDER_DEMURRAGE_SAFETY_MARGIN
+    /// if a margin is ever needed again. Only applies when TargetDemurrageTimestamp is null.
     /// </summary>
     public double DemurrageSafetyMargin { get; set; } =
         Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN") != null
         ? double.Parse(Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN")!)
-        : 0.9995;
+        : 1.0;
 
     /// <summary>
     /// Timeout in seconds for the MaxFlow solver. Default 30s.


### PR DESCRIPTION
## Summary

- Disables the demurrage safety margin by changing the default from `0.9995` to `1.0`
- The 0.05% haircut was blocking exact-amount refunds from organizations that held precisely the required balance
- Demurrage drift over realistic 60s delays is ~0.000014%, making the previous margin orders of magnitude too aggressive
- The `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` env var override remains available if a margin is ever needed

## Root Cause

Organization accounts that held exactly the refund amount in trusted tokens had their maxFlow reduced below the threshold by the safety margin. Confirmed for multiple affected users via production pathfinder logs.

## Test plan

- [x] All pathfinder tests pass (existing tests use explicit margin values, not the default)
- [ ] Deploy to staging and verify maxFlow accuracy
- [ ] Rolling deploy to prod