### PR TITLE
fix(rpc): keep NethermindWsProxy and session state in sync on eviction

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/NethermindWsProxy.cs
+++ b/src/Rpc/Circles.Rpc.Host/NethermindWsProxy.cs
@@ -51,7 +51,8 @@ public sealed class NethermindWsProxy : IAsyncDisposable
         WebSocket clientWs,
         SemaphoreSlim clientSendLock,
         JsonElement @params,
-        CancellationToken ct)
+        CancellationToken ct,
+        Action<string>? onEvicted = null)
     {
         await EnsureConnectedAsync(ct);
 
@@ -93,7 +94,8 @@ public sealed class NethermindWsProxy : IAsyncDisposable
                 NethermindSubId: nethermindSubId,
                 ClientWs: clientWs,
                 ClientSendLock: clientSendLock,
-                OriginalParams: @params.Clone());
+                OriginalParams: @params.Clone(),
+                OnEvicted: onEvicted);
 
             _byProxyId[proxyId] = entry;
             _nethermindToProxy[nethermindSubId] = proxyId;
@@ -382,9 +384,19 @@ public sealed class NethermindWsProxy : IAsyncDisposable
                 entry.ClientSendLock.Release();
             }
         }
+        catch (OperationCanceledException) when (_cts.IsCancellationRequested)
+        {
+            // Server shutting down — leave subscription in place; DisposeAsync handles cleanup.
+        }
         catch (OperationCanceledException)
         {
-            // Server shutting down or send timeout — don't remove, let DisposeAsync handle it
+            // 5-second SendAsync timeout — client is unresponsive. Drop the subscription
+            // so we don't leak proxy mappings or keep the upstream eth_subscribe alive
+            // for a dead client.
+            _logger.LogWarning(
+                "Notification send timed out for proxy={ProxyId}, removing stale subscription",
+                proxyId);
+            RemoveStaleSubscription(proxyId);
         }
         catch (Exception ex)
         {
@@ -403,6 +415,12 @@ public sealed class NethermindWsProxy : IAsyncDisposable
             _ = SendBestEffortUnsubscribeAsync(removed.NethermindSubId);
 
             RpcMetrics.ActiveEthSubscriptions.Dec();
+
+            // Notify the owning session so its per-session state (e.g. _ethSubIds) stays in
+            // sync with the proxy's view; otherwise the session's subscription-limit count
+            // and eth_unsubscribe handling would diverge from reality.
+            NotifyEvicted(removed);
+
             _logger.LogInformation("Removed stale eth subscription proxy={ProxyId}", proxyId);
         }
     }
@@ -539,6 +557,7 @@ public sealed class NethermindWsProxy : IAsyncDisposable
                             entry.ProxyId, response);
                         _byProxyId.TryRemove(entry.ProxyId, out _);
                         RpcMetrics.ActiveEthSubscriptions.Dec();
+                        NotifyEvicted(entry);
                     }
                 }
                 finally
@@ -551,6 +570,7 @@ public sealed class NethermindWsProxy : IAsyncDisposable
                 _logger.LogWarning(ex, "Failed to re-subscribe proxy={ProxyId}", entry.ProxyId);
                 _byProxyId.TryRemove(entry.ProxyId, out _);
                 RpcMetrics.ActiveEthSubscriptions.Dec();
+                NotifyEvicted(entry);
             }
         }
     }
@@ -621,5 +641,19 @@ public sealed class NethermindWsProxy : IAsyncDisposable
         string NethermindSubId,
         WebSocket ClientWs,
         SemaphoreSlim ClientSendLock,
-        JsonElement OriginalParams);
+        JsonElement OriginalParams,
+        Action<string>? OnEvicted = null);
+
+    private void NotifyEvicted(SubscriptionEntry entry)
+    {
+        if (entry.OnEvicted is null) return;
+        try
+        {
+            entry.OnEvicted(entry.ProxyId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "OnEvicted callback threw for proxy={ProxyId}", entry.ProxyId);
+        }
+    }
 }

