### PR TITLE
Support score-group path minting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ If you're developing the plugin, building packages, or running services locally,
 - **[Rpc](src/Rpc/Circles.Rpc.Host/README.md)** - Rpc service
 - **[Cache](src/Cache/README.md)** - Cache service
 - **[Metrics Exporter](src/Metrics/Circles.Metrics.Exporter/README.md)** - Prometheus metrics exporter
+- **[Score-group mint along path](docs/score-group-mint-along-path.md)** - Score-group routing, cache graph fields, and mint-limit capacity
+- **[Reindexing Guide](docs/partial-table-reindexing.md)** - Full and selected-table reindex/backfill procedures
 
 Quick commands for developers:
 

--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -62,6 +62,9 @@ services:
       - IPFS_GATEWAYS=https://circles-profiles.myfilebase.com
       - IPFS_MAX_PARALLELISM=192
       - REINDEX_FROM_BLOCK=${REINDEX_FROM_BLOCK:-}
+      - REINDEX_TABLES=${REINDEX_TABLES:-}
+      - REINDEX_ALL_TABLES=${REINDEX_ALL_TABLES:-}
+      - REINDEX_ALLOW_PARTIAL_DEPENDENCIES=${REINDEX_ALLOW_PARTIAL_DEPENDENCIES:-}
     healthcheck:
       test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8545'"]
       interval: 60s

--- a/docs/indexer-flow.md
+++ b/docs/indexer-flow.md
@@ -65,7 +65,8 @@ This document describes the internal state machine and block processing flow of 
 │                              INITIAL STATE                                    │
 │                                                                               │
 │  1. Check REINDEX_FROM_BLOCK env var (only once per process)                 │
-│     └── If set: DeleteAllGreaterOrEqualBlock(reindexFromBlock)               │
+│     ├── If set without REINDEX_TABLES: require REINDEX_ALL_TABLES=true       │
+│     └── If set with REINDEX_TABLES: backfill selected tables before live     │
 │                                                                               │
 │  2. Calculate effective resume point:                                         │
 │     ├── latestBlock = MAX(blockNumber) from System_Block                     │
@@ -104,6 +105,8 @@ This document describes the internal state machine and block processing flow of 
 │                         NEWHEAD HANDLING                                      │
 │                                                                               │
 │  latestBlock = Database.LatestBlock()                                         │
+│                                                                               │
+│  Selected-table reindex already ran during Initial before live notification. │
 │                                                                               │
 │  Decision:                                                                    │
 │  ┌────────────────────────────────────────────────────────────────────────┐   │

--- a/docs/partial-table-reindexing.md
+++ b/docs/partial-table-reindexing.md
@@ -107,11 +107,14 @@ If interrupted, run the same command again to resume from the last completed bat
 
 ## Option B: Full Reindex via `REINDEX_FROM_BLOCK`
 
-For major changes affecting many tables, set an environment variable and restart. The plugin handles everything automatically.
+For major changes affecting many tables, set the reindex block plus an explicit
+full-reindex confirmation flag and restart. The plugin handles the deletion and
+resync automatically.
 
 ### How It Works
 
-1. On startup, the StateMachine checks for `REINDEX_FROM_BLOCK` env var
+1. On startup, the StateMachine checks for `REINDEX_FROM_BLOCK` and
+   `REINDEX_ALL_TABLES=true`
 2. Executes `DELETE FROM table WHERE blockNumber >= X` on **ALL event tables**
 3. Sets internal `_reindexCleanupDone` flag (prevents re-deletion on retry/error)
 4. Reinitializes all caches from the cleaned database
@@ -140,6 +143,7 @@ source .env
 # For payment gateway: use 43610000 (before first gateway at 43,610,829)
 # For full V2 reindex: use 36501311 (V2 launch block)
 echo "REINDEX_FROM_BLOCK=43610000" >> .env
+echo "REINDEX_ALL_TABLES=true" >> .env
 
 # 5. Start the indexer - it will:
 #    - Delete ALL tables from block 43,610,000 onwards
@@ -152,12 +156,12 @@ echo "REINDEX_FROM_BLOCK=43610000" >> .env
 
 # 7. IMPORTANT: After reindex completes, REMOVE the env var!
 #    Otherwise it will re-delete data on next restart.
-# Edit .env and remove the REINDEX_FROM_BLOCK line
+# Edit .env and remove the REINDEX_FROM_BLOCK and REINDEX_ALL_TABLES lines
 ```
 
 ### What Gets Deleted
 
-When `REINDEX_FROM_BLOCK=43610000` is set:
+When `REINDEX_FROM_BLOCK=43610000` and `REINDEX_ALL_TABLES=true` are set:
 
 | Affected         | Action                                 |
 | ---------------- | -------------------------------------- |
@@ -178,6 +182,94 @@ Deleted 1234 rows from CrcV2_PaymentGateway_GatewayCreated
 ...
 [REINDEX] Data deletion complete. Will resync from specified block.
 ```
+
+## Option C: Selected Table Reindex via `REINDEX_TABLES`
+
+Use `REINDEX_TABLES` when new event tables were added and those tables can be
+backfilled independently from existing tables.
+
+```bash
+REINDEX_FROM_BLOCK=38900000
+REINDEX_TABLES=CrcV2_ScoreGroup_GroupInitialized,CrcV2_ScoreGroup_MerkleRootUpdated,CrcV2_ScoreGroup_HistoricalSupply,CrcV2_ScoreGroup_PersonalMinted,CrcV2_ScoreGroup_RouterMinted
+```
+
+### How It Works
+
+1. On startup, the StateMachine resolves each `REINDEX_TABLES` entry to a known
+   physical event table.
+2. It rejects unknown tables, views, and non-targetable system/pathfinder log
+   tables.
+3. It validates known dependency closures. For example, selecting any
+   `CrcV2_ScoreGroup_*` table requires selecting the complete score-group table
+   set unless `REINDEX_ALLOW_PARTIAL_DEPENDENCIES=true` is explicitly set.
+4. Before entering live sync or sending the initial live notification, it deletes
+   rows from only those tables with `blockNumber >= REINDEX_FROM_BLOCK`.
+5. It replays blocks from `REINDEX_FROM_BLOCK` to the current indexed
+   `System_Block` head and writes only events mapped to those selected tables.
+6. It does not write `System_Block` during the selected-table backfill.
+7. The following live notification causes cache/pathfinder consumers to refresh.
+
+### Dependency Rules
+
+`REINDEX_TABLES` is a table-selection mechanism with explicit dependency guards
+for known coupled table families. It does not infer arbitrary semantic
+dependencies from SQL views or application code.
+
+Safe uses:
+
+- Backfilling new, independent event tables.
+- Rebuilding all tables owned by one newly added parser.
+- Rebuilding a complete closed set of related tables when the operator knows the
+  dependency closure.
+
+Unsafe uses:
+
+- Reindexing a core transfer/balance/trust table without its derived tables.
+- Reindexing only one side of a parser that emits both raw and synthetic events.
+- Deleting a table that existing views or cache warmup logic depend on while
+  leaving related base tables at a different semantic version.
+
+Views are not selected directly; they update from their base tables. Caches are
+reinitialized from the database at process start, so an inconsistent table set
+can produce internally inconsistent cache state even when the database schema is
+valid.
+
+For score-group mint-along-path, the selected-table set is the five
+`CrcV2_ScoreGroup_*` tables listed above. The process fails closed if only part
+of that set is selected. Those tables are read by score-group router and
+capacity logic but do not replace existing transfer/trust/group base tables.
+
+For intentionally partial repairs, set:
+
+```bash
+REINDEX_ALLOW_PARTIAL_DEPENDENCIES=true
+```
+
+Use this only when the missing dependency tables are intentionally untouched and
+the resulting state has been reviewed.
+
+### Full Reindex Guard
+
+`REINDEX_FROM_BLOCK` without `REINDEX_TABLES` is a full table deletion from that
+block. It now requires an explicit confirmation flag:
+
+```bash
+REINDEX_FROM_BLOCK=38900000
+REINDEX_ALL_TABLES=true
+```
+
+Without `REINDEX_ALL_TABLES=true`, startup fails instead of silently deleting
+all event data from the block.
+
+### Operational Rules
+
+- Leave `REINDEX_TABLES` empty for normal operation.
+- Always remove `REINDEX_FROM_BLOCK`, `REINDEX_TABLES`, `REINDEX_ALL_TABLES`,
+  and `REINDEX_ALLOW_PARTIAL_DEPENDENCIES` after the reindex completes.
+- Prefer a full `REINDEX_FROM_BLOCK` when changing existing parser semantics or
+  any table used as a base for balance, trust, or transfer views.
+- Run staging verification after selected-table backfill before deploying the
+  same table set to production.
 
 ## Adding New Events to the Backfill Tool
 
@@ -253,7 +345,10 @@ docker build -t circles-backfill:local -f docker/backfill.Dockerfile .
 
 | Variable                     | Description                                | Example      |
 | ---------------------------- | ------------------------------------------ | ------------ |
-| `REINDEX_FROM_BLOCK`         | Delete all data >= this block and resync   | `43610000`   |
+| `REINDEX_FROM_BLOCK`         | Reindex start block                        | `43610000`   |
+| `REINDEX_TABLES`             | Optional selected physical table list      | `CrcV2_ScoreGroup_PersonalMinted` |
+| `REINDEX_ALL_TABLES`         | Required confirmation for full reindex     | `true`       |
+| `REINDEX_ALLOW_PARTIAL_DEPENDENCIES` | Override known dependency closure checks | `true` |
 | `CIRCLES_PLUGIN_DISABLED`    | Run Nethermind without indexing (RPC-only) | `true`       |
 | `POSTGRES_CONNECTION_STRING` | Database connection                        | `Server=...` |
 | `START_BLOCK`                | Initial sync start block (fresh DB only)   | `36501311`   |

--- a/docs/rpc-pathfinder.md
+++ b/docs/rpc-pathfinder.md
@@ -207,6 +207,28 @@ See the [Circles SDK](https://github.com/aboutcircles/circles-sdk) for helper fu
 
 ---
 
+## Score-Group Mint Along Path
+
+Score-group minting uses the same pathfinder surface as other V2 paths. Internally
+the graph can route different groups through different router contracts and can
+cap score-group collateral edges by the mint policy's currently available
+capacity.
+
+The cache-backed graph endpoint may include two optional sections:
+
+- `groupRouters`: group address to router address mapping.
+- `scoreGroupMintLimits`: available capacity per group and collateral token.
+
+These sections are needed when the pathfinder builds its graph from the cache
+service instead of direct Postgres queries. They prevent two classes of invalid
+paths: using the wrong router for a group and routing more collateral into a
+score group than the mint policy can accept.
+
+See [Score-Group Mint Along Path](score-group-mint-along-path.md) for
+configuration, router-selection rules, and custom mint policy notes.
+
+---
+
 ## Network Snapshot
 
 The Pathfinder service provides a `/snapshot` endpoint that returns the complete trust graph and balance data. This is useful for clients that want to cache the network state locally.

--- a/docs/score-group-mint-along-path.md
+++ b/docs/score-group-mint-along-path.md
@@ -1,0 +1,131 @@
+# Score-Group Mint Along Path
+
+This document describes how score-group minting is represented in the indexer,
+cache graph, and pathfinder.
+
+## Scope
+
+The implementation is not hard-coded to one router address in the graph model:
+groups can have individual router addresses, and the pathfinder stores a
+`group -> router` mapping.
+
+The score-group mint-limit calculation is specific to mint policies that emit the
+score-group events indexed by `Circles.Index.CirclesV2.ScoreGroup`:
+
+- `GroupInitialized`
+- `MerkleRootUpdated`
+- `HistoricalSupply`
+- `PersonalMinted`
+- `RouterMinted`
+
+Other custom mint policies can reuse the generic parts:
+
+- indexed event tables
+- per-group router mapping
+- cache graph extension fields
+- graph capacity hooks
+
+They still need their own parser/schema and, if they have custom mint limits,
+their own capacity calculation. The current `ScoreGroupMintLimitReader` encodes
+the score-group policy formula and should not be assumed correct for arbitrary
+mint policies.
+
+## Router Selection
+
+Base groups continue to use `V2_BASE_GROUP_ROUTER`.
+
+Score groups are included when:
+
+- their `mint` address is configured in `V2_SCORE_GROUP_MINT_POLICIES`, and
+- a router is available through indexed `GroupInitialized.pathMintRouter`
+
+If no indexed per-group router exists, the score group is not routed through the
+base-group router and is not routed through an environment fallback. This avoids
+producing paths that would use a router not configured in contract state.
+
+Multiple score routers are supported when the contracts emit distinct
+`GroupInitialized.pathMintRouter` values per group.
+
+## Cache Graph Fields
+
+The cache service's `/api/pathfinder/graph` response includes optional fields:
+
+- `groupRouters`: maps each routed group to the router that should handle its
+  mint path.
+- `scoreGroupMintLimits`: maps `(group, collateralToken)` to the current
+  available mint capacity.
+
+They are optional for backward compatibility and for deployments that load the
+pathfinder graph directly from Postgres. They are needed when the pathfinder runs
+from the cache graph snapshot instead of direct SQL. Without these fields, a
+cache-backed pathfinder could either use the wrong router or over-route into a
+score group beyond what the mint policy will accept.
+
+## Score-Group Mint Capacity
+
+The available capacity for a `(group, collateral)` pair is calculated as:
+
+```text
+available =
+  demurraged(latest historical max supply for collateral)
+  + demurraged(latest personal minted amount for group/collateral)
+  - current demurraged treasury collateral balance
+```
+
+If no `HistoricalSupply` event exists yet for a collateral, the reader falls
+back to current demurraged supply from `V_CrcV2_BalancesByAccountAndToken`.
+
+The pathfinder applies the result as a cap on the pool-to-score-group edge. A
+zero or negative available limit removes that collateral edge for the score
+group.
+
+### Contract Correspondence
+
+The formula mirrors the router/migration branch in the score mint policy source
+copied under `../circles-groups/src/deployment/OffchainScoreBasedMintPolicy.sol.sol`:
+
+```solidity
+uint256 historicalSupplyOnToday = getHistoricalSupplyOnToday(collateral[i]);
+uint256 mintedAmountOnToday = getMintedAmountOnToday(group, collateral[i]);
+uint256 maxLimit = historicalSupplyOnToday + mintedAmountOnToday;
+uint256 treasuryBalance = HUB.balanceOf(treasury, collateral[i]);
+uint256 currentLimit = maxLimit - treasuryBalance;
+if (amounts[i] > currentLimit) revert AmountExceedsCollateralLimit();
+```
+
+The indexer/pathfinder does not replace the contract check. It estimates the
+same limit from indexed events and balances before building a path. The deployed
+contract remains authoritative at execution time, so live routing applies
+`PATHFINDER_DEMURRAGE_SAFETY_MARGIN` below the estimated limit to reduce the
+risk of crossing the on-chain limit between graph build and transaction
+execution.
+
+Before production rollout, verify that the deployed mint policy bytecode/source
+for `V2_SCORE_GROUP_MINT_POLICIES` matches the copied deployment source used for
+this correspondence check.
+
+## Configuration
+
+```bash
+V2_SCORE_GROUP_MINT_POLICIES=0x...
+```
+
+`V2_SCORE_GROUP_MINT_POLICIES` is comma-separated. Score-router addresses are
+not configured as a global fallback; they are read from indexed
+`GroupInitialized.pathMintRouter` events.
+
+## Adding Another Mint Policy
+
+For a mint policy with different rules:
+
+1. Add an indexer parser/schema for its events.
+2. Add any router-discovery event to the graph load path.
+3. Add a capacity reader if the policy has mint caps.
+4. Add cache graph fields only if the pathfinder must work from the cache
+   snapshot.
+5. Add tests for:
+   - env unset behavior
+   - base-group behavior unchanged
+   - router selection
+   - capacity capping
+   - cache-backed and direct-SQL graph parity

--- a/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
 using FluentAssertions;
+using System.Globalization;
 using System.Net;
 using Npgsql;
 
@@ -217,7 +218,7 @@ public class ControllerTests
         // V1 balance is converted from CRC to Circles (approx 2.1x inflation factor)
         // V2 balance remains 200, V1 100 CRC becomes ~211 Circles
         // Total should be > 300 (would be 300 if no conversion applied)
-        var balance = decimal.Parse(response!.Balance);
+        var balance = decimal.Parse(response!.Balance, CultureInfo.InvariantCulture);
         balance.Should().BeGreaterThan(300m, "V1 CRC should be converted to time-circles with inflation factor > 1");
         balance.Should().BeLessThan(450m, "Converted balance should be within reasonable range (200 V2 + ~211-250 V1)");
     }
