### PR TITLE
fix(pathfinder): demurrage safety margin 0.999999 (~7 min drift)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder/README.md
+++ b/src/Pathfinder/Circles.Pathfinder/README.md
@@ -209,7 +209,7 @@ The pathfinder can load its trust graph from the **Cache Service** (recommended)
 |----------|---------|-------------|
 | `MAX_CONCURRENT_REQUESTS` | `max(CPUCount × 2, 8)` | Max concurrent pathfinder requests |
 | `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | `10` | MaxFlow solver timeout per request |
-| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `1.0` | Multiplicative factor on demurraged balances (1.0 = disabled, <1.0 = haircut) |
+| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `0.999999` | Demurrage safety margin (~7 min drift coverage; 1.0 = disabled) |
 | `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | `true` | Exclude consented avatars from intermediary positions in paths |
 
 ### Materialized View Refresh

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -39,17 +39,17 @@ public class Settings
 
     /// <summary>
     /// Safety margin factor applied to demurraged balances to account for the delay
-    /// between graph-build time and on-chain execution. Default 1.0 (disabled).
-    /// The previous default of 0.9995 (0.05% haircut) blocked exact-amount transfers
+    /// between graph-build time and on-chain execution. Default 0.999999 (~7 min drift).
+    /// Only relevant for transfers using 100% of available balance (e.g. refunds).
+    /// The previous default of 0.9995 (~60h drift) blocked exact-amount transfers
     /// when the sender held precisely the required balance (e.g. organization refunds).
-    /// Demurrage drift over a realistic 60s delay is ~0.000014%, making even 0.9995
-    /// orders of magnitude too aggressive. Override via PATHFINDER_DEMURRAGE_SAFETY_MARGIN
-    /// if a margin is ever needed again. Only applies when TargetDemurrageTimestamp is null.
+    /// Override via PATHFINDER_DEMURRAGE_SAFETY_MARGIN. Set to 1.0 to disable entirely.
+    /// Only applies when TargetDemurrageTimestamp is null (live mode).
     /// </summary>
     public double DemurrageSafetyMargin { get; set; } =
         Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN") != null
         ? double.Parse(Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN")!)
-        : 1.0;
+        : 0.999999;
 
     /// <summary>
     /// Timeout in seconds for the MaxFlow solver. Default 30s.


### PR DESCRIPTION
Cherry-pick of 31039d7c from dev. Replaces #321 which was auto-closed when the shared branch was deleted during #320 merge.

Sets `DemurrageSafetyMargin` to `0.999999` (~7 min drift tolerance) instead of the current `1.0` (disabled).