### PR TITLE
revert: restore IpfsDownloader + ipfs_files pipeline on staging

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/ProfilesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/ProfilesController.cs
@@ -117,8 +117,66 @@ public class ProfilesController : ControllerBase
         }
     }
 
-    // Profile content endpoints (content/{cid}, content/batch) removed —
-    // profile content is now served by the profile pinning service via /api/rawBatch.
-    // The pinning service serves from its verified DB, immune to IPFS gateway failures.
-    // See: PROFILE_CONTENT_SERVICE_URL env var in CacheServiceClient.
+    /// <summary>
+    /// Get profile content (IPFS payload) for a single CID
+    /// </summary>
+    [HttpGet("content/{cid}")]
+    public async Task<ActionResult<ProfileContentResponse>> GetProfileContent(string cid)
+    {
+        try
+        {
+            var lastBlock = _state.LastProcessedBlock;
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            var content = await _ipfsCache.GetAsync(cid);
+            var cleanedContent = IpfsContentCache.StripJsonLdFields(content);
+
+            return Ok(new ProfileContentResponse(cid, cleanedContent, lastBlock, timestamp));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting profile content for CID {Cid}", cid);
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
+
+    /// <summary>
+    /// Get profile content (IPFS payloads) for multiple CIDs in batch
+    /// </summary>
+    [HttpPost("content/batch")]
+    public async Task<ActionResult<ProfileContentResponse[]>> GetProfileContentBatch([FromBody] ProfileContentBatchRequest request)
+    {
+        // Validate batch size
+        if (request.Cids.Length > MaxBatchSize)
+        {
+            return BadRequest(new { error = $"Batch size exceeds limit of {MaxBatchSize} CIDs" });
+        }
+
+        _logger.LogDebug(
+            "Profile content batch lookup requested for {Count} CIDs from {RemoteIp}",
+            request.Cids.Length,
+            GetRemoteIp());
+
+        try
+        {
+            var lastBlock = _state.LastProcessedBlock;
+            var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            var contents = await _ipfsCache.GetBatchAsync(request.Cids);
+            var results = new ProfileContentResponse[request.Cids.Length];
+
+            for (int i = 0; i < request.Cids.Length; i++)
+            {
+                var cleanedContent = IpfsContentCache.StripJsonLdFields(contents[i]);
+                results[i] = new ProfileContentResponse(request.Cids[i], cleanedContent, lastBlock, timestamp);
+            }
+
+            return Ok(results);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting batch profile content");
+            return StatusCode(500, new { error = "Internal server error" });
+        }
+    }
 }

--- a/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Avatars.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_Crc_Avatars.sql
@@ -125,15 +125,69 @@ END;
 $$;
 
 -- ================================================================
--- IPFS queue triggers — REMOVED
--- Profile content is now served by the profile pinning service
--- (PROFILE_CONTENT_SERVICE_URL). The ipfs_queue and ipfs_files tables
--- are kept for now but no longer written to.
--- Drop the triggers that previously inserted into ipfs_queue:
+-- ipfs_enqueue_triggers.sql
+-- Automatically adds CID rows to ipfs_queue whenever metadata-
+-- digest rows land in the V1/V2 tables.
+--
+-- Assumes a `base58_encode(bytea)` function is available.
 -- ================================================================
-DROP TRIGGER IF EXISTS trg_enq_ipfs_v1 ON public."CrcV1_UpdateMetadataDigest";
-DROP TRIGGER IF EXISTS trg_enq_ipfs_v2 ON public."CrcV2_UpdateMetadataDigest";
-DROP FUNCTION IF EXISTS public.enqueue_ipfs_from_update();
+-- ----------------------------------------------------------------
+-- 1. Trigger function (statement-level, shared by both tables)
+-- ----------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.enqueue_ipfs_from_update()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+BEGIN
+    /*  Collect all distinct CIDs created by this INSERT and push only the
+        ones we haven’t already downloaded or queued.  */
+    WITH candidate_cids AS (
+                SELECT DISTINCT
+               base58_encode(decode('1220','hex') || nr."metadataDigest") AS cid,
+               nr."metadataDigest"                                             AS metadata_digest
+        FROM new_rows nr
+        WHERE nr."metadataDigest" IS NOT NULL
+     ),
+              missing AS (
+                 SELECT cid, metadata_digest
+                 FROM candidate_cids c
+                 WHERE NOT EXISTS (SELECT 1 FROM ipfs_files f WHERE f.cid = c.cid)
+                   AND NOT EXISTS (SELECT 1 FROM ipfs_queue q WHERE q.cid = c.cid)
+              )
+         INSERT INTO ipfs_queue (cid, metadata_digest, status, attempt_count, next_retry, updated_at)
+              SELECT cid, metadata_digest, 'PENDING', 0, NOW(), NOW()
+        FROM missing
+    ON CONFLICT DO NOTHING; -- double-insert safety
+
+    RETURN NULL;
+END;
+$$;
+
+-- ----------------------------------------------------------------
+-- 2. Attach the trigger to both metadata-digest tables
+-- ----------------------------------------------------------------
+-- V1
+DROP TRIGGER IF EXISTS trg_enq_ipfs_v1
+    ON public."CrcV1_UpdateMetadataDigest";
+
+CREATE TRIGGER trg_enq_ipfs_v1
+    AFTER INSERT
+    ON public."CrcV1_UpdateMetadataDigest"
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT
+EXECUTE FUNCTION public.enqueue_ipfs_from_update();
+
+-- V2
+DROP TRIGGER IF EXISTS trg_enq_ipfs_v2
+    ON public."CrcV2_UpdateMetadataDigest";
+
+CREATE TRIGGER trg_enq_ipfs_v2
+    AFTER INSERT
+    ON public."CrcV2_UpdateMetadataDigest"
+    REFERENCING NEW TABLE AS new_rows
+    FOR EACH STATEMENT
+EXECUTE FUNCTION public.enqueue_ipfs_from_update();
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 

--- a/src/Index/Circles.Index.Profiles/IpfsDownloader.cs
+++ b/src/Index/Circles.Index.Profiles/IpfsDownloader.cs
@@ -1,0 +1,457 @@
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+using Dapper;
+using Npgsql;
+
+// Entry point ─────────────────────────────────────────────────────────────────
+public static class IpfsDownloader
+{
+    // === Config ==============================================================
+    private static readonly int MaxParallelism = GetEnvInt("IPFS_MAX_PARALLELISM", 192);
+    private static readonly int HttpTimeoutSeconds = GetEnvInt("IPFS_HTTP_TIMEOUT_SEC", 1);
+    private static readonly int MaxBackoffSeconds = GetEnvInt("IPFS_MAX_BACKOFF_SEC", 3600 * 72);
+    private static readonly int StatsIntervalSec = GetEnvInt("IPFS_STATS_INTERVAL_SEC", 30);
+    private static readonly int ErrorMaxLen = GetEnvInt("IPFS_ERROR_MAX_LEN", 1024);
+    private static readonly int WriterBatchSize = GetEnvInt("IPFS_WRITER_BATCH_SIZE", 256);
+    private static readonly long MaxDownloadBytes = GetEnvLong("IPFS_MAX_DOWNLOAD_BYTES", 164L * 1024);
+    private static readonly int ChannelCapacity = MaxParallelism * 8;
+
+    private static readonly string[] Gateways =
+        Environment.GetEnvironmentVariable("IPFS_GATEWAYS") is { Length: > 0 } gwEnv
+            ? gwEnv.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            : ["https://circles-profiles.myfilebase.com"];
+
+    private static int GetEnvInt(string name, int @default) =>
+        int.TryParse(Environment.GetEnvironmentVariable(name), out var val) && val > 0
+            ? val
+            : @default;
+
+    private static long GetEnvLong(string name, long @default) =>
+        long.TryParse(Environment.GetEnvironmentVariable(name), out var val) && val > 0
+            ? val
+            : @default;
+
+    // === Globals ==============================================================
+
+    private static readonly HttpClient[] _clients =
+        Gateways.Select(gw =>
+        {
+            var handler = new SocketsHttpHandler
+            {
+                MaxConnectionsPerServer = MaxParallelism,
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            };
+
+            return new HttpClient(handler)
+            {
+                BaseAddress = new Uri(gw, UriKind.Absolute),
+                Timeout = TimeSpan.FromSeconds(HttpTimeoutSeconds)
+            };
+        }).ToArray();
+
+    private static int _roundRobin;
+
+    private static readonly Channel<PersistJob> PersistQueue =
+        Channel.CreateBounded<PersistJob>(
+            new BoundedChannelOptions(ChannelCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait
+            });
+
+    private static long _okCount;
+    private static long _failCount;
+    private static long _bytesTotal;
+
+    // === Main =================================================================
+    public static async Task Main(CancellationToken ct, string connectionString)
+    {
+        Console.WriteLine("[BOOT] starting IPFS downloader");
+
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        Task writerTask = Task.Run(
+            () => WriterLoopAsync(PersistQueue.Reader, ct, connectionString),
+            ct);
+
+        Task reaperTask = Task.Run(
+            () => ReaperLoopAsync(ct, connectionString),
+            ct);
+
+        Task statsTask = Task.Run(
+            () => StatsLoopAsync(ct),
+            ct);
+
+        while (!ct.IsCancellationRequested)
+        {
+            List<QueueRow> batch;
+            try
+            {
+                batch = await ReserveAsync(conn, MaxParallelism * 4);
+            }
+            catch (PostgresException pgEx) when (IsTransient(pgEx))
+            {
+                Console.WriteLine($"[WARN] transient DB error during reserve: {pgEx.Message}");
+                await ReopenAsync(conn, ct);
+                await Task.Delay(1000, ct);
+                continue;
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                Console.WriteLine($"[WARN] reserve failed: {ex.Message}");
+                await Task.Delay(1000, ct);
+                continue;
+            }
+
+            if (batch.Count == 0)
+            {
+                await Task.Delay(100, ct);
+                continue;
+            }
+
+            ParallelOptions opts = new()
+            {
+                MaxDegreeOfParallelism = MaxParallelism,
+                CancellationToken = ct
+            };
+
+            await Parallel.ForEachAsync(batch, opts,
+                async (row, ct) => { await ProcessAsync(row, ct); });
+        }
+
+        Console.WriteLine("[SHUTDOWN] cancelling…");
+        PersistQueue.Writer.Complete();
+        await Task.WhenAll(writerTask, statsTask, reaperTask);
+        foreach (HttpClient c in _clients) c.Dispose();
+        Console.WriteLine("[SHUTDOWN] done");
+    }
+
+    private static async Task ReaperLoopAsync(CancellationToken ct, string connectionString)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            try
+            {
+                await using var conn = new NpgsqlConnection(connectionString);
+                await conn.OpenAsync(ct);
+                const string reset = @"
+                UPDATE ipfs_queue
+                   SET status     = 'FAILED',
+                       next_retry = NOW(),
+                       updated_at = NOW()
+                 WHERE status = 'IN_PROGRESS'
+                   AND updated_at < NOW() - INTERVAL '1 minute';";
+                await conn.ExecuteAsync(reset, ct);
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                Console.WriteLine($"[REAPER] failed: {ex.Message}");
+            }
+        }
+    }
+
+    // === Work reservation =====================================================
+    private static async Task<List<QueueRow>> ReserveAsync(
+        NpgsqlConnection conn,
+        int limit)
+    {
+        const string sql = @"
+            WITH pick AS (
+                SELECT cid, attempt_count
+                  FROM ipfs_queue
+                 WHERE status IN ('PENDING','FAILED')
+                   AND next_retry <= NOW()
+                 ORDER BY next_retry
+                 LIMIT @limit
+                 FOR UPDATE SKIP LOCKED
+            )
+            UPDATE ipfs_queue q
+               SET status     = 'IN_PROGRESS',
+                   updated_at = NOW()
+              FROM pick
+             WHERE q.cid = pick.cid
+          RETURNING q.cid AS ""Cid"",
+                    q.metadata_digest AS ""MetadataDigest"",
+                    q.attempt_count AS ""AttemptCount"";
+        ";
+
+        IEnumerable<QueueRow> rows = await conn.QueryAsync<QueueRow>(sql, new { limit });
+        return rows.ToList();
+    }
+
+    // === One download =========================================================
+    private static async Task ProcessAsync(
+        QueueRow row,
+        CancellationToken ct)
+    {
+        bool success;
+        bool blacklisted = false;
+        string? json = null;
+        string? error = null;
+        Stopwatch sw = Stopwatch.StartNew();
+
+        try
+        {
+            HttpClient client = NextClient();
+
+            using HttpRequestMessage req = new(HttpMethod.Get, $"ipfs/{row.Cid}");
+            using HttpResponseMessage resp =
+                await client.SendAsync(req, HttpCompletionOption.ResponseHeadersRead, ct);
+
+            resp.EnsureSuccessStatusCode();
+
+            long? contentLength = resp.Content.Headers.ContentLength;
+            if (contentLength.HasValue && contentLength.Value > MaxDownloadBytes)
+            {
+                blacklisted = true;
+                throw new InvalidOperationException(
+                    $"Payload too large: {contentLength.Value} B > {MaxDownloadBytes} B");
+            }
+
+            await using var stream = await resp.Content.ReadAsStreamAsync(ct);
+            using var ms = new MemoryStream();
+
+            byte[] buffer = new byte[8192];
+            int read;
+            long total = 0;
+            while ((read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), ct)) > 0)
+            {
+                total += read;
+                if (total > MaxDownloadBytes)
+                {
+                    blacklisted = true;
+                    throw new InvalidOperationException(
+                        $"Payload exceeded limit {MaxDownloadBytes} B while streaming");
+                }
+
+                ms.Write(buffer, 0, read);
+            }
+
+            json = Encoding.UTF8.GetString(ms.ToArray());
+
+            // -------- JSON validation --------
+            try
+            {
+                JsonDocument.Parse(json);
+                success = true;
+            }
+            catch (JsonException)
+            {
+                success = false;
+                blacklisted = true;
+                error = "invalid JSON payload";
+            }
+        }
+        catch (Exception ex) when (!ct.IsCancellationRequested)
+        {
+            success = false;
+            error = ex.Message;
+            Console.WriteLine($"[WARN] download failed for {row.Cid}: {error}");
+        }
+        finally
+        {
+            sw.Stop();
+        }
+
+        int nextAttempt = success ? row.AttemptCount : row.AttemptCount + 1;
+        long sizeBytes = json is not null ? Encoding.UTF8.GetByteCount(json) : 0;
+
+        if (success)
+        {
+            Console.WriteLine($"[OK]   {row.Cid}  {sizeBytes} B  {sw.ElapsedMilliseconds} ms");
+            Interlocked.Add(ref _bytesTotal, sizeBytes);
+            Interlocked.Increment(ref _okCount);
+        }
+        else
+        {
+            Interlocked.Increment(ref _failCount);
+        }
+
+        await PersistQueue.Writer.WriteAsync(
+            new PersistJob(row.Cid, row.MetadataDigest, success, blacklisted, json, error, nextAttempt), ct);
+    }
+
+    private static HttpClient NextClient()
+    {
+        int index = Interlocked.Increment(ref _roundRobin);
+        return _clients[index % _clients.Length];
+    }
+
+    // === Dedicated writer =====================================================
+    private static async Task WriterLoopAsync(
+        ChannelReader<PersistJob> reader,
+        CancellationToken ct,
+        string connectionString)
+    {
+        await using var conn = new NpgsqlConnection(connectionString);
+        await conn.OpenAsync(ct);
+
+        while (!ct.IsCancellationRequested && await reader.WaitToReadAsync(ct))
+        {
+            var batch = new List<PersistJob>(WriterBatchSize);
+            while (batch.Count < WriterBatchSize && reader.TryRead(out var job))
+            {
+                batch.Add(job);
+            }
+
+            if (conn.FullState != System.Data.ConnectionState.Open)
+                await ReopenAsync(conn, ct);
+
+            try
+            {
+                await using var tx = await conn.BeginTransactionAsync(ct);
+
+                // successes
+                var completed = batch.Where(j => j.Success).ToList();
+                if (completed.Count > 0)
+                {
+                    const string insertFile = @"
+                        INSERT INTO ipfs_files (cid, metadata_digest, payload)
+                        VALUES (@cid, @metadata_digest, @json::jsonb)
+                        ON CONFLICT DO NOTHING;";
+                    await conn.ExecuteAsync(insertFile,
+                        completed.Select(j => new
+                        {
+                            cid = j.Cid,
+                            metadata_digest = j.MetadataDigest,
+                            json = j.Json
+                        }), tx);
+
+                    const string markDone = @"
+                        UPDATE ipfs_queue
+                           SET status     = 'COMPLETED',
+                               updated_at = NOW()
+                         WHERE cid = ANY(@cids);";
+                    await conn.ExecuteAsync(markDone,
+                        new { cids = completed.Select(j => j.Cid).ToArray() }, tx);
+                }
+
+                // blacklisted
+                var blacklisted = batch.Where(j => j.Blacklisted).ToList();
+                foreach (var job in blacklisted)
+                {
+                    string errorTrunc = Truncate(job.Error);
+                    const string markBlack = @"
+                        UPDATE ipfs_queue
+                           SET status        = 'BLACKLISTED',
+                               attempt_count = @nextAttempt,
+                               last_error    = @error,
+                               updated_at    = NOW()
+                         WHERE cid = @cid;";
+                    await conn.ExecuteAsync(markBlack, new
+                    {
+                        cid = job.Cid,
+                        nextAttempt = job.NextAttempt,
+                        error = errorTrunc
+                    }, tx);
+                }
+
+                // regular failures
+                var failed = batch.Where(j => !j.Success && !j.Blacklisted).ToList();
+                foreach (var job in failed)
+                {
+                    TimeSpan backoff = CalcBackoff(job.NextAttempt);
+
+                    string errorTrunc = Truncate(job.Error);
+                    const string markFail = @"
+                        UPDATE ipfs_queue
+                           SET status        = 'FAILED',
+                               attempt_count = @nextAttempt,
+                               last_error    = @error,
+                               next_retry    = NOW() + @backoff,
+                               updated_at    = NOW()
+                         WHERE cid = @cid;";
+                    await conn.ExecuteAsync(markFail, new
+                    {
+                        cid = job.Cid,
+                        nextAttempt = job.NextAttempt,
+                        error = errorTrunc,
+                        backoff
+                    }, tx);
+                }
+
+                await tx.CommitAsync(ct);
+            }
+            catch (PostgresException pgEx) when (IsTransient(pgEx))
+            {
+                Console.WriteLine($"[WARN] writer transient DB error: {pgEx.SqlState} – {pgEx.Message}");
+                await ReopenAsync(conn, ct);
+            }
+            catch (Exception ex) when (!ct.IsCancellationRequested)
+            {
+                Console.WriteLine($"[ERROR] writer crashed while persisting: {ex}");
+            }
+        }
+    }
+
+    // === Stats loop ===========================================================
+    private static async Task StatsLoopAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(TimeSpan.FromSeconds(StatsIntervalSec), ct);
+
+            long ok = Interlocked.Exchange(ref _okCount, 0);
+            long fail = Interlocked.Exchange(ref _failCount, 0);
+            long mb = Interlocked.Exchange(ref _bytesTotal, 0) / 1_000_000;
+
+            Console.WriteLine(
+                $"[STATS] last {StatsIntervalSec}s  ok={ok}  fail={fail}  MB={mb}  queued={PersistQueue.Reader.Count}/{ChannelCapacity}");
+        }
+    }
+
+    // === Helpers ==============================================================
+    private static TimeSpan CalcBackoff(int attempt)
+    {
+        double baseSec = Math.Pow(2, Math.Min(attempt, 16));
+        double jitterFactor = 0.5 + Random.Shared.NextDouble();
+        double secs = baseSec * jitterFactor;
+
+        return secs > MaxBackoffSeconds
+            ? TimeSpan.FromSeconds(MaxBackoffSeconds)
+            : TimeSpan.FromSeconds(secs);
+    }
+
+    private static bool IsTransient(PostgresException ex) =>
+        ex.IsTransient ||
+        (ex.SqlState is { Length: 5 } state && state.StartsWith("08", StringComparison.Ordinal));
+
+    private static async Task ReopenAsync(NpgsqlConnection conn, CancellationToken ct)
+    {
+        try
+        {
+            await conn.CloseAsync();
+        }
+        catch
+        {
+            /* ignore */
+        }
+
+        await conn.OpenAsync(ct);
+    }
+
+    private static string Truncate(string? text) =>
+        string.IsNullOrEmpty(text)
+            ? string.Empty
+            : text!.Length > ErrorMaxLen
+                ? text[..ErrorMaxLen]
+                : text;
+
+    // === Record types =========================================================
+    private sealed record QueueRow(string Cid, byte[] MetadataDigest, int AttemptCount);
+
+    private sealed record PersistJob(
+        string Cid,
+        byte[] MetadataDigest,
+        bool Success,
+        bool Blacklisted,
+        string? Json,
+        string? Error,
+        int NextAttempt);
+}