@@ -244,7 +245,7 @@ public class ControllerTests
         response.Should().NotBeNull();
         // Raw CRC sum is 150, but CRC→Circles conversion applies ~2.1x inflation factor
         // V2 balance (200) should NOT be included
-        var balance = decimal.Parse(response!.Balance);
+        var balance = decimal.Parse(response!.Balance, CultureInfo.InvariantCulture);
         balance.Should().BeGreaterThan(150m, "V1 CRC should be converted to time-circles with inflation factor > 1");
         balance.Should().BeLessThan(350m, "Converted balance should be within reasonable range (~316 for 150 CRC)");
     }

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -173,6 +173,8 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderGroupRow>? Groups,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderGroupRouterRow>? GroupRouters,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderGroupTrustRow>? GroupTrusts,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderConsentedFlowRow>? ConsentedFlow,
@@ -181,7 +183,9 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<string>? Organizations,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-    IReadOnlyList<PathfinderWrapperMappingRow>? WrapperMappings
+    IReadOnlyList<PathfinderWrapperMappingRow>? WrapperMappings,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderScoreGroupMintLimitRow>? ScoreGroupMintLimits
 );
 
 public record PathfinderBalanceRow(
@@ -200,6 +204,17 @@ public record PathfinderTrustRow(
 );
 
 public record PathfinderGroupRow(string GroupAddress);
+
+public record PathfinderGroupRouterRow(
+    string GroupAddress,
+    string RouterAddress
+);
+
+public record PathfinderScoreGroupMintLimitRow(
+    string GroupAddress,
+    string CollateralToken,
+    string AvailableLimit
+);
 
 public record PathfinderGroupTrustRow(
     string GroupAddress,

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Numerics;
 using System.Text.RegularExpressions;
 using Circles.Cache.Service.Caches;
@@ -31,6 +32,8 @@ public class BalancesController : ControllerBase
     private const uint V2_INFLATION_DAY_ZERO = 1_602_720_000;
 
     private string GetRemoteIp() => HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+
+    private static string FormatDecimal(decimal value) => value.ToString(CultureInfo.InvariantCulture);
 
     /// <summary>
     /// Applies V2 demurrage to a cached balance using the stored lastActivity timestamp.
@@ -127,7 +130,7 @@ public class BalancesController : ControllerBase
 
                     balances.Add(new TokenBalanceResponse(
                         TokenId: tokenId,
-                        Balance: balance.ToString(),
+                        Balance: FormatDecimal(balance),
                         TokenOwner: tokenOwner,
                         Version: 1,
                         TokenType: "CrcV1_Signup",
@@ -218,7 +221,7 @@ public class BalancesController : ControllerBase
 
                     balances.Add(new TokenBalanceResponse(
                         TokenId: tokenId,
-                        Balance: displayBalance.ToString(),
+                        Balance: FormatDecimal(displayBalance),
                         TokenOwner: tokenOwner,
                         Version: 2,
                         TokenType: tokenType,
@@ -285,7 +288,7 @@ public class BalancesController : ControllerBase
             }
 
             return Ok(new TotalBalanceResponse(
-                totalCircles.ToString(),
+                FormatDecimal(totalCircles),
                 lastBlock,
                 timestamp
             ));
@@ -337,7 +340,7 @@ public class BalancesController : ControllerBase
             }
 
             return Ok(new TotalBalanceResponse(
-                total.ToString(),
+                FormatDecimal(total),
                 lastBlock,
                 timestamp
             ));
@@ -407,7 +410,7 @@ public class BalancesController : ControllerBase
             var total = v1Total + v2Total;
 
             return Ok(new TotalBalanceResponse(
-                total.ToString(),
+                FormatDecimal(total),
                 lastBlock,
                 timestamp
             ));

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -477,10 +477,10 @@ public class PathfinderGraphController : ControllerBase
             """;
 
         using var command = new NpgsqlCommand(sql, connection);
-            command.Parameters.AddWithValue("lastBlock", lastBlock);
-            command.Parameters.AddWithValue("groups", scoreGroups);
-            command.Parameters.AddWithValue("scoreMintPolicies", ScoreGroupMintPolicies.ToArray());
-            command.CommandTimeout = 60;
+        command.Parameters.AddWithValue("lastBlock", lastBlock);
+        command.Parameters.AddWithValue("groups", scoreGroups);
+        command.Parameters.AddWithValue("scoreMintPolicies", ScoreGroupMintPolicies.ToArray());
+        command.CommandTimeout = 60;
 
         var result = new Dictionary<string, (string Treasury, string Policy)>();
         using var reader = command.ExecuteReader();

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -4,6 +4,7 @@ using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
 using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
+using Npgsql;
 
 namespace Circles.Cache.Service.Controllers;
 
@@ -18,6 +19,7 @@ public class PathfinderGraphController : ControllerBase
 {
     private readonly CacheContainer _caches;
     private readonly CacheServiceState _state;
+    private readonly NpgsqlDataSource? _dataSource;
     private readonly ILogger<PathfinderGraphController> _logger;
 
     /// <summary>
@@ -29,6 +31,21 @@ public class PathfinderGraphController : ControllerBase
         Environment.GetEnvironmentVariable("V2_STANDARD_MINT_POLICY")?.Trim().ToLowerInvariant()
         ?? "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
 
+    private static readonly HashSet<string> ScoreGroupMintPolicies =
+        (Environment.GetEnvironmentVariable("V2_SCORE_GROUP_MINT_POLICIES") ?? "")
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(x => x.ToLowerInvariant())
+            .ToHashSet();
+
+    private static readonly string BaseGroupRouter =
+        Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.Trim().ToLowerInvariant()
+        ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static readonly double DemurrageSafetyMargin =
+        Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN") != null
+            ? double.Parse(Environment.GetEnvironmentVariable("PATHFINDER_DEMURRAGE_SAFETY_MARGIN")!, CultureInfo.InvariantCulture)
+            : 0.999999;
+
     private const int SchemaVersion = 1;
 
     /// <summary>V2 Hub epoch on gnosis mainnet: 2020-10-15 00:00 UTC (same as V1).</summary>
@@ -39,9 +56,19 @@ public class PathfinderGraphController : ControllerBase
         CacheContainer caches,
         CacheServiceState state,
         ILogger<PathfinderGraphController> logger)
+        : this(caches, state, null, logger)
+    {
+    }
+
+    public PathfinderGraphController(
+        CacheContainer caches,
+        CacheServiceState state,
+        NpgsqlDataSource? dataSource,
+        ILogger<PathfinderGraphController> logger)
     {
         _caches = caches;
         _state = state;
+        _dataSource = dataSource;
         _logger = logger;
     }
 
@@ -79,8 +106,14 @@ public class PathfinderGraphController : ControllerBase
             // Pre-compute shared lookups once per request
             var registrations = new CacheRegistrationSet(_caches);
             var wrapperLookup = new CacheWrapperLookup(_caches);
-            var routerGroups = sections.Contains("trust") || sections.Contains("groups") || sections.Contains("grouptrusts")
-                ? GetRouterFilteredGroups()
+            var needsRouterGroups = sections.Contains("trust") ||
+                                    sections.Contains("groups") ||
+                                    sections.Contains("grouprouters") ||
+                                    sections.Contains("grouptrusts") ||
+                                    sections.Contains("scoregroupmintlimits");
+            var indexedScoreGroupRouters = needsRouterGroups ? LoadIndexedScoreGroupRouters(lastBlock) : [];
+            var routerGroups = needsRouterGroups
+                ? GetRouterFilteredGroups(indexedScoreGroupRouters)
                 : null;
             var avatarToWrappers = sections.Contains("trust")
                 ? BuildAvatarToWrappersIndex()
@@ -93,11 +126,15 @@ public class PathfinderGraphController : ControllerBase
                 Balances: sections.Contains("balances") ? BuildBalances(registrations, wrapperLookup) : null,
                 Trust: sections.Contains("trust") ? BuildTrust(registrations, routerGroups!, avatarToWrappers!) : null,
                 Groups: sections.Contains("groups") ? BuildGroups(routerGroups!) : null,
+                GroupRouters: sections.Contains("grouprouters") ? BuildGroupRouters(routerGroups!, indexedScoreGroupRouters) : null,
                 GroupTrusts: sections.Contains("grouptrusts") ? BuildGroupTrusts(registrations, routerGroups!) : null,
                 ConsentedFlow: sections.Contains("consentedflow") ? BuildConsentedFlow(registrations) : null,
                 Avatars: sections.Contains("avatars") ? BuildAvatars() : null,
                 Organizations: sections.Contains("organizations") ? BuildOrganizations() : null,
-                WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings(registrations) : null
+                WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings(registrations) : null,
+                ScoreGroupMintLimits: sections.Contains("scoregroupmintlimits")
+                    ? BuildScoreGroupMintLimits(registrations, routerGroups!, indexedScoreGroupRouters, lastBlock)
+                    : null
             );
 
             _logger.LogDebug(
@@ -124,7 +161,7 @@ public class PathfinderGraphController : ControllerBase
     private static HashSet<string> ParseInclude(string? include)
     {
         if (string.IsNullOrWhiteSpace(include))
-            return new HashSet<string> { "balances", "trust", "groups", "grouptrusts", "consentedflow", "avatars", "organizations", "wrappermappings" };
+            return new HashSet<string> { "balances", "trust", "groups", "grouprouters", "grouptrusts", "scoregroupmintlimits", "consentedflow", "avatars", "organizations", "wrappermappings" };
 
         return new HashSet<string>(
             include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -280,6 +317,281 @@ public class PathfinderGraphController : ControllerBase
         return groups;
     }
 
+    private List<PathfinderGroupRouterRow> BuildGroupRouters(
+        HashSet<string> routerGroups,
+        IReadOnlyDictionary<string, string> indexedScoreGroupRouters)
+    {
+        var groupRouters = new List<PathfinderGroupRouterRow>(routerGroups.Count);
+        foreach (var groupAddr in routerGroups)
+        {
+            if (!_caches.Groups.ReadOnlyDictionary.TryGetValue(groupAddr, out var group))
+                continue;
+
+            var isScoreGroup = ScoreGroupMintPolicies.Contains(group.Mint.ToLowerInvariant());
+            string routerAddress;
+            if (isScoreGroup)
+            {
+                if (!indexedScoreGroupRouters.TryGetValue(groupAddr, out routerAddress!))
+                    continue;
+            }
+            else
+            {
+                routerAddress = BaseGroupRouter;
+            }
+
+            groupRouters.Add(new PathfinderGroupRouterRow(
+                GroupAddress: groupAddr,
+                RouterAddress: routerAddress
+            ));
+        }
+
+        return groupRouters;
+    }
+
+    private List<PathfinderScoreGroupMintLimitRow> BuildScoreGroupMintLimits(
+        IRegistrationSet registrations,
+        HashSet<string> routerGroups,
+        IReadOnlyDictionary<string, string> indexedScoreGroupRouters,
+        long lastBlock)
+    {
+        if (ScoreGroupMintPolicies.Count == 0)
+            return [];
+        if (_dataSource == null)
+            return [];
+
+        var scoreRouterGroups = new HashSet<string>(
+            routerGroups.Where(groupAddr =>
+                indexedScoreGroupRouters.ContainsKey(groupAddr) &&
+                _caches.Groups.ReadOnlyDictionary.TryGetValue(groupAddr, out var group) &&
+                ScoreGroupMintPolicies.Contains(group.Mint.ToLowerInvariant())));
+        if (scoreRouterGroups.Count == 0)
+            return [];
+
+        IReadOnlyList<ScoreGroupMintLimitRow> rows;
+        try
+        {
+            using var connection = _dataSource.OpenConnection();
+            var groupMetadata = LoadScoreGroupMetadata(connection, scoreRouterGroups, lastBlock);
+            var baseRows = BuildScoreGroupMintLimitBaseRows(registrations, scoreRouterGroups, groupMetadata);
+            rows = ScoreGroupMintLimitReader.ReadFromBaseRows(
+                connection,
+                ScoreGroupMintPolicies.ToArray(),
+                baseRows,
+                targetTimestamp: null,
+                safetyMargin: DemurrageSafetyMargin,
+                commandTimeoutSeconds: 60,
+                maxBlock: lastBlock);
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            _logger.LogWarning(
+                ex,
+                "Score-group mint limit tables are not available yet; omitting score-group mint limits from pathfinder graph snapshot");
+            return [];
+        }
+
+        return rows
+            .Select(row => new PathfinderScoreGroupMintLimitRow(
+                row.GroupAddress,
+                row.CollateralToken,
+                row.AvailableLimit))
+            .ToList();
+    }
+
+    private Dictionary<string, string> LoadIndexedScoreGroupRouters(long lastBlock)
+    {
+        if (_dataSource == null || ScoreGroupMintPolicies.Count == 0)
+            return [];
+
+        const string sql = """
+            SELECT DISTINCT ON ("group")
+                "group",
+                LOWER("pathMintRouter")
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE "blockNumber" <= @lastBlock
+              AND LOWER("emitter") = ANY(@scoreMintPolicies)
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
+            """;
+
+        try
+        {
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("lastBlock", lastBlock);
+            command.Parameters.AddWithValue("scoreMintPolicies", ScoreGroupMintPolicies.ToArray());
+            command.CommandTimeout = 60;
+
+            var result = new Dictionary<string, string>();
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                result[reader.GetString(0).ToLowerInvariant()] = reader.GetString(1).ToLowerInvariant();
+            }
+
+            return result;
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            _logger.LogWarning(
+                ex,
+                "Score-group router table is not available yet; score groups will be omitted from the pathfinder graph snapshot");
+            return [];
+        }
+    }
+
+    private static Dictionary<string, (string Treasury, string Policy)> LoadScoreGroupMetadata(
+        NpgsqlConnection connection,
+        HashSet<string> routerGroups,
+        long lastBlock)
+    {
+        var scoreGroups = routerGroups.ToArray();
+        if (scoreGroups.Length == 0)
+            return [];
+
+        const string sql = """
+            WITH latest_score_group AS (
+                SELECT DISTINCT ON ("group")
+                    "group" AS group_address,
+                    LOWER("emitter") AS policy
+                FROM "CrcV2_ScoreGroup_GroupInitialized"
+                WHERE "blockNumber" <= @lastBlock
+                  AND LOWER("emitter") = ANY(@scoreMintPolicies)
+                ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+            ),
+            latest_register_group AS (
+                SELECT DISTINCT ON ("group")
+                    "group" AS group_address,
+                    LOWER("treasury") AS treasury,
+                    LOWER("mint") AS mint
+                FROM "CrcV2_RegisterGroup"
+                WHERE "blockNumber" <= @lastBlock
+                  AND "group" = ANY(@groups)
+                ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+            )
+            SELECT
+                rg.group_address,
+                rg.treasury,
+                COALESCE(lsg.policy, rg.mint) AS policy
+            FROM latest_register_group rg
+            LEFT JOIN latest_score_group lsg ON lsg.group_address = rg.group_address;
+            """;
+
+        using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("lastBlock", lastBlock);
+            command.Parameters.AddWithValue("groups", scoreGroups);
+            command.Parameters.AddWithValue("scoreMintPolicies", ScoreGroupMintPolicies.ToArray());
+            command.CommandTimeout = 60;
+
+        var result = new Dictionary<string, (string Treasury, string Policy)>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            result[reader.GetString(0).ToLowerInvariant()] = (
+                reader.GetString(1).ToLowerInvariant(),
+                reader.GetString(2).ToLowerInvariant());
+        }
+
+        return result;
+    }
+
+    private List<ScoreGroupMintLimitBaseRow> BuildScoreGroupMintLimitBaseRows(
+        IRegistrationSet registrations,
+        HashSet<string> routerGroups,
+        Dictionary<string, (string Treasury, string Policy)> groupMetadata)
+    {
+        var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var groupTokens = new Dictionary<string, HashSet<string>>();
+        var trustedTokens = new HashSet<string>();
+
+        foreach (var kvp in _caches.V2TrustRelations.ReadOnlyDictionary)
+        {
+            var separatorIndex = kvp.Key.IndexOf(':');
+            if (separatorIndex < 0)
+                continue;
+
+            var truster = kvp.Key[..separatorIndex];
+            var trustee = kvp.Key[(separatorIndex + 1)..];
+            if (!groupMetadata.ContainsKey(truster))
+                continue;
+
+            if (!CirclesInvariants.IsValidGroupTrustEdge(truster, trustee, kvp.Value, now, registrations, routerGroups))
+                continue;
+
+            if (!groupTokens.TryGetValue(truster, out var tokens))
+            {
+                tokens = new HashSet<string>();
+                groupTokens[truster] = tokens;
+            }
+
+            tokens.Add(trustee);
+            trustedTokens.Add(trustee);
+        }
+
+        var tokenSupply = new Dictionary<string, BigInteger>();
+        var accountTokenBalances = new Dictionary<(string Account, string Token), BigInteger>();
+
+        foreach (var kvp in _caches.V2BalancesByAccountAndToken.ReadOnlyDictionary)
+        {
+            var separatorIndex = kvp.Key.IndexOf(':');
+            if (separatorIndex < 0)
+                continue;
+
+            var account = kvp.Key[..separatorIndex];
+            var token = kvp.Key[(separatorIndex + 1)..];
+            if (!trustedTokens.Contains(token))
+                continue;
+
+            var demurragedBalance = DemurrageCachedV2Balance(kvp.Key, kvp.Value);
+            if (demurragedBalance <= BigInteger.Zero)
+                continue;
+
+            tokenSupply[token] = tokenSupply.GetValueOrDefault(token) + demurragedBalance;
+            accountTokenBalances[(account, token)] = demurragedBalance;
+        }
+
+        var rows = new List<ScoreGroupMintLimitBaseRow>();
+        foreach (var (group, tokens) in groupTokens)
+        {
+            if (!groupMetadata.TryGetValue(group, out var metadata))
+                continue;
+
+            foreach (var token in tokens)
+            {
+                accountTokenBalances.TryGetValue((metadata.Treasury, token), out var treasuryBalance);
+                tokenSupply.TryGetValue(token, out var currentSupply);
+
+                rows.Add(new ScoreGroupMintLimitBaseRow(
+                    group,
+                    token,
+                    metadata.Policy,
+                    treasuryBalance,
+                    currentSupply));
+            }
+        }
+
+        return rows;
+    }
+
+    private BigInteger DemurrageCachedV2Balance(string balanceKey, decimal balance)
+    {
+        if (balance <= 0)
+            return BigInteger.Zero;
+
+        if (!_caches.V2LastActivity.TryGetValue(balanceKey, out var lastActivity) ||
+            lastActivity < V2InflationDayZero)
+        {
+            return BigInteger.Zero;
+        }
+
+        var attoBalance = CirclesConverter.CirclesToAttoCircles(balance);
+        var targetDay = CirclesConverter.DayFromTimestamp(DateTimeOffset.UtcNow, V2InflationDayZero);
+        var lastActivityDay = (ulong)(lastActivity - V2InflationDayZero) / (ulong)SecondsPerDay;
+        var daysDelta = targetDay > lastActivityDay ? targetDay - lastActivityDay : 0;
+        return daysDelta == 0
+            ? attoBalance
+            : CirclesConverter.InflationaryToDemurrage(attoBalance, daysDelta);
+    }
+
     /// <summary>
     /// Builds group trust rows — trust edges where truster is a router-filtered group.
     /// </summary>
@@ -425,14 +737,16 @@ public class PathfinderGraphController : ControllerBase
     }
 
     /// <summary>
-    /// Returns the set of group addresses that use the standard treasury.
+    /// Returns the set of group addresses supported by the pathfinder.
     /// </summary>
-    private HashSet<string> GetRouterFilteredGroups()
+    private HashSet<string> GetRouterFilteredGroups(IReadOnlyDictionary<string, string> indexedScoreGroupRouters)
     {
         var result = new HashSet<string>();
         foreach (var kvp in _caches.Groups.ReadOnlyDictionary)
         {
-            if (kvp.Value.Mint.Equals(StandardTreasuryMint, StringComparison.OrdinalIgnoreCase))
+            var mint = kvp.Value.Mint.ToLowerInvariant();
+            if (mint == StandardTreasuryMint ||
+                (ScoreGroupMintPolicies.Contains(mint) && indexedScoreGroupRouters.ContainsKey(kvp.Key)))
             {
                 result.Add(kvp.Key);
             }

--- a/src/Common/Circles.Common/IDatabase.cs
+++ b/src/Common/Circles.Common/IDatabase.cs
@@ -36,6 +36,12 @@ public interface IDatabase : IReadonlyDatabase
     /// </summary>
     Task DeleteAllGreaterOrEqualBlock(long reorgAt);
 
+    /// <summary>
+    /// Deletes data from selected physical tables from the specified block onwards.
+    /// Used for adding/backfilling new event tables without wiping the entire index.
+    /// </summary>
+    Task DeleteTablesGreaterOrEqualBlock(long reorgAt, IReadOnlyCollection<string> tableNames);
+
     Task WriteBatch(string @namespace, string table, IEnumerable<object> data, ISchemaPropertyMap propertyMap);
 
     /// <summary>

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -1,0 +1,298 @@
+using System.Globalization;
+using System.Numerics;
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Circles.Common;
+
+public sealed record ScoreGroupMintLimitRow(
+    string GroupAddress,
+    string CollateralToken,
+    string AvailableLimit);
+
+public sealed record ScoreGroupMintLimitBaseRow(
+    string GroupAddress,
+    string CollateralToken,
+    string Policy,
+    BigInteger TreasuryBalance,
+    BigInteger CurrentSupply);
+
+public static class ScoreGroupMintLimitReader
+{
+    private const uint InflationDayZeroUnix = 1_602_720_000;
+
+    private const string BaseRowsSql = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                LOWER("emitter") AS policy
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
+              AND LOWER("emitter") = ANY(@scoreMintPolicies)
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        score_groups AS (
+            SELECT
+                g."group" AS group_address,
+                LOWER(g."treasury") AS treasury,
+                LOWER(COALESCE(lsg.policy, g."mint")) AS policy
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group lsg ON lsg.group_address = g."group"
+            WHERE (@maxBlock::bigint IS NULL OR g."blockNumber" <= @maxBlock)
+              AND LOWER(g."mint") = ANY(@scoreMintPolicies)
+              AND lsg.group_address IS NOT NULL
+        ),
+        group_tokens AS (
+            SELECT
+                sg.group_address,
+                sg.treasury,
+                sg.policy,
+                t.trustee AS trusted_token
+            FROM score_groups sg
+            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = sg.group_address
+            INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
+        ),
+        token_supply AS (
+            SELECT
+                b."tokenAddress",
+                SUM(b."demurragedTotalBalance")::text AS current_supply
+            FROM "V_CrcV2_BalancesByAccountAndToken" b
+            INNER JOIN (SELECT DISTINCT trusted_token FROM group_tokens) gt
+                ON gt.trusted_token = b."tokenAddress"
+            GROUP BY b."tokenAddress"
+        )
+        SELECT
+            gt.group_address,
+            gt.trusted_token,
+            gt.policy,
+            COALESCE(tb."demurragedTotalBalance", 0)::text AS treasury_balance,
+            COALESCE(ts.current_supply, '0') AS current_supply
+        FROM group_tokens gt
+        LEFT JOIN "V_CrcV2_BalancesByAccountAndToken" tb
+            ON tb.account = gt.treasury
+           AND tb."tokenAddress" = gt.trusted_token
+        LEFT JOIN token_supply ts
+            ON ts."tokenAddress" = gt.trusted_token;
+        """;
+
+    private const string HistoricalSql = """
+        SELECT DISTINCT ON (LOWER("emitter"), "collateral")
+            LOWER("emitter") AS policy,
+            "collateral"::text AS collateral,
+            "supply"::text AS supply,
+            "day"::text AS day
+        FROM "CrcV2_ScoreGroup_HistoricalSupply"
+        WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+          AND (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
+        ORDER BY LOWER("emitter"), "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
+        """;
+
+    private const string PersonalSql = """
+        SELECT DISTINCT ON (LOWER("emitter"), "group", "collateral")
+            LOWER("emitter") AS policy,
+            "group" AS group_address,
+            "collateral"::text AS collateral,
+            "mintedAmountOnToday"::text AS minted_amount,
+            "day"::text AS day
+        FROM "CrcV2_ScoreGroup_PersonalMinted"
+        WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+          AND (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
+        ORDER BY LOWER("emitter"), "group", "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
+        """;
+
+    public static IReadOnlyList<ScoreGroupMintLimitRow> Read(
+        NpgsqlConnection connection,
+        string[] scoreMintPolicies,
+        DateTimeOffset? targetTimestamp,
+        double safetyMargin,
+        int commandTimeoutSeconds,
+        long? maxBlock = null,
+        NpgsqlTransaction? transaction = null)
+    {
+        var policies = scoreMintPolicies
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .ToArray();
+
+        if (policies.Length == 0)
+            return [];
+
+        var baseRows = ReadBaseRows(connection, policies, commandTimeoutSeconds, maxBlock, transaction);
+        return ReadFromBaseRows(
+            connection,
+            policies,
+            baseRows,
+            targetTimestamp,
+            safetyMargin,
+            commandTimeoutSeconds,
+            maxBlock,
+            transaction);
+    }
+
+    public static IReadOnlyList<ScoreGroupMintLimitRow> ReadFromBaseRows(
+        NpgsqlConnection connection,
+        string[] scoreMintPolicies,
+        IEnumerable<ScoreGroupMintLimitBaseRow> baseRows,
+        DateTimeOffset? targetTimestamp,
+        double safetyMargin,
+        int commandTimeoutSeconds,
+        long? maxBlock = null,
+        NpgsqlTransaction? transaction = null)
+    {
+        var policies = scoreMintPolicies
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .ToArray();
+
+        if (policies.Length == 0)
+            return [];
+
+        var historical = ReadHistorical(connection, policies, commandTimeoutSeconds, maxBlock, transaction);
+        var personal = ReadPersonal(connection, policies, commandTimeoutSeconds, maxBlock, transaction);
+        var targetDay = CirclesConverter.DayFromTimestamp(targetTimestamp ?? DateTimeOffset.UtcNow, InflationDayZeroUnix);
+        var applyMargin = targetTimestamp == null && safetyMargin < 1.0;
+
+        var rows = new List<ScoreGroupMintLimitRow>();
+        foreach (var row in baseRows)
+        {
+            var group = row.GroupAddress.ToLowerInvariant();
+            var collateralToken = row.CollateralToken.ToLowerInvariant();
+            var policy = row.Policy.ToLowerInvariant();
+            var treasuryBalance = row.TreasuryBalance;
+            var currentSupply = row.CurrentSupply;
+            var collateralId = AddressToTokenId(collateralToken);
+
+            var historicalSupply = historical.TryGetValue((policy, collateralId), out var historicalState)
+                ? DiscountToTargetDay(historicalState.Amount, historicalState.Day, targetDay)
+                : currentSupply;
+
+            var personalMinted = personal.TryGetValue((policy, group, collateralId), out var personalState)
+                ? DiscountToTargetDay(personalState.Amount, personalState.Day, targetDay)
+                : BigInteger.Zero;
+
+            var available = historicalSupply + personalMinted - treasuryBalance;
+            if (available < BigInteger.Zero)
+                available = BigInteger.Zero;
+
+            if (applyMargin && available > BigInteger.Zero)
+                available = (BigInteger)((double)available * safetyMargin);
+
+            rows.Add(new ScoreGroupMintLimitRow(
+                group,
+                collateralToken,
+                available.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        return rows;
+    }
+
+    private static IReadOnlyList<ScoreGroupMintLimitBaseRow> ReadBaseRows(
+        NpgsqlConnection connection,
+        string[] policies,
+        int commandTimeoutSeconds,
+        long? maxBlock,
+        NpgsqlTransaction? transaction)
+    {
+        var rows = new List<ScoreGroupMintLimitBaseRow>();
+        using var command = new NpgsqlCommand(BaseRowsSql, connection, transaction);
+        command.CommandTimeout = commandTimeoutSeconds;
+        command.Parameters.AddWithValue("scoreMintPolicies", policies);
+        AddMaxBlockParameter(command, maxBlock);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            var group = reader.GetString(0).ToLowerInvariant();
+            var collateralToken = reader.GetString(1).ToLowerInvariant();
+            var policy = reader.GetString(2).ToLowerInvariant();
+            var treasuryBalance = ParseBigInteger(reader.GetString(3));
+            var currentSupply = ParseBigInteger(reader.GetString(4));
+            rows.Add(new ScoreGroupMintLimitBaseRow(
+                group,
+                collateralToken,
+                policy,
+                treasuryBalance,
+                currentSupply));
+        }
+
+        return rows;
+    }
+
+    private static Dictionary<(string Policy, string Collateral), (BigInteger Amount, ulong Day)> ReadHistorical(
+        NpgsqlConnection connection,
+        string[] policies,
+        int commandTimeoutSeconds,
+        long? maxBlock,
+        NpgsqlTransaction? transaction)
+    {
+        var result = new Dictionary<(string, string), (BigInteger, ulong)>();
+        using var command = new NpgsqlCommand(HistoricalSql, connection, transaction);
+        command.CommandTimeout = commandTimeoutSeconds;
+        command.Parameters.AddWithValue("scoreMintPolicies", policies);
+        AddMaxBlockParameter(command, maxBlock);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            result[(reader.GetString(0), reader.GetString(1))] = (
+                ParseBigInteger(reader.GetString(2)),
+                ParseUInt64(reader.GetString(3)));
+        }
+
+        return result;
+    }
+
+    private static Dictionary<(string Policy, string Group, string Collateral), (BigInteger Amount, ulong Day)> ReadPersonal(
+        NpgsqlConnection connection,
+        string[] policies,
+        int commandTimeoutSeconds,
+        long? maxBlock,
+        NpgsqlTransaction? transaction)
+    {
+        var result = new Dictionary<(string, string, string), (BigInteger, ulong)>();
+        using var command = new NpgsqlCommand(PersonalSql, connection, transaction);
+        command.CommandTimeout = commandTimeoutSeconds;
+        command.Parameters.AddWithValue("scoreMintPolicies", policies);
+        AddMaxBlockParameter(command, maxBlock);
+
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            result[(reader.GetString(0), reader.GetString(1).ToLowerInvariant(), reader.GetString(2))] = (
+                ParseBigInteger(reader.GetString(3)),
+                ParseUInt64(reader.GetString(4)));
+        }
+
+        return result;
+    }
+
+    private static BigInteger DiscountToTargetDay(BigInteger amount, ulong storedDay, ulong targetDay)
+    {
+        var delta = targetDay > storedDay ? targetDay - storedDay : 0;
+        return delta == 0 ? amount : CirclesConverter.InflationaryToDemurrage(amount, delta);
+    }
+
+    private static string AddressToTokenId(string address)
+    {
+        var hex = address.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? address[2..] : address;
+        if (hex.Length != 40)
+            throw new FormatException($"Invalid token address '{address}'.");
+
+        return BigInteger.Parse("00" + hex, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture)
+            .ToString(CultureInfo.InvariantCulture);
+    }
+
+    private static BigInteger ParseBigInteger(string value) =>
+        BigInteger.Parse(value, CultureInfo.InvariantCulture);
+
+    private static ulong ParseUInt64(string value) =>
+        ulong.Parse(value, CultureInfo.InvariantCulture);
+
+    private static void AddMaxBlockParameter(NpgsqlCommand command, long? maxBlock)
+    {
+        var parameter = command.Parameters.Add("maxBlock", NpgsqlDbType.Bigint);
+        parameter.Value = (object?)maxBlock ?? DBNull.Value;
+    }
+}

--- a/src/Common/Circles.Common/Settings.cs
+++ b/src/Common/Circles.Common/Settings.cs
@@ -72,20 +72,26 @@ public class Settings
             : WriteMode.Auto;
 
     /// <summary>
-    /// The block number to reindex ALL tables from.
-    /// Set via REINDEX_FROM_BLOCK environment variable.
-    ///
-    /// Example: REINDEX_FROM_BLOCK=12000000
-    ///
-    /// This deletes data from ALL tables from the specified block onwards,
-    /// reinitializes caches, and resyncs from that block.
-    ///
-    /// IMPORTANT: Remove this env var after reindexing completes to avoid re-deleting data on restart.
-    ///
-    /// Note: Partial table reindexing is NOT supported. All tables must be at the same block height
-    /// for data consistency. The old TABLE_START_BLOCKS env var is deprecated.
+    /// The block number to reindex from. Without REINDEX_TABLES this reindexes ALL tables only
+    /// when REINDEX_ALL_TABLES=true is also set.
+    /// With REINDEX_TABLES this deletes and backfills only the named physical tables.
+    /// Example: REINDEX_FROM_BLOCK=38900000 REINDEX_TABLES=CrcV2_ScoreGroup_HistoricalSupply,CrcV2_ScoreGroup_PersonalMinted
+    /// IMPORTANT: Remove these env vars after reindexing completes to avoid re-running on restart.
     /// </summary>
     public readonly long? ReindexFromBlock;
+
+    public readonly bool ReindexAllTables =
+        string.Equals(Environment.GetEnvironmentVariable("REINDEX_ALL_TABLES"), "true", StringComparison.OrdinalIgnoreCase);
+
+    public readonly bool ReindexAllowPartialDependencies =
+        string.Equals(Environment.GetEnvironmentVariable("REINDEX_ALLOW_PARTIAL_DEPENDENCIES"), "true", StringComparison.OrdinalIgnoreCase);
+
+    public readonly string[] ReindexTables =
+        Environment.GetEnvironmentVariable("REINDEX_TABLES")?.Split(',')
+            .Select(x => x.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray()
+        ?? [];
 
     public Settings()
     {
@@ -228,6 +234,13 @@ public class Settings
     public readonly string BaseGroupRouter =
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.ToLowerInvariant()
         ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    public readonly string[] ScoreGroupMintPolicies =
+        Environment.GetEnvironmentVariable("V2_SCORE_GROUP_MINT_POLICIES")?.Split(',')
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray()
+        ?? [];
 
     public readonly string BaseGroupDeployer =
         Environment.GetEnvironmentVariable("BASE_GROUP_DEPLOYER")?.ToLowerInvariant()

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/Circles.Index.CirclesV2.ScoreGroup.csproj
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/Circles.Index.CirclesV2.ScoreGroup.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <Version>0.0.1</Version>
+        <Authors>Gnosis Service GmbH</Authors>
+        <Copyright>Gnosis Service GmbH</Copyright>
+        <Product>Circles</Product>
+        <PackageId>Gnosis.Circles.Nethermind.Plugin.CirclesV2.ScoreGroup</PackageId>
+        <Description>Score group mint policy indexing for Circles V2</Description>
+        <PackageTags>circles;blockchain;indexing</PackageTags>
+        <RepositoryUrl>https://github.com/aboutcircles/circles-nethermind-plugin</RepositoryUrl>
+        <PackageProjectUrl>https://github.com/aboutcircles/circles-nethermind-plugin</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
+        <ProjectReference Include="..\Circles.Index.Query\Circles.Index.Query.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -1,0 +1,151 @@
+using Circles.Common;
+using Nethermind.Int256;
+
+namespace Circles.Index.CirclesV2.ScoreGroup;
+
+public record GroupInitialized(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string Group,
+    string MerkleTreeManager,
+    string PathMintRouter) : IIndexEvent;
+
+public record MerkleRootUpdated(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string Group,
+    byte[] NewMerkleRoot) : IIndexEvent;
+
+public record HistoricalSupply(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    UInt256 Collateral,
+    UInt256 Supply,
+    UInt256 Day) : IIndexEvent;
+
+public record PersonalMinted(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string Group,
+    UInt256 Collateral,
+    UInt256 Amount,
+    UInt256 Score,
+    UInt256 MintedAmountOnToday,
+    UInt256 Day) : IIndexEvent;
+
+public record RouterMinted(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string Group,
+    UInt256 Collateral,
+    UInt256 Amount,
+    UInt256 CurrentAvailableLimit) : IIndexEvent;
+
+public class DatabaseSchema : BaseDatabaseSchema
+{
+    public static readonly EventSchema GroupInitialized = EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event GroupInitialized(address indexed group,address indexed merkleTreeManager,address pathMintRouter)");
+
+    public static readonly EventSchema MerkleRootUpdated = EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot)");
+
+    public static readonly EventSchema HistoricalSupply = EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event HistoricalSupply(uint256 indexed collateral,uint256 supply,uint256 day)");
+
+    public static readonly EventSchema PersonalMinted = EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event PersonalMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 score,uint256 mintedAmountOnToday,uint256 day)");
+
+    public static readonly EventSchema RouterMinted = EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event RouterMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 currentAvailableLimit)");
+
+    public DatabaseSchema()
+    {
+        AddMappings<GroupInitialized>(
+            ns: "CrcV2_ScoreGroup",
+            table: "GroupInitialized",
+            eventSchema: GroupInitialized,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("group", e => e.Group),
+                ("merkleTreeManager", e => e.MerkleTreeManager),
+                ("pathMintRouter", e => e.PathMintRouter)
+            ]);
+
+        AddMappings<MerkleRootUpdated>(
+            ns: "CrcV2_ScoreGroup",
+            table: "MerkleRootUpdated",
+            eventSchema: MerkleRootUpdated,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("group", e => e.Group),
+                ("newMerkleRoot", e => e.NewMerkleRoot)
+            ]);
+
+        AddMappings<HistoricalSupply>(
+            ns: "CrcV2_ScoreGroup",
+            table: "HistoricalSupply",
+            eventSchema: HistoricalSupply,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("collateral", e => e.Collateral),
+                ("supply", e => e.Supply),
+                ("day", e => e.Day)
+            ]);
+
+        AddMappings<PersonalMinted>(
+            ns: "CrcV2_ScoreGroup",
+            table: "PersonalMinted",
+            eventSchema: PersonalMinted,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("group", e => e.Group),
+                ("collateral", e => e.Collateral),
+                ("amount", e => e.Amount),
+                ("score", e => e.Score),
+                ("mintedAmountOnToday", e => e.MintedAmountOnToday),
+                ("day", e => e.Day)
+            ]);
+
+        AddMappings<RouterMinted>(
+            ns: "CrcV2_ScoreGroup",
+            table: "RouterMinted",
+            eventSchema: RouterMinted,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("group", e => e.Group),
+                ("collateral", e => e.Collateral),
+                ("amount", e => e.Amount),
+                ("currentAvailableLimit", e => e.CurrentAvailableLimit)
+            ]);
+    }
+}

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
@@ -1,0 +1,174 @@
+using System.Collections.Immutable;
+using Circles.Common;
+using Circles.Index.Query;
+using Nethermind.Core;
+using Nethermind.Core.Crypto;
+using Nethermind.Core.Extensions;
+using Nethermind.Int256;
+using Nethermind.Logging;
+
+namespace Circles.Index.CirclesV2.ScoreGroup;
+
+public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
+{
+    private static readonly Hash256 GroupInitializedTopic = new(DatabaseSchema.GroupInitialized.Topic);
+    private static readonly Hash256 MerkleRootUpdatedTopic = new(DatabaseSchema.MerkleRootUpdated.Topic);
+    private static readonly Hash256 HistoricalSupplyTopic = new(DatabaseSchema.HistoricalSupply.Topic);
+    private static readonly Hash256 PersonalMintedTopic = new(DatabaseSchema.PersonalMinted.Topic);
+    private static readonly Hash256 RouterMintedTopic = new(DatabaseSchema.RouterMinted.Topic);
+
+    public static readonly RollbackCache<Address, object?> ScoreGroupPolicies = new("ScoreGroupPolicies");
+
+    public IRollbackCache[] Caches { get; } = [ScoreGroupPolicies];
+
+    public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
+    {
+        var seed = policyAddresses.ToDictionary(a => a, _ => (object?)null);
+
+        var query = new Select("CrcV2_ScoreGroup", "GroupInitialized", ["emitter"], [], [], int.MaxValue, false,
+            int.MaxValue);
+        foreach (var row in database.Select(query.ToSql(database)).Rows)
+        {
+            seed[new Address(row[0]?.ToString() ?? throw new InvalidOperationException("Score group policy address is null"))] = null;
+        }
+
+        ScoreGroupPolicies.Seed(seed);
+        logger.Info($" * Cached {seed.Count} score group mint policy contracts");
+
+        return Task.CompletedTask;
+    }
+
+    public IEnumerable<IIndexEvent> ParseTransaction(
+        Block block,
+        int transactionIndex,
+        Transaction transaction,
+        TxReceipt receipt,
+        IReadOnlyList<IIndexEvent> events)
+    {
+        yield break;
+    }
+
+    public IEnumerable<IIndexEvent> ParseLog(
+        Block block,
+        Transaction transaction,
+        TxReceipt receipt,
+        LogEntry log,
+        int logIndex)
+    {
+        if (log.Topics.Length == 0 || !ScoreGroupPolicies.ContainsKey(log.Address))
+        {
+            yield break;
+        }
+
+        var topic = log.Topics[0];
+        if (topic == GroupInitializedTopic)
+        {
+            yield return ParseGroupInitialized(block, receipt, log, logIndex);
+        }
+        else if (topic == MerkleRootUpdatedTopic)
+        {
+            yield return ParseMerkleRootUpdated(block, receipt, log, logIndex);
+        }
+        else if (topic == HistoricalSupplyTopic)
+        {
+            yield return ParseHistoricalSupply(block, receipt, log, logIndex);
+        }
+        else if (topic == PersonalMintedTopic)
+        {
+            yield return ParsePersonalMinted(block, receipt, log, logIndex);
+        }
+        else if (topic == RouterMintedTopic)
+        {
+            yield return ParseRouterMinted(block, receipt, log, logIndex);
+        }
+    }
+
+    private static GroupInitialized ParseGroupInitialized(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var manager = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[2].Bytes);
+        var router = new Address(log.Data.Slice(12, 20)).ToLowerHex();
+
+        return new GroupInitialized(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            group,
+            manager,
+            router);
+    }
+
+    private static MerkleRootUpdated ParseMerkleRootUpdated(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+
+        return new MerkleRootUpdated(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            group,
+            log.Data.ToArray());
+    }
+
+    private static HistoricalSupply ParseHistoricalSupply(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        var data = log.Data.AsSpan();
+
+        return new HistoricalSupply(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            Uint(log.Topics[1].Bytes),
+            Uint(data.Slice(0, 32)),
+            Uint(data.Slice(32, 32)));
+    }
+
+    private static PersonalMinted ParsePersonalMinted(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var data = log.Data.AsSpan();
+
+        return new PersonalMinted(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            group,
+            Uint(log.Topics[2].Bytes),
+            Uint(data.Slice(0, 32)),
+            Uint(data.Slice(32, 32)),
+            Uint(data.Slice(64, 32)),
+            Uint(data.Slice(96, 32)));
+    }
+
+    private static RouterMinted ParseRouterMinted(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var data = log.Data.AsSpan();
+
+        return new RouterMinted(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            group,
+            Uint(log.Topics[2].Bytes),
+            Uint(data.Slice(0, 32)),
+            Uint(data.Slice(32, 32)));
+    }
+
+    private static UInt256 Uint(ReadOnlySpan<byte> bytes) => new(bytes, true);
+}

