### PR TITLE
chore(deps): Wave 3c — Testcontainers v3→v4 + System.Reflection.Metadata 8→10

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -18,8 +18,8 @@
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
         <PackageReference Include="Npgsql" Version="9.0.3" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="3.10.0" />
-        <PackageReference Include="System.Reflection.Metadata" Version="8.0.0" />
+        <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+        <PackageReference Include="System.Reflection.Metadata" Version="10.0.5" />
         <PackageReference Include="Nethermind.ReferenceAssemblies" Version="$(NethermindReferenceAssembliesVersion)" PrivateAssets="all" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary

Wave 3 bundle 3c (test-deps group). Combines dependabot PRs #253, #254 into a single test-only PR.

- \`Testcontainers.PostgreSql\` 3.10.0 → 4.11.0 (major)
- \`System.Reflection.Metadata\` 8.0.0 → 10.0.5 (.NET 10 GA train)

Single csproj edit (\`src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj\`). 1 file, +2/-2 lines.

## Important caveat

\`CirclesRpcModuleTests\` is \`[Ignore]\`-annotated (\"Requires Nethermind runtime; temporarily skipped until Nethermind build artifacts are available\") and additionally guarded at runtime by a check for Nethermind reference assemblies in \`nethermind-dev/\`. Neither CI nor local runs without the submodule populated will start the Postgres container.

So this PR validates the Testcontainers v3→v4 upgrade at **API/compile level only**. The PostgreSqlBuilder fluent surface used in this repo (\`WithImage\` / \`WithDatabase\` / \`WithUsername\` / \`WithPassword\` / \`StartAsync\`) is stable across v3→v4. When the fixture is re-enabled, the container start path will be exercised end-to-end.

For future test authors: \`UntilPortIsAvailable(int)\` was removed in Testcontainers.PostgreSql 4.10.0. Not used today, but a common Stack Overflow snippet — use \`UntilPortIsAvailable(uint)\` overload or the default postgres wait strategy instead.

## Test plan

- [x] \`dotnet restore\` clean
- [x] \`dotnet build -c Release\` — 0 errors, 102 warnings (all pre-existing)
- [x] \`./scripts/test.sh\` — 5/5 projects, 1219 pass / 0 fail / 390 skip
- [x] Security review: no advisories on either target version
- [x] Logic review: no breaking changes for current usage
- [ ] No staging deploy needed — test-only deps, never shipped to runtime services

## Supersedes

Closes #253, #254 once merged.