### PR TITLE
fix: validate score-router mint paths

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -17,6 +17,7 @@ public class HubContractValidatorTests
     private const string Carol = "0x0000000000000000000000000000000000000003";
     private const string Dave = "0x0000000000000000000000000000000000000004";
     private const string Router = "0x0000000000000000000000000000000000000099";
+    private const string ScoreRouter = "0x0000000000000000000000000000000000000098";
     private const string GroupA = "0x00000000000000000000000000000000000000a1";
     private const string GroupB = "0x00000000000000000000000000000000000000a2";
 
@@ -35,6 +36,7 @@ public class HubContractValidatorTests
     private class MockContractState : IContractState
     {
         public string? Router { get; set; }
+        public HashSet<string> Routers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> Groups { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> Consented { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<(string Truster, string CirclesId)> Trusts { get; set; } = new();
@@ -43,6 +45,9 @@ public class HubContractValidatorTests
         public bool RegisterAll { get; set; } = true; // Default: all considered registered
 
         public string? RouterAddress => Router;
+        public bool IsRouter(string address) =>
+            (Router != null && string.Equals(Router, address, StringComparison.OrdinalIgnoreCase))
+            || Routers.Contains(address);
         public bool IsGroup(string address) => Groups.Contains(address);
         public bool HasAdvancedUsageFlags(string address) => Consented.Contains(address);
         public bool IsRegistered(string address) => RegisterAll || Registered.Contains(address);
@@ -476,6 +481,30 @@ public class HubContractValidatorTests
         var violations = new List<ValidationViolation>();
         HubContractValidator.ValidateCollateralBeforeMint(steps, state, violations);
         Assert.That(violations, Is.Empty);
+    }
+
+    [Test]
+    public void Rule6_GroupSpecificScoreRouterCountsAsCollateral()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            Routers = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, Alice, "100"),
+            Step(ScoreRouter, GroupA, Alice, "100"),
+            Step(GroupA, Bob, GroupA, "100"),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateCollateralBeforeMint(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "A group-specific score router must satisfy the same collateral-before-mint rule as the base router.");
     }
 
     // ═══════════════════════════════════════════

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -19,6 +19,14 @@ public sealed class CapacityGraphContractState : IContractState
     public string? RouterAddress =>
         _graph.RouterNode.HasValue ? AddressIdPool.StringOf(_graph.RouterNode.Value) : null;
 
