### PR TITLE
chore(deps): Wave 3a — Nethereum.Web3 4.29 → 6.1 + Nethereum.Util 5.0 → 5.8

### DIFF
--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="9.0.3" />
-    <PackageReference Include="Nethereum.Util" Version="5.0.0" />
+    <PackageReference Include="Nethereum.Util" Version="5.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
+++ b/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="System.CommandLine" Version="2.0.3" />
         <PackageReference Include="Npgsql" Version="9.0.3" />
-        <PackageReference Include="Nethereum.Util" Version="5.0.0" />
+        <PackageReference Include="Nethereum.Util" Version="5.8.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.ContractClient/Circles.Index.ContractClient.csproj
+++ b/src/Index/Circles.Index.ContractClient/Circles.Index.ContractClient.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethereum.Web3" Version="4.29.0" />
+      <PackageReference Include="Nethereum.Web3" Version="6.1.0" />
     </ItemGroup>
 
 </Project>

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -18,7 +18,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Nethereum.Util" Version="5.0.0" />
+    <PackageReference Include="Nethereum.Util" Version="5.8.0" />
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Wave 3 bundle 3a (Nethereum group). Combines dependabot PRs #339 (Nethereum.Web3) and #181 (Nethereum.Util) and aligns Nethereum.Util in Circles.Index.Backfill (missed by dependabot grouping).

- \`Circles.Index.ContractClient\`: Nethereum.Web3 4.29.0 → 6.1.0
- \`Circles.Common\`: Nethereum.Util 5.0.0 → 5.8.0
- \`Circles.Rpc.Host\`: Nethereum.Util 5.0.0 → 5.8.0
- \`Circles.Index.Backfill\`: Nethereum.Util 5.0.0 → 5.8.0 (consistency, not in dependabot's grouping)

No source code changes — both bumps are API-compatible with our usage.

## Surface area

- Nethereum.Web3 — single caller: \`Circles.Index.ContractClient/CirclesV2HubClient.cs\`
- Nethereum.Util — four callers: \`Common/KeccakHelper.cs\`, \`Rpc.Host/AbiEncoder.cs\`, \`Index.Backfill/EventRegistry.cs\`, \`Pathfinder.Tests/AnvilExecutionHelper.cs\`

## Test plan

- [x] \`dotnet restore\` clean (only pre-existing Newtonsoft.Json CVE warnings)
- [x] \`dotnet build -c Release\` — 0 errors, 108 warnings (all pre-existing)
- [x] \`./scripts/test.sh\` — 5/5 projects pass, 1219 tests pass, 0 fail, 390 skipped (Anvil/staging-dependent suites)
- [ ] CI green on this PR
- [ ] Rolling staging deploy (rpc, pathfinder, cache, index, metrics — narrowest tags)
- [ ] 30-min staging soak: \`/health\`, \`/ready\`, Loki errors, \`circles_db_query_duration_seconds\` p95
- [ ] Smoke: \`./scripts/test-rpc.sh\` against staging1 and staging2

## Supersedes

Closes #339, #181 once merged (delete branches after).