### PR TITLE
fix(rpc): scope flow-scope events to avatar's transactions

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -298,6 +298,48 @@ public class RpcMethodSnapshotTests
         Assert.That(result.TryGetProperty("nextCursor", out _), Is.True);
     }
 
+    [Test]
+    public async Task GetEvents_WithAddressFilter_FlowScopeEventsTiedToAvatarTxs()
+    {
+        // Regression: address-filtered circles_events used to include
+        // CrcV2_FlowEdgesScope* rows from txs the avatar wasn't part of,
+        // because flow-scope tables have no address column and the server
+        // skipped the address predicate entirely. Every flow-scope event
+        // returned for an address-filtered query must share a transactionHash
+        // with at least one address-bearing event in the same response.
+        var result = await CallRpc("circles_events", KnownV2Human, null, null, null, null, false);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
+
+        var addressBearingTxs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var flowScopeTxs = new List<string>();
+
+        foreach (var element in result.EnumerateArray())
+        {
+            if (!element.TryGetProperty("event", out var eventNameProp)) continue;
+            if (!element.TryGetProperty("values", out var values)) continue;
+            if (!values.TryGetProperty("transactionHash", out var txHashProp)) continue;
+
+            var eventName = eventNameProp.GetString() ?? string.Empty;
+            var txHash = txHashProp.GetString() ?? string.Empty;
+            if (string.IsNullOrEmpty(txHash)) continue;
+
+            if (eventName.StartsWith("CrcV2_FlowEdgesScope", StringComparison.Ordinal))
+            {
+                flowScopeTxs.Add(txHash);
+            }
+            else
+            {
+                addressBearingTxs.Add(txHash);
+            }
+        }
+
+        foreach (var txHash in flowScopeTxs)
+        {
+            Assert.That(addressBearingTxs, Does.Contain(txHash),
+                $"Flow-scope event in tx {txHash} has no address-bearing event for {KnownV2Human} in the same response");
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // Profile queries
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -719,6 +719,52 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         var sortOrder = sortAscending == true ? "ASC" : "DESC";
         var cursorComparison = sortAscending == true ? ">" : "<";
 
+        // Pre-build the tx-hash subquery used to address-filter flow-scope event
+        // tables. Tables like CrcV2_FlowEdgesScopeLastEnded / *_SingleStarted
+        // have no address column, so we can't filter them directly by avatar.
+        // Without this restriction, the previous logic skipped the address
+        // predicate for those tables entirely and returned every flow-scope
+        // event in the block range regardless of avatar — a bug that surfaced
+        // as profile pages showing transfers from unrelated transactions.
+        // Scope the subquery to ALL address-bearing event tables (not just
+        // those in eventTypes) so flow-scope events stay tied to genuine
+        // avatar participation even when the caller filters event types.
+        string? addressTxHashSubquery = null;
+        if (address != null)
+        {
+            var addressTxQueries = new List<string>();
+            foreach (var addrTable in eventTables)
+            {
+                if (!addrTable.Value.Any()) continue;
+
+                var nameParts = addrTable.Key.Split('_', 2);
+                if (nameParts.Length < 2) continue;
+                var ns = nameParts[0];
+                if (ns == "System" || ns.StartsWith('V')) continue;
+
+                var cols = DatabaseSchemaMap.GetTableColumns(addrTable.Key);
+                if (cols == null
+                    || !cols.ContainsKey("transactionHash")
+                    || !cols.ContainsKey("blockNumber"))
+                {
+                    continue;
+                }
+
+                var addrPredicate = $"({string.Join(" OR ", addrTable.Value.Select(c => $"\"{c}\" = @address"))})";
+                var subClauses = new List<string> { addrPredicate };
+                if (fromBlock.HasValue) subClauses.Add("\"blockNumber\" >= @fromBlock");
+                if (toBlock.HasValue) subClauses.Add("\"blockNumber\" <= @toBlock");
+
+                var subWhere = $" WHERE {string.Join(" AND ", subClauses)}";
+                addressTxQueries.Add($"SELECT \"transactionHash\" FROM \"{addrTable.Key}\"{subWhere}");
+            }
+
+            if (addressTxQueries.Count > 0)
+            {
+                addressTxHashSubquery = string.Join(" UNION ", addressTxQueries);
+            }
+        }
+
         foreach (var table in relevantTables)
         {
             // Extract namespace from table name (format: "Namespace_TableName")
@@ -751,10 +797,26 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
             var whereClauses = new List<string>();
 
-            // Basic address filter - only add if address is specified and table has address columns
-            if (address != null && table.Value.Any())
+            // Address filter. For tables that have address columns (most event
+            // tables) we filter directly. For tables without address columns
+            // (flow-scope: CrcV2_FlowEdgesScope*) we restrict to txHashes
+            // where this avatar appears in any address-bearing event in the
+            // same block range. If no address-bearing table exists for this
+            // address we skip the table entirely rather than over-returning.
+            if (address != null)
             {
-                whereClauses.Add($"({string.Join(" OR ", table.Value.Select(col => $"t.\"{col}\" = @address"))})");
+                if (table.Value.Any())
+                {
+                    whereClauses.Add($"({string.Join(" OR ", table.Value.Select(col => $"t.\"{col}\" = @address"))})");
+                }
+                else if (addressTxHashSubquery != null)
+                {
+                    whereClauses.Add($"t.\"transactionHash\" IN ({addressTxHashSubquery})");
+                }
+                else
+                {
+                    continue;
+                }
             }
 
             // Block range filters

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -729,6 +729,8 @@ Query indexed blockchain events with advanced filtering. Returns a **flat array*
 
 **Returns:** Flat event array (for paginated results with `hasMore`/`nextCursor`, use `circles_events_paginated`)
 