--- a/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
+++ b/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
@@ -58,6 +58,8 @@
     </ProjectReference>
     <ProjectReference Include="..\Circles.Index.CirclesV2.PaymentGateway\Circles.Index.CirclesV2.PaymentGateway.csproj">
     </ProjectReference>
+    <ProjectReference Include="..\Circles.Index.CirclesV2.ScoreGroup\Circles.Index.CirclesV2.ScoreGroup.csproj">
+    </ProjectReference>
     <ProjectReference Include="..\Circles.Index.CirclesViews\Circles.Index.CirclesViews.csproj">
     </ProjectReference>
     <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj">

--- a/src/Index/Circles.Index.DatabaseSchemaProvider/DatabaseSchemaProvider.cs
+++ b/src/Index/Circles.Index.DatabaseSchemaProvider/DatabaseSchemaProvider.cs
@@ -27,6 +27,7 @@ public static class Schemas
         new CirclesV2.NameRegistry.DatabaseSchema(),
         new CirclesV2.OIC.DatabaseSchema(),
         new CirclesV2.PaymentGateway.DatabaseSchema(),
+        new CirclesV2.ScoreGroup.DatabaseSchema(),
         new CirclesV2.StandardTreasury.DatabaseSchema(),
         new CirclesV2.TokenOffers.DatabaseSchema(),
         new CirclesViews.DatabaseSchema(),

