### PR TITLE
fix: stabilize score group routing services

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -4,6 +4,7 @@ using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
 using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
 
 namespace Circles.Cache.Service.Controllers;
@@ -60,6 +61,7 @@ public class PathfinderGraphController : ControllerBase
     {
     }
 
+    [ActivatorUtilitiesConstructor]
     public PathfinderGraphController(
         CacheContainer caches,
         CacheServiceState state,

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -63,25 +63,31 @@ public record RouterMinted(
 
 public class DatabaseSchema : BaseDatabaseSchema
 {
-    public static readonly EventSchema GroupInitialized = EventSchema.FromSolidity(
+    public static readonly EventSchema GroupInitialized = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event GroupInitialized(address indexed group,address indexed merkleTreeManager,address pathMintRouter)");
+        "event GroupInitialized(address indexed group,address indexed merkleTreeManager,address pathMintRouter)"));
 
-    public static readonly EventSchema MerkleRootUpdated = EventSchema.FromSolidity(
+    public static readonly EventSchema MerkleRootUpdated = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot)");
+        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot)"));
 
-    public static readonly EventSchema HistoricalSupply = EventSchema.FromSolidity(
+    public static readonly EventSchema HistoricalSupply = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event HistoricalSupply(uint256 indexed collateral,uint256 supply,uint256 day)");
+        "event HistoricalSupply(uint256 indexed collateral,uint256 supply,uint256 day)"));
 
-    public static readonly EventSchema PersonalMinted = EventSchema.FromSolidity(
+    public static readonly EventSchema PersonalMinted = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event PersonalMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 score,uint256 mintedAmountOnToday,uint256 day)");
+        "event PersonalMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 score,uint256 mintedAmountOnToday,uint256 day)"));
 
-    public static readonly EventSchema RouterMinted = EventSchema.FromSolidity(
+    public static readonly EventSchema RouterMinted = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event RouterMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 currentAvailableLimit)");
+        "event RouterMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 currentAvailableLimit)"));
+
+    private static EventSchema WithEmitterColumn(EventSchema schema)
+    {
+        schema.Columns.Insert(5, new EventFieldSchema("emitter", ValueTypes.Address, true));
+        return schema;
+    }
 
     public DatabaseSchema()
     {

--- a/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
@@ -21,6 +21,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Circles.Index.CirclesV2\Circles.Index.CirclesV2.csproj" />
+      <ProjectReference Include="..\Circles.Index.CirclesV2.ScoreGroup\Circles.Index.CirclesV2.ScoreGroup.csproj" />
       <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
     </ItemGroup>
 

--- a/src/Index/Circles.Index.CirclesV2.Tests/ScoreGroupDatabaseSchemaTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/ScoreGroupDatabaseSchemaTests.cs
@@ -1,0 +1,34 @@
+using Circles.Common;
+using ScoreGroupDatabaseSchema = Circles.Index.CirclesV2.ScoreGroup.DatabaseSchema;
+
+namespace Circles.Index.CirclesV2.Tests;
+
+[TestFixture]
+public class ScoreGroupDatabaseSchemaTests
+{
+    [Test]
+    public void ScoreGroupEventSchemas_IncludeEmitterColumnForPolicyScopedQueries()
+    {
+        var schemas = new[]
+        {
+            ScoreGroupDatabaseSchema.GroupInitialized,
+            ScoreGroupDatabaseSchema.MerkleRootUpdated,
+            ScoreGroupDatabaseSchema.HistoricalSupply,
+            ScoreGroupDatabaseSchema.PersonalMinted,
+            ScoreGroupDatabaseSchema.RouterMinted
+        };
+
+        Assert.Multiple(() =>
+        {
+            foreach (var schema in schemas)
+            {
+                var emitterColumns = schema.Columns.Where(c => c.Column == "emitter").ToList();
+
+                Assert.That(emitterColumns, Has.Count.EqualTo(1), $"{schema.Table} must expose one emitter column");
+                Assert.That(schema.Columns[5].Column, Is.EqualTo("emitter"), $"{schema.Table} emitter column must follow base log columns");
+                Assert.That(schema.Columns[5].Type, Is.EqualTo(ValueTypes.Address), $"{schema.Table} emitter column must be an address");
+                Assert.That(schema.Columns[5].IsIndexed, Is.True, $"{schema.Table} emitter column should be indexed for policy filters");
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add the score-group event emitter column to table schemas used by policy-scoped queries
- mark the cache graph controller constructor that should be selected by dependency injection
- add a regression test for the score-group event schema shape

## Test plan
- `dotnet test src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj`
- `dotnet test src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj`
- `docker build -f docker/Index.Dockerfile -t circles-index-scoregroup-regression-fix:local .`
- `docker build -f docker/cache-service.Dockerfile -t circles-cache-scoregroup-regression-fix:local .`
