### PR TITLE
chore(deps): mask Nethermind 1.37.1 /health ClUnavailable false-positive

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -25,6 +25,19 @@ services:
       - ../.state/jwtsecret-gnosis/jwt.hex:/jwt.hex
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+    # WORKAROUND for Nethermind 1.37.1 /health endpoint regression (upstream issue
+    # NethermindEth/nethermind#11473, fix PR #11474 — not in 1.37.1).
+    # The CL-message tracker is wired to a no-op singleton; the real one polled by
+    # NodeHealthService never receives updates, so /health flips to Unhealthy with
+    # `ClUnavailable` after `MaxIntervalClRequestTime` (default 300s) regardless of
+    # actual EL↔CL state. Setting the interval to Int32.MaxValue (≈68 years)
+    # effectively disables this specific check until the upstream fix lands.
+    # CL outage detection is still covered by the separate `ConsensusNotHealthy`
+    # alert (probes Lighthouse `/eth/v1/node/health` directly) and the full-stack
+    # `/ready` probe.
+    # REMOVE the `--HealthChecks.MaxIntervalClRequestTime=...` line below when
+    # bumping to Nethermind 1.37.2 or later (verify by checking that #11474 is
+    # merged into the target version).
     command: |
       --config=gnosis
       --datadir=/data
@@ -49,6 +62,7 @@ services:
       --Network.EnableUPnP=${NETHERMIND_ENABLE_UPNP:-false}
       --HealthChecks.Enabled=true
       --HealthChecks.UIEnabled=true
+      --HealthChecks.MaxIntervalClRequestTime=2147483647
       --Metrics.Enabled=true
       --Metrics.ExposePort=6060
     env_file:


### PR DESCRIPTION
## Summary
Adds `--HealthChecks.MaxIntervalClRequestTime=2147483647` (≈68 years, effectively never) to `nethermind-gnosis` in `docker/docker-compose.gnosis.yml` to mask Nethermind 1.37.1's `/health` endpoint regression.

## Background
1.37.1 ships a bug where `BaseMergePluginModule` registers a no-op `IEngineRequestsTracker` that overrides the real `ClHealthRequestsTracker` from `HealthChecksPlugin`. Engine API ForkChoice / NewPayload calls update the no-op tracker; `NodeHealthService` polls the real one, which therefore never receives updates. After `MaxIntervalClRequestTime` (default 300s), `/health` flips to `Unhealthy` with `Errors: ["ClUnavailable"]` regardless of actual EL↔CL state.

Tracking: NethermindEth/nethermind#11473
Fix:      NethermindEth/nethermind#11474 (open, not in 1.37.1)

## Why an effectively-infinite value?
The real tracker is never updated, so any finite timeout eventually fires. `Int32.MaxValue` seconds (≈68 years) means it never fires in practice. CL outage detection remains covered independently by:
- `ConsensusNotHealthy` Alertmanager alert — probes Lighthouse `/eth/v1/node/health` directly
- `/ready` full-stack probe — checks EL sync, indexer, DB, pathfinder

Losing the redundant CL signal in `nethermind/health` is acceptable until 1.37.2 lands.

## Verification
Live nodes (staging1, staging2) running this exact flag value (manually applied 2026-05-04 06:55 UTC) — `nethermind/health` returns 200 stably; chain advancing; smoke tests pass.

## Test plan
- [ ] CI green
- [ ] Merge to staging
- [ ] Next `make deploy-staging-rolling` carries the workaround through ansible (no manual edit drift)
- [ ] Issue tracker: when 1.37.2 ships PR #11474, open follow-up to remove this line + comment block

## Removal
When bumping to Nethermind 1.37.2 or later: delete the `--HealthChecks.MaxIntervalClRequestTime=...` line and the surrounding comment block.