### PR TITLE
feat(score-router): hard-gate approveCRC + circles_getScoreGroupMintLimits RPC

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -226,7 +226,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new HashSet<int>(cap.RegisteredAvatarIds),
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
-            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -476,7 +477,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new HashSet<int>(cap.RegisteredAvatarIds),
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
-            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -707,7 +709,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new HashSet<int>(cap.RegisteredAvatarIds),
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
-            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits));
+            new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
@@ -1,0 +1,66 @@
+using Circles.Pathfinder.Data;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Validation;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Unit tests for CapacityGraphContractState — the bridge from the runtime CapacityGraph
+/// to IContractState consumed by HubContractValidator. Pins the IsApprovedForAll lookup
+/// direction (account=router → operator=avatar) and the behaviors that C3 will later
+/// tighten (fail-open on empty approvals is current behavior; documented but not changed
+/// here).
+/// </summary>
+[TestFixture, Parallelizable]
+public class CapacityGraphContractStateTests
+{
+    private static readonly string ScoreRouter = "0xf2ff000000000000000000000000000000000009";
+    private static readonly string Alice = "0xf2aa000000000000000000000000000000000002";
+    private static readonly string Bob = "0xf2bb000000000000000000000000000000000003";
+
+    [Test]
+    public void IsApprovedForAll_PopulatedApprovals_ReturnsTrueForApprovedOperator()
+    {
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        int aliceId = AddressIdPool.IdOf(Alice);
+
+        var g = new CapacityGraph();
+        g.AddAvatar(aliceId);
+        g.OperatorApprovals[routerId] = new HashSet<int> { aliceId };
+
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsApprovedForAll(ScoreRouter, Alice), Is.True);
+    }
+
+    [Test]
+    public void IsApprovedForAll_PopulatedApprovals_ReturnsFalseForKnownButUnapprovedOperator()
+    {
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        int aliceId = AddressIdPool.IdOf(Alice);
+        int bobId = AddressIdPool.IdOf(Bob);
+
+        var g = new CapacityGraph();
+        g.AddAvatar(aliceId);
+        g.AddAvatar(bobId);
+        g.OperatorApprovals[routerId] = new HashSet<int> { aliceId };
+
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsApprovedForAll(ScoreRouter, Bob), Is.False,
+            "Bob is known to the graph but not in the router's approval set.");
+    }
+
+    [Test]
+    public void IsApprovedForAll_EmptyApprovals_ReturnsTrue_CurrentBehavior()
+    {
+        // Pins the current fail-open default: with no OperatorApprovals at all, the gate
+        // is assumed inapplicable (legacy behavior — only score-group policies populate
+        // approvals). C3 will tighten this to fail-closed when score policies are
+        // configured; this test documents the pre-C3 state so the change is visible.
+        var g = new CapacityGraph();
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsApprovedForAll(ScoreRouter, Alice), Is.True);
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -847,6 +847,10 @@ public class GraphFactoryTests
     [Test]
     public void GraphFactory_ScoreGroupMintLimit_CapsCollateralEdge()
     {
+        // Score-group collateral edges are source-dependent (gated by Hub.isApprovedForAll
+        // on the score router); they are reconstructed per-request from the filtered path,
+        // not from the base snapshot. The test exercises the production path with Alice
+        // as an approved operator of the score router.
         var mock = new HelperMock();
         mock.AddRegisteredAvatar(Alice);
         mock.AddRegisteredAvatar(TokenA);
@@ -855,6 +859,7 @@ public class GraphFactoryTests
         mock.AddGroupRouter(GroupG, ScoreRouterAddr);
         mock.AddTrust(ScoreRouterAddr, TokenA);
         mock.AddScoreGroupMintLimit(GroupG, TokenA, "25000000000000000000");
+        mock.AddOperatorApproval(ScoreRouterAddr, Alice);
         mock.AddBalance(
             AddressIdPool.IdOf(Alice.ToLowerInvariant()),
             AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
@@ -864,7 +869,8 @@ public class GraphFactoryTests
         var bg = factory.V2BalanceGraph();
         var tg = factory.V2TrustGraph();
         var trustLookup = GraphFactory.BuildTrustLookup(tg);
-        var cg = factory.CreateCapacityGraph(bg, trustLookup);
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob });
 
         var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
         var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
