### PR TITLE
fix: convert score group numeric mappings

### DIFF
--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -1,3 +1,4 @@
+using System.Numerics;
 using Circles.Common;
 using Nethermind.Int256;
 
@@ -121,9 +122,9 @@ public class DatabaseSchema : BaseDatabaseSchema
             databaseFieldMap:
             [
                 ("emitter", e => e.Emitter),
-                ("collateral", e => e.Collateral),
-                ("supply", e => e.Supply),
-                ("day", e => e.Day)
+                ("collateral", e => (BigInteger)e.Collateral),
+                ("supply", e => (BigInteger)e.Supply),
+                ("day", e => (BigInteger)e.Day)
             ]);
 
         AddMappings<PersonalMinted>(
@@ -134,11 +135,11 @@ public class DatabaseSchema : BaseDatabaseSchema
             [
                 ("emitter", e => e.Emitter),
                 ("group", e => e.Group),
-                ("collateral", e => e.Collateral),
-                ("amount", e => e.Amount),
-                ("score", e => e.Score),
-                ("mintedAmountOnToday", e => e.MintedAmountOnToday),
-                ("day", e => e.Day)
+                ("collateral", e => (BigInteger)e.Collateral),
+                ("amount", e => (BigInteger)e.Amount),
+                ("score", e => (BigInteger)e.Score),
+                ("mintedAmountOnToday", e => (BigInteger)e.MintedAmountOnToday),
+                ("day", e => (BigInteger)e.Day)
             ]);
 
         AddMappings<RouterMinted>(
@@ -149,9 +150,9 @@ public class DatabaseSchema : BaseDatabaseSchema
             [
                 ("emitter", e => e.Emitter),
                 ("group", e => e.Group),
-                ("collateral", e => e.Collateral),
-                ("amount", e => e.Amount),
-                ("currentAvailableLimit", e => e.CurrentAvailableLimit)
+                ("collateral", e => (BigInteger)e.Collateral),
+                ("amount", e => (BigInteger)e.Amount),
+                ("currentAvailableLimit", e => (BigInteger)e.CurrentAvailableLimit)
             ]);
     }
 }

--- a/src/Index/Circles.Index.CirclesV2.Tests/ScoreGroupDatabaseSchemaTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/ScoreGroupDatabaseSchemaTests.cs
@@ -1,4 +1,7 @@
+using System.Numerics;
 using Circles.Common;
+using Nethermind.Int256;
+using Circles.Index.CirclesV2.ScoreGroup;
 using ScoreGroupDatabaseSchema = Circles.Index.CirclesV2.ScoreGroup.DatabaseSchema;
 
 namespace Circles.Index.CirclesV2.Tests;
@@ -29,6 +32,35 @@ public class ScoreGroupDatabaseSchemaTests
                 Assert.That(schema.Columns[5].Type, Is.EqualTo(ValueTypes.Address), $"{schema.Table} emitter column must be an address");
                 Assert.That(schema.Columns[5].IsIndexed, Is.True, $"{schema.Table} emitter column should be indexed for policy filters");
             }
+        });
+    }
+
+    [Test]
+    public void ScoreGroupBigIntMappings_ReturnBigIntegerForNumericColumns()
+    {
+        var dbSchema = new ScoreGroupDatabaseSchema();
+        var map = dbSchema.SchemaPropertyMap.Map[("CrcV2_ScoreGroup", "PersonalMinted")];
+        var personalMinted = new PersonalMinted(
+            BlockNumber: 1,
+            Timestamp: 2,
+            TransactionIndex: 3,
+            LogIndex: 4,
+            TransactionHash: "0xabc",
+            Emitter: "0x1111111111111111111111111111111111111111",
+            Group: "0x2222222222222222222222222222222222222222",
+            Collateral: new UInt256(123),
+            Amount: new UInt256(456),
+            Score: new UInt256(789),
+            MintedAmountOnToday: new UInt256(101112),
+            Day: new UInt256(131415));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(map["collateral"](personalMinted), Is.TypeOf<BigInteger>());
+            Assert.That(map["amount"](personalMinted), Is.TypeOf<BigInteger>());
+            Assert.That(map["score"](personalMinted), Is.TypeOf<BigInteger>());
+            Assert.That(map["mintedAmountOnToday"](personalMinted), Is.TypeOf<BigInteger>());
+            Assert.That(map["day"](personalMinted), Is.TypeOf<BigInteger>());
         });
     }
 }


### PR DESCRIPTION
## Summary
- convert score-group uint256 event mappings to BigInteger before database writes
- add a regression test for score-group numeric field mapping types

## Test plan
- `dotnet test src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj`
- `docker build -f docker/Index.Dockerfile -t circles-index-scoregroup-uint256-fix:local .`
