### PR TITLE
fix(pathfinder): close consented-source -> non-Group leak + enforce audit safety net

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -196,7 +196,10 @@ internal sealed class FindPathHandler(
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
 
-                // Path audit: record Hub.sol rule violations (observe-only, alert via Prometheus)
+                // Path audit: when HubContractValidator detected Hub.sol rule violations,
+                // the produced path would revert on-chain. Record metrics, log, then replace
+                // the broken transfers with the canonical empty response so the wallet can't
+                // submit a doomed tx. The API contract still returns MaxFlowResponse — never errors.
                 if (mfr.ValidationErrors > 0)
                 {
                     FindPathMetrics.PathAuditViolationsTotal.WithLabels("any").Inc();
@@ -207,10 +210,28 @@ internal sealed class FindPathHandler(
                     }
 
                     log.LogError(
-                        "Path audit: Hub.sol rule violations detected — path may revert on-chain. " +
+                        "Path audit: Hub.sol rule violations detected — replacing path with empty response. " +
                         "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}",
                         safeSource, safeSink, mfr.GraphBlock,
                         mfr.Transfers?.Count ?? 0, mfr.ValidationErrors);
+
+                    FindPathMetrics.PathAuditBlockedTotal.WithLabels("any").Inc();
+                    if (mfr.ValidationViolationRules != null)
+                    {
+                        foreach (var rule in mfr.ValidationViolationRules)
+                            FindPathMetrics.PathAuditBlockedTotal.WithLabels(rule).Inc();
+                    }
+
+                    var emptyResponse = new MaxFlowResponse("0", new List<TransferPathStep>(), null)
+                    {
+                        ReqId = mfr.ReqId,
+                        GraphBlock = mfr.GraphBlock,
+                        ValidationErrors = mfr.ValidationErrors,
+                        ValidationViolationRules = mfr.ValidationViolationRules,
+                        ValidatorException = mfr.ValidatorException
+                    };
+                    result = emptyResponse;
+                    mfr = emptyResponse;
                 }
                 if (mfr.ValidatorException)
                     FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
@@ -387,7 +408,7 @@ internal sealed class FindPathHandler(
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
 
-                // Track Hub.sol rule violations (same as live path)
+                // Track Hub.sol rule violations (same as live path) — and replace with empty.
                 if (mfr.ValidationErrors > 0)
                 {
                     FindPathMetrics.PathAuditViolationsTotal.WithLabels("any").Inc();
@@ -398,10 +419,28 @@ internal sealed class FindPathHandler(
                     }
 
                     log.LogError(
-                        "Historical path audit: Hub.sol rule violations — " +
+                        "Historical path audit: Hub.sol rule violations — replacing path with empty response. " +
                         "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}",
                         safeSource, safeSink, blockNumber,
                         mfr.Transfers?.Count ?? 0, mfr.ValidationErrors);
+
+                    FindPathMetrics.PathAuditBlockedTotal.WithLabels("any").Inc();
+                    if (mfr.ValidationViolationRules != null)
+                    {
+                        foreach (var rule in mfr.ValidationViolationRules)
+                            FindPathMetrics.PathAuditBlockedTotal.WithLabels(rule).Inc();
+                    }
+
+                    var emptyResponse = new MaxFlowResponse("0", new List<TransferPathStep>(), null)
+                    {
+                        ReqId = mfr.ReqId,
+                        GraphBlock = mfr.GraphBlock,
+                        ValidationErrors = mfr.ValidationErrors,
+                        ValidationViolationRules = mfr.ValidationViolationRules,
+                        ValidatorException = mfr.ValidatorException
+                    };
+                    result = emptyResponse;
+                    mfr = emptyResponse;
                 }
 
                 log.LogInformation(

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
@@ -35,7 +35,16 @@ internal class FindPathMetrics
     public static readonly Counter PathAuditViolationsTotal =
         Metrics.CreateCounter(
             "circles_path_audit_violations_total",
-            "Hub.sol rule violations detected in pathfinder output (non-blocking, alert-only)",
+            "Hub.sol rule violations detected in pathfinder output",
+            new CounterConfiguration { LabelNames = new[] { "rule" } });
+
+    // Path audit: counts when the safety net replaced a violating response with the empty path.
+    // Should track 1:1 with PathAuditViolationsTotal — divergence indicates a code path that
+    // detects but does not block. Counter exists per rule so we can tell which rule triggered.
+    public static readonly Counter PathAuditBlockedTotal =
+        Metrics.CreateCounter(
+            "circles_path_audit_blocked_total",
+            "Pathfinder responses replaced with empty path because audit detected a Hub.sol violation",
             new CounterConfiguration { LabelNames = new[] { "rule" } });
 
     // Canary: validator threw an unexpected exception (non-zero = validator bug, not pathfinder bug)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs
@@ -422,11 +422,14 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Source and sink are consented — they should NOT be treated as intermediaries.
+    /// Consented source and sink with a non-consented intermediary — path is still excluded.
+    /// Pre-2026-04-28 the filter exempted endpoints, missing that the edge Alice(consented)→Bob(non-consented)
+    /// itself violates Hub.sol's isPermittedFlow regardless of Bob's intermediary status.
+    /// Hub.sol checks every edge: if from is consented, to must be consented.
     /// </summary>
     [Test]
     [Category("consented-flow")]
-    public void ConsentedIntermediary_SourceAndSinkConsented_NotExcluded()
+    public void ConsentedIntermediary_ConsentedEndpoints_NonConsentedHop_StillExcluded()
     {
         var graph = CreateCapacityGraph(
             new HashSet<int> { Alice, Carol },
@@ -435,12 +438,14 @@ public class ConsentedFlowValidationTests
 
         var edges = new List<(int From, int To, int Token, long Flow)>
         {
-            (Alice, Bob, AliceToken, 500),
+            (Alice, Bob, AliceToken, 500),  // consented → non-consented: rejected by Hub.sol
             (Bob, Carol, AliceToken, 500)
         };
 
         bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Carol);
-        Assert.That(result, Is.False, "Source and sink consented but should not be treated as intermediaries");
+        Assert.That(result, Is.True,
+            "Even if both endpoints are consented, a non-consented hop in between is rejected by Hub.sol " +
+            "isPermittedFlow on the consented-source→non-consented-hop edge");
     }
 
     /// <summary>
@@ -466,15 +471,16 @@ public class ConsentedFlowValidationTests
     }
 
     /// <summary>
-    /// Direct transfer (no intermediaries): source=consented → sink.
-    /// Should NOT be excluded since there are no intermediaries.
+    /// Direct transfer with no consent involvement at all — path is not excluded.
+    /// (Originally tested consented-source → non-consented-sink as "no intermediaries to exclude",
+    /// but Hub.sol rejects that edge directly. This test now verifies the genuine no-consent case.)
     /// </summary>
     [Test]
     [Category("consented-flow")]
-    public void ConsentedIntermediary_DirectTransfer_NoExclusion()
+    public void ConsentedIntermediary_DirectTransfer_NoConsentInvolved_NotExcluded()
     {
         var graph = CreateCapacityGraph(
-            new HashSet<int> { Alice },
+            new HashSet<int> { Carol }, // Carol exists in consented set but is not on the path
             new Dictionary<int, HashSet<int>>());
         var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = true });
 
@@ -484,7 +490,31 @@ public class ConsentedFlowValidationTests
         };
 
         bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Bob);