+> **Address filter behavior on flow-scope events:** When `address` is set, tables that have no address column (e.g. `CrcV2_FlowEdgesScopeLastEnded`, `CrcV2_FlowEdgesScopeSingleStarted`) are restricted to transactions where some address-bearing event for that avatar exists in the same block range. Without this restriction, address-filtered queries would over-return every flow-scope event in the range regardless of avatar.
+
 ```bash
 # All events for a specific transaction
 curl -X POST http://localhost:8081 -H 'Content-Type: application/json' -d '{


### PR DESCRIPTION
## Summary

`circles_events` (and by extension `circles_events_paginated` and the `circlesV2_pagedEvents` WebSocket subscription — all share `CirclesRpcModule.GetEvents`) over-returned `CrcV2_FlowEdgesScope*` rows when called with an `address` filter. Flow-scope tables have no address column, so the basic address predicate (`\"col\" = @address`) wasn't added for them — every flow-scope row in the block range came back regardless of avatar. Symptom: profile views showing transfers from unrelated transactions.

## Fix

`CirclesRpcModule.GetEvents` now pre-builds a `UNION` subquery over **all** address-bearing event tables (across all namespaces, scoped to `address` + block range) that returns the set of `transactionHash` values where the avatar appears. Address-less tables are restricted with `t.\"transactionHash\" IN (<subquery>)`. If no address-bearing table contributes to the subquery, the address-less tables are skipped entirely (fail-closed) instead of over-returning.

Important detail: the subquery iterates the full event-table set (not the caller's `eventTypes` filter), so a request that asks **only** for flow-scope rows still gets the avatar-scoped tx anchor.

## Reviews

Three review agents (security-engineer, feature-dev:code-explorer, pr-review-toolkit:code-reviewer) ran against the diff:
- No SQL-injection or validation regressions (table/column names are compile-time-derived schema, values bound via `NpgsqlParameter`).
- No data-integrity bugs. All edge cases covered: `eventTypes=[]`, multiple flow-scope events per tx, same-block different-tx, cursor pagination.
- Code-reviewer: clean.

## Test plan

- [x] Unit tests pass locally (RPC project, RpcRegression skipped without `TEST_ENV_URL`)
- [x] Build clean (0 errors)
- [x] Snapshot regression test (`GetEvents_WithAddressFilter_FlowScopeEventsTiedToAvatarTxs`) runs green against staging, post-deploy (also verified per-node via SNI: staging1 + staging2 both return 0 leakage)
- [x] Cross-check a known-buggy avatar on staging — 72 flow-scope rows / 5 distinct flow-scope txs / 9 address-bearing txs / **0 leakage** on both nodes
- [ ] No notable p95 regression on `circles_events` — not formally measured (deferred; bounded by existing 30s DB timeout + rate limiter)

## Watch-outs

- The new subquery is a `UNION` over ~30+ event tables. With `address` filter and no `fromBlock`/`toBlock`/cursor, the plan can scan history per address-bearing table; bounded by the existing 30s DB timeout and per-IP rate limiter, but worth watching p95 on staging before promoting to prod.