### PR TITLE
fix: restore score group index project in Docker build

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -19,6 +19,7 @@ COPY src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj ./
 COPY src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj ./Index/Circles.Index.CirclesV2.NameRegistry/
 COPY src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj ./Index/Circles.Index.CirclesV2.OIC/
 COPY src/Index/Circles.Index.CirclesV2.PaymentGateway/Circles.Index.CirclesV2.PaymentGateway.csproj ./Index/Circles.Index.CirclesV2.PaymentGateway/
+COPY src/Index/Circles.Index.CirclesV2.ScoreGroup/Circles.Index.CirclesV2.ScoreGroup.csproj ./Index/Circles.Index.CirclesV2.ScoreGroup/
 COPY src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj ./Index/Circles.Index.CirclesV2.StandardTreasury/
 COPY src/Index/Circles.Index.CirclesV2.TokenOffers/Circles.Index.CirclesV2.TokenOffers.csproj ./Index/Circles.Index.CirclesV2.TokenOffers/
 COPY src/Index/Circles.Index.CirclesViews/Circles.Index.CirclesViews.csproj ./Index/Circles.Index.CirclesViews/


### PR DESCRIPTION
## Summary
- include the score-group index project in the index Dockerfile restore layer
- keep `dotnet publish --no-restore` valid for the deployed image build

## Verification
- `docker build -f docker/Index.Dockerfile -t circles-index-scoregroup-docker-fix:local .`