### PR TITLE
feat: Nethermind 1.36.2 + Lighthouse v8.1.3 for Gnosis Osaka hard fork

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -43,7 +43,7 @@ RUN dotnet publish \
     -o /circles-nethermind-plugin \
     --no-restore
 
-FROM nethermind/nethermind:1.36.0 AS base
+FROM nethermind/nethermind:1.36.2 AS base
 
 # Install psql for manual DB operations (runs as root, compose sets runtime user)
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*

--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -71,7 +71,7 @@ services:
 
   consensus-gnosis:
     container_name: consensus-gnosis
-    image: sigp/lighthouse:v8.1.0
+    image: sigp/lighthouse:v8.1.3
     restart: always
     depends_on:
       nethermind-gnosis:

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -260,7 +260,7 @@ Uncomment the `consensus-gnosis` service in `docker-compose.caddy.yml` if you ne
 ```yaml
 consensus-gnosis:
   container_name: consensus-gnosis
-  image: sigp/lighthouse:v7.1.0
+  image: sigp/lighthouse:v8.1.3
   # ... rest of configuration
 ```
 

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
   </ItemGroup>
 

--- a/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
+++ b/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.0" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <NethermindReferenceAssembliesVersion>1.36.0</NethermindReferenceAssembliesVersion>
+        <NethermindReferenceAssembliesVersion>1.36.2</NethermindReferenceAssembliesVersion>
         <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../..'))</RepoRoot>
         <NethermindRuntimeDir>$(RepoRoot)/nethermind-dev/nethermind</NethermindRuntimeDir>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- Bump Nethermind 1.36.0 → 1.36.2 (Docker base image + 4 NuGet ReferenceAssemblies)
- Bump Lighthouse v8.1.0 → v8.1.3 (docker-compose image)
- Fix stale Lighthouse version in docs/reverse-proxy.md (v7.1.0 → v8.1.3)

**Deadline**: Gnosis Chain Osaka hard fork activates April 14, 2026 (epoch 1714688). Lighthouse v8.1.3 is a mandatory security patch that also sets the Fulu fork epoch.

No code changes — version bumps only. `Nethermind.Numerics.Int256` (1.3.6) and Autofac (9.0.0) unchanged (independently versioned, no coupling).

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — all 5 test projects pass
- [ ] Deploy staging1 (drain → deploy → verify versions/sync/health → restore)
- [ ] Deploy staging2 (same rolling procedure)
- [ ] Monitor both nodes for 15-30 min post-deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Nethermind runtime component to version 1.36.2
  * Updated Lighthouse consensus component to version 1.8.1.3
  * Updated supporting dependency versions across the application

* **Documentation**
  * Updated configuration examples to reflect latest component versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->