### PR TITLE
chore(deps): bump Nethermind 1.37.1 → 1.37.2 + drop /health workaround

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -43,7 +43,7 @@ RUN dotnet publish \
     -o /circles-nethermind-plugin \
     --no-restore
 
-FROM nethermind/nethermind:1.37.1 AS base
+FROM nethermind/nethermind:1.37.2 AS base
 
 # Install psql for manual DB operations (runs as root, compose sets runtime user)
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*

--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -25,19 +25,6 @@ services:
       - ../.state/jwtsecret-gnosis/jwt.hex:/jwt.hex
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
-    # WORKAROUND for Nethermind 1.37.1 /health endpoint regression (upstream issue
-    # NethermindEth/nethermind#11473, fix PR #11474 — not in 1.37.1).
-    # The CL-message tracker is wired to a no-op singleton; the real one polled by
-    # NodeHealthService never receives updates, so /health flips to Unhealthy with
-    # `ClUnavailable` after `MaxIntervalClRequestTime` (default 300s) regardless of
-    # actual EL↔CL state. Setting the interval to Int32.MaxValue (≈68 years)
-    # effectively disables this specific check until the upstream fix lands.
-    # CL outage detection is still covered by the separate `ConsensusNotHealthy`
-    # alert (probes Lighthouse `/eth/v1/node/health` directly) and the full-stack
-    # `/ready` probe.
-    # REMOVE the `--HealthChecks.MaxIntervalClRequestTime=...` line below when
-    # bumping to Nethermind 1.37.2 or later (verify by checking that #11474 is
-    # merged into the target version).
     command: |
       --config=gnosis
       --datadir=/data
@@ -62,7 +49,6 @@ services:
       --Network.EnableUPnP=${NETHERMIND_ENABLE_UPNP:-false}
       --HealthChecks.Enabled=true
       --HealthChecks.UIEnabled=true
-      --HealthChecks.MaxIntervalClRequestTime=2147483647
       --Metrics.Enabled=true
       --Metrics.ExposePort=6060
     env_file:


### PR DESCRIPTION
## Summary

- Bumps `nethermind/nethermind:1.37.1 → 1.37.2` in `docker/Index.Dockerfile`.
- Removes the `--HealthChecks.MaxIntervalClRequestTime=2147483647` mitigation flag (and its workaround comment block) from the `nethermind-gnosis` command in `docker/docker-compose.gnosis.yml`.

## Why

1.37.1 shipped a regression where `IEngineRequestsTracker` overrode the real `ClHealthRequestsTracker` registered by `HealthChecksPlugin`, causing `/health` to flip to `Unhealthy` with `ClUnavailable` after `MaxIntervalClRequestTime` (default 300s) regardless of actual EL↔CL state. Tracking issue `NethermindEth/nethermind#11473`; fix `#11474` (cherry-picked to `release/1.37.2` via `#11482`) is now in 1.37.2.

With the upstream fix in place, the Int32.MaxValue mitigation flag is no longer needed and should be removed so `/health` regains real CL-outage signal at the default 300s threshold.

## Test plan

- [ ] CI build green.
- [ ] After deploy on staging1: `curl -fsS http://localhost:8545/health` returns `200` with `status: Healthy` and no `ClUnavailable` entry.
- [ ] Re-probe staging1 at +5 / +15 / +60 min (the regression manifested exactly at the `MaxIntervalClRequestTime` boundary, so 60+ minutes of clean `/health` with default 300s tolerance proves the fix).
- [ ] `consensus-gnosis` (Lighthouse) `/eth/v1/node/health` stays green; `Synced Chain Head` cycling in nethermind-gnosis logs.
- [ ] Same checks on staging2 after rolling deploy.
- [ ] `RpcReadyDown` and `ConsensusNotHealthy` Prometheus alerts stay silent.