### PR TITLE
fix(pathfinder): post-merge review followups (validator + historical + tests)

### DIFF
--- a/scripts/verify-flowscope-fix.sh
+++ b/scripts/verify-flowscope-fix.sh
@@ -82,6 +82,19 @@ probe() {
         return 1
     fi
 
+    # circles_events can return HTTP 200 with a JSON-RPC error body. Without this
+    # guard, (.result // []) collapses to an empty array and the script reports a
+    # clean run from a failed call.
+    if ! jq -e '.error | not' <<<"$body" >/dev/null; then
+        echo "ERROR: JSON-RPC error from $url: $(jq -c '.error' <<<"$body")" >&2
+        return 1
+    fi
+
+    if ! jq -e '(.result | type) == "array"' <<<"$body" >/dev/null; then
+        echo "ERROR: JSON-RPC result from $url is not an array" >&2
+        return 1
+    fi
+
     local wall_seconds total flow leaked
     wall_seconds=$(python3 -c "print(($end_ns - $start_ns) / 1e9)")
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -91,7 +91,9 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         SELECT t1.truster, t1.trustee FROM active_trust t1
         INNER JOIN registered_avatars a1 ON a1.avatar = t1.truster
         INNER JOIN registered_avatars a2 ON a2.avatar = t1.trustee
-        LEFT JOIN "CrcV2_RegisterGroup" t2 ON t2."group" = t1.truster
+        LEFT JOIN "CrcV2_RegisterGroup" t2
+            ON t2."group" = t1.truster
+           AND t2."blockNumber" <= {0}
         WHERE t2."group" IS NULL
         """;
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -443,6 +443,12 @@ internal sealed class FindPathHandler(
                     mfr = emptyResponse;
                 }
 
+                // Track validator exceptions on the historical path the same way the
+                // live path does — otherwise validator bugs disappear from telemetry
+                // whenever a request uses X-Max-Block-Number.
+                if (mfr.ValidatorException)
+                    FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
+
                 log.LogInformation(
                     "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",
                     route, safeSource, safeSink, safeTargetFlow,

--- a/src/Pathfinder/Circles.Pathfinder.Tests/FuzzDifferentialTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/FuzzDifferentialTests.cs
@@ -320,19 +320,42 @@ public class FuzzDifferentialTests
         var pfExcl = new V2Pathfinder(settings: new Settings { ExcludeConsentedIntermediaries = true });
         var pfVal = new V2Pathfinder(settings: new Settings { ExcludeConsentedIntermediaries = false });
 
-        MaxFlowResponse resultExcl, resultVal;
+        // Compute each mode independently so a one-sided BAD_INPUT can't mask a
+        // mode-specific regression. The skip budget is only consumed when *both*
+        // modes reject the same graph for the same reason (degenerate generator).
+        bool exclBadInput = false, valBadInput = false;
+        MaxFlowResponse? resultExcl = null, resultVal = null;
+
         try
         {
             resultExcl = pfExcl.ComputeMaxFlowWithPath(graph, new FlowRequest { Source = srcAddr, Sink = snkAddr }, target);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("BAD_INPUT"))
+        {
+            exclBadInput = true;
+        }
+
+        try
+        {
             resultVal = pfVal.ComputeMaxFlowWithPath(graph, new FlowRequest { Source = srcAddr, Sink = snkAddr }, target);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("BAD_INPUT"))
+        {
+            valBadInput = true;
+        }
+
+        if (exclBadInput && valBadInput)
         {
             int skips = Interlocked.Increment(ref _consentFuzzSkipCount);
             Assert.That(skips, Is.LessThanOrEqualTo(ConsentFuzzMaxSkips),
                 $"Consent fuzz skipped {skips} iterations with BAD_INPUT — graph generator is producing degenerate graphs");
             return;
         }
+
+        Assert.That(exclBadInput, Is.False,
+            "Exclusion mode threw BAD_INPUT while validation mode did not — mode-specific regression");
+        Assert.That(valBadInput, Is.False,
+            "Validation mode threw BAD_INPUT while exclusion mode did not — mode-specific regression");
 
         var state = new CapacityGraphContractState(graph);
 

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -487,7 +487,12 @@ public class V2Pathfinder
                 }
 
                 ctx.ValidationErrors = errorViolations.Count;
-                ctx.ValidationViolationRules = errorViolations.Select(v => v.Rule).ToList();
+                // Deduplicate rules so per-rule audit metrics aren't multiply incremented
+                // when a single response has several violations of the same rule.
+                ctx.ValidationViolationRules = errorViolations
+                    .Select(v => v.Rule)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
             }
             catch (Exception ex)
             {

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -383,6 +383,19 @@ public static class HubContractValidator
             var to = steps[i].To.ToLowerInvariant();
             var tokenOwner = steps[i].TokenOwner.ToLowerInvariant();
 
+            // Resolve ERC20 wrapper to its underlying avatar before trust checks.
+            // Hub.sol resolves the token ID to the underlying avatar — without this
+            // step, a wrapped-token edge fails IsPermittedFlow against the wrapper
+            // contract address rather than the avatar that actually owns the token.
+            // Mirrors the resolution already done in Rule 3 (TokenIdValidity) and
+            // SimulationCanaryService.ResolveWrapperTokenOwners.
+            if (state.IsWrapperToken(tokenOwner))
+            {
+                var underlying = state.ResolveWrapperToAvatar(tokenOwner);
+                if (!string.IsNullOrWhiteSpace(underlying))
+                    tokenOwner = underlying.ToLowerInvariant();
+            }
+
             // Router→Group: internal group mint — Hub.sol uses Router as _sender,
             // isPermittedFlow does not apply (Hub.sol:723). Safe to skip.
             if (router != null && from == router && state.IsGroup(to))


### PR DESCRIPTION
## Summary

Six post-merge review followups from #350, bundled because each is a small, independent change in the same area of the codebase.

## Fixes

| Item | File | Change |
|---|---|---|
| Validator wrapper resolution | `HubContractValidator.cs` (Rule 4) | `ValidateIsPermittedFlow` resolves ERC20 wrapper → underlying avatar before trust checks. Wrapped-token edges no longer produce false `IsPermittedFlow` violations. Mirrors the existing Rule 3 (TokenIdValidity) resolution and `SimulationCanaryService.ResolveWrapperTokenOwners`. |
| Audit-rule dedup | `V2Pathfinder.cs` | `ValidationViolationRules` dedupes by rule before export so `PathAuditViolationsTotal{rule=...}` isn't multiply incremented per response. |
| Historical block ceiling | `HistoricalLoadGraph.cs` | Group-exclusion join now bounds `CrcV2_RegisterGroup` to `blockNumber <= {0}`. Previously older snapshots could wrongly exclude an avatar that became a group only later. |
| Historical telemetry parity | `FindPathHandler.cs` | Historical branch now increments `CanaryValidatorExceptionTotal` when `mfr.ValidatorException` is set, same as the live path. Validator exceptions on `X-Max-Block-Number` requests no longer disappear from metrics. |
| One-sided `BAD_INPUT` | `FuzzDifferentialTests.cs` | Run the two pathfinder modes independently. The skip budget only consumes when *both* reject the same graph for the same reason; a one-sided `BAD_INPUT` now fails the test as a mode-specific regression. |
| JSON-RPC error guard | `scripts/verify-flowscope-fix.sh` | `circles_events` can return HTTP 200 with `{"error": ...}`. Without this guard, `(.result // [])` collapsed to an empty array and the script reported a clean run from a failed call. |

## Verification

- [x] `dotnet build -c Release` — 0 errors
- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/...` — 978 pass / 0 fail / 270 skip
- [x] HubContractValidatorTests still pass (cover wrapper resolution paths)
- [x] FuzzDifferentialTests still pass (40 repeats × multiple variants)
- [ ] CI green
- [ ] Staging soak — exercise wrapped-token flows + historical X-Max-Block-Number requests