--- a/src/Index/Circles.Index.Profiles/IpfsQueueInserter.cs
+++ b/src/Index/Circles.Index.Profiles/IpfsQueueInserter.cs
@@ -1,0 +1,45 @@
+using Dapper;
+using Npgsql;
+
+/// <summary>
+/// High-performance, thread-safe helper to bulk-insert CIDs into the ipfs_queue table.
+/// </summary>
+public static class IpfsQueueInserter
+{
+    private static readonly string ConnectionString =
+        Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING") ?? throw new Exception("Postgres connection (env var: POSTGRES_CONNECTION_STRING) string not found");
+
+    private static readonly NpgsqlDataSource DataSource = NpgsqlDataSource.Create(ConnectionString);
+
+    /// <summary>
+    /// Fast path for a single CID.
+    /// </summary>
+    public static Task InsertAsync(string cid, CancellationToken ct = default) =>
+        InsertAsync([cid], ct);
+
+    /// <summary>
+    /// Bulk-inserts CIDs. Uses one round-trip and lets Postgres de-dupe via
+    /// <c>ON CONFLICT DO NOTHING</c>.
+    /// </summary>
+    public static async Task InsertAsync(IEnumerable<string> cids, CancellationToken ct = default)
+    {
+        string[] cidArray = (cids as string[]) ?? cids.ToArray();
+
+        bool nothingToInsert = cidArray.Length == 0;
+        if (nothingToInsert)
+        {
+            return;
+        }
+
+        const string sql = @"
+            INSERT INTO ipfs_queue (cid, status, attempt_count, next_retry, updated_at)
+            SELECT cid, 'PENDING', 0, NOW(), NOW()
+              FROM unnest(@cids) cid
+            ON CONFLICT DO NOTHING;";
+
+        await using NpgsqlConnection conn = await DataSource.OpenConnectionAsync(ct);
+
+        // Dapper maps string[] → text[] automatically.
+        await conn.ExecuteAsync(sql, new { cids = cidArray });
+    }
+}

