### PR TITLE
fix(cache,pathfinder): organizations cache pipeline + quantized groups propagation

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
@@ -44,7 +44,7 @@ public class CachePathfinderConformanceTests
     private const string WrapperUnregistered = "0x0000000000000000000000000000000000000012";
 
     private const long Block = 100;
-    private const long CurrentTimestamp = 10000;
+    private const long CurrentTimestamp = 1_702_000_000; // 2023-12-08, must be after V2InflationDayZero
     // Must be after wall-clock time since BuildTrust uses DateTimeOffset.UtcNow
     private static readonly long FutureExpiry = DateTimeOffset.UtcNow.ToUnixTimeSeconds() + 86400 * 365;
     private const long PastExpiry = 500;

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -179,6 +179,8 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<string>? Avatars,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<string>? Organizations,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderWrapperMappingRow>? WrapperMappings
 );
 

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -96,11 +96,12 @@ public class PathfinderGraphController : ControllerBase
                 GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(registrations, routerGroups!) : null,
                 ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow(registrations) : null,
                 Avatars: sections.Contains("avatars") ? BuildAvatars() : null,
+                Organizations: sections.Contains("organizations") ? BuildOrganizations() : null,
                 WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings(registrations) : null
             );
 
             _logger.LogDebug(
-                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}, wrappers={Wrappers}",
+                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}, orgs={Orgs}, wrappers={Wrappers}",
                 lastBlock,
                 response.Balances?.Count ?? 0,
                 response.Trust?.Count ?? 0,
@@ -108,6 +109,7 @@ public class PathfinderGraphController : ControllerBase
                 response.GroupTrusts?.Count ?? 0,
                 response.ConsentedFlow?.Count ?? 0,
                 response.Avatars?.Count ?? 0,
+                response.Organizations?.Count ?? 0,
                 response.WrapperMappings?.Count ?? 0);
 
             return Ok(response);
@@ -122,7 +124,7 @@ public class PathfinderGraphController : ControllerBase
     private static HashSet<string> ParseInclude(string? include)
     {
         if (string.IsNullOrWhiteSpace(include))
-            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars", "wrappermappings" };
+            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars", "organizations", "wrappermappings" };
 
         return new HashSet<string>(
             include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -328,6 +330,23 @@ public class PathfinderGraphController : ControllerBase
             avatars.Add(address);
         }
         return avatars;
+    }
+
+    /// <summary>
+    /// Returns all V2 organization addresses from the cache.
+    /// Organizations are stored in V2Avatars with type "CrcV2_RegisterOrganization".
+    /// The pathfinder uses this to populate CapacityGraph.OrganizationNodes for
+    /// canary simulation gating (orgs can't be simulated — Hub.sol requires operator approval).
+    /// </summary>
+    private List<string> BuildOrganizations()
+    {
+        var organizations = new List<string>();
+        foreach (var kvp in _caches.V2Avatars.ReadOnlyDictionary)
+        {
+            if (kvp.Value.Type == "CrcV2_RegisterOrganization")
+                organizations.Add(kvp.Key);
+        }
+        return organizations;
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/FuzzDifferentialTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/FuzzDifferentialTests.cs
@@ -357,11 +357,10 @@ public class FuzzDifferentialTests
     /// The backward propagation of quantization adjustments through group minting edges
     /// is a known fragile area — this fuzzes that code path extensively.
     ///
-    /// KNOWN ISSUE: QuantizeSinkBoundEdgesByToken only quantizes Group-Sink edges but
-    /// doesn't reduce upstream Router-Group collateral, causing NettedFlowMismatch at group
-    /// vertices. This is a documented pre-existing bug — we Assert.Warn instead of Assert.Fail
-    /// so the test logs the occurrence without blocking the suite. Once the quantization
-    /// backward-propagation fix lands, flip this back to Assert.Fail.
+    /// Previously, PropagateQuantizationBackwards could process a group vertex before all
+    /// its downstream successors had been adjusted (BFS ordering bug), causing stale
+    /// collateral scaling and NettedFlowMismatch. Fixed by adding convergence passes
+    /// after the initial BFS — vertices are re-checked until totalIn == totalOut everywhere.
     /// </summary>
     [Test, Repeat(20)]
     public void Fuzz_QuantizedWithGroups_NoConservationViolation()
@@ -409,17 +408,10 @@ public class FuzzDifferentialTests
             .Where(v => v.Rule == "FlowConservation" && v.Severity == "error")
             .ToList();
 
-        if (conservationViolations.Count > 0)
-        {
-            // Log as warning — known pre-existing quantization backward-propagation bug
-            Assert.Warn(
-                $"KNOWN ISSUE: FlowConservation violated in quantized+groups mode " +
-                $"(quantization backward-propagation bug)\n" +
-                $"Graph: {avatars} avatars, {groups} groups, density={density:F2}\n" +
-                $"Violations:\n{string.Join("\n", conservationViolations.Select(v => $"  {v.Message}"))}\n" +
-                "TODO: flip to Assert.Fail once QuantizeSinkBoundEdgesByToken propagates upstream");
-            return; // Skip self-loop check — conservation is already broken
-        }
+        Assert.That(conservationViolations, Is.Empty,
+            $"FlowConservation violated in quantized+groups mode\n" +
+            $"Graph: {avatars} avatars, {groups} groups, density={density:F2}\n" +
+            $"Violations:\n{string.Join("\n", conservationViolations.Select(v => $"  {v.Message}"))}");
 
         // Check for NON-conservation errors that would indicate a new bug
         var otherErrors = validation.Violations

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -15,6 +15,7 @@ public record PathfinderGraphSnapshot(
     IReadOnlyList<PathfinderGraphGroupTrustRow>? GroupTrusts,
     IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow,
     IReadOnlyList<string>? Avatars,
+    IReadOnlyList<string>? Organizations = null,
     IReadOnlyList<PathfinderGraphWrapperMappingRow>? WrapperMappings = null
 );
 
@@ -82,6 +83,9 @@ internal sealed class PathfinderGraphSnapshotDto
     [JsonPropertyName("avatars")]
     public List<string>? Avatars { get; set; }
 
+    [JsonPropertyName("organizations")]
+    public List<string>? Organizations { get; set; }
+
     [JsonPropertyName("wrapperMappings")]
     public List<PathfinderGraphWrapperMappingRow>? WrapperMappings { get; set; }
 
@@ -95,5 +99,6 @@ internal sealed class PathfinderGraphSnapshotDto
         GroupTrusts,
         ConsentedFlow,
         Avatars,
+        Organizations,
         WrapperMappings);
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -75,7 +75,12 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return row.GroupAddress.ToLowerInvariant();
     }
 