@@ -872,6 +878,152 @@ public class GraphFactoryTests
 
         var edge = cg.Edges.Single(e => e.From == poolId && e.To == groupId && e.Token == tokenAId);
         Assert.That(edge.InitialCapacity, Is.EqualTo(25_000_000));
+    }
+
+    private static HelperMock BuildScoreGroupMock(bool approveAlice)
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        mock.AddScoreGroupMintLimit(GroupG, TokenA, "25000000000000000000");
+        if (approveAlice)
+            mock.AddOperatorApproval(ScoreRouterAddr, Alice);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            100_000_000);
+        return mock;
+    }
+
+    /// <summary>
+    /// Base snapshot is source-agnostic; score-router collateral edges are inherently
+    /// source-dependent (gated by Hub.isApprovedForAll on the router). Including them in
+    /// the shared snapshot causes pathfinder to emit reverting paths when the snapshot is
+    /// served directly to a request with a source. Strip them unconditionally.
+    /// </summary>
+    [Test]
+    public void GraphFactory_BaseSnapshot_StripsScoreRouterEdges_WhenSourceUnknown()
+    {
+        var mock = BuildScoreGroupMock(approveAlice: true);
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        var cg = factory.CreateBaseCapacityGraph(bg, trustLookup);
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.False,
+            "Score-group collateral edges must not appear in the source-agnostic base snapshot.");
+    }
+
+    /// <summary>
+    /// Filtered request with a source that the score router has NOT approved must drop the
+    /// score-group collateral edge — emitting it would produce a path that reverts at
+    /// Hub.operateFlowMatrix's isApprovedForAll check.
+    /// </summary>
+    [Test]
+    public void GraphFactory_FilteredRequest_StripsScoreRouterEdges_ForUnapprovedSource()
+    {
+        var mock = BuildScoreGroupMock(approveAlice: false);
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob });
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.False,
+            "Unapproved source must not see score-group collateral edges.");
+    }
+
+    /// <summary>
+    /// C1 regression: when CachedGroupData carries a non-null OperatorApprovals dict, the
+    /// cached-rehydration path in LoadGroupsAndTrackRouter must hydrate the per-request
+    /// graph's OperatorApprovals so the score-router gate at AddTokenPoolOutEdges sees the
+    /// approval. Failure mode if the cache plumbing breaks: filtered requests fail-CLOSED
+    /// → maxFlow=0 for approved users.
+    /// </summary>
+    [Test]
+    public void GraphFactory_CachedGroupData_OperatorApprovals_Hydrated_PreservesApprovedRouterEdges()
+    {
+        var mock = BuildScoreGroupMock(approveAlice: true);
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        int tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        int groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        int routerId = AddressIdPool.IdOf(ScoreRouterAddr.ToLowerInvariant());
+        int poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        var cached = new CachedGroupData(
+            GroupNodes: new HashSet<int> { groupId },
+            OrganizationNodes: new HashSet<int>(),
+            GroupTrustedTokens: new Dictionary<int, HashSet<int>> { [groupId] = new() { tokenAId } },
+            ConsentedAvatars: new HashSet<int>(),
+            RegisteredAvatarIds: new HashSet<int> { aliceId, tokenAId, groupId },
+            WrapperToAvatar: new Dictionary<int, int>(),
+            GroupRouters: new Dictionary<int, int> { [groupId] = routerId },
+            ScoreGroupMintLimits: new Dictionary<(int, int), long> { [(groupId, tokenAId)] = 25_000_000L },
+            OperatorApprovals: new Dictionary<int, HashSet<int>> { [routerId] = new() { aliceId } });
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob }, cached);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.True,
+            "Cached OperatorApprovals must hydrate the per-request graph so approved sources retain the score-router edge.");
+    }
+
+    /// <summary>
+    /// C1 regression: when CachedGroupData.OperatorApprovals is null (the pre-fix bug shape
+    /// at NetworkStateUpdaterService.cs lines 221/471/702), the cached path returns early
+    /// without loading approvals from DB. Approved users then lose their score-router edges
+    /// → maxFlow=0. This test pins the failure mode so it can't silently regress.
+    /// </summary>
+    [Test]
+    public void GraphFactory_CachedGroupData_NullOperatorApprovals_DropsApprovedRouterEdges_C1Regression()
+    {
+        var mock = BuildScoreGroupMock(approveAlice: true);
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        int aliceId = AddressIdPool.IdOf(Alice.ToLowerInvariant());
+        int tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        int groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        int routerId = AddressIdPool.IdOf(ScoreRouterAddr.ToLowerInvariant());
+        int poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        var cached = new CachedGroupData(
+            GroupNodes: new HashSet<int> { groupId },
+            OrganizationNodes: new HashSet<int>(),
+            GroupTrustedTokens: new Dictionary<int, HashSet<int>> { [groupId] = new() { tokenAId } },
+            ConsentedAvatars: new HashSet<int>(),
+            RegisteredAvatarIds: new HashSet<int> { aliceId, tokenAId, groupId },
+            WrapperToAvatar: new Dictionary<int, int>(),
+            GroupRouters: new Dictionary<int, int> { [groupId] = routerId },
+            ScoreGroupMintLimits: new Dictionary<(int, int), long> { [(groupId, tokenAId)] = 25_000_000L },
+            OperatorApprovals: null);
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob }, cached);
+
+        Assert.That(cg.OperatorApprovals.Count, Is.EqualTo(0),
+            "Null OperatorApprovals in cache leaves the per-request graph empty — production must populate the field at NetworkStateUpdaterService.cs lines 221/471/702.");
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.False,
+            "With null cached approvals, even approved users lose score-router edges (C1 fail-CLOSED).");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -15,6 +15,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<(string GroupAddress, string TrustedToken)> _groupTrusts = new();
     private readonly List<(string GroupAddress, string RouterAddress)> _groupRouters = new();
     private readonly List<(string GroupAddress, string CollateralToken, string AvailableLimit)> _scoreGroupMintLimits = new();