--- a/src/Index/Circles.Index/Plugin.cs
+++ b/src/Index/Circles.Index/Plugin.cs
@@ -38,6 +38,8 @@ public class Plugin : INethermindPlugin
     private int _isProcessing;
     private int _newItemsArrived;
     private long _latestHeadToIndex = -1;
+    private Task? _ipfsDownloader;
+
     public Task Init(INethermindApi nethermindApi)
     {
         ILogger baseLogger = nethermindApi.LogManager.GetClassLogger();
@@ -115,7 +117,72 @@ public class Plugin : INethermindPlugin
             , nethermindApi.ReceiptFinder!
             , _cancellationTokenSource.Token);
 
+        // Run the downloader
+        _ipfsDownloader = Task.Run(async () => await RunIpfsDownloader(settings),
+            _cancellationTokenSource.Token);
+
         return Task.CompletedTask;
+    }
+
+    private async Task RunIpfsDownloader(Settings settings)
+    {
+        while (!_cancellationTokenSource.IsCancellationRequested)
+        {
+            try
+            {
+                var seedQuery = @"
+                    WITH digests AS (
+                        SELECT DISTINCT ""metadataDigest""::bytea AS metadata_digest
+                        FROM ""CrcV1_UpdateMetadataDigest""
+                        UNION ALL
+                        SELECT DISTINCT ""metadataDigest""
+                        FROM ""CrcV2_UpdateMetadataDigest""
+                    ), to_enqueue AS (
+                        SELECT
+                            d.metadata_digest
+                        FROM   digests d
+                                   LEFT   JOIN ipfs_queue q
+                                               ON q.metadata_digest = d.metadata_digest
+                                   LEFT   JOIN ipfs_files f
+                                               ON f.metadata_digest = d.metadata_digest
+                        WHERE  q.cid IS NULL
+                          AND  f.metadata_digest IS NULL
+                    ), with_cid as (
+                        select
+                            base58_encode(decode('1220','hex') || to_enqueue.metadata_digest) AS cid,
+                            metadata_digest
+                        from to_enqueue
+                    )
+                    INSERT INTO ipfs_queue (cid, metadata_digest, status, attempt_count, next_retry, updated_at)
+                    SELECT  cid,
+                            metadata_digest,
+                            'PENDING',
+                            0,
+                            NOW(),
+                            NOW()
+                    FROM   with_cid
+                    ON CONFLICT (cid) DO NOTHING;
+                ";
+
+                await using (var connection = new NpgsqlConnection(settings.IndexDbConnectionString))
+                {
+                    await connection.OpenAsync(_cancellationTokenSource.Token);
+                    await using var command = new NpgsqlCommand(seedQuery, connection);
+                    command.CommandTimeout = 600;
+                    await command.ExecuteNonQueryAsync(_cancellationTokenSource.Token);
+                }
+
+                await IpfsDownloader.Main(
+                    _cancellationTokenSource.Token,
+                    settings.IndexDbConnectionString);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("[IPFS Downloader] IPFS downloader failed: " + ex);
+                await Task.Delay(TimeSpan.FromSeconds(1), _cancellationTokenSource.Token);
+                Console.WriteLine("[IPFS Downloader] restarting IPFS downloader");
+            }
+        }
     }
 
     private void LogSettings(InterfaceLogger pluginLogger, Settings settings, IDatabase database)

