### PR TITLE
feat(metrics): Balancer V3 market pricing + /pricing API

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/BusinessKpiMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/BusinessKpiMetrics.cs
@@ -507,9 +507,17 @@ public static class BusinessKpiMetrics
         .CreateGauge("circles_price_last_updated_timestamp",
             "Unix timestamp of last successful price update");
 
+    public static readonly Gauge CrcPriceBalancerXdai = Prometheus.Metrics
+        .CreateGauge("circles_crc_price_balancer_xdai",
+            "Market-based dCRC price in xDAI from Balancer V3 (sCRC/xDAI ÷ convFactor)");
+
+    public static readonly Gauge CrcPriceBalancerConvFactor = Prometheus.Metrics
+        .CreateGauge("circles_crc_price_balancer_conv_factor",
+            "Current sCRC→dCRC conversion factor (demurrage)");
+
     public static readonly Gauge PriceSource = Prometheus.Metrics
         .CreateGauge("circles_price_source",
-            "Price source indicator: 1=CoinGecko live, 2=cached, 3=fallback manual",
+            "Per-source boolean: label=coingecko|cached|fallback|balancer, value=1 when active",
             new GaugeConfiguration { LabelNames = new[] { "source" } });
 
     // ===========================================

--- a/src/Metrics/Circles.Metrics.Exporter/Program.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Program.cs
@@ -18,6 +18,14 @@ builder.Services.AddSingleton(sp =>
 builder.Services.AddHttpClient<PriceService>();
 builder.Services.AddSingleton<PriceService>();
 
+// Balancer V3 pricing (market-based, fallback for CoinGecko)
+builder.Services.AddHttpClient<BalancerPriceService>();
+builder.Services.AddSingleton<BalancerPriceService>();
+
+// Price cache in PostgreSQL (cache-through pattern)
+builder.Services.AddSingleton(sp =>
+    new PriceCacheRepository(connectionString, sp.GetRequiredService<ILogger<PriceCacheRepository>>()));
+
 builder.Services.AddHostedService<KpiCollectorService>();
 
 // Liquidity monitoring services
@@ -49,6 +57,11 @@ builder.Services.AddHealthChecks();
 
 var app = builder.Build();
 
+// Wire up Balancer fallback into PriceService (avoids circular DI)
+var priceService = app.Services.GetRequiredService<PriceService>();
+var balancerService = app.Services.GetRequiredService<BalancerPriceService>();
+priceService.SetBalancerPriceService(balancerService);
+
 // Health check endpoints
 app.MapHealthChecks("/health");
 app.MapGet("/ready", () => Results.Ok("Ready"));
@@ -56,14 +69,103 @@ app.MapGet("/ready", () => Results.Ok("Ready"));
 // Prometheus metrics endpoint
 app.MapMetrics();
 
+// Pricing API endpoint (cache-through: PG → Balancer/CoinGecko → PG)
+app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, BalancerPriceService balancer, PriceService prices, ILogger<Program> logger) =>
+{
+    DateOnly targetDate;
+    if (string.IsNullOrEmpty(date))
+    {
+        targetDate = DateOnly.FromDateTime(DateTime.UtcNow);
+    }
+    else if (!DateOnly.TryParse(date, out targetDate))
+    {
+        return Results.BadRequest(new { error = "Invalid date format. Use YYYY-MM-DD." });
+    }
+
+    // Step 1: Check PG cache
+    PriceCacheRepository.DailyPrice? cached = null;
+    try { cached = await priceCache.GetAsync(targetDate); }
+    catch (Exception ex) { logger.LogWarning(ex, "PG cache lookup failed for {Date}", targetDate); }
+
+    if (cached is not null)
+    {
+        return Results.Ok(new
+        {
+            date = cached.Date.ToString("yyyy-MM-dd"),
+            scrc_xdai = cached.ScrcXdai,
+            conv_factor = cached.ConvFactor,
+            dcrc_xdai = cached.DcrcXdai,
+            xdai_eur = cached.XdaiEur,
+            dcrc_eur = cached.DcrcEur,
+            source = cached.Source,
+            cached = true
+        });
+    }
+
+    // Step 2: Fetch price from Balancer
+    var isToday = targetDate == DateOnly.FromDateTime(DateTime.UtcNow);
+    var scrcXdai = isToday
+        ? await balancer.GetScrcXdaiPriceAsync()
+        : await balancer.GetHistoricScrcXdaiPriceAsync(targetDate);
+
+    if (scrcXdai <= 0)
+    {
+        var ts = new DateTimeOffset(targetDate.ToDateTime(TimeOnly.MinValue), TimeSpan.Zero);
+        return Results.Ok(new
+        {
+            date = targetDate.ToString("yyyy-MM-dd"),
+            scrc_xdai = 0.0,
+            conv_factor = BalancerPriceService.GetConvFactor(ts),
+            dcrc_xdai = 0.0,
+            xdai_eur = 0.0,
+            dcrc_eur = 0.0,
+            source = "unavailable",
+            cached = false,
+            message = "Balancer price unavailable for this date"
+        });
+    }
+
+    var timestamp = new DateTimeOffset(targetDate.ToDateTime(TimeOnly.Parse("12:00")), TimeSpan.Zero);
+    var convFactor = BalancerPriceService.GetConvFactor(timestamp);
+    var dcrcXdai = BalancerPriceService.ConvertScrcToDcrcPrice(scrcXdai, timestamp);
+
+    // Step 3: Fetch xDAI/EUR from CoinGecko
+    var xdaiEur = await prices.GetXdaiEurRateAsync(targetDate);
+    var dcrcEur = xdaiEur > 0 ? dcrcXdai * xdaiEur : 0;
+    var source = isToday ? "balancer_live" : "balancer_historic";
+
+    // Step 4: Store in PG
+    try
+    {
+        await priceCache.UpsertAsync(targetDate, scrcXdai, convFactor, dcrcXdai, xdaiEur, dcrcEur, source);
+    }
+    catch (Exception ex)
+    {
+        logger.LogWarning(ex, "Failed to cache price for {Date}", targetDate);
+    }
+
+    return Results.Ok(new
+    {
+        date = targetDate.ToString("yyyy-MM-dd"),
+        scrc_xdai = scrcXdai,
+        conv_factor = convFactor,
+        dcrc_xdai = dcrcXdai,
+        xdai_eur = xdaiEur,
+        dcrc_eur = dcrcEur,
+        source,
+        cached = false
+    });
+});
+
 // Info endpoint
 app.MapGet("/", () => Results.Ok(new
 {
     Service = "Circles Metrics Exporter",
-    Version = "1.4.0",
+    Version = "1.5.0",
     Endpoints = new[]
     {
         "/metrics - Prometheus metrics (KPIs + Liquidity + Trust Scores + Deployment)",
+        "/pricing?date=YYYY-MM-DD - CRC price lookup (cache-through: PG → Balancer/CoinGecko)",
         "/health - Health check",
         "/ready - Readiness check"
     },
@@ -75,7 +177,8 @@ app.MapGet("/", () => Results.Ok(new
         "Whale transfer tracking",
         "Trust score monitoring (distribution, anomalies, network health)",
         "Trust score history snapshots (daily, 90-day retention)",
-        "Deployment status monitoring (multi-env RPC probing, no DB access needed)"
+        "Deployment status monitoring (multi-env RPC probing, no DB access needed)",
+        "CRC pricing API (Balancer V3 market price, PG cache, EUR conversion)"
     }
 }));
 

--- a/src/Metrics/Circles.Metrics.Exporter/Services/BalancerPriceService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/BalancerPriceService.cs
@@ -1,0 +1,261 @@
+using System.Net.Http.Json;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Circles.Common;
+
+namespace Circles.Metrics.Exporter.Services;
+
+/// <summary>
+/// Fetches sCRC/xDAI market price from the Balancer V3 SOR API.
+/// Used as a fallback when CoinGecko is unavailable, and as the primary
+/// source for the market-based CRC price (vs. the administered token offer rate).
+/// </summary>
+public class BalancerPriceService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<BalancerPriceService> _logger;
+    private readonly string _balancerApiUrl;
+    private string _referenceScrcAddress;
+
+    private const string WXDAI_ADDRESS = "0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d";
+    private const uint INFLATION_DAY_ZERO = 1_602_720_000;
+
+    // Rate limiting: avoid hammering the Balancer API
+    private DateTimeOffset _lastApiCall = DateTimeOffset.MinValue;
+    private static readonly TimeSpan MinTimeBetweenCalls = TimeSpan.FromSeconds(5);
+
+    // Cache
+    private double _cachedScrcXdaiPrice;
+    private DateTimeOffset _lastPriceUpdate = DateTimeOffset.MinValue;
+    private readonly TimeSpan _cacheExpiry;
+
+    public BalancerPriceService(
+        HttpClient httpClient,
+        ILogger<BalancerPriceService> logger,
+        IConfiguration configuration)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+
+        _balancerApiUrl = configuration["Balancer:ApiUrl"] ?? "https://api-v3.balancer.fi/graphql";
+        _referenceScrcAddress = configuration["Balancer:ReferenceScrcAddress"] ?? "";
+        _cacheExpiry = TimeSpan.FromMinutes(configuration.GetValue<int>("Balancer:CacheExpiryMinutes", 5));
+
+        if (string.IsNullOrEmpty(_referenceScrcAddress))
+        {
+            _logger.LogWarning("Balancer:ReferenceScrcAddress not configured. Balancer pricing disabled.");
+        }
+        else if (!Regex.IsMatch(_referenceScrcAddress, @"^0x[0-9a-fA-F]{40}$"))
+        {
+            _logger.LogError("Balancer:ReferenceScrcAddress has invalid format: {Address}. Must be 0x + 40 hex chars. Balancer pricing disabled.",
+                _referenceScrcAddress);
+            _referenceScrcAddress = "";
+        }
+        else
+        {
+            _logger.LogInformation("Balancer pricing configured: sCRC={ScrcAddress}, API={ApiUrl}",
+                _referenceScrcAddress, _balancerApiUrl);
+        }
+    }
+
+    /// <summary>
+    /// Whether the service is configured with a reference sCRC address.
+    /// </summary>
+    public bool IsConfigured => !string.IsNullOrEmpty(_referenceScrcAddress);
+
+    /// <summary>
+    /// Gets the current sCRC/xDAI price from Balancer V3 SOR API.
+    /// Returns 0 if unavailable or not configured.
+    /// </summary>
+    public async Task<double> GetScrcXdaiPriceAsync(CancellationToken ct = default)
+    {
+        if (!IsConfigured) return 0;
+
+        // Check cache
+        if (_lastPriceUpdate + _cacheExpiry > DateTimeOffset.UtcNow && _cachedScrcXdaiPrice > 0)
+            return _cachedScrcXdaiPrice;
+
+        // Rate limiting
+        if (DateTimeOffset.UtcNow - _lastApiCall < MinTimeBetweenCalls)
+            return _cachedScrcXdaiPrice;
+
+        try
+        {
+            var price = await FetchScrcXdaiPriceAsync(ct);
+            if (price > 0)
+            {
+                _cachedScrcXdaiPrice = price;
+                _lastPriceUpdate = DateTimeOffset.UtcNow;
+            }
+            return price;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch sCRC/xDAI price from Balancer V3");
+            return _cachedScrcXdaiPrice; // return stale cache on error
+        }
+    }
+
+    /// <summary>
+    /// Converts an sCRC/xDAI price to dCRC/xDAI using pure C# demurrage math.
+    /// No RPC calls needed — uses CirclesConverter from Circles.Common.
+    /// </summary>
+    public static double ConvertScrcToDcrcPrice(double scrcXdaiPrice, DateTimeOffset timestamp)
+    {
+        if (scrcXdaiPrice <= 0) return 0;
+
+        var day = CirclesConverter.DayFromTimestamp(timestamp, INFLATION_DAY_ZERO);
+        var oneUnit = BigInteger.Parse("1000000000000000000"); // 1e18
+        var demurragedUnit = CirclesConverter.InflationaryToDemurrage(oneUnit, day);
+        var convFactor = (double)demurragedUnit / 1e18;
+
+        if (convFactor <= 0) return 0;
+
+        return scrcXdaiPrice / convFactor;
+    }
+
+    /// <summary>
+    /// Gets the demurrage conversion factor for a given timestamp.
+    /// convFactor = InflationaryToDemurrage(1e18, day) / 1e18
+    /// </summary>
+    public static double GetConvFactor(DateTimeOffset timestamp)
+    {
+        var day = CirclesConverter.DayFromTimestamp(timestamp, INFLATION_DAY_ZERO);
+        var oneUnit = BigInteger.Parse("1000000000000000000");
+        var demurragedUnit = CirclesConverter.InflationaryToDemurrage(oneUnit, day);
+        return (double)demurragedUnit / 1e18;
+    }
+
+    /// <summary>
+    /// Gets the historic sCRC/xDAI price from Balancer V3 tokenGetHistoricalPrices API.
+    /// Returns the closest price to the target date. Returns 0 if unavailable.
+    /// </summary>
+    public async Task<double> GetHistoricScrcXdaiPriceAsync(DateOnly targetDate, CancellationToken ct = default)
+    {
+        if (!IsConfigured) return 0;
+
+        try
+        {
+            // Use ALL range for maximum coverage (daily resolution, goes back to pool creation)
+            var query = $$"""
+            {
+              tokenGetHistoricalPrices(
+                addresses: ["{{_referenceScrcAddress}}"],
+                chain: GNOSIS,
+                range: ALL
+              ) {
+                prices { price timestamp }
+              }
+            }
+            """;
+
+            var request = new HttpRequestMessage(HttpMethod.Post, _balancerApiUrl)
+            {
+                Content = JsonContent.Create(new { query })
+            };
+
+            var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Balancer V3 historic prices API returned {StatusCode}", response.StatusCode);
+                return 0;
+            }
+
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+
+            if (!json.TryGetProperty("data", out var data)
+                || !data.TryGetProperty("tokenGetHistoricalPrices", out var historicalArr)
+                || historicalArr.GetArrayLength() == 0)
+                return 0;
+
+            var prices = historicalArr[0].GetProperty("prices");
+            var targetUnix = new DateTimeOffset(targetDate.ToDateTime(TimeOnly.Parse("12:00")), TimeSpan.Zero)
+                .ToUnixTimeSeconds();
+
+            // Find the closest price point to the target date
+            double closestPrice = 0;
+            long closestDist = long.MaxValue;
+
+            foreach (var entry in prices.EnumerateArray())
+            {
+                if (!long.TryParse(entry.GetProperty("timestamp").GetString(), out var ts))
+                    continue;
+
+                var dist = Math.Abs(ts - targetUnix);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closestPrice = entry.GetProperty("price").GetDouble();
+                }
+            }
+
+            if (closestPrice > 0)
+            {
+                _logger.LogDebug("Historic Balancer price for {Date}: sCRC/xDAI={Price:F8} (dist={Dist}s)",
+                    targetDate, closestPrice, closestDist);
+            }
+
+            return closestPrice;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch historic sCRC/xDAI price for {Date}", targetDate);
+            return 0;
+        }
+    }
+
+    private async Task<double> FetchScrcXdaiPriceAsync(CancellationToken ct)
+    {
+        _lastApiCall = DateTimeOffset.UtcNow;
+
+        // Query Balancer V3 SOR for sCRC → WXDAI swap price
+        // Use 0.1 as swap amount (same as profileChecker.html), multiply result by 10
+        var query = $$"""
+        {
+          sorGetSwapPaths(
+            chain: GNOSIS,
+            swapAmount: "0.1",
+            swapType: EXACT_IN,
+            tokenIn: "{{_referenceScrcAddress}}",
+            tokenOut: "{{WXDAI_ADDRESS}}"
+          ) {
+            returnAmount
+          }
+        }
+        """;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, _balancerApiUrl)
+        {
+            Content = JsonContent.Create(new { query })
+        };
+
+        var response = await _httpClient.SendAsync(request, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Balancer V3 API returned {StatusCode}", response.StatusCode);
+            return 0;
+        }
+
+        var json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+
+        if (json.TryGetProperty("data", out var data)
+            && data.TryGetProperty("sorGetSwapPaths", out var sor)
+            && sor.TryGetProperty("returnAmount", out var returnAmount))
+        {
+            var amountStr = returnAmount.GetString();
+            if (double.TryParse(amountStr, System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var amount) && amount > 0)
+            {
+                // Query used 0.1 tokens, multiply by 10 to get price for 1 token
+                var price = amount * 10;
+                _logger.LogInformation("Balancer V3 sCRC/xDAI price: {Price:F8}", price);
+                return price;
+            }
+        }
+
+        _logger.LogWarning("Balancer V3 API returned unexpected response structure");
+        return 0;
+    }
+}

