### PR TITLE
feat(rpc): add path metrics to circles_searchProfiles

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
@@ -137,6 +137,7 @@ public static class RpcMetrics
     //   proxy_error_then_sql   proxy non-2xx, SQL ran as fallback
     //   proxy_timeout_then_sql proxy threw timeout/transport, SQL ran as fallback
     //   sql_only               ProfilePinningServiceUrl unset, SQL ran directly
+    //   short_circuit_empty    all tokens <=1 char, returned empty without searching
 
     /// <summary>
     /// Total circles_searchProfiles requests, labelled by which code path served them.
@@ -160,7 +161,8 @@ public static class RpcMetrics
         });
 
     /// <summary>
-    /// Distribution of normalized search query lengths (post-trim, post-token-join).
+    /// Distribution of search query lengths after trim, observed for every request
+    /// (including short-circuit-empty rejections).
     /// </summary>
     public static readonly Histogram SearchProfilesQueryLength = Metrics.CreateHistogram(
         "circles_search_profiles_query_length_chars",

--- a/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
@@ -129,4 +129,53 @@ public static class RpcMetrics
         {
             Buckets = new[] { 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 50.0 }
         });
+
+    // ---- circles_searchProfiles instrumentation (Phase 4 measurement) ----
+    // Path label values (kept here so dashboards/alerts can reference one source):
+    //   proxy_hit              proxy returned >=1 result, no SQL ran
+    //   proxy_zero_then_sql    proxy returned [], SQL ran as fallback
+    //   proxy_error_then_sql   proxy non-2xx, SQL ran as fallback
+    //   proxy_timeout_then_sql proxy threw timeout/transport, SQL ran as fallback
+    //   sql_only               ProfilePinningServiceUrl unset, SQL ran directly
+
+    /// <summary>
+    /// Total circles_searchProfiles requests, labelled by which code path served them.
+    /// </summary>
+    public static readonly Counter SearchProfilesPathTotal = Metrics.CreateCounter(
+        "circles_search_profiles_path_total",
+        "Total circles_searchProfiles requests by served path",
+        new CounterConfiguration { LabelNames = new[] { "path" } });
+
+    /// <summary>
+    /// End-to-end circles_searchProfiles duration (RPC entry → return), by path.
+    /// Includes the proxy attempt latency for *_then_sql paths.
+    /// </summary>
+    public static readonly Histogram SearchProfilesDuration = Metrics.CreateHistogram(
+        "circles_search_profiles_duration_seconds",
+        "circles_searchProfiles end-to-end duration in seconds",
+        new HistogramConfiguration
+        {
+            LabelNames = new[] { "path" },
+            Buckets = new[] { 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0 }
+        });
+
+    /// <summary>
+    /// Distribution of normalized search query lengths (post-trim, post-token-join).
+    /// </summary>
+    public static readonly Histogram SearchProfilesQueryLength = Metrics.CreateHistogram(
+        "circles_search_profiles_query_length_chars",
+        "Distribution of circles_searchProfiles query lengths in characters",
+        new HistogramConfiguration
+        {
+            Buckets = new[] { 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0 }
+        });
+
+    /// <summary>
+    /// Total circles_searchProfiles requests that returned zero results, by path.
+    /// Useful for spotting paths where the proxy is "successful" but useless.
+    /// </summary>
+    public static readonly Counter SearchProfilesZeroResultsTotal = Metrics.CreateCounter(
+        "circles_search_profiles_zero_results_total",
+        "Total circles_searchProfiles requests that returned an empty result set",
+        new CounterConfiguration { LabelNames = new[] { "path" } });
 }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -585,12 +585,17 @@ public partial class CirclesRpcModule
             throw new ArgumentException($"limit must not exceed {hardLimit} (got {limit}).");
         }
 
+        var sw = Stopwatch.StartNew();
         string qText = text.Trim();
+        RpcMetrics.SearchProfilesQueryLength.Observe(qText.Length);
+
         string[] tokens = qText.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (!tokens.Any(o => o.Length > 1))
         {
-            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            var emptyResult = new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            RecordSearchProfilesPath("short_circuit_empty", sw.Elapsed, emptyResult);
+            return emptyResult;
         }
 
         if (tokens.Length > 3)
@@ -606,9 +611,6 @@ public partial class CirclesRpcModule
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
-        RpcMetrics.SearchProfilesQueryLength.Observe(qText.Length);
-
-        var sw = Stopwatch.StartNew();
         string path = "sql_only";
 
         // Try profile pinning service first (fast path)

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Circles.Common;
@@ -574,6 +575,8 @@ public partial class CirclesRpcModule
         return await GetProfileByCidBatchInternal(cids);
     }
 