+    private readonly List<(string Account, string Operator)> _operatorApprovals = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
     private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
@@ -119,6 +120,17 @@ public class MockLoadGraph : ILoadGraph
     }
 
     /// <summary>
+    /// Record an ERC-1155 ApprovalForAll. `account` is the ERC-1155 owner who called
+    /// setApprovalForAll, `operator` is the address it approved. For score-router paths,
+    /// `account` is the router and `operator` is the avatar approved to move tokens via
+    /// the router (mirrors ScoreGroupMintRouter.setApprovalForCRC).
+    /// </summary>
+    public void AddOperatorApproval(string account, string @operator)
+    {
+        _operatorApprovals.Add((account.ToLowerInvariant(), @operator.ToLowerInvariant()));
+    }
+
+    /// <summary>
     /// Add a consented flow flag using integer node ID.
     /// </summary>
     public void AddConsentedAvatar(int avatarId, bool hasConsentedFlow = true)
@@ -168,6 +180,12 @@ public class MockLoadGraph : ILoadGraph
         return _scoreGroupMintLimits;
     }
 
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var filter = new HashSet<string>(accounts.Select(a => a.ToLowerInvariant()));
+        return _operatorApprovals.Where(row => filter.Contains(row.Account)).ToList();
+    }
+
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
     {
         return _consentedFlags;
@@ -209,6 +227,7 @@ public class MockLoadGraph : ILoadGraph
         _groups.Clear();
         _groupTrusts.Clear();
         _scoreGroupMintLimits.Clear();
+        _operatorApprovals.Clear();
         _consentedFlags.Clear();
         _registeredAvatars.Clear();
         _wrapperMappings.Clear();

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -40,6 +40,15 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters() => [];
         IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits() => [];
 
+        /// <summary>
+        /// Returns currently-active ERC-1155 operator approvals from the Hub for the given owner
+        /// accounts. Used by the pathfinder to gate Avatar→Router edges: routing through a
+        /// ScoreGroupMintRouter requires the Router to have approved the operator
+        /// (msg.sender of operateFlowMatrix) via Hub.setApprovalForAll. Without it, the
+        /// underlying ERC-1155 transfer in the Router→Group hop reverts.
+        /// </summary>
+        IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts) => [];
+
         IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags();
 
         IEnumerable<string> LoadRegisteredAvatars();
@@ -585,6 +594,50 @@ namespace Circles.Pathfinder.Data
             sw.Stop();
             OnQueryCompleted?.Invoke("score_group_mint_limits", sw.Elapsed);
             return rows.Select(row => (row.GroupAddress, row.CollateralToken, row.AvailableLimit)).ToList();