-    public IEnumerable<string> LoadOrganizations() => [];
+    public IEnumerable<string> LoadOrganizations()
+    {
+        var rows = _snapshot.Organizations ?? [];
+        foreach (var row in rows)
+            yield return row.ToLowerInvariant();
+    }
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -1523,7 +1523,7 @@ public class V2Pathfinder
             outList.Add(i);
         }
 
-        // BFS backwards from sink
+        // Phase 1: BFS backwards from sink to discover all reachable vertices.
         var queue = new Queue<int>();
         var visited = new HashSet<int>();
 
@@ -1538,126 +1538,172 @@ public class V2Pathfinder
             }
         }
 
+        // First pass: BFS discover + adjust
         while (queue.Count > 0)
         {
             int vertex = queue.Dequeue();
             if (!visited.Add(vertex)) continue;
-            if (vertex == sourceId) continue; // Source net flow is allowed to change
+            if (vertex == sourceId) continue;
 
             if (!incomingEdges.TryGetValue(vertex, out var inIndices) || inIndices.Count == 0)
-                continue; // No incoming edges — this is a source vertex
+                continue;
 
-            // Determine if this is a token-converting vertex (e.g., group minting).
-            // At groups: collateral tokens come in, group tokens go out — different types.
-            // At normal intermediaries: same token types flow through.
-            var inTokenTypes = new HashSet<int>();
+            AdjustVertexInflow(edges, vertex, inIndices,
+                outgoingEdges.GetValueOrDefault(vertex), sourceId);
+
+            // Enqueue upstream vertices for discovery
             foreach (int idx in inIndices)
-                inTokenTypes.Add(edges[idx].Token);
+            {
+                int from = edges[idx].From;
+                if (from != sourceId && !visited.Contains(from))
+                    queue.Enqueue(from);
+            }
+        }
 
