### PR TITLE
fix(metrics): harden /pricing handler and Balancer historical lookup

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/Program.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Program.cs
@@ -70,7 +70,7 @@ app.MapGet("/ready", () => Results.Ok("Ready"));
 app.MapMetrics();
 
 // Pricing API endpoint (cache-through: PG → Balancer/CoinGecko → PG)
-app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, BalancerPriceService balancer, PriceService prices, ILogger<Program> logger) =>
+app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, BalancerPriceService balancer, PriceService prices, ILogger<Program> logger, CancellationToken ct) =>
 {
     DateOnly targetDate;
     if (string.IsNullOrEmpty(date))
@@ -82,9 +82,14 @@ app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, Bal
         return Results.BadRequest(new { error = "Invalid date format. Use YYYY-MM-DD." });
     }
 
+    if (targetDate > DateOnly.FromDateTime(DateTime.UtcNow))
+    {
+        return Results.BadRequest(new { error = "Future dates are not supported." });
+    }
+
     // Step 1: Check PG cache
     PriceCacheRepository.DailyPrice? cached = null;
-    try { cached = await priceCache.GetAsync(targetDate); }
+    try { cached = await priceCache.GetAsync(targetDate, ct); }
     catch (Exception ex) { logger.LogWarning(ex, "PG cache lookup failed for {Date}", targetDate); }
 
     if (cached is not null)
@@ -105,8 +110,8 @@ app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, Bal
     // Step 2: Fetch price from Balancer
     var isToday = targetDate == DateOnly.FromDateTime(DateTime.UtcNow);
     var scrcXdai = isToday
-        ? await balancer.GetScrcXdaiPriceAsync()
-        : await balancer.GetHistoricScrcXdaiPriceAsync(targetDate);
+        ? await balancer.GetScrcXdaiPriceAsync(ct)
+        : await balancer.GetHistoricScrcXdaiPriceAsync(targetDate, ct);
 
     if (scrcXdai <= 0)
     {
@@ -130,14 +135,14 @@ app.MapGet("/pricing", async (string? date, PriceCacheRepository priceCache, Bal
     var dcrcXdai = BalancerPriceService.ConvertScrcToDcrcPrice(scrcXdai, timestamp);
 
     // Step 3: Fetch xDAI/EUR from CoinGecko
-    var xdaiEur = await prices.GetXdaiEurRateAsync(targetDate);
+    var xdaiEur = await prices.GetXdaiEurRateAsync(targetDate, ct);
     var dcrcEur = xdaiEur > 0 ? dcrcXdai * xdaiEur : 0;
     var source = isToday ? "balancer_live" : "balancer_historic";
 
     // Step 4: Store in PG
     try
     {
-        await priceCache.UpsertAsync(targetDate, scrcXdai, convFactor, dcrcXdai, xdaiEur, dcrcEur, source);
+        await priceCache.UpsertAsync(targetDate, scrcXdai, convFactor, dcrcXdai, xdaiEur, dcrcEur, source, ct);
     }
     catch (Exception ex)
     {

--- a/src/Metrics/Circles.Metrics.Exporter/Services/BalancerPriceService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/BalancerPriceService.cs
@@ -173,7 +173,11 @@ public class BalancerPriceService
             var targetUnix = new DateTimeOffset(targetDate.ToDateTime(TimeOnly.Parse("12:00")), TimeSpan.Zero)
                 .ToUnixTimeSeconds();
 
-            // Find the closest price point to the target date
+            // Find the closest price point to the target date.
+            // Bound the accepted distance so requests for dates far outside the available
+            // historical range don't silently return a globally-nearest sample (which
+            // would then be cached under a date the data doesn't actually cover).
+            const long MaxAcceptedDistanceSeconds = 36L * 60 * 60; // daily series + tolerance
             double closestPrice = 0;
             long closestDist = long.MaxValue;
 
@@ -188,6 +192,14 @@ public class BalancerPriceService
                     closestDist = dist;
                     closestPrice = entry.GetProperty("price").GetDouble();
                 }
+            }
+
+            if (closestDist > MaxAcceptedDistanceSeconds)
+            {
+                _logger.LogDebug(
+                    "Historic Balancer price for {Date} rejected: nearest sample is {Dist}s away (> {Max}s)",
+                    targetDate, closestDist, MaxAcceptedDistanceSeconds);
+                return 0;
             }
 
             if (closestPrice > 0)

--- a/src/Metrics/Circles.Metrics.Exporter/Services/KpiCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/KpiCollectorService.cs
@@ -1335,12 +1335,19 @@ public class KpiCollectorService : BackgroundService
             BusinessKpiMetrics.PriceSource.WithLabels("fallback").Set(source == PriceService.PriceSource.FallbackManual ? 1 : 0);
             BusinessKpiMetrics.PriceSource.WithLabels("balancer").Set(source == PriceService.PriceSource.BalancerLive ? 1 : 0);
 
-            // Balancer market price (independent gauge, always set when available)
+            // Balancer market price (independent gauge). Always update so a Balancer
+            // outage doesn't leave the previously-published value visible indefinitely
+            // while circles_price_source{source="balancer"} drops to 0.
             if (_priceService.LastBalancerDcrcXdai > 0)
             {
                 BusinessKpiMetrics.CrcPriceBalancerXdai.Set(_priceService.LastBalancerDcrcXdai);
                 BusinessKpiMetrics.CrcPriceBalancerConvFactor.Set(
                     BalancerPriceService.GetConvFactor(DateTimeOffset.UtcNow));
+            }
+            else
+            {
+                BusinessKpiMetrics.CrcPriceBalancerXdai.Set(0);
+                BusinessKpiMetrics.CrcPriceBalancerConvFactor.Set(0);
             }
 
             if (_priceService.LastUpdate > DateTimeOffset.MinValue)


### PR DESCRIPTION
## Summary

Four follow-ups on the metrics-exporter pricing path flagged in the post-merge review of #350. All defensive — none of these change the happy-path response.

## Fixes

1. **Thread `CancellationToken` through the `/pricing` pipeline** (PG cache, Balancer live/historic, CoinGecko). A client disconnect now cancels outbound work; previously the server held the connection open and ran the full pipeline regardless.
2. **Reject future dates with `400`**. A request for tomorrow's date used to fall through to the historical Balancer path and could cache a globally-nearest sample under a future key, making the response look authoritative for a day that does not exist yet.
3. **Bound the Balancer historic match distance** to 36 h. The previous \"closest of all returned points\" logic accepted samples from arbitrarily far away when a request fell outside the available data range, then cached that sample under the requested date.
4. **Always update Balancer gauges**. `CrcPriceBalancerXdai` and `CrcPriceBalancerConvFactor` were only written on success, so a single Balancer outage left stale values visible indefinitely while `circles_price_source{source=\"balancer\"}` correctly dropped to 0.

## Verification

- [x] `dotnet build -c Release src/Metrics/Circles.Metrics.Exporter/...` — 0 errors
- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/...` — 978 pass / 0 fail
- [x] `dotnet test src/Index/Circles.Index.Query.Tests/...` — 18 pass / 0 fail
- [x] No tests reference the changed pricing classes; behavior is exercised in production
- [ ] CI green
- [ ] Staging soak — verify `/pricing?date=2099-01-01` returns 400 and `/pricing?date=<unknown>` returns `source: unavailable`