+        }
+
+        public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+        {
+            var accountSet = accounts
+                .Where(a => !string.IsNullOrWhiteSpace(a))
+                .Select(a => a.ToLowerInvariant())
+                .Distinct()
+                .ToArray();
+
+            if (accountSet.Length == 0)
+                return [];
+
+            var sw = Stopwatch.StartNew();
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(
+                """
+                SELECT account, operator FROM (
+                    SELECT DISTINCT ON (LOWER("account"), LOWER("operator"))
+                        LOWER("account") AS account,
+                        LOWER("operator") AS operator,
+                        "approved" AS approved
+                    FROM "CrcV2_ApprovalForAll"
+                    WHERE LOWER("account") = ANY(@accounts)
+                    ORDER BY LOWER("account"), LOWER("operator"),
+                             "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+                ) latest
+                WHERE approved = true;
+                """,
+                connection);
+
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("accounts", accountSet);
+
+            var results = new List<(string, string)>(64);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                results.Add((reader.GetString(0), reader.GetString(1)));
+            }
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("operator_approvals", sw.Elapsed);
+            return results;
         }
 
         private List<(string GroupAddress, string CollateralToken, string AvailableLimit)>

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -15,7 +15,8 @@ public sealed record CachedGroupData(
     HashSet<int> RegisteredAvatarIds,
     Dictionary<int, int> WrapperToAvatar,
     Dictionary<int, int>? GroupRouters = null,
-    Dictionary<(int GroupAddress, int CollateralToken), long>? ScoreGroupMintLimits = null);
+    Dictionary<(int GroupAddress, int CollateralToken), long>? ScoreGroupMintLimits = null,
+    Dictionary<int, HashSet<int>>? OperatorApprovals = null);
 
 public class CapacityGraph : IGraph<CapacityEdge>
 {
@@ -33,6 +34,15 @@ public class CapacityGraph : IGraph<CapacityEdge>
     public HashSet<int> RouterNodes { get; } = new HashSet<int>();
     public Dictionary<int, int> GroupRouters { get; } = new Dictionary<int, int>();
     public Dictionary<(int GroupAddress, int CollateralToken), long> ScoreGroupMintLimits { get; } = new();
+
+    /// <summary>
+    /// ERC-1155 operator approvals from Hub.ApprovalForAll, keyed by the account (typically a
+    /// ScoreGroupMintRouter) that granted the approval. The value set contains the operator
+    /// node IDs that the account currently approves. Used to gate Avatar→Router edges:
+    /// Hub.operateFlowMatrix reverts if the path includes a Router→Group hop and the caller
+    /// (the operator) is not in this set for that router.
+    /// </summary>
+    public Dictionary<int, HashSet<int>> OperatorApprovals { get; } = new();
 
     // Track which tokens each group trusts
     public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -952,13 +952,17 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 // Router→Group hop. The pathfinder treats the path source as that operator.
                 // When sourceId is provided but unapproved, skip every collateral edge
                 // through this group's router — the resulting path would revert on-chain.
+                // When sourceId is null (base snapshot), the gate cannot be evaluated and
+                // the edges are inherently source-dependent — strip them unconditionally so
+                // the shared snapshot can't emit reverting paths. Per-request filtered
+                // builds reconstruct these edges with proper source context.
                 // A group is a score group iff it has at least one per-collateral mint-limit row.
                 bool isScoreGroup = trustedTokens.Any(t => g.ScoreGroupMintLimits.ContainsKey((groupId, t)));
-                bool requireApproval = sourceId.HasValue && isScoreGroup;
                 bool operatorApproved =
-                    !requireApproval
-                    || (g.OperatorApprovals.TryGetValue(groupRouter, out var approvedOps)
-                        && approvedOps.Contains(sourceId!.Value));
+                    !isScoreGroup
+                    || (sourceId.HasValue
+                        && g.OperatorApprovals.TryGetValue(groupRouter, out var approvedOps)
+                        && approvedOps.Contains(sourceId.Value));
 
                 foreach (var token in trustedTokens)
                 {

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -137,7 +137,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         var (totalGroupTokenEdges, routerFilteredCount) = AddTokenPoolOutEdges(
             capacityGraph, trustLookup,
             virtualSink: null, virtualSinkTrustedTokens: new HashSet<int>(),
-            sinkId: null, new HashSet<int>(), new HashSet<int>());
+            sinkId: null, sourceId: null, new HashSet<int>(), new HashSet<int>());
         capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
         capacityGraph.RouterFilteredEdges = routerFilteredCount;
 
@@ -479,6 +479,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             virtualSinkAddress,
             virtualSinkTrustedTokens,
             sinkId,
+            sourceId,
             toTokensFilter,
             excludedToTokensFilter);
         capacityGraph.TotalGroupTokenEdges = totalGroupTokenEdges;