-            var outTokenTypes = new HashSet<int>();
-            long totalOut = 0;
-            if (outgoingEdges.TryGetValue(vertex, out var outIndices))
+        // Phase 2: Convergence passes over all discovered vertices.
+        // The BFS above may process a vertex before all its downstream successors
+        // have been adjusted (e.g., group G feeds both sink directly and avatar M
+        // indirectly — if G is dequeued before M, G's collateral scaling uses stale
+        // G→M flow). Re-pass until no vertex needs further adjustment.
+        // Convergence is guaranteed: each pass only reduces flows (non-negative integers).
+        const int maxPasses = 20; // Safety limit; practical convergence in 1–3 passes
+        for (int pass = 0; pass < maxPasses; pass++)
+        {
+            bool changed = false;
+            foreach (int vertex in visited)
+            {
+                if (vertex == sourceId) continue;
+                if (!incomingEdges.TryGetValue(vertex, out var inIndices) || inIndices.Count == 0)
+                    continue;
+
+                if (AdjustVertexInflow(edges, vertex, inIndices,
+                        outgoingEdges.GetValueOrDefault(vertex), sourceId))
+                    changed = true;
+            }
+
+            if (!changed) break;
+        }
+    }
+
+    /// <summary>
+    /// Scale incoming edges of a vertex to match its (now-reduced) total outflow.
+    /// Returns true if any edge flow was actually changed.
+    /// </summary>
+    private static bool AdjustVertexInflow(
+        List<FlowEdge> edges,
+        int vertex,
+        List<int> inIndices,
+        List<int>? outIndices,
+        int sourceId)
+    {
+        // Compute token types and totals
+        var inTokenTypes = new HashSet<int>();
+        long totalIn = 0;
+        foreach (int idx in inIndices)
+        {
+            inTokenTypes.Add(edges[idx].Token);
+            totalIn += edges[idx].Flow;
+        }
+
+        var outTokenTypes = new HashSet<int>();
+        long totalOut = 0;
+        if (outIndices != null)
+        {
+            foreach (int idx in outIndices)
+            {
+                outTokenTypes.Add(edges[idx].Token);
+                totalOut += edges[idx].Flow;
+            }
+        }
+
+        if (totalIn <= totalOut) return false; // Already balanced
+
+        // Token conversion: outflow contains token types not present in inflow.
+        // This happens at group minting vertices (collateral in → group token out).
+        // When quantization zeroes a token, in={A,B} out={A} — out IS a subset of in,
+        // so per-token scaling correctly handles it (token B gets scaled to 0).
+        bool isTokenConverting = !outTokenTypes.IsSubsetOf(inTokenTypes);
+
+        if (isTokenConverting)
+        {
+            // Token-converting vertex (group minting): use total-based scaling.
+            // Per-token conservation doesn't apply here — token types change.
+            long allocated = 0;
+            for (int j = 0; j < inIndices.Count; j++)
+            {
+                int idx = inIndices[j];
+                var e = edges[idx];
+                long newFlow;
+
+                if (j == inIndices.Count - 1)
+                    newFlow = totalOut - allocated;
+                else
+                    newFlow = totalIn > 0 ? (e.Flow * totalOut) / totalIn : 0;
+
+                if (newFlow < 0) newFlow = 0;
+                e.Flow = newFlow;
+                allocated += newFlow;
+            }
+        }
+        else
+        {
+            // Same token types in/out: scale per-token independently.
+            // This preserves per-token flow conservation — total-based scaling
+            // would redistribute flow between token types, violating Hub.sol's
+            // per-token NettedFlowMismatch check.
+            var outflowByToken = new Dictionary<int, long>();
+            if (outIndices != null)
             {
                 foreach (int idx in outIndices)
                 {
-                    outTokenTypes.Add(edges[idx].Token);
-                    totalOut += edges[idx].Flow;
+                    var e = edges[idx];
+                    outflowByToken.TryGetValue(e.Token, out long current);
+                    outflowByToken[e.Token] = current + e.Flow;
                 }
             }
 
-            long totalIn = 0;
+            var inByToken = new Dictionary<int, List<int>>();
             foreach (int idx in inIndices)
-                totalIn += edges[idx].Flow;
-
-            if (totalIn <= totalOut) continue; // Already balanced
-
-            // Token conversion: outflow contains token types not present in inflow.
-            // This happens at group minting vertices (collateral in → group token out).
-            // When quantization zeroes a token, in={A,B} out={A} — out IS a subset of in,
-            // so per-token scaling correctly handles it (token B gets scaled to 0).
-            bool isTokenConverting = !outTokenTypes.IsSubsetOf(inTokenTypes);
-
-            if (isTokenConverting)
             {
-                // Token-converting vertex (group minting): use total-based scaling.
-                // Per-token conservation doesn't apply here — token types change.
-                long allocated = 0;
-                for (int j = 0; j < inIndices.Count; j++)
+                int token = edges[idx].Token;
+                if (!inByToken.TryGetValue(token, out var list))
                 {
-                    int idx = inIndices[j];
+                    list = new List<int>();
+                    inByToken[token] = list;
+                }
+                list.Add(idx);
+            }
+
+            foreach (var (token, tokenInIndices) in inByToken)
+            {
+                outflowByToken.TryGetValue(token, out long tokenOut);
+
+                long tokenIn = 0;
+                foreach (int idx in tokenInIndices)
+                    tokenIn += edges[idx].Flow;
+
+                if (tokenIn <= tokenOut) continue;
+
+                long allocated = 0;
+                for (int j = 0; j < tokenInIndices.Count; j++)
+                {
+                    int idx = tokenInIndices[j];
                     var e = edges[idx];
                     long newFlow;
 
-                    if (j == inIndices.Count - 1)
-                        newFlow = totalOut - allocated;
+                    if (j == tokenInIndices.Count - 1)
+                        newFlow = tokenOut - allocated;
                     else
-                        newFlow = totalIn > 0 ? (e.Flow * totalOut) / totalIn : 0;
+                        newFlow = tokenIn > 0 ? (e.Flow * tokenOut) / tokenIn : 0;
 
                     if (newFlow < 0) newFlow = 0;
                     e.Flow = newFlow;
                     allocated += newFlow;
-                    queue.Enqueue(e.From);
-                }
-            }
-            else
-            {
-                // Same token types in/out: scale per-token independently.
-                // This preserves per-token flow conservation — total-based scaling
-                // would redistribute flow between token types, violating Hub.sol's
-                // per-token NettedFlowMismatch check.
-                var outflowByToken = new Dictionary<int, long>();
-                if (outIndices != null)
-                {
-                    foreach (int idx in outIndices)
-                    {
-                        var e = edges[idx];
-                        outflowByToken.TryGetValue(e.Token, out long current);
-                        outflowByToken[e.Token] = current + e.Flow;
-                    }
-                }
-
-                var inByToken = new Dictionary<int, List<int>>();
-                foreach (int idx in inIndices)
-                {
-                    int token = edges[idx].Token;
-                    if (!inByToken.TryGetValue(token, out var list))
-                    {
-                        list = new List<int>();
-                        inByToken[token] = list;
-                    }
-                    list.Add(idx);
-                }
-
-                foreach (var (token, tokenInIndices) in inByToken)
-                {
-                    outflowByToken.TryGetValue(token, out long tokenOut);
-
-                    long tokenIn = 0;
-                    foreach (int idx in tokenInIndices)
-                        tokenIn += edges[idx].Flow;
-
-                    if (tokenIn <= tokenOut) continue;
-
-                    long allocated = 0;
-                    for (int j = 0; j < tokenInIndices.Count; j++)
-                    {
-                        int idx = tokenInIndices[j];
-                        var e = edges[idx];
-                        long newFlow;
-
-                        if (j == tokenInIndices.Count - 1)
-                            newFlow = tokenOut - allocated;
-                        else
-                            newFlow = tokenIn > 0 ? (e.Flow * tokenOut) / tokenIn : 0;
-
-                        if (newFlow < 0) newFlow = 0;
-                        e.Flow = newFlow;
-                        allocated += newFlow;
-                        queue.Enqueue(e.From);
-                    }
                 }
             }
         }
+
+        return true;
     }
 
     /* ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Cache Organizations pipeline**: The entire cache service was missing Organizations — `CacheLoadGraph.LoadOrganizations()` returned `[]`, making `CapacityGraph.OrganizationNodes` permanently empty in cache mode (`USE_CACHE_GRAPH_SOURCE=true`). Added Organizations field through all 4 layers: `PathfinderGraphResponse` → `PathfinderGraphSnapshot` → `PathfinderGraphSnapshotDto` → `CacheLoadGraph`. `BuildOrganizations()` filters `V2Avatars` for `CrcV2_RegisterOrganization` entries.
- **Quantized groups backward propagation**: `PropagateQuantizationBackwards` had a BFS ordering bug — when a group vertex feeds both the sink directly and an intermediary avatar, the BFS could process the group before the intermediary reduced its outgoing edge, leaving stale collateral scaling (NettedFlowMismatch at group vertex → on-chain revert). Fixed by adding convergence passes after the initial BFS that re-check all vertices until `totalIn == totalOut` everywhere.
- **Fuzz test flipped**: `Fuzz_QuantizedWithGroups_NoConservationViolation` upgraded from `Assert.Warn` to `Assert.Fail` — all 20 iterations pass.
- **Pre-existing test fix**: `CachePathfinderConformanceTests.Balances_IncludeValidEntries` had `CurrentTimestamp = 10000` (pre-epoch), causing `BuildBalances` to skip all entries.

## Test plan

- [x] `Fuzz_QuantizedWithGroups_NoConservationViolation` — 20/20 passed with `Assert.Fail`
- [x] `Fuzz_QuantizedMode_ValidatorAgreesWithPathfinder` — passed
- [x] All fuzz/property/quantized tests — 112 passed, 5 skipped (env)
- [x] Full pathfinder test suite — 992 passed, 273 skipped (env), 0 failed
- [x] Full cache service test suite — 250 passed (including previously failing `Balances_IncludeValidEntries`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for organizations in pathfinder graph queries with optional inclusion parameter.
  * Implemented three new validation rules for avatar registration, group registration, and token validity checks.
  * Enhanced error classification to extract and categorise Circles-specific revert codes with greater granularity.

* **Improvements**
  * Improved quantization backward propagation with two-phase convergence approach.
  * Refactored path audit observability from "Canary" labels for better monitoring clarity.
  * Extended graph infrastructure to include group addresses in avatar lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->