+    public bool IsRouter(string address)
+    {
+        var lower = address.ToLowerInvariant();
+        if (!AddressIdPool.TryIdOf(lower, out int id))
+            return false;
+        return _graph.IsRouter(id);
+    }
+
     public bool IsGroup(string address)
     {
         var lower = address.ToLowerInvariant();

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -206,8 +206,6 @@ public static class HubContractValidator
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
-
         // Collect all unique vertex addresses (From and To only — TokenOwner checked by Rule 11)
         var vertices = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
@@ -224,7 +222,7 @@ public static class HubContractValidator
         foreach (var vertex in vertices)
         {
             // Router is a contract address — always registered on-chain
-            if (router != null && vertex == router)
+            if (state.IsRouter(vertex))
                 continue;
 
             // Skip malformed addresses (already caught by Rule 2)
@@ -255,9 +253,6 @@ public static class HubContractValidator
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
-        if (router == null) return; // No router means no group minting in this path
-
         // Detect group-mint pattern: an address X is in a group mint flow when:
         //   1. Router→X edge exists where TokenOwner != X (collateral deposit — someone
         //      else's token is being sent to X, not X's own token being forwarded)
@@ -271,7 +266,7 @@ public static class HubContractValidator
         var receivesFromRouter = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var step in steps)
         {
-            if (step.From.ToLowerInvariant() == router)
+            if (state.IsRouter(step.From))
             {
                 var to = step.To.ToLowerInvariant();
                 // Only track as collateral deposit when the token being sent is NOT
@@ -285,7 +280,7 @@ public static class HubContractValidator
         foreach (var step in steps)
         {
             var from = step.From.ToLowerInvariant();
-            if (step.TokenOwner.ToLowerInvariant() == from && from != router)
+            if (step.TokenOwner.ToLowerInvariant() == from && !state.IsRouter(from))
                 mintCandidates.Add(from);
         }
 
@@ -318,7 +313,6 @@ public static class HubContractValidator
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
         var checked_ = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         for (int i = 0; i < steps.Count; i++)
@@ -330,7 +324,7 @@ public static class HubContractValidator
                 continue;
             if (!tokenOwner.StartsWith("0x") || tokenOwner.Length != 42)
                 continue;
-            if (router != null && tokenOwner == router)
+            if (state.IsRouter(tokenOwner))
                 continue;
 
             // ERC20 wrapper tokens have contract addresses that aren't registered avatars.
@@ -375,8 +369,6 @@ public static class HubContractValidator
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
-
         for (int i = 0; i < steps.Count; i++)
         {
             var from = steps[i].From.ToLowerInvariant();
@@ -398,16 +390,16 @@ public static class HubContractValidator
 
             // Router→Group: internal group mint — Hub.sol uses Router as _sender,
             // isPermittedFlow does not apply (Hub.sol:723). Safe to skip.
-            if (router != null && from == router && state.IsGroup(to))
+            if (state.IsRouter(from) && state.IsGroup(to))
                 continue;
 
             // Avatar→Router: Hub.sol:665-676 runs the full isPermittedFlow check.
             // Router must trust the token owner AND, if sender is consented,
             // advancedUsageFlags[Router] must be non-zero — but Router never calls
             // setAdvancedUsageFlag, so consented senders into Router ALWAYS revert.
-            if (router != null && to == router)
+            if (state.IsRouter(to))
             {
-                if (!state.IsTrusted(router, tokenOwner))
+                if (!state.IsTrusted(to, tokenOwner))
                 {
                     violations.Add(new ValidationViolation(
                         "IsPermittedFlow",
@@ -519,8 +511,7 @@ public static class HubContractValidator
         IContractState state,
         List<ValidationViolation> violations)
     {
-        var router = state.RouterAddress?.ToLowerInvariant();
-        if (router == null) return; // No router means no group minting in this path
+        if (state.RouterAddress == null) return; // No router means no group minting in this path
 
         // Track per-group: cumulative inbound from router, cumulative outbound to avatars
         var groupInbound = new Dictionary<string, BigInteger>();
@@ -536,7 +527,7 @@ public static class HubContractValidator
                 continue;
 
             // Router → Group (collateral deposit)
-            if (from == router && state.IsGroup(to))
+            if (state.IsRouter(from) && state.IsGroup(to))
             {
                 // Ordering check: no outbound should have been seen for this group yet
                 if (groupsWithOutboundSeen.Contains(to))
@@ -551,7 +542,7 @@ public static class HubContractValidator
                 groupInbound[to] = current + flow;
             }
             // Group → Avatar (mint)
-            else if (state.IsGroup(from) && from != router && to != router && !state.IsGroup(to))
+            else if (state.IsGroup(from) && !state.IsRouter(from) && !state.IsRouter(to) && !state.IsGroup(to))
             {
                 groupsWithOutboundSeen.Add(from);
 

--- a/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
@@ -19,6 +19,13 @@ public interface IContractState
     /// <summary>The StandardRouter contract address (null if not set).</summary>
     string? RouterAddress { get; }
 
+    /// <summary>Is the address one of the path mint router contracts known for this graph?</summary>
+    bool IsRouter(string address)
+    {
+        var router = RouterAddress;
+        return router != null && string.Equals(router, address, StringComparison.OrdinalIgnoreCase);
+    }
+
     /// <summary>
     /// Hub.avatars(address) != address(0) — is the address a registered Circles avatar?
     /// Hub.sol:794-805 checks this for ALL flow vertices; error codes 0x24/0x25.


### PR DESCRIPTION
## Summary
- treat all graph-known path mint routers as routers during Hub.sol validation
- count score-router -> score-group collateral before score-group mint edges
- add regression coverage for group-specific score routers

## Incident note
The staging path audit was firing on `CollateralBeforeMint` for score-group routes because validation only recognized the base router address. The handler still replaced rejected paths with empty responses, but valid score-router paths were being counted as validator violations.

## Tests
- `dotnet restore src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj`
- `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj --filter HubContractValidatorTests --no-restore`
- `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj --filter "FullyQualifiedName~HubContractValidatorTests|FullyQualifiedName~PipelineMethodTests|FullyQualifiedName~GraphFactoryTests" --no-restore`
- `./scripts/test.sh pathfinder`

## Live check
- staging path-audit 5m rate is currently 0 for `CollateralBeforeMint` on the queried Prometheus view.