### PR TITLE
perf(rpc): UNION ALL + named flow-scope namespace constant in GetEvents

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs
@@ -36,6 +36,16 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
     private const int MaxInFilterElements = 1000;
 
+    // Namespaces whose address-bearing tables seed the avatar tx-hash CTE used to
+    // address-filter address-less flow-scope tables in GetEvents. Flow-scope events
+    // are emitted exclusively inside Hub.operateFlowMatrix calls, which always also
+    // emit V2 transfer/mint events for participating avatars in the same tx — so V2
+    // is the only namespace whose tx-hashes pull in legitimate flow-scope rows.
+    // If a future protocol introduces flow-scope-style events, add its namespace here
+    // or its address-filtered queries will silently return zero flow-scope rows.
+    private static readonly HashSet<string> FlowScopeAddressFilterNamespaces =
+        new(StringComparer.Ordinal) { "CrcV2" };
+
     #region GetTransactionHistory - Version-specific query builders
 
     /// <summary>
@@ -749,7 +759,7 @@ public partial class CirclesRpcModule : ICirclesRpcModule
                 var nameParts = addrTable.Key.Split('_', 2);
                 if (nameParts.Length < 2) continue;
                 var ns = nameParts[0];
-                if (ns != "CrcV2") continue;
+                if (!FlowScopeAddressFilterNamespaces.Contains(ns)) continue;
 
                 var cols = DatabaseSchemaMap.GetTableColumns(addrTable.Key);
                 if (cols == null
@@ -770,7 +780,10 @@ public partial class CirclesRpcModule : ICirclesRpcModule
 
             if (addressTxQueries.Count > 0)
             {
-                addressTxHashSubquery = string.Join(" UNION ", addressTxQueries);
+                // UNION ALL skips the dedup pass — duplicates are absorbed naturally
+                // by the outer "WHERE transactionHash IN (SELECT ... FROM avatar_txs)"
+                // (set semantics). Cheaper materialization at no result-set cost.
+                addressTxHashSubquery = string.Join(" UNION ALL ", addressTxQueries);
             }
         }
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #348's `WITH avatar_txs AS MATERIALIZED (…)` CTE in `GetEvents`:

1. **`UNION` → `UNION ALL`** on the `avatar_txs` CTE. The outer query uses `WHERE transactionHash IN (SELECT … FROM avatar_txs)`, which is set-semantics — duplicates from the per-table SELECTs are absorbed naturally. The CTE-internal dedup pass was wasted work.

2. **Extract `"CrcV2"` to `FlowScopeAddressFilterNamespaces`** static constant. The hardcoded namespace was a load-bearing assumption (flow-scope events only emit via `Hub.operateFlowMatrix`, so V2 is the only namespace whose tx-hashes pull legitimate flow-scope rows). A future protocol introducing flow-scope-style events would silently get zero rows without surfacing this dependency. The constant + comment make the assumption discoverable and reviewable.

**No result-set change** — both are pure refactors / SQL set-semantics swaps.

## Test plan

- [x] `dotnet build -c Release` — 0 errors, same 64 pre-existing warnings
- [x] `./scripts/test.sh rpc` — green
- [ ] Probe avatar `EXPLAIN (ANALYZE, BUFFERS)` on staging before/after — confirm CTE no longer does sort/dedup pass
- [ ] `scripts/verify-flowscope-fix.sh` differential prod-vs-staging harness — all 3 invariants hold

## Diff

1 file, +15/-2 lines, all in `src/Rpc/Circles.Rpc.Host/CirclesRpcModule.cs`.