+    private enum SearchProxyOutcome { Hit, Zero, Error }
+
     public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null)
     {
         const int hardLimit = 100;
@@ -603,32 +606,64 @@ public partial class CirclesRpcModule
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
+        RpcMetrics.SearchProfilesQueryLength.Observe(qText.Length);
+
+        var sw = Stopwatch.StartNew();
+        string path = "sql_only";
+
         // Try profile pinning service first (fast path)
         if (!string.IsNullOrEmpty(_settings.ProfilePinningServiceUrl))
         {
             try
             {
-                var proxyResult = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
-                if (proxyResult != null)
+                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
+                switch (outcome)
                 {
-                    return proxyResult;
+                    case SearchProxyOutcome.Hit:
+                        RecordSearchProfilesPath("proxy_hit", sw.Elapsed, proxyResult!);
+                        return proxyResult!;
+                    case SearchProxyOutcome.Zero:
+                        path = "proxy_zero_then_sql";
+                        break;
+                    case SearchProxyOutcome.Error:
+                        path = "proxy_error_then_sql";
+                        break;
                 }
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Profile pinning service proxy failed, falling back to SQL");
+                path = ClassifyProxyException(ex);
+                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}), falling back to SQL", path);
             }
         }
 
         // Fallback: direct SQL search
-        return await SearchProfilesViaSql(qText, limit, offset, typeFilter);
+        var sqlResult = await SearchProfilesViaSql(qText, limit, offset, typeFilter);
+        RecordSearchProfilesPath(path, sw.Elapsed, sqlResult);
+        return sqlResult;
     }
+
+    private static void RecordSearchProfilesPath(string path, TimeSpan elapsed, ProfileSearchResult result)
+    {
+        RpcMetrics.SearchProfilesPathTotal.WithLabels(path).Inc();
+        RpcMetrics.SearchProfilesDuration.WithLabels(path).Observe(elapsed.TotalSeconds);
+        if (result.Total == 0)
+        {
+            RpcMetrics.SearchProfilesZeroResultsTotal.WithLabels(path).Inc();
+        }
+    }
+
+    private static string ClassifyProxyException(Exception ex) => ex switch
+    {
+        OperationCanceledException => "proxy_timeout_then_sql",
+        _ => "proxy_error_then_sql",
+    };
 
     /// <summary>
     /// Fast path: proxy search to the profile-pinning service REST API.
-    /// Returns null if the service is unavailable or returns an error.
+    /// Returns an outcome indicating Hit/Zero/Error so the caller can label metrics.
     /// </summary>
-    private async Task<ProfileSearchResult?> SearchProfilesViaProxy(
+    private async Task<(SearchProxyOutcome outcome, ProfileSearchResult? result)> SearchProfilesViaProxy(
         string qText, int limit, int offset, string[]? typeFilter)
     {
         var baseUrl = _settings.ProfilePinningServiceUrl!.TrimEnd('/');
@@ -653,7 +688,7 @@ public partial class CirclesRpcModule
         if (!response.IsSuccessStatusCode)
         {
             _logger?.LogWarning("Profile pinning service returned {StatusCode}", response.StatusCode);
-            return null;
+            return (SearchProxyOutcome.Error, null);
         }
 
         var json = await response.Content.ReadAsStringAsync(cts.Token);
@@ -661,8 +696,7 @@ public partial class CirclesRpcModule
 
         if (proxyResults == null || proxyResults.Length == 0)
         {
-            // Return null to fall through to SQL fallback
-            return null;
+            return (SearchProxyOutcome.Zero, null);
         }
 
         // Safety net: server handles offset, but cap to requested limit
@@ -676,7 +710,7 @@ public partial class CirclesRpcModule
 
         if (addresses.Length == 0)
         {
-            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            return (SearchProxyOutcome.Hit, new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>()));
         }
 
         // Batch avatar info lookup (single DB call instead of N+1)
@@ -712,7 +746,7 @@ public partial class CirclesRpcModule
             ));
         }
 
-        return new ProfileSearchResult(Total: results.Count, Results: results.ToArray());
+        return (SearchProxyOutcome.Hit, new ProfileSearchResult(Total: results.Count, Results: results.ToArray()));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Instruments the proxy/SQL fallback branching of `circles_searchProfiles` with
Prometheus metrics so production behavior can be observed before deciding
whether further SQL optimization is warranted.

## Changes
- New metrics in `RpcMetrics.cs`:
  - `circles_search_profiles_path_total{path}` — counter
  - `circles_search_profiles_duration_seconds{path}` — histogram
  - `circles_search_profiles_query_length_chars` — histogram (no labels)
  - `circles_search_profiles_zero_results_total{path}` — counter
- Refactor: `SearchProfilesViaProxy` returns `(SearchProxyOutcome, ProfileSearchResult?)`
  so the caller can distinguish empty-result vs non-2xx (both previously returned `null`).
- Canonical path label values documented in `RpcMetrics.cs`:
  `proxy_hit`, `proxy_zero_then_sql`, `proxy_error_then_sql`,
  `proxy_timeout_then_sql`, `sql_only`, `short_circuit_empty`.
- Query-length histogram observed once at the top so every request is
  represented, including those rejected by the all-tokens-too-short guard.
- Behavior preserved: same fallback rules, same return shapes, same log messages.

## Test plan
- [ ] Build green (verified locally + pre-push hook)
- [ ] After deploy: confirm \`/metrics\` exposes the new series
- [ ] After ~1 week of traffic on staging1+staging2 + production: review
      path distribution + p95 per path to inform follow-up work