--- a/src/Metrics/Circles.Metrics.Exporter/Services/KpiCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/KpiCollectorService.cs
@@ -1333,6 +1333,15 @@ public class KpiCollectorService : BackgroundService
             BusinessKpiMetrics.PriceSource.WithLabels("coingecko").Set(source == PriceService.PriceSource.CoinGeckoLive ? 1 : 0);
             BusinessKpiMetrics.PriceSource.WithLabels("cached").Set(source == PriceService.PriceSource.Cached ? 1 : 0);
             BusinessKpiMetrics.PriceSource.WithLabels("fallback").Set(source == PriceService.PriceSource.FallbackManual ? 1 : 0);
+            BusinessKpiMetrics.PriceSource.WithLabels("balancer").Set(source == PriceService.PriceSource.BalancerLive ? 1 : 0);
+
+            // Balancer market price (independent gauge, always set when available)
+            if (_priceService.LastBalancerDcrcXdai > 0)
+            {
+                BusinessKpiMetrics.CrcPriceBalancerXdai.Set(_priceService.LastBalancerDcrcXdai);
+                BusinessKpiMetrics.CrcPriceBalancerConvFactor.Set(
+                    BalancerPriceService.GetConvFactor(DateTimeOffset.UtcNow));
+            }
 
             if (_priceService.LastUpdate > DateTimeOffset.MinValue)
             {

--- a/src/Metrics/Circles.Metrics.Exporter/Services/PriceCacheRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/PriceCacheRepository.cs
@@ -1,0 +1,128 @@
+using Npgsql;
+
+namespace Circles.Metrics.Exporter.Services;
+
+/// <summary>
+/// Manages the crc_daily_prices table in postgres-gnosis.
+/// Cache-through pattern: check PG first, fetch externally on miss, store for future lookups.
+/// Same pattern as TrustRepository's trust_scores_history table.
+/// </summary>
+public class PriceCacheRepository
+{
+    private readonly string _connectionString;
+    private readonly ILogger<PriceCacheRepository> _logger;
+    private volatile bool _tableVerified;
+
+    public PriceCacheRepository(string connectionString, ILogger<PriceCacheRepository> logger)
+    {
+        _connectionString = connectionString;
+        _logger = logger;
+    }
+
+    public record DailyPrice(
+        DateOnly Date,
+        double ScrcXdai,
+        double ConvFactor,
+        double DcrcXdai,
+        double XdaiEur,
+        double DcrcEur,
+        string Source,
+        DateTimeOffset FetchedAt);
+
+    /// <summary>
+    /// Gets the cached price for a specific date. Returns null if not cached.
+    /// </summary>
+    public async Task<DailyPrice?> GetAsync(DateOnly date, CancellationToken ct = default)
+    {
+        await EnsureTableExistsAsync(ct);
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(ct);
+
+        const string sql = """
+            SELECT date, scrc_xdai, conv_factor, dcrc_xdai, xdai_eur, dcrc_eur, source, fetched_at
+            FROM crc_daily_prices
+            WHERE date = @date
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("date", date.ToDateTime(TimeOnly.MinValue));
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct))
+            return null;
+
+        return new DailyPrice(
+            Date: DateOnly.FromDateTime(reader.GetDateTime(0)),
+            ScrcXdai: reader.GetDouble(1),
+            ConvFactor: reader.GetDouble(2),
+            DcrcXdai: reader.GetDouble(3),
+            XdaiEur: reader.GetDouble(4),
+            DcrcEur: reader.GetDouble(5),
+            Source: reader.GetString(6),
+            FetchedAt: reader.GetDateTime(7));
+    }
+
+    /// <summary>
+    /// Inserts or updates the price for a specific date.
+    /// </summary>
+    public async Task UpsertAsync(DateOnly date, double scrcXdai, double convFactor,
+        double dcrcXdai, double xdaiEur, double dcrcEur, string source, CancellationToken ct = default)
+    {
+        await EnsureTableExistsAsync(ct);
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(ct);
+
+        const string sql = """
+            INSERT INTO crc_daily_prices (date, scrc_xdai, conv_factor, dcrc_xdai, xdai_eur, dcrc_eur, source, fetched_at)
+            VALUES (@date, @scrc_xdai, @conv_factor, @dcrc_xdai, @xdai_eur, @dcrc_eur, @source, NOW())
+            ON CONFLICT (date) DO UPDATE SET
+                scrc_xdai = EXCLUDED.scrc_xdai,
+                conv_factor = EXCLUDED.conv_factor,
+                dcrc_xdai = EXCLUDED.dcrc_xdai,
+                xdai_eur = EXCLUDED.xdai_eur,
+                dcrc_eur = EXCLUDED.dcrc_eur,
+                source = EXCLUDED.source,
+                fetched_at = EXCLUDED.fetched_at
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("date", date.ToDateTime(TimeOnly.MinValue));
+        cmd.Parameters.AddWithValue("scrc_xdai", scrcXdai);
+        cmd.Parameters.AddWithValue("conv_factor", convFactor);
+        cmd.Parameters.AddWithValue("dcrc_xdai", dcrcXdai);
+        cmd.Parameters.AddWithValue("xdai_eur", xdaiEur);
+        cmd.Parameters.AddWithValue("dcrc_eur", dcrcEur);
+        cmd.Parameters.AddWithValue("source", source);
+
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    private async Task EnsureTableExistsAsync(CancellationToken ct)
+    {
+        if (_tableVerified) return;
+
+        await using var conn = new NpgsqlConnection(_connectionString);
+        await conn.OpenAsync(ct);
+
+        const string sql = """
+            CREATE TABLE IF NOT EXISTS crc_daily_prices (
+                date         DATE PRIMARY KEY,
+                scrc_xdai    DOUBLE PRECISION NOT NULL,
+                conv_factor  DOUBLE PRECISION NOT NULL,
+                dcrc_xdai    DOUBLE PRECISION NOT NULL,
+                xdai_eur     DOUBLE PRECISION NOT NULL DEFAULT 0,
+                dcrc_eur     DOUBLE PRECISION NOT NULL DEFAULT 0,
+                source       TEXT NOT NULL,
+                fetched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """;
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        await cmd.ExecuteNonQueryAsync(ct);
+        _tableVerified = true;
+
+        _logger.LogInformation("crc_daily_prices table verified/created");
+    }
+}

--- a/src/Metrics/Circles.Metrics.Exporter/Services/PriceService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/PriceService.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Circles.Metrics.Exporter.Services;
@@ -14,11 +15,15 @@ public class PriceService
     private readonly string? _apiKey;
     private readonly double _fallbackCrcPriceUsd;
     private readonly TimeSpan _cacheExpiry;
+    private volatile BalancerPriceService? _balancerPriceService;
 
     // Cached prices
     private double _cachedGnoPriceUsd;
     private DateTimeOffset _lastGnoPriceUpdate = DateTimeOffset.MinValue;
     private PriceSource _currentSource = PriceSource.None;
+
+    // Balancer-derived price (market-based, independent of token offer rate)
+    private double _lastBalancerDcrcXdai;
 
     // Rate limiting: 30 requests per minute = 1 request per 2 seconds minimum
     private DateTimeOffset _lastApiCall = DateTimeOffset.MinValue;
@@ -29,7 +34,8 @@ public class PriceService
         None = 0,
         CoinGeckoLive = 1,
         Cached = 2,
-        FallbackManual = 3
+        FallbackManual = 3,
+        BalancerLive = 4
     }
 
     public PriceService(
@@ -111,39 +117,84 @@ public class PriceService
     /// Calculates CRC price in USD based on GNO offer price.
     /// Formula: CRC/USD = (1 / tokenPriceInCrc) × GNO/USD
     /// Where tokenPriceInCrc = how much CRC to get 1 GNO
+    ///
+    /// Fallback chain: CoinGecko → Balancer → Cache → FallbackManual
+    /// Also fetches Balancer market price independently for the circles_crc_price_balancer_xdai gauge.
     /// </summary>
     public async Task<(double crcPriceUsd, double crcPriceGno, PriceSource source)> GetCrcPriceAsync(
         double tokenPriceInCrc,
         CancellationToken ct = default)
     {
+        // Always try to fetch Balancer market price (independent of CoinGecko)
+        await TryUpdateBalancerPriceAsync(ct);
+
         // tokenPriceInCrc = CRC per 1 GNO (e.g., 10000 CRC = 1 GNO)
         // So CRC/GNO = 1 / tokenPriceInCrc (e.g., 0.0001 GNO per CRC)
+        var crcPriceGno = tokenPriceInCrc > 0 ? 1.0 / tokenPriceInCrc : 0;
 
+        // Step 1: Try CoinGecko (primary)
+        var (gnoPriceUsd, source) = await GetGnoPriceUsdAsync(ct);
+
+        if (gnoPriceUsd > 0 && crcPriceGno > 0)
+        {
+            var crcPriceUsd = crcPriceGno * gnoPriceUsd;
+            _logger.LogDebug(
+                "CRC price calculated: ${CrcUsd:F6} (1 CRC = {CrcGno:F8} GNO, GNO = ${GnoUsd:F2})",
+                crcPriceUsd, crcPriceGno, gnoPriceUsd);
+            return (crcPriceUsd, crcPriceGno, source);
+        }
+
+        // Step 2: Try Balancer (fallback) — gives dCRC/xDAI ≈ USD directly
+        if (_lastBalancerDcrcXdai > 0)
+        {
+            _logger.LogInformation("Using Balancer market price as fallback: dCRC/xDAI={Price:F8}", _lastBalancerDcrcXdai);
+            _currentSource = PriceSource.BalancerLive;
+            return (_lastBalancerDcrcXdai, crcPriceGno, PriceSource.BalancerLive);
+        }
+
+        // Step 3: Fallback manual
         if (tokenPriceInCrc <= 0)
         {
-            // No offer price available, use fallback
-            _logger.LogDebug("No token offer price available, using fallback CRC price: ${FallbackPrice}", _fallbackCrcPriceUsd);
+            _logger.LogDebug("No price sources available, using fallback CRC price: ${FallbackPrice}", _fallbackCrcPriceUsd);
             return (_fallbackCrcPriceUsd, 0, PriceSource.FallbackManual);
         }
 
-        var crcPriceGno = 1.0 / tokenPriceInCrc;
-
-        var (gnoPriceUsd, source) = await GetGnoPriceUsdAsync(ct);
-
-        if (gnoPriceUsd <= 0)
-        {
-            // Can't get GNO price, use fallback for CRC
-            return (_fallbackCrcPriceUsd, crcPriceGno, PriceSource.FallbackManual);
-        }
-
-        var crcPriceUsd = crcPriceGno * gnoPriceUsd;
-
-        _logger.LogDebug(
-            "CRC price calculated: ${CrcUsd:F6} (1 CRC = {CrcGno:F8} GNO, GNO = ${GnoUsd:F2})",
-            crcPriceUsd, crcPriceGno, gnoPriceUsd);
-
-        return (crcPriceUsd, crcPriceGno, source);
+        return (_fallbackCrcPriceUsd, crcPriceGno, PriceSource.FallbackManual);
     }
+
+    private async Task TryUpdateBalancerPriceAsync(CancellationToken ct)
+    {
+        if (_balancerPriceService is null || !_balancerPriceService.IsConfigured)
+            return;
+
+        try
+        {
+            var scrcXdai = await _balancerPriceService.GetScrcXdaiPriceAsync(ct);
+            if (scrcXdai > 0)
+            {
+                _lastBalancerDcrcXdai = BalancerPriceService.ConvertScrcToDcrcPrice(scrcXdai, DateTimeOffset.UtcNow);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Balancer price fetch failed (non-critical)");
+        }
+    }
+
+    /// <summary>
+    /// Sets the Balancer price service for fallback pricing.
+    /// Called after DI construction to avoid circular dependency.
+    /// </summary>
+    public void SetBalancerPriceService(BalancerPriceService balancerPriceService)
+    {
+        _balancerPriceService = balancerPriceService;
+    }
+
+    /// <summary>
+    /// Gets the last Balancer-derived dCRC/xDAI price (market-based).
+    /// This is independent of the administered token offer rate.
+    /// </summary>
+    public double LastBalancerDcrcXdai => _lastBalancerDcrcXdai;
 
     /// <summary>
     /// Gets the current price source indicator.
@@ -192,6 +243,75 @@ public class PriceService
         }
 
         return 0;
+    }
+
+    /// <summary>
+    /// Fetches xDAI/EUR rate from CoinGecko for a given date range.
+    /// Uses DAI as proxy (xDAI is bridged DAI on Gnosis Chain, 1:1 peg).
+    /// </summary>
+    public async Task<double> GetXdaiEurRateAsync(DateOnly targetDate, CancellationToken ct = default)
+    {
+        if (string.IsNullOrEmpty(_apiKey))
+            return 0;
+
+        try
+        {
+            var targetTs = new DateTimeOffset(targetDate.ToDateTime(TimeOnly.Parse("12:00")), TimeSpan.Zero)
+                .ToUnixTimeSeconds();
+            var from = targetTs - 86400;
+            var to = targetTs + 86400;
+
+            var isProKey = _apiKey.StartsWith("CG-Pro-", StringComparison.OrdinalIgnoreCase);
+            var baseUrl = isProKey ? "https://pro-api.coingecko.com" : "https://api.coingecko.com";
+            var headerName = isProKey ? "x-cg-pro-api-key" : "x-cg-demo-api-key";
+
+            var url = $"{baseUrl}/api/v3/coins/dai/market_chart/range?vs_currency=eur&from={from}&to={to}";
+
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            request.Headers.Add(headerName, _apiKey);
+            request.Headers.Add("Accept", "application/json");
+
+            var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("CoinGecko DAI/EUR API returned {StatusCode}", response.StatusCode);
+                return 0;
+            }
+
+            var json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            if (!json.TryGetProperty("prices", out var prices))
+                return 0;
+
+            // Find the closest price point to target timestamp
+            double closestPrice = 0;
+            long closestDist = long.MaxValue;
+            var targetMs = targetTs * 1000;
+
+            foreach (var entry in prices.EnumerateArray())
+            {
+                if (entry.GetArrayLength() < 2) continue;
+                var ts = entry[0].GetInt64();
+                var price = entry[1].GetDouble();
+                var dist = Math.Abs(ts - targetMs);
+                if (dist < closestDist)
+                {
+                    closestDist = dist;
+                    closestPrice = price;
+                }
+            }
+
+            if (closestPrice > 0)
+            {
+                _logger.LogDebug("CoinGecko DAI/EUR for {Date}: {Rate:F6}", targetDate, closestPrice);
+            }
+
+            return closestPrice;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch DAI/EUR rate for {Date}", targetDate);
+            return 0;
+        }
     }
 
     // CoinGecko response DTOs