--- a/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
+++ b/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
@@ -265,7 +265,15 @@ public sealed class WebSocketSession : IAsyncDisposable
 
         try
         {
-            var proxyId = await _nethermindProxy.SubscribeAsync(_clientWs, _sendLock, @params, ct);
+            var proxyId = await _nethermindProxy.SubscribeAsync(_clientWs, _sendLock, @params, ct,
+                onEvicted: evictedId =>
+                {
+                    // Proxy evicted (send timeout or re-subscribe failure) — drop our
+                    // local tracking so the per-session subscription limit and
+                    // eth_unsubscribe handling stay consistent with proxy state.
+                    lock (_subListLock)
+                        _ethSubIds.Remove(evictedId);
+                });
 
             lock (_subListLock)
                 _ethSubIds.Add(proxyId);

--- a/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
+++ b/src/Rpc/Circles.Rpc.Host/WebSocketSession.cs
@@ -25,6 +25,11 @@ public sealed class WebSocketSession : IAsyncDisposable
     // Track subscriptions for cleanup
     private readonly List<string> _circlesSubIds = new();
     private readonly List<string> _ethSubIds = new();
+    // Tracks proxy IDs the proxy evicted before the session could record them in
+    // _ethSubIds (race: notification forwarder can fail and trigger OnEvicted while
+    // SubscribeAsync is still returning to the caller). Any pending Add must
+    // consult this set first, otherwise the id leaks permanently.
+    private readonly HashSet<string> _preEvictedEthIds = new();
     private readonly object _subListLock = new();
 
     public WebSocketSession(
@@ -271,12 +276,35 @@ public sealed class WebSocketSession : IAsyncDisposable
                     // Proxy evicted (send timeout or re-subscribe failure) — drop our
                     // local tracking so the per-session subscription limit and
                     // eth_unsubscribe handling stay consistent with proxy state.
+                    // If the eviction races ahead of the SubscribeAsync return, record
+                    // the id as pre-evicted so the pending Add below is suppressed.
                     lock (_subListLock)
-                        _ethSubIds.Remove(evictedId);
+                    {
+                        if (!_ethSubIds.Remove(evictedId))
+                            _preEvictedEthIds.Add(evictedId);
+                    }
                 });
 
+            bool evictedBeforeRegistration;
             lock (_subListLock)
-                _ethSubIds.Add(proxyId);
+            {
+                evictedBeforeRegistration = _preEvictedEthIds.Remove(proxyId);
+                if (!evictedBeforeRegistration)
+                    _ethSubIds.Add(proxyId);
+            }
+
+            if (evictedBeforeRegistration)
+            {
+                // Proxy already evicted this subscription (e.g. notification forward
+                // failed before SubscribeAsync returned). The proxy has cleaned up
+                // upstream; surface failure to the client instead of returning a
+                // proxy id that no longer maps to anything.
+                _logger.LogWarning(
+                    "eth_subscribe: proxy={ProxyId} evicted before session could register",
+                    proxyId);
+                await SendErrorAsync(id, -32000, "eth_subscribe failed: subscription evicted before registration", ct);
+                return;
+            }
 
             await SendResultAsync(id, proxyId, ct);
         }


### PR DESCRIPTION
## Summary

Two state-machine bugs in the WS subscription proxy flagged in the post-merge review of #350.

## Bugs

1. **5-second `SendAsync` timeout was treated as shutdown.** When forwarding a notification to a client took longer than 5 s, the resulting `OperationCanceledException` was caught and the subscription was left in place \"for `DisposeAsync` to handle.\" That leaves an orphaned proxy mapping and a live upstream `eth_subscribe` after the client WS has effectively stopped responding.
2. **Failed re-subscribes desynced proxy and session state.** `ResubscribeAllAsync` removes from `_byProxyId` on failure, but `WebSocketSession._ethSubIds` keeps the same proxy ID. After that, the client can hit a phantom per-session subscription limit, or an `eth_unsubscribe` for an ID the proxy no longer knows about returns `true` to the client.

## Fix

- Distinguish the shutdown vs. timeout cases via a `when (_cts.IsCancellationRequested)` filter; the timeout branch now logs and removes the stale subscription via `RemoveStaleSubscription`.
- Add an `Action<string>? OnEvicted` field on `SubscriptionEntry` and an optional `onEvicted` parameter on `SubscribeAsync`. `WebSocketSession.HandleEthSubscribeAsync` passes a callback that prunes `_ethSubIds` so per-session state stays in sync with the proxy.
- Invoke the callback from both proxy-initiated eviction sites: `RemoveStaleSubscription` and the two failure paths in `ResubscribeAllAsync`. Invocation is wrapped in `NotifyEvicted` with try/catch so a misbehaving consumer can't break proxy bookkeeping.

## Verification

- [x] `dotnet build -c Release src/Rpc/Circles.Rpc.Host/...` — 0 errors
- [x] `dotnet test src/Rpc/Circles.Rpc.Host.Tests/...` — 137 pass / 0 fail / 109 skip
- [ ] CI green
- [ ] Staging soak — verify subscription counts behave correctly under simulated client unresponsiveness and Nethermind reconnect