--- a/src/Index/Circles.Index.Postgres/PostgresDb.cs
+++ b/src/Index/Circles.Index.Postgres/PostgresDb.cs
@@ -794,6 +794,47 @@ public class PostgresDb : ReadonlyPostgresDb, IDatabase
         }
     }
 
+    public async Task DeleteTablesGreaterOrEqualBlock(long reorgAt, IReadOnlyCollection<string> tableNames)
+    {
+        if (tableNames.Count == 0)
+            return;
+
+        var knownTables = Schema.Tables.Values
+            .Where(table => !table.Namespace.StartsWith("V_")
+                            && table.Table != DatabaseSchema.PathfinderRequestLog
+                            && table.Table != DatabaseSchema.PathfinderResponseLog)
+            .Select(table => $"{table.Namespace}_{table.Table}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var requestedTables = tableNames
+            .Select(table => table.Trim())
+            .Where(table => !string.IsNullOrWhiteSpace(table))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        foreach (var tableName in requestedTables)
+        {
+            if (!knownTables.Contains(tableName))
+                throw new ArgumentException($"Unknown or non-reindexable table '{tableName}'.");
+        }
+
+        await using var connection = await DataSource.OpenConnectionAsync();
+        foreach (var tableName in requestedTables)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"DELETE FROM {QuoteIdentifier(tableName)} WHERE \"blockNumber\" >= @reorgAt;";
+            command.Parameters.AddWithValue("@reorgAt", reorgAt);
+            command.CommandTimeout = 600;
+
+            var rowsDeleted = await command.ExecuteNonQueryAsync();
+            if (rowsDeleted > 0)
+                Console.WriteLine($"Deleted {rowsDeleted} rows from {tableName}");
+        }
+    }
+
+    private static string QuoteIdentifier(string identifier) =>
+        "\"" + identifier.Replace("\"", "\"\"", StringComparison.Ordinal) + "\"";
+
     /// <summary>
     /// Upsert a single (tableName -> blockNumber) mapping.
     /// </summary>

