### PR TITLE
ci(deps): Wave 3b — bump GH Actions across all workflows

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: TestResults/
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
           path: TestResults/coverage/
@@ -75,12 +75,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload snapshot test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: snapshot-test-results
           path: TestResults/snapshot/
@@ -116,12 +116,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -143,7 +143,7 @@ jobs:
 
       - name: Upload regression test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: regression-test-results
           path: TestResults/regression/

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -35,7 +35,7 @@ jobs:
           languages: csharp
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -54,12 +54,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Dependency Review
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/deploy-staging-smart.yml
+++ b/.github/workflows/deploy-staging-smart.yml
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for CI build and test
-        uses: lewagon/wait-on-check-action@v1.3.4
+        uses: lewagon/wait-on-check-action@v1.5.0
         with:
           ref: ${{ github.sha }}
           check-name: "build-and-test"
@@ -95,7 +95,7 @@ jobs:
       any_deploy: ${{ steps.set-flags.outputs.any_deploy }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
 
@@ -42,7 +42,7 @@ jobs:
           ./scripts/nuget-pack.sh --clean
 
       - name: Upload package artifacts
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: nupkgs/*.nupkg


### PR DESCRIPTION
## Summary

Wave 3 bundle 3b (GitHub Actions group). Combines dependabot PRs #175, #176, #177, #178 into a single workflow-only PR.

- \`actions/checkout\` v4 → v6 (9 occurrences across 5 workflows)
- \`actions/setup-dotnet\` v4 → v5 (6 occurrences)
- \`actions/upload-artifact\` v6 → v7 (5 occurrences)
- \`lewagon/wait-on-check-action\` v1.3.4 → v1.5.0 (1 occurrence)

5 files changed, +21/-21 lines. No source code, no workflow logic changes — only \`@version\` refs.

## Why these versions are safe for this repo

- **checkout v4→v6**: skips v5 deliberately. Only material change in v5/v6 is Node 20→24 runtime (transparent on GitHub-hosted runners) and credential persistence moving to \`\$RUNNER_TEMP\`. No effect on \`submodules: recursive\` or \`fetch-depth: 0\` usage.
- **setup-dotnet v4→v5**: \`dotnet-version: '10.0.x'\` resolution unchanged when target matches or exceeds the runner's preinstalled .NET. The v5 footgun (latest preinstalled overriding intent) only bites when specifying a *lower* version.
- **upload-artifact v6→v7**: name-uniqueness and immutability constraints landed in v4/v5; already in effect. All 5 upload sites use distinct names (\`test-results\`, \`coverage-reports\`, \`snapshot-test-results\`, \`regression-test-results\`, \`nuget-packages\`).
- **wait-on-check-action v1.3.4→v1.5.0**: \`check-name\` matching and \`allowed-conclusions\` semantics unchanged.

## Test plan

- [x] Diff verified: 21/21 expected version refs bumped, no leftover old refs
- [x] Security review: no advisories on target versions; no \`GITHUB_TOKEN\` scope changes
- [x] Logic review: no breaking changes for this repo's actual usage patterns
- [ ] CI runs — note: the CI workflows themselves only trigger on PRs targeting \`dev\`/\`main\`, so this PR (vs \`staging\`) won't gate on CI run, same as Wave 1/2/3a. Effective validation comes when staging→dev promotion runs CI on the merged commit.
- [ ] No staging deploy needed — workflow-only change, doesn't touch runtime services.

## Supersedes

Closes #175, #176, #177, #178 once merged.