### PR TITLE
chore(deps): wave 1 — telemetry, runtime, and test dependency bumps

### DIFF
--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj
+++ b/src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
 
     <!-- OpenTelemetry Tracing -->
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />

--- a/src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj
+++ b/src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj
@@ -9,10 +9,10 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="NUnit" Version="4.5.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="NUnit" Version="4.6.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
@@ -9,10 +9,10 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="NUnit" Version="4.5.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="NUnit" Version="4.6.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
@@ -9,10 +9,10 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="NUnit" Version="4.5.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="NUnit" Version="4.6.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
+++ b/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
+++ b/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.66" />
+      <PackageReference Include="Dapper" Version="2.1.72" />
       <PackageReference Include="Npgsql" Version="9.0.3" />
     </ItemGroup>
 

--- a/src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj
+++ b/src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj
@@ -13,13 +13,13 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -32,7 +32,7 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
       <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
@@ -26,15 +26,15 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+        <PackageReference Include="NUnit" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
     </ItemGroup>
 

--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -12,10 +12,10 @@
 
     <ItemGroup>
         <PackageReference Include="coverlet.collector" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="NUnit" Version="4.5.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+        <PackageReference Include="NUnit" Version="4.6.0" />
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Npgsql" Version="9.0.3" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />


### PR DESCRIPTION
## Summary

Wave 1 of a coordinated dependency-update batch. Bundles five dependabot PRs into a single change. Patch-version-only or no-API-impact bumps; coordinated to land on staging together for deployment validation before promotion to dev.

## Bumps

| Package | From | To | Supersedes |
|---|---|---|---|
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.0 | 1.15.3 | #343 |
| System.Collections.Immutable | 8.0.0 | 10.0.6 | #340 |
| Dapper | 2.1.66 | 2.1.72 | #215 |
| Microsoft.AspNetCore.Mvc.Testing | 10.0.3 | 10.0.7 | #353 |
| Microsoft.NET.Test.Sdk | 18.0.1 | 18.5.1 | #353 |
| NUnit | 4.5.0 | 4.6.0 | #353 |
| NUnit.Analyzers | 4.11.2 | 4.13.0 | #353 |
| NUnit3TestAdapter | 6.1.0 | 6.2.0 | #353 |
| docker/login-action | v3 | v4 | #212 |

`Microsoft.NET.Test.Sdk` 18.5.1 includes a fix for a `System.Collections.Immutable` binding mismatch that aligns with the bump of the same package in this PR.

## Verification

- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 5 projects / 0 failed
- [ ] CI green on this PR
- [ ] Staging deploy + RPC smoke + indexer tip-catchup
- [ ] Close superseded dependabot PRs (#343, #340, #215, #353, #212) after merge

## Test plan

- [ ] Build green on CI
- [ ] All snapshot/regression test jobs green
- [ ] Deploy to staging1, drain → verify → staging2 (rolling)
- [ ] `./scripts/test-rpc.sh https://rpc-staging.aboutcircles.com` 200 OK across `circles_*`
- [ ] Indexer tip catches up on both staging nodes