--- a/src/Index/Circles.Index/BlockIndexer.cs
+++ b/src/Index/Circles.Index/BlockIndexer.cs
@@ -51,11 +51,16 @@ public record BlockWithReceipts(Block Block, TxReceipt[] Receipts);
 public class ImportFlow(
     IBlockTree blockTree,
     IReceiptFinder receiptFinder,
-    Context context)
+    Context context,
+    ISet<(string Namespace, string Table)>? tableFilter = null,
+    bool writeBlocks = true)
 {
     private static readonly IndexPerformanceMetrics Metrics = new();
 
     private readonly InsertBuffer<BlockWithEventCounts> _blockBuffer = new();
+    private readonly HashSet<(string Namespace, string Table)>? _tableFilter =
+        tableFilter == null ? null : new HashSet<(string Namespace, string Table)>(tableFilter);
+    private readonly bool _writeBlocks = writeBlocks;
     private long _blocksSinceLastInfoLog = 0;
     private DateTime _lastFlushTime = DateTime.UtcNow;
     private DateTime _lastFlushLogTime = DateTime.UtcNow;
@@ -83,16 +88,24 @@ public class ImportFlow(
 
         foreach (var indexEvent in allEvents)
         {
+            if (!context.Database.Schema.EventDtoTableMap.Map.TryGetValue(indexEvent.GetType(), out var tableName))
+                continue;
+
+            if (_tableFilter != null && !_tableFilter.Contains(tableName))
+                continue;
+
             await context.Sink.AddEvent(indexEvent);
-            var tableName = context.Database.Schema.EventDtoTableMap.Map[indexEvent.GetType()];
             var tableNameString = $"{tableName.Namespace}_{tableName.Table}";
             eventCounts[tableNameString] = eventCounts.GetValueOrDefault(tableNameString) + 1;
         }
 
         var block = data.Item1.Block;
-        await AddBlock(new BlockWithEventCounts(
-            new SimpleBlock(block.Number, block.Timestamp, block.Hash?.ToString()),
-            eventCounts));
+        if (_writeBlocks)
+        {
+            await AddBlock(new BlockWithEventCounts(
+                new SimpleBlock(block.Number, block.Timestamp, block.Hash?.ToString()),
+                eventCounts));
+        }
         Metrics.LogBlockWithReceipts(data.Item1);
     }
 

--- a/src/Index/Circles.Index/Circles.Index.csproj
+++ b/src/Index/Circles.Index/Circles.Index.csproj
@@ -83,6 +83,9 @@
     <ProjectReference Include="..\Circles.Index.CirclesV2.PaymentGateway\Circles.Index.CirclesV2.PaymentGateway.csproj">
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>
+    <ProjectReference Include="..\Circles.Index.CirclesV2.ScoreGroup\Circles.Index.CirclesV2.ScoreGroup.csproj">
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
     <ProjectReference Include="..\Circles.Index.CirclesViews\Circles.Index.CirclesViews.csproj">
       <PrivateAssets>all</PrivateAssets>
     </ProjectReference>

--- a/src/Index/Circles.Index/Plugin.cs
+++ b/src/Index/Circles.Index/Plugin.cs
@@ -95,6 +95,8 @@ public class Plugin : INethermindPlugin
             new CirclesV2.PaymentGateway.LogParser(settings.PaymentGatewayFactoryAddresses.Select(o => new Address(o))
                 .ToImmutableHashSet()),
             new CirclesV2.OIC.LogParser(new(settings.OICContractAddress)),
+            new CirclesV2.ScoreGroup.LogParser(settings.ScoreGroupMintPolicies.Select(o => new Address(o))
+                .ToImmutableHashSet()),
             new CirclesV2.InvitationsAtScale.LogParser(
                 settings.InvitationAtScaleInvitationFarmAddresses.Select(a => new Address(a)).ToImmutableHashSet(),
                 settings.InvitationAtScaleInvitationModuleAddresses.Select(a => new Address(a)).ToImmutableHashSet(),
@@ -201,6 +203,14 @@ public class Plugin : INethermindPlugin
         pluginLogger.Info(" * port: " + connectionStringBuilder.Port);
         pluginLogger.Info(" * user: " + connectionStringBuilder.Username);
         pluginLogger.Info(" * write mode: " + settings.WriteMode);
+        if (settings.ReindexFromBlock.HasValue)
+            pluginLogger.Warn(" * REINDEX_FROM_BLOCK: " + settings.ReindexFromBlock.Value);
+        if (settings.ReindexTables.Length > 0)
+            pluginLogger.Warn(" * REINDEX_TABLES: " + string.Join(", ", settings.ReindexTables));
+        if (settings.ReindexAllTables)
+            pluginLogger.Warn(" * REINDEX_ALL_TABLES: true");
+        if (settings.ReindexAllowPartialDependencies)
+            pluginLogger.Warn(" * REINDEX_ALLOW_PARTIAL_DEPENDENCIES: true");
 
         if (settings.IndexReadonlyDbConnectionString != null)
         {
@@ -230,6 +240,7 @@ public class Plugin : INethermindPlugin
         pluginLogger.Info(" * V2 Invitation-at-scale referrals modules: " + string.Join(", ", settings.InvitationAtScaleReferralsModuleAddresses));
         pluginLogger.Info(" * V2 Invitation-at-scale quota grant modules: " + string.Join(", ", settings.InvitationAtScaleQuotaGrantModuleAddresses));
         pluginLogger.Info(" * V2 Base Group Router: " + settings.BaseGroupRouter);
+        pluginLogger.Info(" * V2 Score Group Mint Policies: " + string.Join(", ", settings.ScoreGroupMintPolicies));
         pluginLogger.Info(" * V2 Invitation Farms: " + string.Join(", ", settings.InvitationAtScaleInvitationFarmAddresses));
         pluginLogger.Info(" * V2 Invitation Modules: " + string.Join(", ", settings.InvitationAtScaleInvitationModuleAddresses));
         pluginLogger.Info(" * V2 Referrals Modules: " + string.Join(", ", settings.InvitationAtScaleReferralsModuleAddresses));

--- a/src/Index/Circles.Index/StateMachine.cs
+++ b/src/Index/Circles.Index/StateMachine.cs
@@ -85,32 +85,42 @@ public class StateMachine(
                     {
                         case EnterState:
                             {
-                                // Handle REINDEX_FROM_BLOCK for full reindexing (only once per process lifetime)
-                                //
-                                // IMPORTANT: Partial table reindexing is NOT supported because it creates data
-                                // inconsistency between tables and caches. All tables must be at the same block height.
-                                //
-                                // Use REINDEX_FROM_BLOCK=12000000 to reindex ALL tables from that block.
-                                // Remove the env var after reindexing completes to avoid re-deleting data on restart.
-
-                                if (!_reindexCleanupDone && context.Settings.ReindexFromBlock.HasValue)
-                                {
-                                    var reindexFromBlock = context.Settings.ReindexFromBlock.Value;
-                                    context.Logger.Info($"[REINDEX] Reindexing ALL tables from block {reindexFromBlock:N0}");
-
-                                    // Delete from all tables
-                                    await context.Database.DeleteAllGreaterOrEqualBlock(reindexFromBlock);
-
-                                    context.Logger.Info("[REINDEX] Data deletion complete. Will resync from specified block.");
-                                    _reindexCleanupDone = true;
-                                }
-
                                 // Determine the effective resume point by checking both System_Block and all event tables.
                                 // This is critical: we must use the SAME block for cleanup and sync start to avoid
                                 // cache conflicts (caches track block numbers and require monotonically increasing blocks).
                                 context.Logger.Info("Initializing: Finding the safe resume point...");
 
                                 var latestBlock = context.Database.LatestBlock() ?? 0;
+
+                                if (!_reindexCleanupDone && context.Settings.ReindexFromBlock.HasValue)
+                                {
+                                    var reindexFromBlock = context.Settings.ReindexFromBlock.Value;
+                                    var targetedTables = ResolveReindexTableIds();
+
+                                    if (targetedTables.Count > 0)
+                                    {
+                                        context.Logger.Info("[REINDEX] Initializing parser caches before selected-table backfill...");
+                                        await InitializeCaches(latestBlock);
+                                        await TargetedReindex(reindexFromBlock, latestBlock, targetedTables);
+                                    }
+                                    else
+                                    {
+                                        if (!context.Settings.ReindexAllTables)
+                                        {
+                                            throw new InvalidOperationException(
+                                                "REINDEX_FROM_BLOCK without REINDEX_TABLES is a full-table reindex. " +
+                                                "Set REINDEX_ALL_TABLES=true to confirm this destructive operation.");
+                                        }
+
+                                        context.Logger.Info($"[REINDEX] Reindexing ALL tables from block {reindexFromBlock:N0}");
+                                        await context.Database.DeleteAllGreaterOrEqualBlock(reindexFromBlock);
+                                        context.Logger.Info("[REINDEX] Data deletion complete. Will resync from specified block.");
+                                        latestBlock = context.Database.LatestBlock() ?? 0;
+                                    }
+
+                                    _reindexCleanupDone = true;
+                                }
+
                                 var firstGap = context.Database.FirstGap();
                                 var safeResumeBlock = context.Database.GetSafeResumeBlock();
 
@@ -479,6 +489,113 @@ public class StateMachine(
             await Task.Yield();
         }
     }
+
+    private async IAsyncEnumerable<long> BlocksInRange(long fromBlock, long toBlock)
+    {
+        var start = Math.Max(fromBlock, context.Settings.StartBlock);
+        for (long i = start; i <= toBlock; i++)
+        {
+            yield return i;
+            await Task.Yield();
+        }
+    }
+
+    private async Task<Range<long>> TargetedReindex(
+        long fromBlock,
+        long toBlock,
+        HashSet<(string Namespace, string Table)> tableIds)
+    {
+        if (tableIds.Count == 0 || toBlock < fromBlock)
+            return new Range<long>();
+
+        context.Logger.Info(
+            $"[REINDEX] Backfilling selected tables from {fromBlock:N0} to {toBlock:N0}: " +
+            $"{string.Join(", ", tableIds.Select(PhysicalTableName))}");
+
+        await context.Database.DeleteTablesGreaterOrEqualBlock(fromBlock, tableIds.Select(PhysicalTableName).ToArray());
+
+        ImportFlow flow = new(blockTree, receiptFinder, context, tableIds, writeBlocks: false);
+        var importedBlockRange = await flow.Run(BlocksInRange(fromBlock, toBlock), cancellationToken);
+        await context.Sink.Flush();
+        await flow.FlushBlocks();
+
+        context.Logger.Info(
+            $"[REINDEX] Selected table backfill complete for range {importedBlockRange.Min}-{importedBlockRange.Max}. " +
+            "Remove REINDEX_FROM_BLOCK and REINDEX_TABLES before restarting.");
+
+        return importedBlockRange;
+    }
+
+    private HashSet<(string Namespace, string Table)> ResolveReindexTableIds()
+    {
+        var result = new HashSet<(string Namespace, string Table)>();
+        if (context.Settings.ReindexTables.Length == 0)
+            return result;
+
+        var byPhysicalName = context.Database.Schema.Tables.Keys
+            .Where(id => !id.Namespace.StartsWith("System", StringComparison.OrdinalIgnoreCase)
+                         && !id.Namespace.StartsWith("V_", StringComparison.OrdinalIgnoreCase))
+            .ToDictionary(PhysicalTableName, id => id, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rawTableName in context.Settings.ReindexTables)
+        {
+            var tableName = rawTableName.Trim();
+            if (!byPhysicalName.TryGetValue(tableName, out var tableId))
+            {
+                throw new ArgumentException(
+                    $"Unknown or non-targetable REINDEX_TABLES entry '{tableName}'. " +
+                    $"Use physical table names such as CrcV2_ScoreGroup_HistoricalSupply.");
+            }
+
+            result.Add(tableId);
+        }
+
+        ValidateReindexDependencies(result);
+        return result;
+    }
+
+    private void ValidateReindexDependencies(HashSet<(string Namespace, string Table)> selected)
+    {
+        if (context.Settings.ReindexAllowPartialDependencies)
+        {
+            context.Logger.Warn(
+                "[REINDEX] REINDEX_ALLOW_PARTIAL_DEPENDENCIES=true; known dependency closure checks are disabled.");
+            return;
+        }
+
+        var dependencyGroups = new[]
+        {
+            new[]
+            {
+                ("CrcV2_ScoreGroup", "GroupInitialized"),
+                ("CrcV2_ScoreGroup", "MerkleRootUpdated"),
+                ("CrcV2_ScoreGroup", "HistoricalSupply"),
+                ("CrcV2_ScoreGroup", "PersonalMinted"),
+                ("CrcV2_ScoreGroup", "RouterMinted")
+            }
+        };
+
+        foreach (var group in dependencyGroups)
+        {
+            var groupSet = group.ToHashSet();
+            if (!selected.Overlaps(groupSet) || groupSet.IsSubsetOf(selected))
+                continue;
+
+            var missing = groupSet
+                .Except(selected)
+                .Select(PhysicalTableName)
+                .OrderBy(x => x)
+                .ToArray();
+
+            throw new InvalidOperationException(
+                "REINDEX_TABLES selects part of a known dependent table group. " +
+                "Add the missing tables or set REINDEX_ALLOW_PARTIAL_DEPENDENCIES=true only for an intentionally partial repair. " +
+                $"Missing: {string.Join(", ", missing)}");
+        }
+    }
+
+    private static string PhysicalTableName((string Namespace, string Table) tableId) =>
+        $"{tableId.Namespace}_{tableId.Table}";
 
     private async Task<Range<long>> Sync(long toBlock)
     {

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -224,7 +224,9 @@ public class NetworkStateUpdaterService : BackgroundService
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),
-            new Dictionary<int, int>(cap.WrapperToAvatar));
+            new Dictionary<int, int>(cap.WrapperToAvatar),
+            new Dictionary<int, int>(cap.GroupRouters),
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -472,7 +474,9 @@ public class NetworkStateUpdaterService : BackgroundService
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),
-            new Dictionary<int, int>(cap.WrapperToAvatar));
+            new Dictionary<int, int>(cap.WrapperToAvatar),
+            new Dictionary<int, int>(cap.GroupRouters),
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -701,7 +705,9 @@ public class NetworkStateUpdaterService : BackgroundService
             cap.GroupTrustedTokens.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
             new HashSet<int>(cap.ConsentedAvatars),
             new HashSet<int>(cap.RegisteredAvatarIds),
-            new Dictionary<int, int>(cap.WrapperToAvatar));
+            new Dictionary<int, int>(cap.WrapperToAvatar),
+            new Dictionary<int, int>(cap.GroupRouters),
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -15,6 +15,7 @@ public class GraphFactoryTests
 {
     // Valid 42-char hex addresses (0x + 40 hex) — required for IsValidEthereumAddress checks
     private static readonly string RouterAddr = "0xf1ff000000000000000000000000000000000001";
+    private static readonly string ScoreRouterAddr = "0xf1ff000000000000000000000000000000000009";
     private static readonly string Alice = "0xf1aa000000000000000000000000000000000002";
     private static readonly string Bob = "0xf1bb000000000000000000000000000000000003";
     // Carol available for future multi-hop tests
@@ -810,6 +811,93 @@ public class GraphFactoryTests
         int tokenBId = AddressIdPool.IdOf(TokenB.ToLowerInvariant());
         Assert.That(cg.AvatarNodes.ContainsKey(tokenBId), Is.True,
             "Group-trusted token should be registered as avatar node (DB path)");
+    }
+
+    [Test]
+    public void GraphFactory_GroupSpecificRouterTrust_AllowsScoreGroupCollateral()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+        var cg = factory.CreateCapacityGraph(bg, trustLookup);
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var scoreRouterId = AddressIdPool.IdOf(ScoreRouterAddr.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.RouterForGroup(groupId), Is.EqualTo(scoreRouterId));
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.True,
+            "Score group collateral should be gated by the score router trust, not the base router trust.");
+    }
+
+    [Test]
+    public void GraphFactory_ScoreGroupMintLimit_CapsCollateralEdge()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        mock.AddScoreGroupMintLimit(GroupG, TokenA, "25000000000000000000");
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+        var cg = factory.CreateCapacityGraph(bg, trustLookup);
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        var edge = cg.Edges.Single(e => e.From == poolId && e.To == groupId && e.Token == tokenAId);
+        Assert.That(edge.InitialCapacity, Is.EqualTo(25_000_000));
+    }
+
+    [Test]
+    public void GraphFactory_GroupRouterRows_DoNotAddUnsupportedGroups()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddGroupRouter(GroupH, ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var tg = factory.V2TrustGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(tg);
+        var cg = factory.CreateCapacityGraph(bg, trustLookup);
+
+        var groupGId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var groupHId = AddressIdPool.IdOf(GroupH.ToLowerInvariant());
+
+        Assert.That(cg.GroupRouters.ContainsKey(groupGId), Is.True);
+        Assert.That(cg.GroupRouters.ContainsKey(groupHId), Is.False,
+            "A router row must not create a group that was filtered out by LoadGroups.");
+        Assert.That(cg.GroupNodes.Contains(groupHId), Is.False);
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -13,6 +13,8 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> _balances = new();
     private readonly List<string> _groups = new();
     private readonly List<(string GroupAddress, string TrustedToken)> _groupTrusts = new();
+    private readonly List<(string GroupAddress, string RouterAddress)> _groupRouters = new();
+    private readonly List<(string GroupAddress, string CollateralToken, string AvailableLimit)> _scoreGroupMintLimits = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
     private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
@@ -106,6 +108,16 @@ public class MockLoadGraph : ILoadGraph
             _trusts.Add((_routerAddress, trustedToken.ToLowerInvariant(), 100));
     }
 
