### PR TITLE
perf(rpc): V2-narrow + materialize avatar tx-hash CTE in GetEvents

### DIFF
--- a/scripts/verify-flowscope-fix.sh
+++ b/scripts/verify-flowscope-fix.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify-flowscope-fix.sh
+#
+# Differential verification for PR #347-fix (V2-narrowed MATERIALIZED CTE).
+# Compares prod (pre-fix, has over-return bug) vs staging-direct (post-fix)
+# for `circles_events` with an `address` filter. Asserts:
+#
+#   1. Latency improvement: staging wall time ≤ ~2x prod wall time
+#   2. Correctness improvement: staging returns ≤ prod's flow-scope row count
+#   3. Bug invariant on prod: at least one flow-scope row whose txHash
+#      doesn't share with any address-bearing row in the same response
+#      (proves the bug existed; if 0, the chosen avatar isn't a useful repro).
+#   4. Fix invariant on staging: every flow-scope row's txHash appears in
+#      at least one address-bearing row in the same response (proves the
+#      fix works on real data).
+#
+# Usage:
+#   ./verify-flowscope-fix.sh <prod-url> <staging-url> [avatar1] [avatar2] ...
+#
+# Examples:
+#   ./verify-flowscope-fix.sh https://rpc.aboutcircles.com https://staging1-direct/ \
+#     0x227642eBD3a801E7b44A5bb956c02C2d97Ca71F0
+#
+# Defaults to the blackbox-rpc-functional probe avatar if none given.
+
+PROD_URL="${1:-}"
+STAGING_URL="${2:-}"
+shift 2 2>/dev/null || true
+
+if [[ -z "$PROD_URL" || -z "$STAGING_URL" ]]; then
+    echo "Usage: $0 <prod-url> <staging-url> [avatar1] [avatar2] ..." >&2
+    exit 2
+fi
+
+AVATARS=("$@")
+if [[ ${#AVATARS[@]} -eq 0 ]]; then
+    AVATARS=("0x227642eBD3a801E7b44A5bb956c02C2d97Ca71F0")
+fi
+
+# Colors (fall back to none if not a tty)
+if [[ -t 1 ]]; then
+    BOLD=$'\033[1m'; GREEN=$'\033[0;32m'; RED=$'\033[0;31m'
+    YELLOW=$'\033[0;33m'; CYAN=$'\033[0;36m'; NC=$'\033[0m'
+else
+    BOLD=''; GREEN=''; RED=''; YELLOW=''; CYAN=''; NC=''
+fi
+
+PASS=0
+FAIL=0
+SUMMARY=""
+
+# Run circles_events for an avatar against an endpoint.
+# Echo: "<wall_seconds> <total_rows> <flowscope_rows> <leaked_flowscope_rows>"
+# Exit non-zero on transport error.
+probe() {
+    local url="$1" avatar="$2"
+    local payload
+    payload=$(printf '{"jsonrpc":"2.0","method":"circles_events","params":["%s",null,null,null,null,true],"id":1}' "$avatar")
+
+    local start_ns end_ns body http_code
+    start_ns=$(python3 -c 'import time;print(time.time_ns())')
+
+    # Capture body and HTTP status. 30s ceiling.
+    local tmpfile
+    tmpfile=$(mktemp)
+    http_code=$(curl -sS --max-time 30 -o "$tmpfile" -w '%{http_code}' \
+        -H 'Content-Type: application/json' \
+        -d "$payload" \
+        "$url" 2>&1) || {
+        echo "ERROR: $http_code" >&2
+        rm -f "$tmpfile"
+        return 1
+    }
+    end_ns=$(python3 -c 'import time;print(time.time_ns())')
+    body=$(cat "$tmpfile")
+    rm -f "$tmpfile"
+
+    if [[ "$http_code" != "200" ]]; then
+        echo "ERROR: HTTP $http_code from $url" >&2
+        return 1
+    fi
+
+    local wall_seconds total flow leaked
+    wall_seconds=$(python3 -c "print(($end_ns - $start_ns) / 1e9)")
+
+    # Compute counts via jq:
+    #   total: number of result entries
+    #   flow: count of CrcV2_FlowEdgesScope* entries
+    #   leaked: count of CrcV2_FlowEdgesScope* entries whose transactionHash
+    #     does NOT appear in any non-flow-scope entry in the same response
+    read -r total flow leaked < <(jq -r '
+        (.result // []) as $r
+        | ($r | map(select(.event | test("^CrcV2_FlowEdgesScope")) | .values.transactionHash)) as $flow_txs
+        | ($r | map(select(.event | test("^CrcV2_FlowEdgesScope") | not) | .values.transactionHash)) as $addr_txs
+        | ($r | length) as $total
+        | ($flow_txs | length) as $flow_count
+        | ($flow_txs - $addr_txs | length) as $leaked
+        | "\($total) \($flow_count) \($leaked)"
+    ' <<<"$body")
+
+    printf '%s %s %s %s\n' "$wall_seconds" "$total" "$flow" "$leaked"
+}
+
+# Format a number to 2 decimals if it's a float
+fmt() {
+    awk -v n="$1" 'BEGIN { if (n ~ /\./) printf "%.2f", n; else printf "%s", n }'
+}
+
+assert() {
+    local label="$1" cond="$2" detail="$3"
+    if [[ "$cond" == "true" ]]; then
+        printf "  ${GREEN}✓${NC} %s — %s\n" "$label" "$detail"
+        PASS=$((PASS+1))
+    else
+        printf "  ${RED}✗${NC} %s — %s\n" "$label" "$detail"
+        FAIL=$((FAIL+1))
+        SUMMARY+=$'\n  - '"$label: $detail"
+    fi
+}
+
+echo "${BOLD}verify-flowscope-fix${NC}"
+echo "  prod    = $PROD_URL"
+echo "  staging = $STAGING_URL"
+echo "  avatars = ${AVATARS[*]}"
+echo
+
+for avatar in "${AVATARS[@]}"; do
+    echo "${BOLD}${CYAN}avatar ${avatar}${NC}"
+
+    set +e
+    prod_out=$(probe "$PROD_URL" "$avatar")
+    prod_rc=$?
+    staging_out=$(probe "$STAGING_URL" "$avatar")
+    staging_rc=$?
+    set -e
+
+    if [[ $prod_rc -ne 0 || $staging_rc -ne 0 ]]; then
+        printf "  ${RED}✗${NC} probe failed (prod_rc=%s staging_rc=%s)\n" "$prod_rc" "$staging_rc"
+        FAIL=$((FAIL+1))
+        continue
+    fi
+
+    read -r prod_wall prod_total prod_flow prod_leaked <<<"$prod_out"
+    read -r staging_wall staging_total staging_flow staging_leaked <<<"$staging_out"
+
+    printf "  %-12s %-10s %-10s %-12s %-12s\n" "endpoint" "wall(s)" "total" "flow-scope" "leaked"
+    printf "  %-12s ${YELLOW}%-10s${NC} %-10s %-12s %-12s\n" \
+        "prod" "$(fmt "$prod_wall")" "$prod_total" "$prod_flow" "$prod_leaked"
+    printf "  %-12s ${GREEN}%-10s${NC} %-10s %-12s %-12s\n" \
+        "staging" "$(fmt "$staging_wall")" "$staging_total" "$staging_flow" "$staging_leaked"
+    echo
+
+    # Assertion 1: staging latency ≤ 2× prod
+    if (( $(awk -v s="$staging_wall" -v p="$prod_wall" 'BEGIN { print (s <= p * 2 + 0.5) }') )); then
+        assert "latency" "true" "staging $(fmt "$staging_wall")s ≤ 2× prod $(fmt "$prod_wall")s + 0.5s headroom"
+    else
+        assert "latency" "false" "staging $(fmt "$staging_wall")s > 2× prod $(fmt "$prod_wall")s + 0.5s headroom"
+    fi
+
+    # Assertion 2: staging returns ≤ prod flow-scope rows (fix is more restrictive)
+    if [[ "$staging_flow" -le "$prod_flow" ]]; then
+        assert "correctness" "true" "staging flow-scope rows ($staging_flow) ≤ prod ($prod_flow)"
+    else
+        assert "correctness" "false" "staging returned MORE flow-scope rows than prod"
+    fi
+
+    # Assertion 3: prod has the bug (≥1 leaked row) — informative, not blocking
+    if [[ "$prod_leaked" -gt 0 ]]; then
+        printf "  ${YELLOW}i${NC} prod over-return repro: $prod_leaked flow-scope rows leak (txHash not in address-bearing rows of same response)\n"
+    else
+        printf "  ${YELLOW}i${NC} prod over-return NOT reproduced for this avatar — pick a more active one to confirm bug\n"
+    fi
+
+    # Assertion 4: staging has zero leaks (fix invariant)
+    if [[ "$staging_leaked" -eq 0 ]]; then
+        assert "fix invariant" "true" "staging flow-scope rows all share txHash with address-bearing rows"
+    else
+        assert "fix invariant" "false" "staging leaked $staging_leaked flow-scope rows — fix did NOT close over-return"
+    fi
+
+    echo
+done
+
+echo "${BOLD}summary${NC}: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+if [[ $FAIL -gt 0 ]]; then
+    echo "${RED}failures:${NC}${SUMMARY}"
+    exit 1
+fi

--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -340,6 +340,27 @@ public class RpcMethodSnapshotTests
         }
     }
 
+    [Test]
+    public async Task GetEvents_AddressWithNoV2Events_ReturnsNoFlowScopeRows()
+    {
+        // Fail-closed branch: when the V2 address-bearing UNION returns an
+        // empty set (avatar has no V2 events at all — here a guaranteed-empty
+        // burn address), the materialized avatar_txs CTE is not built and
+        // address-less flow-scope tables are skipped entirely. This must
+        // never over-return flow-scope rows from unrelated transactions.
+        const string emptyAvatar = "0xdead000000000000000000000000000000000000";
+        var result = await CallRpc("circles_events", emptyAvatar, null, null, null, null, false);
+        Assert.That(result.ValueKind, Is.EqualTo(JsonValueKind.Array));
+
+        foreach (var element in result.EnumerateArray())
+        {
+            if (!element.TryGetProperty("event", out var eventNameProp)) continue;
+            var eventName = eventNameProp.GetString() ?? string.Empty;
+            Assert.That(eventName, Does.Not.StartWith("CrcV2_FlowEdgesScope"),
+                $"address-less flow-scope row leaked through fail-closed branch for empty avatar (event {eventName})");
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // Profile queries
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -726,9 +726,18 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         // predicate for those tables entirely and returned every flow-scope
         // event in the block range regardless of avatar — a bug that surfaced
         // as profile pages showing transfers from unrelated transactions.
-        // Scope the subquery to ALL address-bearing event tables (not just
-        // those in eventTypes) so flow-scope events stay tied to genuine
-        // avatar participation even when the caller filters event types.
+        //
+        // Scope to V2 address-bearing tables only: flow-scope events are
+        // emitted exclusively inside Hub.operateFlowMatrix calls, which always
+        // also emit V2 transfer/mint events in the same tx. A flow-scope row
+        // never appears in a V1- or wrapper-only tx, so other namespaces
+        // contribute zero useful tx hashes — and including them would
+        // wrongly tie unrelated multi-call txs to flow-scope events.
+        //
+        // Wrapped at finalSql composition into "WITH avatar_txs AS
+        // MATERIALIZED (...)" so PG evaluates the UNION exactly once and
+        // address-less flow-scope tables hash-join into the materialized
+        // set instead of re-executing the UNION per address-less table.
         string? addressTxHashSubquery = null;
         if (address != null)
         {
@@ -740,7 +749,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 var nameParts = addrTable.Key.Split('_', 2);
                 if (nameParts.Length < 2) continue;
                 var ns = nameParts[0];
-                if (ns == "System" || ns.StartsWith('V')) continue;
+                if (ns != "CrcV2") continue;
 
                 var cols = DatabaseSchemaMap.GetTableColumns(addrTable.Key);
                 if (cols == null
@@ -811,7 +820,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 }
                 else if (addressTxHashSubquery != null)
                 {
-                    whereClauses.Add($"t.\"transactionHash\" IN ({addressTxHashSubquery})");
+                    whereClauses.Add("t.\"transactionHash\" IN (SELECT \"transactionHash\" FROM avatar_txs)");
                 }
                 else
                 {
@@ -857,6 +866,16 @@ public partial class CirclesRpcModule : ICirclesRpcModule
         // Fetch one extra row to determine if there are more results
         var finalSql = string.Join(" UNION ALL ", queries);
         finalSql = $"SELECT * FROM ({finalSql}) combined ORDER BY \"blockNumber\" {sortOrder}, \"transactionIndex\" {sortOrder}, \"logIndex\" {sortOrder} LIMIT {effectiveLimit + 1}";
+
+        // Prepend the materialized CTE (when we built one) so the avatar's
+        // tx-hash set is evaluated exactly once. Address-less flow-scope
+        // tables reference avatar_txs via WHERE ... IN (SELECT ... FROM
+        // avatar_txs) and hash-join into the materialized set instead of
+        // re-executing the UNION per table.
+        if (addressTxHashSubquery != null)
+        {
+            finalSql = $"WITH avatar_txs AS MATERIALIZED ({addressTxHashSubquery}) {finalSql}";
+        }
 
         // Execute the combined query
         await using var connection = await CreateConnectionAsync();

--- a/src/Rpc/Circles.Rpc.Host/README.md
+++ b/src/Rpc/Circles.Rpc.Host/README.md
@@ -729,7 +729,7 @@ Query indexed blockchain events with advanced filtering. Returns a **flat array*
 
 **Returns:** Flat event array (for paginated results with `hasMore`/`nextCursor`, use `circles_events_paginated`)
 
-> **Address filter behavior on flow-scope events:** When `address` is set, tables that have no address column (e.g. `CrcV2_FlowEdgesScopeLastEnded`, `CrcV2_FlowEdgesScopeSingleStarted`) are restricted to transactions where some address-bearing event for that avatar exists in the same block range. Without this restriction, address-filtered queries would over-return every flow-scope event in the range regardless of avatar.
+> **Address filter behavior on flow-scope events:** When `address` is set, tables that have no address column (e.g. `CrcV2_FlowEdgesScopeLastEnded`, `CrcV2_FlowEdgesScopeSingleStarted`) are restricted to transactions where the avatar appears in some V2 address-bearing event in the same block range. Flow-scope events are emitted only inside `Hub.operateFlowMatrix` calls, which always also emit V2 transfer/mint events for the participating avatars in the same tx — so V2 namespace coverage is sufficient. Without this restriction, address-filtered queries would over-return every flow-scope event in the range regardless of avatar.
 
 ```bash
 # All events for a specific transaction


### PR DESCRIPTION
## Summary

Fixes the ~12.5x latency regression PR #347 introduced on `circles_events` with an `address` filter (1.77s prod → ~22s staging on the blackbox probe avatar). Two compounding issues addressed:

1. **V2-namespace narrowing** of the per-table tx-hash UNION. `CrcV2_FlowEdgesScope*` events are emitted only inside `Hub.operateFlowMatrix` calls, which always also emit V2 transfer/mint events for participating avatars in the same tx. V1/wrapper tables in the UNION contribute zero useful tx hashes (and would over-return on multi-call txs).
2. **Materialized CTE** instead of inlined-IN. Wraps the UNION in `WITH avatar_txs AS MATERIALIZED (...)` prepended to `finalSql`; address-less flow-scope tables reference the CTE via `IN (SELECT "transactionHash" FROM avatar_txs)`. PG materializes once and hash-joins, instead of re-evaluating the UNION per address-less table.

Same `WITH ... AS MATERIALIZED` idiom is already used 10+ places: `balanceQuery.sql`, `TrustRepository.cs`, `V_TrustScores_Current.sql`, `M_CrcV2_Groups.sql`, etc.

Empty-CTE fail-closed branch preserved: when no V2 address-bearing tables match, no CTE is emitted and address-less tables are skipped.

## Test plan

- [x] Local build — 0 errors
- [x] `./scripts/test.sh rpc` — 137 passed, 0 failed (109 skipped: TEST_ENV_URL-gated)
- [x] New unit-style test `GetEvents_AddressWithNoV2Events_ReturnsNoFlowScopeRows` covers empty-CTE branch
- [x] Existing snapshot regression `GetEvents_WithAddressFilter_FlowScopeEventsTiedToAvatarTxs` unchanged
- [ ] Differential prod vs staging-direct: `scripts/verify-flowscope-fix.sh https://rpc.aboutcircles.com https://staging1-direct/` — assert latency ≤ 2× prod, fix-invariant holds, prod-bug confirmed
- [ ] Alert clearing on staging2 (`HighRpcLatencyAlert`, `RpcMethodFailingAlert`, `RpcMethodSlowAlert`, `HealthCheckSlowAlert`)
- [ ] EXPLAIN (ANALYZE, BUFFERS) on staging probe to confirm MATERIALIZED + hash-join plan

## Verification on staging (per node, before DNS restore)

\`\`\`bash
time curl -sS --max-time 30 -X POST -H 'Content-Type: application/json' \\
  -d '{"jsonrpc":"2.0","method":"circles_events","params":["0x227642eBD3a801E7b44A5bb956c02C2d97Ca71F0",null,null,null,null,true],"id":1}' \\
  https://staging1-direct/ | jq '.result | length'

# Then run differential check:
./scripts/verify-flowscope-fix.sh https://rpc.aboutcircles.com https://staging1-direct/
\`\`\`

Pass criteria: wall time < 5s; staging flow-scope row count ≤ prod; staging fix-invariant green (every flow-scope row's txHash appears in an address-bearing row).

## Review (pre-push)

- **Architecture**: invariant verified against `Events.cs`/`LogParser.cs`/`DatabaseSchema.cs` — every flow-scope tx co-emits V2 transfer/mint events. CTE scoping correct in PG14+. Empty branch correct. Subscription path unaffected (passes `address: null`, skips CTE). Verdict: ship.
- **Code review**: no bugs, no convention violations, bash script portable. Verdict: ship.
- **DB analyst**: MATERIALIZED keyword honored in PG15+ (compose runs PG17). Indexes adequate. Predicts ~5-8s wall time. Verdict: ship.

## Deferred follow-ups (separate PRs)

- \`tokenAddress\` is in \`TransferSingle\`/\`TransferBatch\` address-bearing column lists — produces a spurious bitmap scan on every avatar query. Pre-existing in PR #347 logic; would benefit from a column-role schema marker.
- Switch CTE \`UNION\` → \`UNION ALL\` (dedup at IN-check is cheaper for active avatars).
- Extract \`"CrcV2"\` to a named constant \`FlowScopeAddressFilterNamespaces\` so future protocol additions surface this dependency.
- V2 composite \`(address, blockNumber)\` indexes — only if post-fix p95 is still poor.
- \`work_mem\` may need bumping on staging if probe avatar's tx-hash set spills (>35K txs); confirm via post-deploy EXPLAIN.

## What this does not change

- Address-filtered semantics: same as PR #347 — flow-scope rows still tied to txs the avatar participated in. Now V2-only and faster.
- WS subscription path: unchanged (uses address=null and skips the CTE).
- V1 events: no change. Legacy, low write volume, no flow-scope semantics.