### PR TITLE
fix(pathfinder): close two races in HistoricalGraphCache

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -30,6 +30,10 @@ public sealed class HistoricalGraphCache
     private readonly ConcurrentDictionary<long, CachedHistoricalGraph> _cache = new();
     private readonly ConcurrentDictionary<long, SemaphoreSlim> _loadLocks = new();
 
+    // Serializes capacity-check + publish so concurrent loads of different blocks
+    // can't both observe free capacity, both skip eviction, and both insert past _maxEntries.
+    private readonly object _cacheMutationGate = new();
+
     /// <summary>
     /// Limits concurrent historical graph loads to prevent DB/memory exhaustion.
     /// Separate from the pathfinder's request semaphore.
@@ -84,31 +88,37 @@ public sealed class HistoricalGraphCache
                 return cached.Factory;
             }
 
-            // Evict oldest if at capacity (bounded loop)
-            var evictionAttempts = 0;
-            while (_cache.Count >= _maxEntries && evictionAttempts++ < _maxEntries + 1)
-            {
-                EvictOldest();
-            }
-
             // Acquire global load semaphore to limit concurrent DB pressure
             await _globalLoadSemaphore.WaitAsync();
+            GraphFactory factory;
             try
             {
-                var factory = await Task.Run(() => LoadGraph(blockNumber));
+                factory = await Task.Run(() => LoadGraph(blockNumber));
+            }
+            finally
+            {
+                _globalLoadSemaphore.Release();
+            }
+
+            // Atomic capacity-check + publish: holding _cacheMutationGate ensures
+            // two concurrent loads of different blocks can't both bypass eviction
+            // and grow the cache past _maxEntries.
+            lock (_cacheMutationGate)
+            {
+                var evictionAttempts = 0;
+                while (_cache.Count >= _maxEntries && evictionAttempts++ < _maxEntries + 1)
+                {
+                    EvictOldest();
+                }
 
                 _cache[blockNumber] = new CachedHistoricalGraph
                 {
                     Factory = factory,
                     LastAccessedTicks = DateTimeOffset.UtcNow.Ticks
                 };
+            }
 
-                return factory;
-            }
-            finally
-            {
-                _globalLoadSemaphore.Release();
-            }
+            return factory;
         }
         finally
         {
@@ -190,8 +200,12 @@ public sealed class HistoricalGraphCache
 
         if (oldestKey >= 0 && _cache.TryRemove(oldestKey, out _))
         {
-            if (_loadLocks.TryRemove(oldestKey, out var evictedLock))
-                evictedLock.Dispose();
+            // Drop the per-block load lock entry but DO NOT dispose it: a duplicate-load
+            // waiter may still hold a reference and call Release() in its finally block,
+            // which would throw ObjectDisposedException. Leaving the SemaphoreSlim to GC
+            // is correct — SemaphoreSlim.Dispose docs explicitly forbid disposing while
+            // any thread can still access it.
+            _loadLocks.TryRemove(oldestKey, out _);
 
             _logger.LogInformation("Evicted historical graph for block {Block}", oldestKey);
         }


### PR DESCRIPTION
## Summary

Fixes two concurrency bugs flagged in the post-merge review of #350. The historical-graph-cache code path is reachable when `/findMaxFlow` is called with the `X-Max-Block-Number` header.

## Bugs

1. **Capacity check + publish were not atomic.** Two concurrent loads of *different* blocks could both observe `_cache.Count < _maxEntries`, both skip eviction, and both insert — letting the cache grow past its bound and defeating the memory cap.
2. **`SemaphoreSlim.Dispose()` was called from the eviction path.** A duplicate-load waiter that already held a reference to that semaphore would call `Release()` in its `finally` block and throw `ObjectDisposedException`. `SemaphoreSlim.Dispose` is documented to be unsafe while any thread can still access the instance.

## Fix

- Add a dedicated `_cacheMutationGate` lock; eviction and publish now happen as one atomic step under that gate, so the cache size bound holds even with concurrent loads.
- Move the eviction loop to run *after* the load completes (still bounded by `_maxEntries + 1` iterations) so it pairs with the publish under the same gate.
- Remove the `evictedLock.Dispose()` call. The dictionary entry is still removed (frees the slot), and the `SemaphoreSlim` instance is left to GC once the duplicate-load waiter finishes — this is the documented correct usage.

## Verification

- [x] `dotnet build -c Release src/Pathfinder/Circles.Pathfinder.Host/...` — 0 errors
- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/...` — 978 pass / 0 fail / 270 skip
- [x] `./scripts/test.sh` — 5 projects / 0 fail
- [ ] CI green
- [ ] Staging soak (test infra is staging-only for this code path)

## Test plan

- [ ] Build green on CI
- [ ] All test jobs green
- [ ] Deploy to staging and exercise `/findMaxFlow` with `X-Max-Block-Number` header
- [ ] Confirm no `ObjectDisposedException` traces in logs after sustained load