+    public void AddGroupRouter(string groupAddress, string routerAddress)
+    {
+        _groupRouters.Add((groupAddress.ToLowerInvariant(), routerAddress.ToLowerInvariant()));
+    }
+
+    public void AddScoreGroupMintLimit(string groupAddress, string collateralToken, string availableLimit)
+    {
+        _scoreGroupMintLimits.Add((groupAddress.ToLowerInvariant(), collateralToken.ToLowerInvariant(), availableLimit));
+    }
+
     /// <summary>
     /// Add a consented flow flag using integer node ID.
     /// </summary>
@@ -144,6 +156,16 @@ public class MockLoadGraph : ILoadGraph
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
         return _groupTrusts;
+    }
+
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+    {
+        return _groupRouters;
+    }
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+    {
+        return _scoreGroupMintLimits;
     }
 
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
@@ -186,6 +208,7 @@ public class MockLoadGraph : ILoadGraph
         _balances.Clear();
         _groups.Clear();
         _groupTrusts.Clear();
+        _scoreGroupMintLimits.Clear();
         _consentedFlags.Clear();
         _registeredAvatars.Clear();
         _wrapperMappings.Clear();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PipelineMethodTests.cs
@@ -19,6 +19,7 @@ public class PipelineMethodTests
     private static readonly int D = AddressIdPool.IdOf("0xdd04pipeline_d");
     private static readonly int Group1 = AddressIdPool.IdOf("0xdd05pipeline_group1");
     private static readonly int Router = AddressIdPool.IdOf("0xdd06pipeline_router");
+    private static readonly int ScoreRouter = AddressIdPool.IdOf("0xdd16pipeline_score_router");
 
     private static readonly int TokenA = AddressIdPool.IdOf("0xdd07pipeline_tokenA");
     private static readonly int TokenB = AddressIdPool.IdOf("0xdd08pipeline_tokenB");
@@ -318,6 +319,27 @@ public class PipelineMethodTests
         Assert.That(result[1].From, Is.EqualTo(Router));
         Assert.That(result[1].To, Is.EqualTo(Group1));
         Assert.That(result[1].Flow, Is.EqualTo(500));