### PR DESCRIPTION
## Summary

- **BalancerPriceService**: Balancer V3 `sorGetSwapPaths` for live sCRC/xDAI + `tokenGetHistoricalPrices` for historic lookups
- **PriceCacheRepository**: PG `crc_daily_prices` table (cache-through pattern, like `trust_scores_history`)
- **PriceService**: Balancer fallback chain (CoinGecko → Balancer → Cache → FallbackManual) + CoinGecko DAI/EUR
- **`/pricing?date=YYYY-MM-DD`**: Cache-through API endpoint for CRC price lookup
- **New gauges**: `circles_crc_price_balancer_xdai`, `circles_crc_price_balancer_conv_factor`

### Why
Token offer `tokenPriceInCRC` is an administered rate (GNO bonus program), not a market price. For invoicing and the marketplaceExplorer, we need the Balancer pool rate (market price) with sCRC→dCRC conversion.

### Key details
- Reference token: gCRC static wrapper `0xeef7b1f06b092625228c835dd5d5b14641d1e54a` (~703k CRC in Balancer vault)
- Demurrage conversion uses `CirclesConverter.InflationaryToDemurrage()` (pure C#, no RPC)
- No subgraph needed — Balancer V3 API has `tokenGetHistoricalPrices` (daily resolution back to Dec 2025)
- Infra PR (Caddy route + env vars): aboutcircles/aboutcircles-infrastructure#TBD

## Test plan
- [ ] Deploy to staging with `BALANCER_REFERENCE_SCRC` env var
- [ ] Verify `circles_crc_price_balancer_xdai` gauge in Prometheus
- [ ] Test `/pricing?date=today` returns live Balancer price
- [ ] Test `/pricing?date=2026-03-15` returns historic price
- [ ] Disable CoinGecko key → verify Balancer fallback activates
- [ ] Verify `crc_daily_prices` table created and populated