--- a/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
+++ b/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
@@ -13,13 +13,11 @@ public class CacheServiceClient
     private readonly HttpClient _httpClient;
     private readonly ILogger<CacheServiceClient>? _logger;
     private readonly string _baseUrl;
-    private readonly string _profileContentBaseUrl;
 
-    public CacheServiceClient(HttpClient httpClient, string baseUrl, ILogger<CacheServiceClient>? logger = null, string? profileContentBaseUrl = null)
+    public CacheServiceClient(HttpClient httpClient, string baseUrl, ILogger<CacheServiceClient>? logger = null)
     {
         _httpClient = httpClient;
         _baseUrl = baseUrl.TrimEnd('/');
-        _profileContentBaseUrl = (profileContentBaseUrl ?? baseUrl).TrimEnd('/');
         _logger = logger;
     }
 
@@ -319,14 +317,30 @@ public class CacheServiceClient
     }
 
     /// <summary>
-    /// Get profile content (IPFS payloads) for multiple CIDs in batch.
-    /// Routes to the profile pinning service when PROFILE_CONTENT_SERVICE_URL is set.
+    /// Get profile content (IPFS payload) for a single CID
+    /// </summary>
+    public async Task<ProfileContentResponse?> GetProfileContentAsync(string cid, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var url = $"{_baseUrl}/api/profiles/content/{cid}";
+            return await _httpClient.GetFromJsonAsync<ProfileContentResponse>(url, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error getting profile content from cache service for CID {Cid}", cid);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Get profile content (IPFS payloads) for multiple CIDs in batch
     /// </summary>
     public async Task<ProfileContentResponse[]> GetProfileContentBatchAsync(string[] cids, CancellationToken cancellationToken = default)
     {
         try
         {
-            var url = $"{_profileContentBaseUrl}/api/rawBatch";
+            var url = $"{_baseUrl}/api/profiles/content/batch";
             var request = new ProfileContentBatchRequest(cids);
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();

--- a/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
+++ b/src/Rpc/Circles.Rpc.CacheServiceClient/CacheServiceClient.cs
@@ -326,7 +326,7 @@ public class CacheServiceClient
     {
         try
         {
-            var url = $"{_profileContentBaseUrl}/rawBatch";
+            var url = $"{_profileContentBaseUrl}/api/rawBatch";
             var request = new ProfileContentBatchRequest(cids);
             var response = await _httpClient.PostAsJsonAsync(url, request, cancellationToken);
             response.EnsureSuccessStatusCode();

--- a/src/Rpc/Circles.Rpc.CacheServiceClient/Models/CacheServiceModels.cs
+++ b/src/Rpc/Circles.Rpc.CacheServiceClient/Models/CacheServiceModels.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace Circles.Rpc.CacheServiceClient.Models;
 
 /// <summary>
@@ -145,19 +143,16 @@ public record TokenInfoResponse(
 public record TokenInfoBatchRequest(string[] TokenAddresses);
 
 /// <summary>
-/// Response for profile content (IPFS payload) queries.
-/// Uses JsonPropertyName to accept camelCase from the profile pinning service.
+/// Response for profile content (IPFS payload) queries
 /// </summary>
 public record ProfileContentResponse(
-    [property: JsonPropertyName("cid")] string Cid,
-    [property: JsonPropertyName("content")] string? Content,
-    [property: JsonPropertyName("lastProcessedBlock")] long LastProcessedBlock = -1,
-    [property: JsonPropertyName("timestamp")] long Timestamp = 0
+    string Cid,
+    string? Content,
+    long LastProcessedBlock = -1,
+    long Timestamp = 0
 );
 
 /// <summary>
 /// Batch request for profile content
 /// </summary>
-public record ProfileContentBatchRequest(
-    [property: JsonPropertyName("cids")] string[] Cids
-);
+public record ProfileContentBatchRequest(string[] Cids);

--- a/src/Rpc/Circles.Rpc.Host/BuilderSetup.cs
+++ b/src/Rpc/Circles.Rpc.Host/BuilderSetup.cs
@@ -87,7 +87,7 @@ public static class BuilderSetup
                 var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
                 var httpClient = httpClientFactory.CreateClient();
                 var logger = sp.GetService<ILogger<CacheServiceClient.CacheServiceClient>>();
-                return new CacheServiceClient.CacheServiceClient(httpClient, settings.CacheServiceUrl, logger, settings.ProfileContentServiceUrl);
+                return new CacheServiceClient.CacheServiceClient(httpClient, settings.CacheServiceUrl, logger);
             });
         }
 

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -484,8 +484,7 @@ public partial class CirclesRpcModule
             return result;
         }
 
-        // Fetch profile content from the profile pinning service (or cache-service fallback).
-        // The pinning service serves from its verified DB — no IPFS gateway dependency.
+        // Try cache service first, then fall back to database
         if (_settings.UseCacheService && _cacheServiceClient != null)
         {
             try
@@ -512,8 +511,43 @@ public partial class CirclesRpcModule
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Profile content service fetch failed — returning nulls for missing CIDs");
+                _logger?.LogWarning(ex, "Cache service profile content fetch failed, falling back to database");
+                // Fall through to database
             }
+        }
+
+        // Fallback: Fetch missing profiles from database
+        const string query = @"
+            SELECT f.payload
+            FROM unnest(@cids) WITH ORDINALITY as u(_cid, _index)
+            LEFT JOIN ipfs_files f ON f.cid = u._cid
+            ORDER BY u._index";
+
+        await using var connection = await CreateConnectionAsync();
+        await using var command = new NpgsqlCommand(query, connection);
+        command.Parameters.AddWithValue("cids", missingCids.ToArray());
+
+        await using var reader = await command.ExecuteReaderAsync();
+        int readCount = 0;
+        while (await reader.ReadAsync())
+        {
+            int targetIndex = missingCidIndexes[readCount];
+            string targetCid = cids[targetIndex];
+
+            if (!reader.IsDBNull(0))
+            {
+                var payloadStr = reader.GetString(0);
+                var profile = JsonSerializer.Deserialize<JsonElement>(payloadStr);
+                var cleanedProfile = StripJsonLdFields(profile);
+                result[targetIndex] = cleanedProfile;
+                _profileByCidCache.Set(targetCid, cleanedProfile, new MemoryCacheEntryOptions { Size = 1 });
+            }
+            else
+            {
+                result[targetIndex] = null;
+            }
+
+            readCount++;
         }
 
         return result;

--- a/src/Rpc/Circles.Rpc.Host/Settings.cs
+++ b/src/Rpc/Circles.Rpc.Host/Settings.cs
@@ -32,16 +32,6 @@ public class Settings : Circles.Common.Settings
     public readonly string? ProfilePinningServiceUrl =
         Environment.GetEnvironmentVariable("PROFILE_PINNING_SERVICE_URL");
 
-    /// <summary>
-    /// Separate base URL for profile content resolution (IPFS payload by CID).
-    /// When set, CacheServiceClient uses this for GetProfileContent* calls
-    /// instead of CACHE_SERVICE_URL. Points to the profile pinning service
-    /// which serves content from its verified DB rather than IPFS gateways.
-    /// Falls back to CACHE_SERVICE_URL if not set.
-    /// </summary>
-    public readonly string? ProfileContentServiceUrl =
-        Environment.GetEnvironmentVariable("PROFILE_CONTENT_SERVICE_URL");
-
     #region RPC-specific database timeout configuration
 
     /// <summary>


### PR DESCRIPTION
## Summary
Reverts #296 and #311 on staging. Restores:
- IpfsDownloader (IPFS gateway fetch loop)
- IpfsQueueInserter
- DB triggers (trg_enq_ipfs_v1, trg_enq_ipfs_v2) that auto-enqueue new CIDs
- Tier 3 database fallback for content resolution
- Content endpoints (/api/profiles/content/{cid}, /api/profiles/content/batch)

## Why
`circles_searchProfiles` and `circles_query` search depend on `ipfs_files` being populated.
Without IpfsDownloader, new profiles aren't written to `ipfs_files` → search breaks for new registrations.
Keeping nethermind unchanged until the search dependency on `ipfs_files` is resolved.

## After merge + deploy
- IpfsDownloader resumes on startup, seeds missing CIDs from metadata digests
- DB triggers re-created, new profiles auto-enqueued
- Gap profiles (registered during ~24h window) backfilled by seed query