+    }
+
+    [Test]
+    public void Router_AvatarToScoreGroup_UsesGroupSpecificRouter()
+    {
+        var graph = MakeGraph(groups: new[] { Group1 });
+        graph.SetRouter(Router);
+        graph.SetGroupRouter(Group1, ScoreRouter);
+
+        var edges = new List<FlowEdge>
+        {
+            new(A, Group1, TokenA, 1000) { Flow = 500 },
+        };
+
+        var result = _pathfinder.InsertRouterInTransfers(edges, graph);
+
+        Assert.That(result, Has.Count.EqualTo(2));
+        Assert.That(result[0].From, Is.EqualTo(A));
+        Assert.That(result[0].To, Is.EqualTo(ScoreRouter));
+        Assert.That(result[1].From, Is.EqualTo(ScoreRouter));
+        Assert.That(result[1].To, Is.EqualTo(Group1));
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -25,7 +25,10 @@
         <None Remove="Data\Queries\balanceQuery.sql" />
         <None Remove="Data\Queries\trustQuery.sql" />
         <None Remove="Data\Queries\groupQuery.sql" />
+        <None Remove="Data\Queries\groupQuery.fallback.sql" />
         <None Remove="Data\Queries\groupTrustQuery.sql" />
+        <None Remove="Data\Queries\groupTrustQuery.fallback.sql" />
+        <None Remove="Data\Queries\groupRouterQuery.sql" />
         <None Remove="Data\Queries\consentedFlowQuery.sql" />
         <None Remove="Data\Queries\balanceFullStateQuery.sql" />
         <None Remove="Data\Queries\trustFullStateQuery.sql" />
@@ -43,7 +46,10 @@
         <EmbeddedResource Include="Data\Queries\balanceQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\groupQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\groupQuery.fallback.sql" />
         <EmbeddedResource Include="Data\Queries\groupTrustQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\groupTrustQuery.fallback.sql" />
+        <EmbeddedResource Include="Data\Queries\groupRouterQuery.sql" />
         <EmbeddedResource Include="Data\Queries\consentedFlowQuery.sql" />
         <EmbeddedResource Include="Data\Queries\balanceFullStateQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustFullStateQuery.sql" />

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -16,7 +16,9 @@ public record PathfinderGraphSnapshot(
     IReadOnlyList<PathfinderGraphConsentedFlowRow>? ConsentedFlow,
     IReadOnlyList<string>? Avatars,
     IReadOnlyList<string>? Organizations = null,
-    IReadOnlyList<PathfinderGraphWrapperMappingRow>? WrapperMappings = null
+    IReadOnlyList<PathfinderGraphWrapperMappingRow>? WrapperMappings = null,
+    IReadOnlyList<PathfinderGraphGroupRouterRow>? GroupRouters = null,
+    IReadOnlyList<PathfinderGraphScoreGroupMintLimitRow>? ScoreGroupMintLimits = null
 );
 
 public record PathfinderGraphBalanceRow(
@@ -35,6 +37,17 @@ public record PathfinderGraphTrustRow(
 );
 
 public record PathfinderGraphGroupRow(string GroupAddress);
+
+public record PathfinderGraphGroupRouterRow(
+    string GroupAddress,
+    string RouterAddress
+);
+
+public record PathfinderGraphScoreGroupMintLimitRow(
+    string GroupAddress,
+    string CollateralToken,
+    string AvailableLimit
+);
 
 public record PathfinderGraphGroupTrustRow(
     string GroupAddress,
@@ -74,6 +87,12 @@ internal sealed class PathfinderGraphSnapshotDto
     [JsonPropertyName("groups")]
     public List<PathfinderGraphGroupRow>? Groups { get; set; }
 
+    [JsonPropertyName("groupRouters")]
+    public List<PathfinderGraphGroupRouterRow>? GroupRouters { get; set; }
+
+    [JsonPropertyName("scoreGroupMintLimits")]
+    public List<PathfinderGraphScoreGroupMintLimitRow>? ScoreGroupMintLimits { get; set; }
+
     [JsonPropertyName("groupTrusts")]
     public List<PathfinderGraphGroupTrustRow>? GroupTrusts { get; set; }
 
@@ -100,5 +119,7 @@ internal sealed class PathfinderGraphSnapshotDto
         ConsentedFlow,
         Avatars,
         Organizations,
-        WrapperMappings);
+        WrapperMappings,
+        GroupRouters,
+        ScoreGroupMintLimits);
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -89,6 +89,20 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return (row.GroupAddress.ToLowerInvariant(), row.TrustedToken.ToLowerInvariant());
     }
 
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+    {
+        var rows = _snapshot.GroupRouters ?? [];
+        foreach (var row in rows)
+            yield return (row.GroupAddress.ToLowerInvariant(), row.RouterAddress.ToLowerInvariant());
+    }
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+    {
+        var rows = _snapshot.ScoreGroupMintLimits ?? [];
+        foreach (var row in rows)
+            yield return (row.GroupAddress.ToLowerInvariant(), row.CollateralToken.ToLowerInvariant(), row.AvailableLimit);
+    }
+
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
     {
         var rows = _snapshot.ConsentedFlow ?? [];

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -141,6 +141,12 @@ public class IncrementalLoadGraph : ILoadGraph
         return _trustState.GetGroupTrusts(routerGroups, _maxBlockTimestamp, _avatarState.AvatarSet);
     }
 
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+        => _inner.LoadGroupRouters();
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+        => _inner.LoadScoreGroupMintLimits();
+
     /// <summary>
     /// Delegates to inner LoadGraph — consented flow table is small, fast query.
     /// </summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -20,6 +20,8 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<string> Groups,
         IReadOnlyList<string> Organizations,
         IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts,
+        IReadOnlyList<(string GroupAddress, string RouterAddress)> GroupRouters,
+        IReadOnlyList<(string GroupAddress, string CollateralToken, string AvailableLimit)> ScoreGroupMintLimits,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
         IReadOnlyList<string> RegisteredAvatars,
         IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings
@@ -35,6 +37,8 @@ namespace Circles.Pathfinder.Data
         IEnumerable<string> LoadGroups();
         IEnumerable<string> LoadOrganizations();
         IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts();
+        IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters() => [];
+        IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits() => [];
 
         IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags();
 
@@ -221,7 +225,7 @@ namespace Circles.Pathfinder.Data
         // Load groups
         public IEnumerable<string> LoadGroups()
         {
-            var groupQuery = LoadQueryFromResource("groupQuery.sql");
+            var groupQuery = LoadQueryFromResource(ScoreGroupTablesAvailable() ? "groupQuery.sql" : "groupQuery.fallback.sql");
             var results = new List<string>(1_000);
 
             var sw = Stopwatch.StartNew();
@@ -230,6 +234,7 @@ namespace Circles.Pathfinder.Data
             using var command = new NpgsqlCommand(groupQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
             command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -269,7 +274,7 @@ namespace Circles.Pathfinder.Data
         // Load group trust relationships
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
         {
-            var groupTrustQuery = LoadQueryFromResource("groupTrustQuery.sql");
+            var groupTrustQuery = LoadQueryFromResource(ScoreGroupTablesAvailable() ? "groupTrustQuery.sql" : "groupTrustQuery.fallback.sql");
             var results = new List<(string GroupAddress, string TrustedToken)>(5_000);
 
             var sw = Stopwatch.StartNew();
@@ -278,6 +283,7 @@ namespace Circles.Pathfinder.Data
             using var command = new NpgsqlCommand(groupTrustQuery, connection);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
             command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -307,16 +313,19 @@ namespace Circles.Pathfinder.Data
 
             var balances = LoadV2BalancesInternal(connection, tx);
             var trust = LoadV2TrustInternal(connection, tx);
-            var groups = LoadGroupsInternal(connection, tx);
+            var scoreGroupTablesAvailable = ScoreGroupTablesAvailable(connection, tx);
+            var groups = LoadGroupsInternal(connection, tx, scoreGroupTablesAvailable);
             var organizations = LoadOrganizationsInternal(connection, tx);
-            var groupTrusts = LoadGroupTrustsInternal(connection, tx);
+            var groupTrusts = LoadGroupTrustsInternal(connection, tx, scoreGroupTablesAvailable);
+            var groupRouters = LoadGroupRoutersInternal(connection, tx, scoreGroupTablesAvailable);
+            var scoreGroupMintLimits = LoadScoreGroupMintLimitsInternal(connection, tx, scoreGroupTablesAvailable);
             var consentedFlags = LoadConsentedFlowFlagsInternal(connection, tx);
             var registeredAvatars = LoadRegisteredAvatarsInternal(connection, tx);
             var wrapperMappings = LoadWrapperMappingsInternal(connection, tx);
 
             tx.Commit();
 
-            return new LoadAllResult(balances, trust, groups, organizations, groupTrusts, consentedFlags, registeredAvatars, wrapperMappings);
+            return new LoadAllResult(balances, trust, groups, organizations, groupTrusts, groupRouters, scoreGroupMintLimits, consentedFlags, registeredAvatars, wrapperMappings);
         }
 
         private List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
@@ -382,9 +391,9 @@ namespace Circles.Pathfinder.Data
             return results;
         }
 
-        private List<string> LoadGroupsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
+        private List<string> LoadGroupsInternal(NpgsqlConnection connection, NpgsqlTransaction tx, bool scoreGroupTablesAvailable)
         {
-            var groupQuery = LoadQueryFromResource("groupQuery.sql");
+            var groupQuery = LoadQueryFromResource(scoreGroupTablesAvailable ? "groupQuery.sql" : "groupQuery.fallback.sql");
             var results = new List<string>(1_000);
 
             var sw = Stopwatch.StartNew();
@@ -392,6 +401,7 @@ namespace Circles.Pathfinder.Data
             using var command = new NpgsqlCommand(groupQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
             command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -426,9 +436,9 @@ namespace Circles.Pathfinder.Data
         }
 
         private List<(string GroupAddress, string TrustedToken)>
-            LoadGroupTrustsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
+            LoadGroupTrustsInternal(NpgsqlConnection connection, NpgsqlTransaction tx, bool scoreGroupTablesAvailable)
         {
-            var groupTrustQuery = LoadQueryFromResource("groupTrustQuery.sql");
+            var groupTrustQuery = LoadQueryFromResource(scoreGroupTablesAvailable ? "groupTrustQuery.sql" : "groupTrustQuery.fallback.sql");
             var results = new List<(string GroupAddress, string TrustedToken)>(5_000);
 
             var sw = Stopwatch.StartNew();
@@ -436,6 +446,7 @@ namespace Circles.Pathfinder.Data
             using var command = new NpgsqlCommand(groupTrustQuery, connection, tx);
             command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
             command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
             using var reader = command.ExecuteReader();
 
             while (reader.Read())
@@ -446,6 +457,154 @@ namespace Circles.Pathfinder.Data
             sw.Stop();
             OnQueryCompleted?.Invoke("group_trusts", sw.Elapsed);
             return results;
+        }
+
+        public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+        {
+            if (!ScoreGroupTablesAvailable())
+                return LoadBaseGroupRouters();
+
+            var groupRouterQuery = LoadQueryFromResource("groupRouterQuery.sql");
+            var results = new List<(string GroupAddress, string RouterAddress)>(1_000);
+
+            var sw = Stopwatch.StartNew();
+            using var connection = _dataSource.OpenConnection();
+
+            using var command = new NpgsqlCommand(groupRouterQuery, connection);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("group_routers", sw.Elapsed);
+            return results;
+        }
+
+        private List<(string GroupAddress, string RouterAddress)>
+            LoadGroupRoutersInternal(NpgsqlConnection connection, NpgsqlTransaction tx, bool scoreGroupTablesAvailable)
+        {
+            if (!scoreGroupTablesAvailable)
+                return LoadBaseGroupRoutersInternal(connection, tx);
+
+            var groupRouterQuery = LoadQueryFromResource("groupRouterQuery.sql");
+            var results = new List<(string GroupAddress, string RouterAddress)>(1_000);
+
+            var sw = Stopwatch.StartNew();
+
+            using var command = new NpgsqlCommand(groupRouterQuery, connection, tx);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+            using var reader = command.ExecuteReader();
+
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("group_routers", sw.Elapsed);
+            return results;
+        }
+
+        private List<(string GroupAddress, string RouterAddress)> LoadBaseGroupRouters()
+        {
+            var results = new List<(string GroupAddress, string RouterAddress)>(1_000);
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(
+                """
+                SELECT "group", LOWER(@standardRouter)
+                FROM "CrcV2_RegisterGroup"
+                WHERE "mint" = LOWER(@mintPolicy);
+                """,
+                connection);
+
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            return results;
+        }
+
+        private List<(string GroupAddress, string RouterAddress)> LoadBaseGroupRoutersInternal(
+            NpgsqlConnection connection,
+            NpgsqlTransaction tx)
+        {
+            var results = new List<(string GroupAddress, string RouterAddress)>(1_000);
+            using var command = new NpgsqlCommand(
+                """
+                SELECT "group", LOWER(@standardRouter)
+                FROM "CrcV2_RegisterGroup"
+                WHERE "mint" = LOWER(@mintPolicy);
+                """,
+                connection,
+                tx);
+
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+            command.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            return results;
+        }
+
+        public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+        {
+            if (_settings.ScoreGroupMintPolicies.Length == 0)
+                return [];
+
+            var sw = Stopwatch.StartNew();
+            using var connection = _dataSource.OpenConnection();
+
+            var rows = ScoreGroupMintLimitReader.Read(
+                connection,
+                _settings.ScoreGroupMintPolicies,
+                _settings.TargetDemurrageTimestamp,
+                _settings.DemurrageSafetyMargin,
+                _settings.PathfinderGroupTimeoutSeconds);
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("score_group_mint_limits", sw.Elapsed);
+            return rows.Select(row => (row.GroupAddress, row.CollateralToken, row.AvailableLimit)).ToList();
+        }
+
+        private List<(string GroupAddress, string CollateralToken, string AvailableLimit)>
+            LoadScoreGroupMintLimitsInternal(NpgsqlConnection connection, NpgsqlTransaction tx, bool scoreGroupTablesAvailable)
+        {
+            if (_settings.ScoreGroupMintPolicies.Length == 0 || !scoreGroupTablesAvailable)
+                return [];
+
+            var sw = Stopwatch.StartNew();
+            var rows = ScoreGroupMintLimitReader.Read(
+                connection,
+                _settings.ScoreGroupMintPolicies,
+                _settings.TargetDemurrageTimestamp,
+                _settings.DemurrageSafetyMargin,
+                _settings.PathfinderGroupTimeoutSeconds,
+                transaction: tx);
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("score_group_mint_limits", sw.Elapsed);
+            return rows.Select(row => (row.GroupAddress, row.CollateralToken, row.AvailableLimit)).ToList();
         }
 
         private List<(string Avatar, bool HasConsentedFlow)>
@@ -945,6 +1104,22 @@ namespace Circles.Pathfinder.Data
             sw.Stop();
             OnQueryCompleted?.Invoke("wrapper_mappings", sw.Elapsed);
             return results;
+        }
+
+        private bool ScoreGroupTablesAvailable()
+        {
+            using var connection = _dataSource.OpenConnection();
+            return ScoreGroupTablesAvailable(connection, null);
+        }
+
+        private static bool ScoreGroupTablesAvailable(NpgsqlConnection connection, NpgsqlTransaction? tx)
+        {
+            using var command = new NpgsqlCommand(
+                "SELECT to_regclass('public.\"CrcV2_ScoreGroup_GroupInitialized\"') IS NOT NULL",
+                connection,
+                tx);
+
+            return command.ExecuteScalar() is bool available && available;
         }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.fallback.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupQuery.fallback.sql
@@ -1,0 +1,4 @@
+SELECT
+    "group" AS group_address
+FROM "CrcV2_RegisterGroup"
+WHERE "mint" = LOWER(@mintPolicy);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupRouterQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupRouterQuery.sql
@@ -8,7 +8,9 @@ WITH latest_score_group AS (
 ),
 supported_groups AS (
     SELECT
-        g."group" AS group_address
+        g."group" AS group_address,
+        g."mint",
+        sg.router_address
     FROM "CrcV2_RegisterGroup" g
     LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
     WHERE g."mint" = LOWER(@mintPolicy)
@@ -18,5 +20,9 @@ supported_groups AS (
        )
 )
 SELECT
-    group_address
+    group_address,
+    CASE
+        WHEN router_address IS NOT NULL THEN router_address
+        ELSE LOWER(@standardRouter)
+    END AS router_address
 FROM supported_groups;

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.fallback.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.fallback.sql
@@ -1,0 +1,9 @@
+WITH registered_avatars AS MATERIALIZED (
+{{registered_avatars_cte_body}})
+SELECT
+    t.truster as group_address,
+    t.trustee as trusted_token
+FROM "V_CrcV2_TrustRelations" t
+INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
+INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
+WHERE g."mint" = LOWER(@mintPolicy);

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/groupTrustQuery.sql
@@ -1,9 +1,27 @@
 WITH registered_avatars AS MATERIALIZED (
-{{registered_avatars_cte_body}})
+{{registered_avatars_cte_body}}),
+latest_score_group AS (
+    SELECT DISTINCT ON ("group")
+        "group" AS group_address,
+        "pathMintRouter" AS router_address
+    FROM "CrcV2_ScoreGroup_GroupInitialized"
+    WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+    ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+),
+supported_groups AS (
+    SELECT
+        g."group" AS group_address
+    FROM "CrcV2_RegisterGroup" g
+    LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+    WHERE g."mint" = LOWER(@mintPolicy)
+       OR (
+           LOWER(g."mint") = ANY(@scoreMintPolicies)
+           AND sg.router_address IS NOT NULL
+       )
+)
 SELECT
     t.truster as group_address,
     t.trustee as trusted_token
 FROM "V_CrcV2_TrustRelations" t
-INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
+INNER JOIN supported_groups g ON g.group_address = t.truster
 INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
-WHERE g."mint" = LOWER(@mintPolicy);

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -13,7 +13,9 @@ public sealed record CachedGroupData(
     Dictionary<int, HashSet<int>> GroupTrustedTokens,
     HashSet<int> ConsentedAvatars,
     HashSet<int> RegisteredAvatarIds,
-    Dictionary<int, int> WrapperToAvatar);
+    Dictionary<int, int> WrapperToAvatar,
+    Dictionary<int, int>? GroupRouters = null,
+    Dictionary<(int GroupAddress, int CollateralToken), long>? ScoreGroupMintLimits = null);
 
 public class CapacityGraph : IGraph<CapacityEdge>
 {
@@ -28,6 +30,9 @@ public class CapacityGraph : IGraph<CapacityEdge>
     public HashSet<int> GroupNodes { get; } = new HashSet<int>();
     public HashSet<int> OrganizationNodes { get; } = new HashSet<int>();
     public int? RouterNode { get; set; }
+    public HashSet<int> RouterNodes { get; } = new HashSet<int>();
+    public Dictionary<int, int> GroupRouters { get; } = new Dictionary<int, int>();
+    public Dictionary<(int GroupAddress, int CollateralToken), long> ScoreGroupMintLimits { get; } = new();
 
     // Track which tokens each group trusts
     public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();
@@ -84,19 +89,38 @@ public class CapacityGraph : IGraph<CapacityEdge>
         GroupNodes.Add(groupAddress);
     }
 
+    public void SetGroupRouter(int groupAddress, int routerAddress)
+    {
+        AddGroup(groupAddress);
+        SetRouter(routerAddress);
+        GroupRouters[groupAddress] = routerAddress;
+    }
+
     // Track the router node ID for post-processing.
     // Note: Router is added as an avatar node but has no edges in the capacity graph during construction.
     // It's only used during path post-processing to insert router steps between Avatar→Group transfers.
     public void SetRouter(int routerAddress)
     {
         AddAvatar(routerAddress);
-        RouterNode = routerAddress;
+        RouterNodes.Add(routerAddress);
+        RouterNode ??= routerAddress;
     }
 
     // Helper methods
     public bool IsGroup(int nodeAddress) => GroupNodes.Contains(nodeAddress);
     public bool IsOrganization(int nodeAddress) => OrganizationNodes.Contains(nodeAddress);
-    public bool IsRouter(int nodeAddress) => RouterNode.HasValue && RouterNode.Value == nodeAddress;
+    public bool IsRouter(int nodeAddress) => RouterNodes.Contains(nodeAddress);
+
+    public int RouterForGroup(int groupAddress)
+    {
+        if (GroupRouters.TryGetValue(groupAddress, out var routerAddress))
+            return routerAddress;
+
+        if (RouterNode.HasValue)
+            return RouterNode.Value;
+
+        throw new InvalidOperationException("No router is configured for group minting.");
+    }
 
     public void AddCapacityEdge(int from, int to, int token, long capacity)
     {

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -672,6 +672,19 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         {
             foreach (var groupId in cached.GroupNodes)
                 capacityGraph.AddGroup(groupId);
+            if (cached.GroupRouters != null)
+            {
+                foreach (var (groupId, groupRouterId) in cached.GroupRouters)
+                {
+                    if (cached.GroupNodes.Contains(groupId))
+                        capacityGraph.SetGroupRouter(groupId, groupRouterId);
+                }
+            }
+            if (cached.ScoreGroupMintLimits != null)
+            {
+                foreach (var (key, limit) in cached.ScoreGroupMintLimits)
+                    capacityGraph.ScoreGroupMintLimits[key] = limit;
+            }
             foreach (var orgId in cached.OrganizationNodes)
                 capacityGraph.OrganizationNodes.Add(orgId);
             foreach (var (groupId, tokens) in cached.GroupTrustedTokens)
@@ -687,10 +700,32 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         // Load groups from DB
         var groups = loadGraph.LoadGroups().ToList();
+        var loadedGroupIds = new HashSet<int>();
         foreach (var groupAddress in groups)
         {
             int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
             capacityGraph.AddGroup(groupId);
+            loadedGroupIds.Add(groupId);
+        }
+
+        foreach (var (groupAddress, groupRouterAddress) in loadGraph.LoadGroupRouters())
+        {
+            int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
+            if (!loadedGroupIds.Contains(groupId))
+                continue;
+
+            int groupRouterId = AddressIdPool.IdOf(groupRouterAddress.ToLowerInvariant());
+            capacityGraph.SetGroupRouter(groupId, groupRouterId);
+        }
+
+        foreach (var (groupAddress, collateralToken, availableLimit) in loadGraph.LoadScoreGroupMintLimits())
+        {
+            if (!UInt256.TryParse(availableLimit, out var parsedLimit))
+                continue;
+
+            int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
+            int tokenId = AddressIdPool.IdOf(collateralToken.ToLowerInvariant());
+            capacityGraph.ScoreGroupMintLimits[(groupId, tokenId)] = CirclesConverter.TruncateToInt64(parsedLimit);
         }
 
         // Load organizations from DB (needed for canary source-type filtering)
@@ -869,20 +904,18 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         // checks trustMarkers[router][token] for every Avatar→Router edge
         // in operateFlowMatrix, so tokens not trusted by the Router would
         // revert on-chain even though the pathfinder found a valid flow.
-        HashSet<int>? routerTrusts = null;
-        if (g.RouterNode.HasValue)
-        {
-            accountTrusts.TryGetValue(g.RouterNode.Value, out routerTrusts);
-            if (routerTrusts == null)
-                _logger.LogWarning("Router node is set but has no trust entries in accountTrusts — all group collateral edges will be blocked");
-        }
-
         int routerFilteredCount = 0;
         int totalGroupTokenEdges = 0;
         foreach (var groupId in g.GroupNodes)
         {
             if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
             {
+                var groupRouter = g.RouterForGroup(groupId);
+                accountTrusts.TryGetValue(groupRouter, out var routerTrusts);
+                if (routerTrusts == null)
+                    _logger.LogWarning("Router node {Router} has no trust entries in accountTrusts — group collateral edges for {Group} will be blocked",
+                        AddressIdPool.StringOf(groupRouter), AddressIdPool.StringOf(groupId));
+
                 foreach (var token in trustedTokens)
                 {
                     totalGroupTokenEdges++;
@@ -893,6 +926,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                     if (routerTrusts == null || !routerTrusts.Contains(token))
                     {
                         routerFilteredCount++;
+                        continue;
+                    }
+
+                    if (g.ScoreGroupMintLimits.TryGetValue((groupId, token), out var availableLimit) &&
+                        availableLimit <= 0)
+                    {
                         continue;
                     }
 
@@ -914,7 +953,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
             foreach (var a in acceptors)
             {
-                g.AddCapacityEdge(pool, a, token, long.MaxValue);
+                var capacity = g.ScoreGroupMintLimits.TryGetValue((a, token), out var availableLimit)
+                    ? availableLimit
+                    : long.MaxValue;
+                if (capacity <= 0)
+                    continue;
+
+                g.AddCapacityEdge(pool, a, token, capacity);
             }
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -140,4 +140,15 @@ public class Settings
         Environment.GetEnvironmentVariable("V2_STANDARD_MINT_POLICY")?.ToLowerInvariant()
         ?? "0xcdfc5135aec0afbf102c108e7f5c8a88c6112842";
 
+    /// <summary>
+    /// Additional mint policies whose groups participate in pathfinding.
+    /// Score groups are included only when an indexed
+    /// CrcV2_ScoreGroup_GroupInitialized event provides their path mint router.
+    /// </summary>
+    public string[] ScoreGroupMintPolicies { get; set; } =
+        Environment.GetEnvironmentVariable("V2_SCORE_GROUP_MINT_POLICIES")?.Split(',')
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray()
+        ?? [];
 }

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -377,8 +377,7 @@ public class V2Pathfinder
 
         {
             int groupMints = ctx.Edges.Count(e => ctx.Graph.IsGroup(e.From));
-            int routerNode = ctx.Graph.RouterNode ?? -1;
-            int collateralEdges = ctx.Edges.Count(e => e.From == routerNode && ctx.Graph.IsGroup(e.To));
+            int collateralEdges = ctx.Edges.Count(e => ctx.Graph.IsRouter(e.From) && ctx.Graph.IsGroup(e.To));
             _logger.LogInformation("[{ReqId}] MintSort: groups={Groups}, collateral={Collateral}, total={Total}",
                 ctx.ReqId, groupMints, collateralEdges, ctx.Edges.Count);
         }
@@ -567,7 +566,6 @@ public class V2Pathfinder
             return transfers;
 
         var result = new List<FlowEdge>();
-        int routerId = capacityGraph.RouterNode.Value;
 
         foreach (var transfer in transfers)
         {
@@ -577,6 +575,8 @@ public class V2Pathfinder
                 !capacityGraph.IsRouter(transfer.From) &&
                 capacityGraph.IsGroup(transfer.To))
             {
+                var routerId = capacityGraph.RouterForGroup(transfer.To);
+
                 // Split into Avatar → Router → Group
                 // Avatar → Router (same token)
                 result.Add(new FlowEdge(transfer.From, routerId, transfer.Token, transfer.InitialCapacity)


### PR DESCRIPTION
## Summary
- Add score-group event indexing for `GroupInitialized`, merkle roots, historical supply, personal mints, and router mints.
- Add per-group router support to the pathfinder graph so base groups keep the base router while score groups use indexed `GroupInitialized.pathMintRouter` only.
- Add score-group mint-limit capacity caps for path routing and expose `groupRouters` / `scoreGroupMintLimits` in the cache graph.
- Add selected-table reindex support with fail-closed score-group dependency checks and a guard against accidental full DB wipes.
- Document score-group routing, mint-limit assumptions, future custom policy extension points, and selected-table reindexing.

## Safety notes
- No global score-router fallback is used for routing; score groups require indexed contract state.
- Future custom mint policies do not share the score-group limit formula automatically; they need their own parser/schema/limit provider if their events or caps differ.
- Existing base-group routing remains on the base router path.

## Test plan
- [x] `make build`
- [x] `make test-unit`
- [x] Review agents ran; follow-up findings were addressed before this PR.
- [x] Secret scan of changed implementation/docs found no leaked private key or secret value.

## Follow-up
- Staging deployment and path migration testing should happen after this PR lands to staging.