@@ -685,6 +686,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 foreach (var (key, limit) in cached.ScoreGroupMintLimits)
                     capacityGraph.ScoreGroupMintLimits[key] = limit;
             }
+            if (cached.OperatorApprovals != null)
+            {
+                foreach (var (cachedRouterId, operators) in cached.OperatorApprovals)
+                    capacityGraph.OperatorApprovals[cachedRouterId] = new HashSet<int>(operators);
+            }
             foreach (var orgId in cached.OrganizationNodes)
                 capacityGraph.OrganizationNodes.Add(orgId);
             foreach (var (groupId, tokens) in cached.GroupTrustedTokens)
@@ -726,6 +732,29 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
             int tokenId = AddressIdPool.IdOf(collateralToken.ToLowerInvariant());
             capacityGraph.ScoreGroupMintLimits[(groupId, tokenId)] = CirclesConverter.TruncateToInt64(parsedLimit);
+        }
+
+        // Load ERC-1155 operator approvals granted BY the known group routers.
+        // These gate Avatar→Router edges: Hub.operateFlowMatrix reverts if the caller
+        // (operator/msg.sender) is not approved by the Router that holds tokens on the path.
+        var routerAddresses = capacityGraph.GroupRouters.Values
+            .Select(AddressIdPool.StringOf)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct()
+            .ToList();
+        if (routerAddresses.Count > 0)
+        {
+            foreach (var (account, op) in loadGraph.LoadOperatorApprovals(routerAddresses))
+            {
+                int approvingRouterId = AddressIdPool.IdOf(account.ToLowerInvariant());
+                int operatorId = AddressIdPool.IdOf(op.ToLowerInvariant());
+                if (!capacityGraph.OperatorApprovals.TryGetValue(approvingRouterId, out var approved))
+                {
+                    approved = new HashSet<int>();
+                    capacityGraph.OperatorApprovals[approvingRouterId] = approved;
+                }
+                approved.Add(operatorId);
+            }
         }
 
         // Load organizations from DB (needed for canary source-type filtering)
@@ -873,6 +902,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         int? virtualSink,
         HashSet<int> virtualSinkTrustedTokens,
         int? sinkId,