-        Assert.That(result, Is.False, "Direct transfer has no intermediaries to exclude");
+        Assert.That(result, Is.False,
+            "Direct transfer between non-consented avatars is not affected by exclusion mode");
+    }
+
+    /// <summary>
+    /// Direct transfer from consented source to non-consented sink — Hub.sol rejects.
+    /// Even though there are no intermediaries, the direct edge itself violates isPermittedFlow.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void ConsentedIntermediary_DirectTransfer_ConsentedSource_NonConsentedSink_Excluded()
+    {
+        var graph = CreateCapacityGraph(
+            new HashSet<int> { Alice }, // Alice is consented, Bob is not
+            new Dictionary<int, HashSet<int>>());
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = true });
+
+        var edges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (Alice, Bob, AliceToken, 500)
+        };
+
+        bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Bob);
+        Assert.That(result, Is.True,
+            "Direct edge consented → non-consented violates Hub.sol isPermittedFlow regardless of position");
     }
 
     /// <summary>
@@ -541,6 +571,61 @@ public class ConsentedFlowValidationTests
         bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Bob);
         Assert.That(result, Is.True,
             "Consented source → Group must be excluded even when sender is source — Avatar(consented)→Router fails on-chain");
+    }
+
+    /// <summary>
+    /// Regression for the prod 2026-04-28 violation (PathfinderPathAuditViolation alert).
+    /// Consented source → non-consented human intermediary slipped past the exclusion filter
+    /// because the existing rules (consented avatar in intermediary slot) didn't fire when
+    /// the intermediary was a regular human and the consented party was the source vertex.
+    /// Hub.sol's isPermittedFlow rejects this — advancedUsageFlags[Bob] is required but unset.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void ConsentedIntermediary_ConsentedSource_NonConsentedHuman_PathExcluded()
+    {
+        var graph = CreateCapacityGraph(
+            new HashSet<int> { Alice }, // Only Alice (source) is consented
+            new Dictionary<int, HashSet<int>>());
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = true });
+
+        var edges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (Alice, Bob, AliceToken, 500),  // consented → non-consented: Hub.sol rejects
+            (Bob, Carol, AliceToken, 500)
+        };
+
+        bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Carol);
+        Assert.That(result, Is.True,
+            "Consented source → non-consented human intermediary must be excluded — " +
+            "Hub.sol isPermittedFlow requires advancedUsageFlags[to] when from is consented");
+    }
+
+    /// <summary>
+    /// Symmetric case to the prod regression: consented source → consented sink with
+    /// only consented avatars in between would be valid per Hub.sol — but the existing
+    /// "exclude-intermediaries" mode is intentionally pessimistic and drops ALL paths that
+    /// touch consented avatars in non-endpoint positions. Documents that behavior.
+    /// </summary>
+    [Test]
+    [Category("consented-flow")]
+    public void ConsentedIntermediary_AllConsentedChain_StillExcludedInPessimisticMode()
+    {
+        var graph = CreateCapacityGraph(
+            new HashSet<int> { Alice, Bob, Carol }, // entire chain consented
+            new Dictionary<int, HashSet<int>>());
+        var pathfinder = new V2Pathfinder(settings: new Settings { DisableConsentedFlow = true });
+
+        var edges = new List<(int From, int To, int Token, long Flow)>
+        {
+            (Alice, Bob, AliceToken, 500),
+            (Bob, Carol, AliceToken, 500)
+        };
+
+        bool result = pathfinder.PathHasConsentedIntermediary(edges, graph, Alice, Carol);
+        Assert.That(result, Is.True,
+            "Exclude-intermediaries mode is intentionally conservative — " +
+            "paths through consented intermediaries are dropped even if all-consented and Hub-valid");
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -90,6 +90,23 @@ public class V2Pathfinder
         if (ctx is null)
             return new MaxFlowResponse("0", new List<TransferPathStep>(), null);
 
+        // Hub.sol invariant: if advancedUsageFlags[from]==true then advancedUsageFlags[to]==true is required
+        // for every flow edge (Hub.sol:668-676 isPermittedFlow). By induction, a consented source can ONLY
+        // reach consented sinks. Skip the solver entirely — any path it found would be rejected by the
+        // path-level filter or the audit safety net anyway.
+        if (capacityGraph.ConsentedAvatars.Contains(ctx.SourceId)
+            && !capacityGraph.ConsentedAvatars.Contains(ctx.SinkId))
+        {
+            _logger.LogInformation(
+                "[{ReqId}] Consented source → non-consented sink — no path possible per Hub.sol isPermittedFlow",
+                ctx.ReqId);
+            return new MaxFlowResponse("0", new List<TransferPathStep>(), null)
+            {
+                ReqId = ctx.ReqId,
+                GraphBlock = capacityGraph.Block
+            };
+        }
+
         SolveAndExtractPaths(ctx);
         PruneByMaxTransfers(ctx);
         ConvertToFlowEdges(ctx);
@@ -831,6 +848,13 @@ public class V2Pathfinder
             // Non-consented sender → Group: safe — standard trust applies after Router insertion.
             if (graph.IsGroup(to))
                 continue;
+
+            // Consented sender → non-consented non-Group receiver: violates Hub.sol isPermittedFlow.
+            // Hub.sol:668-676 requires advancedUsageFlags[to]==true when advancedUsageFlags[from]==true.
+            // Mirrors the validation-mode check in PathHasConsentViolation.
+            // Closes the consented-source → regular-human-intermediary case (prod 2026-04-28).
+            if (graph.ConsentedAvatars.Contains(from) && !graph.ConsentedAvatars.Contains(to))
+                return true;
 
             if (from != sourceId && from != sinkId && graph.ConsentedAvatars.Contains(from))
                 return true;


### PR DESCRIPTION
Companion to #345.

## TL;DR

The `PathfinderPathAuditViolationAlert` (warning, IsPermittedFlow rule) that fired earlier today on prod1 and prod2 was **not** a `consented → Group` case — it was `consented user → non-consented regular human → …`. #345 doesn't catch this. **Both PRs together close the full Hub.sol `isPermittedFlow` rule.** Do not deploy #345 to prod without this PR.

## Why #345 alone is insufficient

`Hub.sol:668-676 isPermittedFlow(from, to, tokenOwner)`:

```
if (!advancedUsageFlags[from]) return isTrusted(to, tokenOwner);
return isTrusted(from, to) && advancedUsageFlags[to];
```

When `from` is consented, every receiver in the flow matrix must also be consented. The pre-#345 `PathHasConsentedIntermediary` only dropped paths where a **consented avatar** sat in an intermediary slot. #345 added the `consented → Group` branch (Router has no `advancedUsageFlags` so `Avatar(consented) → Router` always reverts). This PR adds the `consented → non-consented non-Group` branch — the actual failure mode that fired in prod.

| Edge shape | Closed by |
|---|---|
| consented sender → Group | #345 |
| consented sender → non-consented non-Group avatar | this PR |
| consented sender → consented receiver | both — allowed |

## Changes

### Producer fix — `V2Pathfinder.cs`
- `PathHasConsentedIntermediary`: new rule drops any path edge where `consented from → non-consented non-Group to`. Mirrors the validation-mode `PathHasConsentViolation` and Hub.sol exactly.
- `ComputeMaxFlowWithPath`: early-out when source is consented and sink is not — Hub invariant guarantees no path exists, so skip the solver and return canonical empty `MaxFlowResponse`.

### Safety net — `FindPathHandler.cs` + `FindPathMetrics.cs`
- Promoted `HubContractValidator` from observe-only to enforcing (live + historical paths). On `ValidationErrors > 0`, replace the broken response with `new MaxFlowResponse(\"0\", [], …)` instead of serving a path that would revert on-chain.
- API contract unchanged: still returns `MaxFlowResponse`, never an HTTP error.
- New metric `circles_path_audit_blocked_total{rule}` tracks "detected and blocked" 1:1 with the existing detection counter — divergence between the two counters indicates a bug class that detects but doesn't block.

### Tests
- Updated 2 existing tests that encoded the buggy \"endpoints-exempt\" assumption to assert Hub-aligned semantics.
- Added `ConsentedIntermediary_ConsentedSource_NonConsentedHuman_PathExcluded` (regression for the prod failure mode).
- Added `ConsentedIntermediary_AllConsentedChain_StillExcludedInPessimisticMode` (documents the conservative mode).

## Behavior

After this PR + #345:
- Consented → non-consented payments return `{\"maxFlow\":\"0\",\"transfers\":[]}` instead of doomed paths.
- Even if a future bug produces an invalid path, the audit blocks it before serving — `circles_path_audit_blocked_total` will increment.
- No change for non-consented sources (the vast majority of traffic).

**Rollback**: revert this commit, redeploy. < 2 min.

## Test plan

- [x] `./scripts/test.sh pathfinder` — 978 pass, 0 fail, 270 skipped (staging/Anvil-dependent)
- [x] `dotnet build Circles.sln -c Release` — 0 errors
- [x] Three reviewer agents (security / correctness / code review) — no high-confidence issues
- [ ] Rolling deploy to staging1, verify metric flat, restore
- [ ] Rolling deploy to staging2, verify, restore
- [ ] Soak on staging — both `circles_path_audit_violations_total` and `circles_path_audit_blocked_total` should stay 0 under normal traffic; if they increment, both should increment together
- [ ] **Prod rollout requires #345 + this PR together** — open separate prod-deploy plan

## Key files
- `src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs` — producer fix + early-out
- `src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs` — audit promotion (live + historical)
- `src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs` — `PathAuditBlockedTotal` counter
- `src/Pathfinder/Circles.Pathfinder.Tests/ConsentedFlowValidationTests.cs` — regression coverage