### PR TITLE
chore(deps): Wave 3d — Npgsql 9.0.3 → 10.0.1 (DB driver across full solution)

### DIFF
--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
 
     <!-- PostgreSQL -->
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.1" />
 
     <!-- Dependency Injection -->
     <PackageReference Include="Autofac" Version="9.1.0" />
@@ -34,7 +34,7 @@
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
 
     <!-- Numerics for Circles calculations -->
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />

--- a/src/Common/Circles.Common.TestUtils/Circles.Common.TestUtils.csproj
+++ b/src/Common/Circles.Common.TestUtils/Circles.Common.TestUtils.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql" Version="9.0.3" />
+        <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.1" />
     <PackageReference Include="Nethereum.Util" Version="5.8.0" />
   </ItemGroup>
 

--- a/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
+++ b/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.CommandLine" Version="2.0.3" />
-        <PackageReference Include="Npgsql" Version="9.0.3" />
+        <PackageReference Include="Npgsql" Version="10.0.1" />
         <PackageReference Include="Nethereum.Util" Version="5.8.0" />
     </ItemGroup>
 

--- a/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
+++ b/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="9.0.3" />
+      <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.Postgres/Circles.Index.Postgres.csproj
+++ b/src/Index/Circles.Index.Postgres/Circles.Index.Postgres.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="9.0.3" />
+      <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
+++ b/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
@@ -18,7 +18,7 @@
 
     <ItemGroup>
       <PackageReference Include="Dapper" Version="2.1.72" />
-      <PackageReference Include="Npgsql" Version="9.0.3" />
+      <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
+++ b/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="9.0.3" />
+      <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Metrics/Circles.Metrics.Exporter/Circles.Metrics.Exporter.csproj
+++ b/src/Metrics/Circles.Metrics.Exporter/Circles.Metrics.Exporter.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
 
     <!-- PostgreSQL -->
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.1" />
 
     <!-- Monitoring -->
     <PackageReference Include="prometheus-net" Version="8.2.1" />

--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -35,7 +35,7 @@
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
       <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
       <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-      <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+      <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
       <PackageReference Include="prometheus-net" Version="8.2.1" />
       <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     </ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -18,7 +18,7 @@
     <ItemGroup>
         <PackageReference Include="Google.OrTools" Version="9.15.6755" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Npgsql" Version="9.0.3" />
+        <PackageReference Include="Npgsql" Version="10.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
         <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Npgsql" Version="9.0.3" />
+        <PackageReference Include="Npgsql" Version="10.0.1" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
         <PackageReference Include="System.Reflection.Metadata" Version="10.0.5" />
         <PackageReference Include="Nethermind.ReferenceAssemblies" Version="$(NethermindReferenceAssembliesVersion)" PrivateAssets="all" />

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.3" />
+    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
     <PackageReference Include="prometheus-net" Version="8.2.1" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
@@ -36,7 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
+    <PackageReference Include="Npgsql" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Wave 3 bundle 3d (Npgsql group). Supersedes dependabot #184. Bumps Npgsql + Npgsql.OpenTelemetry 9.0.3 → 10.0.1 across all 13 csproj files in the solution — dependabot's grouping only covered 3 csprojs, but the full solution requires uniform Npgsql to avoid assembly load conflicts (per CLAUDE.md \`### .NET 10 Migration\`).

13 files changed, +15/-15 lines. **Zero source code changes** — Npgsql 10's public surface (\`NpgsqlConnection\` / \`NpgsqlCommand\` / \`NpgsqlParameter\` / \`NpgsqlDataSource\` / \`NpgsqlBatch\`) is API-compatible with this codebase's usage.

## Runtime behavior changes worth watching

Two reviews (security + logic) found these are non-issues for our codebase, documented for the soak watch:

1. **GSS Encryption Mode flipped from \`Disable\` to \`Prefer\`** (Npgsql 10 default). On Linux containers without \`libgssapi-krb5-2\` (i.e., the project's Docker images), expect a one-time Kerberos-probe warning at startup. Driver falls back transparently — connection succeeds. Optional follow-up: add \`GSS Encryption Mode=Disable\` to connection strings to silence the noise.
2. **\`PostgresException.BatchCommand\` is null by default** in Npgsql 10 (prevents query/param leaks in logs). Codebase does not inspect this field anywhere — verified via grep.
3. **\`date\` / \`time\` columns now return \`DateOnly\` / \`TimeOnly\`** instead of \`DateTime\` / \`TimeSpan\`. Codebase reads all temporal values as \`BIGINT\` Unix epoch — verified via call-site review.
4. **TLS chain validation tightened to root CAs only** (libpq-aligned). Not applicable to current \`sslmode=disable\`/\`prefer\` LAN connections.
5. **Npgsql internal OTel metric/span names** renamed for OTel alignment. Codebase uses its own \`circles_db_query_duration_seconds\` Prometheus histograms; no dashboard breakage.

## Why this is safer than the major version implies

- All \`NpgsqlParameter\`s use explicit \`NpgsqlDbType\` enum (no \`AddWithValue\` magic for non-trivial types)
- All temporal columns are \`BIGINT\` (Unix epoch), never \`timestamp\`/\`date\`/\`time\`
- No custom enums, no \`cidr\`/\`inet\`/\`uuid\` mappings affected
- No \`EnableLegacyTimestampBehavior\` reliance
- Pool sizes/idle lifetimes set explicitly via \`NpgsqlDataSourceBuilder\`
- No GSSAPI usage in current connection strings

## Surface area

DB driver across:
- **Cache.Service** (cache layer for RPC reads)
- **Pathfinder.Host** (path computation service)
- **Rpc.Host** (JSON-RPC service)
- **Metrics.Exporter** (analytics stack)
- **Indexer plugin** (via \`Index.*\` projects, runs inside nethermind-gnosis container)

Rolling staging deploy required — drain → deploy gnosis stack per node → 30-min soak watch.

## Test plan

- [x] All 15 Npgsql refs at 10.0.1, none at 9.0.3 (verified via grep)
- [x] \`dotnet restore\` clean
- [x] \`dotnet build -c Release\` — 0 errors, 109 warnings (all pre-existing)
- [x] \`./scripts/test.sh\` — 5/5 projects, 1219 pass / 0 fail / 390 skip
- [x] Security review: no advisories on 9.0.3 or 10.0.1
- [x] Logic review: no real risks for current usage; GSS log noise expected
- [ ] Rolling staging deploy: rpc, pathfinder, cache, index (gnosis stack), metrics-exporter
- [ ] Watch \`/health\` and \`/ready\` per service per node during soak
- [ ] Watch Loki for: GSS noise (informational), connection errors (real), \`PostgresException\` patterns
- [ ] Watch \`circles_db_query_duration_seconds\` p95 vs. baseline

## Supersedes

Closes #184 once merged.