+        int? sourceId,
         HashSet<int> toTokensFilter,
         HashSet<int> excludedToTokensFilter)
     {
@@ -906,6 +936,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         // revert on-chain even though the pathfinder found a valid flow.
         int routerFilteredCount = 0;
         int totalGroupTokenEdges = 0;
+        int approvalFilteredCount = 0;
         foreach (var groupId in g.GroupNodes)
         {
             if (g.GroupTrustedTokens.TryGetValue(groupId, out var trustedTokens))
@@ -915,6 +946,19 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 if (routerTrusts == null)
                     _logger.LogWarning("Router node {Router} has no trust entries in accountTrusts — group collateral edges for {Group} will be blocked",
                         AddressIdPool.StringOf(groupRouter), AddressIdPool.StringOf(groupId));
+
+                // Score-group routers require ERC-1155 approval from the Router for the
+                // operator (msg.sender of operateFlowMatrix) before Hub will execute the
+                // Router→Group hop. The pathfinder treats the path source as that operator.
+                // When sourceId is provided but unapproved, skip every collateral edge
+                // through this group's router — the resulting path would revert on-chain.
+                // A group is a score group iff it has at least one per-collateral mint-limit row.
+                bool isScoreGroup = trustedTokens.Any(t => g.ScoreGroupMintLimits.ContainsKey((groupId, t)));
+                bool requireApproval = sourceId.HasValue && isScoreGroup;
+                bool operatorApproved =
+                    !requireApproval
+                    || (g.OperatorApprovals.TryGetValue(groupRouter, out var approvedOps)
+                        && approvedOps.Contains(sourceId!.Value));
 
                 foreach (var token in trustedTokens)
                 {
@@ -935,6 +979,13 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                         continue;
                     }
 
+                    // approveCRC gate (ERC-1155 operator approval Router→source).
+                    if (!operatorApproved)
+                    {
+                        approvalFilteredCount++;
+                        continue;
+                    }
+
                     if (!tokenToAvatars.TryGetValue(token, out var list))
                         tokenToAvatars[token] = list = new List<int>();
                     if (!list.Contains(groupId))
@@ -945,6 +996,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
         if (routerFilteredCount > 0)
             _logger.LogInformation("Filtered {Count} group collateral edges where Router does not trust the token", routerFilteredCount);
+        if (approvalFilteredCount > 0)
+            _logger.LogInformation("Filtered {Count} group collateral edges where source is not an approved operator of the score router", approvalFilteredCount);
 
         foreach (var (token, acceptors) in tokenToAvatars)
         {

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -110,4 +110,51 @@ public sealed class CapacityGraphContractState : IContractState
             return null;
         return AddressIdPool.StringOf(avatarId);
     }
+
+    /// <summary>
+    /// Hub.isApprovedForAll(account, operator). Permissive when no approval data is loaded —
+    /// the GraphFactory only populates OperatorApprovals when a score-group policy is
+    /// configured, so absence here means the rule is not applicable in this build.
+    /// </summary>
+    public bool IsApprovedForAll(string account, string @operator)
+    {
+        if (_graph.OperatorApprovals.Count == 0)
+            return true;
+
+        var accountLower = account.ToLowerInvariant();
+        var operatorLower = @operator.ToLowerInvariant();
+
+        if (!AddressIdPool.TryIdOf(accountLower, out int accountId))
+            return true;
+
+        if (!AddressIdPool.TryIdOf(operatorLower, out int operatorId))
+            return false;
+
+        return _graph.OperatorApprovals.TryGetValue(accountId, out var approvedOps)
+               && approvedOps.Contains(operatorId);
+    }
+
+    /// <summary>
+    /// True when the address is a known score-group mint router for some group in this graph.
+    /// Detected by membership in OperatorApprovals (populated only for score routers) or
+    /// by being the routing endpoint of a group that has per-collateral mint limits.
+    /// </summary>
+    public bool IsScoreRouter(string address)
+    {
+        var lower = address.ToLowerInvariant();
+        if (!AddressIdPool.TryIdOf(lower, out int id))
+            return false;
+
+        if (_graph.OperatorApprovals.ContainsKey(id))
+            return true;
+
+        foreach (var (groupId, routerId) in _graph.GroupRouters)
+        {
+            if (routerId != id) continue;
+            if (_graph.GroupTrustedTokens.TryGetValue(groupId, out var tokens) &&
+                tokens.Any(t => _graph.ScoreGroupMintLimits.ContainsKey((groupId, t))))
+                return true;
+        }
+        return false;
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -36,7 +36,7 @@ public static class HubContractValidator
         ValidateAvatarRegistration(filtered, source, sink, state, violations);
         ValidateGroupRegistration(filtered, state, violations);
         ValidateTokenIdValidity(filtered, state, violations);
-        ValidateIsPermittedFlow(filtered, state, violations);
+        ValidateIsPermittedFlow(filtered, source, state, violations);
         ValidateFlowConservation(filtered, source, sink, violations);
         ValidateCollateralBeforeMint(filtered, state, violations);
         ValidateNoDuplicateEdges(filtered, violations);
@@ -368,7 +368,15 @@ public static class HubContractValidator
         IReadOnlyList<TransferPathStep> steps,
         IContractState state,
         List<ValidationViolation> violations)
+        => ValidateIsPermittedFlow(steps, source: string.Empty, state, violations);
+
+    internal static void ValidateIsPermittedFlow(
+        IReadOnlyList<TransferPathStep> steps,
+        string source,
+        IContractState state,
+        List<ValidationViolation> violations)
     {
+        var sourceLower = source.ToLowerInvariant();
         for (int i = 0; i < steps.Count; i++)
         {
             var from = steps[i].From.ToLowerInvariant();
@@ -414,6 +422,18 @@ public static class HubContractValidator
                     violations.Add(new ValidationViolation(
                         "IsPermittedFlow",
                         $"Edge {i}: Avatar→Router — consented sender '{from}' cannot route through Router (Router has no advancedUsageFlags)",
+                        i, "error"));
+                }
+
+                // ScoreGroupMintRouter requires ERC-1155 operator approval from Router→source
+                // (the path's source acts as msg.sender in operateFlowMatrix). Without it the
+                // Router→Group hop reverts on safeBatchTransferFrom. We surface this as a
+                // distinct rule so the SDK can offer "tap to approve" instead of a revert.
+                if (state.IsScoreRouter(to) && !state.IsApprovedForAll(to, sourceLower))
+                {
+                    violations.Add(new ValidationViolation(
+                        "ApproveCRCRequired",
+                        $"Edge {i}: Avatar→Router — score router '{to}' has not approved source '{sourceLower}' as ERC-1155 operator; call ScoreGroupMintRouter.setApprovalForCRC([source]) once before retrying",
                         i, "error"));
                 }
                 continue;

--- a/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
@@ -44,4 +44,20 @@ public interface IContractState
     /// Returns null if the address is not a wrapper.
     /// </summary>
     string? ResolveWrapperToAvatar(string wrapperAddress);
+
+    /// <summary>
+    /// Hub.isApprovedForAll(account, operator) — has the account granted ERC-1155 operator
+    /// rights to the given operator? Required for any Hub.operateFlowMatrix call whose
+    /// path contains a from-vertex other than the operator/sender.
+    /// Returns true (permissive) if no approval data is loaded — keeps unrelated
+    /// validation paths from regressing when approvals are not yet indexed.
+    /// </summary>
+    bool IsApprovedForAll(string account, string @operator) => true;
+
+    /// <summary>
+    /// True when this address is a score-group mint router (per-group, set via
+    /// ScoreGroupMintRouter at OffchainScoreBasedMintPolicy.initializeGroup).
+    /// Used to scope the approveCRC rule so it only fires for score-router edges.
+    /// </summary>
+    bool IsScoreRouter(string address) => false;
 }

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -391,6 +391,17 @@ public interface ICirclesRpcModule
     Task<JsonElement> FindPathV2(FlowRequest flowRequest);
 
     /// <summary>
+    /// Returns per-(group, collateral) mint headroom for score-group mint policies.
+    /// Pre-flight handle for SDKs that want to validate Branch B headroom before
+    /// submitting an operateFlowMatrix. When <paramref name="collateralToken"/> is
+    /// supplied, returns just the single matching row; otherwise returns every
+    /// collateral the group currently trusts that has non-zero available capacity.
+    /// </summary>
+    /// <param name="groupAddress">Score group address to inspect.</param>
+    /// <param name="collateralToken">Optional collateral CRC token (avatar address). Filters the result to one row.</param>
+    Task<ScoreGroupMintLimitsResponse> GetScoreGroupMintLimits(string groupAddress, string? collateralToken = null);
+
+    /// <summary>
     /// Gets a snapshot of the entire Circles trust network.
     /// This method proxies the request to an external Pathfinder service.
     /// Returns the raw pathfinder response to match production behavior.
@@ -652,6 +663,21 @@ public record PagedEventsResponse(
     [property: JsonPropertyName("hasMore")] bool HasMore,
     [property: JsonPropertyName("nextCursor")] string? NextCursor
 );
+
+/// <summary>
+/// Single per-(group, collateral) row in a score-group mint-limits RPC response.
+/// </summary>
+public record ScoreGroupMintLimitRpcRow(
+    [property: JsonPropertyName("group")] string Group,
+    [property: JsonPropertyName("collateral")] string Collateral,
+    [property: JsonPropertyName("available")] string Available);
+
+/// <summary>
+/// Response for circles_getScoreGroupMintLimits.
+/// </summary>
+public record ScoreGroupMintLimitsResponse(
+    [property: JsonPropertyName("group")] string Group,
+    [property: JsonPropertyName("rows")] ScoreGroupMintLimitRpcRow[] Rows);
 
 /// <summary>
 /// Health check response.

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -695,6 +695,7 @@ static async Task<object> DispatchSingleRequest(
             "circles_getTransferData" => await ReflectionHandler(request, rpcModule),
             "circles_getTokenHolders" => await ReflectionHandler(request, rpcModule),
             "circlesV2_findPath" => await HandleV2FindPath(request, rpcModule),
+            "circles_getScoreGroupMintLimits" => await ReflectionHandler(request, rpcModule),
             // System & Query Methods
             "circles_getBlockByTimestamp" => await HandleGetBlockByTimestamp(request, rpcModule),
             "circles_events" => await HandleEventsLegacy(request, rpcModule),

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
@@ -1,0 +1,50 @@
+using Circles.Common;
+
+namespace Circles.Rpc.Host;
+
+/// <summary>
+/// Score-group mint-policy read endpoints exposed via JSON-RPC.
+/// </summary>
+public partial class CirclesRpcModule : ICirclesRpcModule
+{
+    public async Task<ScoreGroupMintLimitsResponse> GetScoreGroupMintLimits(
+        string groupAddress,
+        string? collateralToken = null)
+    {
+        var group = (groupAddress ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(group))
+            throw new ArgumentException("groupAddress is required", nameof(groupAddress));
+
+        var collateralFilter = string.IsNullOrWhiteSpace(collateralToken)
+            ? null
+            : collateralToken!.Trim().ToLowerInvariant();
+
+        var policies = _settings.ScoreGroupMintPolicies;
+        if (policies == null || policies.Length == 0)
+            return new ScoreGroupMintLimitsResponse(group, Array.Empty<ScoreGroupMintLimitRpcRow>());
+
+        await using var connection = await CreateConnectionAsync();
+
+        // RPC pre-flight uses live time + no client-side safety margin: the on-chain policy
+        // applies its own per-day demurrage in beforeMintPolicy. The SDK can subtract its own
+        // safety margin if desired.
+        var rows = ScoreGroupMintLimitReader.Read(
+            connection,
+            policies,
+            targetTimestamp: null,
+            safetyMargin: 1.0,
+            commandTimeoutSeconds: _settings.DatabaseQueryTimeoutSeconds);
+
+        var filtered = rows
+            .Where(row => string.Equals(row.GroupAddress, group, StringComparison.OrdinalIgnoreCase))
+            .Where(row => collateralFilter == null
+                          || string.Equals(row.CollateralToken, collateralFilter, StringComparison.OrdinalIgnoreCase))
+            .Select(row => new ScoreGroupMintLimitRpcRow(
+                row.GroupAddress,
+                row.CollateralToken,
+                row.AvailableLimit))
+            .ToArray();
+
+        return new ScoreGroupMintLimitsResponse(group, filtered);
+    }
+}


### PR DESCRIPTION
## Summary

Closes two gaps for score-group mint paths.

**1. approveCRC hard-gate.** Pathfinder previously had zero awareness of ERC-1155 operator approvals. Paths through a score-group mint router for a not-yet-approved source returned positive maxFlow and then reverted at `safeBatchTransferFrom` inside `Hub.operateFlowMatrix`. This change indexes `ApprovalForAll` per router and drops the user→router edge for any source that the router has not approved as an operator. The defensive validator layer emits a new `ApproveCRCRequired` violation rule so SDKs can surface a "tap to approve" action instead of a generic revert.

**2. `circles_getScoreGroupMintLimits` RPC.** New JSON-RPC method returning per-(group, collateral) headroom rows from `ScoreGroupMintLimitReader`. SDK pre-flight handle for Branch B mints; optional `collateralToken` filter returns a single row.

## Changes

- `CapacityGraph.OperatorApprovals` keyed by router id → set of approved operator ids.
- `ILoadGraph.LoadOperatorApprovals(accounts)` reads latest approval state from `CrcV2_ApprovalForAll`. Default interface impl is empty for legacy mocks.
- `GraphFactory.AddTokenPoolOutEdges` takes an optional `sourceId` and, for score groups (detected by presence of per-collateral mint-limit rows), drops the group-token edge when the router has not approved that source.
- `IContractState.IsApprovedForAll` + `IsScoreRouter` (default impls keep existing implementations source-compatible).
- `HubContractValidator.ValidateIsPermittedFlow` threads the path source and emits `ApproveCRCRequired` on Avatar→Router edges into score routers when the source is not an approved operator. A second internal overload preserves the 3-arg signature so existing tests build unchanged.
- New `circles_getScoreGroupMintLimits(group, collateralToken?)` JSON-RPC, wired through `Program.cs` via the existing reflection handler and implemented in a new partial class `CirclesRpcModule.ScoreGroup.cs`.

## Test plan

- [x] `dotnet build` clean (0 errors, warnings unchanged).
- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests` — 983 passing, 0 failing.
- [ ] Live staging: `circles_getScoreGroupMintLimits` returns expected per-collateral rows for the deployed score group.
- [ ] Live staging: `circlesV2_findPath` for a source without `setApprovalForCRC` returns no path crossing the score router (or, when the path is otherwise valid, the validator emits `ApproveCRCRequired`).
- [ ] After source calls `ScoreGroupMintRouter.setApprovalForCRC([source])`, re-run findPath returns a valid path through the score router.