### PR TITLE
deps: Nethermind 1.37.1 + Autofac 9.1.0 + Int256 1.5.0 (Wave 2 atomic bundle)

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -43,7 +43,7 @@ RUN dotnet publish \
     -o /circles-nethermind-plugin \
     --no-restore
 
-FROM nethermind/nethermind:1.36.2 AS base
+FROM nethermind/nethermind:1.37.1 AS base
 
 # Install psql for manual DB operations (runs as root, compose sets runtime user)
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*

--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Npgsql" Version="9.0.3" />
 
     <!-- Dependency Injection -->
-    <PackageReference Include="Autofac" Version="9.0.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
 
     <!-- Monitoring -->
@@ -37,7 +37,7 @@
     <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
 
     <!-- Numerics for Circles calculations -->
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
 
     <!-- OpenAPI documentation -->
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
+++ b/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
@@ -26,7 +26,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
+++ b/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
+++ b/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.36.2" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
+++ b/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
+++ b/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index/Circles.Index.csproj
+++ b/src/Index/Circles.Index/Circles.Index.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.0.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
   </ItemGroup>
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -41,7 +41,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -62,7 +62,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
-        <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+        <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -5,7 +5,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <NethermindReferenceAssembliesVersion>1.36.2</NethermindReferenceAssembliesVersion>
+        <NethermindReferenceAssembliesVersion>1.37.1</NethermindReferenceAssembliesVersion>
         <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../..'))</RepoRoot>
         <NethermindRuntimeDir>$(RepoRoot)/nethermind-dev/nethermind</NethermindRuntimeDir>
     </PropertyGroup>

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nethereum.Util" Version="5.0.0" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.3.6" />
+    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.0.0" />
+    <PackageReference Include="Autofac" Version="9.1.0" />
     <PackageReference Include="Npgsql" Version="9.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Bumps `Nethermind.ReferenceAssemblies` 1.36.2 → 1.37.1
- Bumps `Nethermind.Numerics.Int256` 1.3.6 → 1.5.0
- Bumps `Autofac` 9.0.0 → 9.1.0 (required: Nethermind 1.37.1's `Nethermind.Api` references Autofac 9.1.0; mismatch produces CS1705 at link time)
- Bumps `nethermind/nethermind` Docker base image 1.36.2 → 1.37.1 (`docker/Index.Dockerfile`)

Atomic bundle — all four bumps must land together. Supersedes #251, #351, #352.

## Audit
Plugin's surface into Nethermind APIs (`IBlockTree.Head`, `NewHeadBlock` event, `SyncModeSelector.Current`, `IBlockTree.FindBlock`, `IReceiptFinder.Get`) was reviewed against 1.37.1's worldstate refactor. All call sites compile against 1.37.1 and tests pass with no regression.

No Vault, NDM, eth/66, eth/67, `EngineApiVersion`, `IsMining`, or `StoreReceipts` references — plugin is event-indexer only, unaffected by 1.37.1's protocol/Engine API changes.

Local results:
- `dotnet build -c Release` — 0 errors, 143 warnings (all pre-existing categories: internal `Settings.DisableConsentedFlow` deprecation warnings introduced in #345/#346/#358, plus the documented `Newtonsoft.Json` CVE and `NU1510` pruning notes)
- `./scripts/test.sh` — 1219 passed, 0 failed, 390 skipped (staging-/Anvil-dependent)

## Test plan
- [ ] CI green: build-and-test, CodeQL, snapshot-tests, regression-tests, formatting
- [ ] Rolling deploy node 1: indexer healthy, tip catches up
- [ ] RPC smoke node 1: `./scripts/test-rpc.sh` against staging URL — all `circles_*` 200 OK
- [ ] Rolling deploy node 2: indexer healthy, tip catches up
- [ ] RPC smoke node 2
- [ ] EL ↔ CL: `nethermind` logs show no `EngineApiVersion` mismatch with the consensus client