### PR TITLE
fix(rpc): CodeRabbit review fixes for WS unification

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/NethermindWsProxy.cs
+++ b/src/Rpc/Circles.Rpc.Host/NethermindWsProxy.cs
@@ -398,8 +398,36 @@ public sealed class NethermindWsProxy : IAsyncDisposable
         if (_byProxyId.TryRemove(proxyId, out var removed))
         {
             _nethermindToProxy.TryRemove(removed.NethermindSubId, out _);
+
+            // Best-effort upstream unsubscribe — stop Nethermind from sending orphaned notifications
+            _ = SendBestEffortUnsubscribeAsync(removed.NethermindSubId);
+
             RpcMetrics.ActiveEthSubscriptions.Dec();
             _logger.LogInformation("Removed stale eth subscription proxy={ProxyId}", proxyId);
+        }
+    }
+
+    private async Task SendBestEffortUnsubscribeAsync(string nethermindSubId)
+    {
+        try
+        {
+            if (_ws?.State != WebSocketState.Open) return;
+
+            var requestId = Interlocked.Increment(ref _nextRequestId);
+            var request = JsonSerializer.SerializeToUtf8Bytes(new
+            {
+                jsonrpc = "2.0",
+                method = "eth_unsubscribe",
+                @params = new[] { nethermindSubId },
+                id = requestId
+            });
+            await SendToNethermindAsync(request, _cts.Token);
+        }
+        catch (ObjectDisposedException) { /* shutdown race — expected */ }
+        catch (OperationCanceledException) { /* shutdown — expected */ }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Best-effort eth_unsubscribe failed for {SubId}", nethermindSubId);
         }
     }
 

--- a/src/Rpc/Circles.Rpc.Host/Settings.cs
+++ b/src/Rpc/Circles.Rpc.Host/Settings.cs
@@ -10,8 +10,9 @@ public class Settings : Circles.Common.Settings
         ?? "http://localhost:8545";
 
     public readonly string NethermindWsUrl =
-        Environment.GetEnvironmentVariable("NETHERMIND_WS_URL")
-        ?? (Environment.GetEnvironmentVariable("NETHERMIND_RPC_URL") ?? "http://localhost:8545")
+        (Environment.GetEnvironmentVariable("NETHERMIND_WS_URL")
+        ?? Environment.GetEnvironmentVariable("NETHERMIND_RPC_URL")
+        ?? "http://localhost:8545")
             .Replace("https://", "wss://")
             .Replace("http://", "ws://");
 

--- a/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
+++ b/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
@@ -237,23 +237,23 @@ public sealed class WebSocketSession : IAsyncDisposable
 
     private async Task HandleEthSubscribeAsync(JsonElement root, JsonElement? id, CancellationToken ct)
     {
-        if (!_settings.EthSubscribeEnabled)
-        {
-            await SendErrorAsync(id, -32601, "eth_subscribe is disabled on this node", ct);
-            return;
-        }
-
         if (!TryCheckSubscriptionLimit(out _))
         {
             await SendErrorAsync(id, -32000, $"Subscription limit reached ({MaxSubscriptionsPerSession})", ct);
             return;
         }
 
-        // Backward compat: eth_subscribe(["circles", ...]) → route to circles
+        // Backward compat: eth_subscribe(["circles", ...]) → route to circles (works even when eth proxy is disabled)
         if (IsCirclesCompatSubscription(root))
         {
             _logger.LogWarning("Deprecated: eth_subscribe with 'circles' topic — use circles_subscribe instead");
             await HandleCirclesSubscribeFromEthCompatAsync(root, id, ct);
+            return;
+        }
+
+        if (!_settings.EthSubscribeEnabled)
+        {
+            await SendErrorAsync(id, -32601, "eth_subscribe is disabled on this node", ct);
             return;
         }
 


### PR DESCRIPTION
## Summary
Follow-up to #333 — fixes 3 issues found by CodeRabbit review:

- **Settings**: `NETHERMIND_WS_URL=http://...` was not normalized to `ws://` — only the fallback path did the scheme replacement
- **WebSocketSession**: `EthSubscribeEnabled=false` kill switch blocked the backward compat `eth_subscribe(["circles",...])` path, which is handled locally and doesn't need Nethermind
- **NethermindWsProxy**: `RemoveStaleSubscription` now sends best-effort `eth_unsubscribe` to Nethermind before dropping local mappings (prevents orphaned upstream subscriptions)

## Test plan
- [ ] `dotnet build` passes (verified: 0 errors)
- [ ] Tests pass (verified: 137 passed, 0 failed)
- [ ] 2 review agents confirmed no new issues
- [ ] Redeploy staging1 + staging2 and re-verify all 7 WS tests