### PR TITLE
fix(pathfinder): score-router source-of-truth + wrapper delegation

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -227,7 +227,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
-            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
+            new HashSet<int>(cap.ScoreRouterIds));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -478,7 +479,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
-            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
+            new HashSet<int>(cap.ScoreRouterIds));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -710,7 +712,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.WrapperToAvatar),
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
-            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)));
+            cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
+            new HashSet<int>(cap.ScoreRouterIds));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
@@ -63,4 +63,44 @@ public class CapacityGraphContractStateTests
 
         Assert.That(state.IsApprovedForAll(ScoreRouter, Alice), Is.True);
     }
+
+    [Test]
+    public void IsScoreRouter_AddressInScoreRouterIds_ReturnsTrue()
+    {
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        var g = new CapacityGraph();
+        g.ScoreRouterIds.Add(routerId);
+
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsScoreRouter(ScoreRouter), Is.True);
+    }
+
+    [Test]
+    public void IsScoreRouter_AddressNotInScoreRouterIds_ReturnsFalse_EvenWithOperatorApprovals()
+    {
+        // C2: the legacy heuristic returned true when an address had an OperatorApprovals
+        // entry — incidental, not source-of-truth. Post-C2, only ScoreRouterIds (loaded
+        // from CrcV2_ScoreGroup.GroupInitialized) classifies score routers.
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        int aliceId = AddressIdPool.IdOf(Alice);
+        var g = new CapacityGraph();
+        g.AddAvatar(aliceId);
+        g.OperatorApprovals[routerId] = new HashSet<int> { aliceId };
+        // intentionally do NOT add to ScoreRouterIds
+
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsScoreRouter(ScoreRouter), Is.False,
+            "OperatorApprovals membership alone must no longer classify a router as a score router.");
+    }
+
+    [Test]
+    public void IsScoreRouter_UnknownAddress_ReturnsFalse()
+    {
+        var g = new CapacityGraph();
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsScoreRouter(ScoreRouter), Is.False);
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -857,6 +857,7 @@ public class GraphFactoryTests
         mock.AddGroup(GroupG);
         mock.AddGroupTrust(GroupG, TokenA);
         mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddScoreRouter(ScoreRouterAddr);
         mock.AddTrust(ScoreRouterAddr, TokenA);
         mock.AddScoreGroupMintLimit(GroupG, TokenA, "25000000000000000000");
         mock.AddOperatorApproval(ScoreRouterAddr, Alice);
@@ -888,6 +889,7 @@ public class GraphFactoryTests
         mock.AddGroup(GroupG);
         mock.AddGroupTrust(GroupG, TokenA);
         mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddScoreRouter(ScoreRouterAddr);
         mock.AddTrust(ScoreRouterAddr, TokenA);
         mock.AddScoreGroupMintLimit(GroupG, TokenA, "25000000000000000000");
         if (approveAlice)
@@ -977,7 +979,8 @@ public class GraphFactoryTests
             WrapperToAvatar: new Dictionary<int, int>(),
             GroupRouters: new Dictionary<int, int> { [groupId] = routerId },
             ScoreGroupMintLimits: new Dictionary<(int, int), long> { [(groupId, tokenAId)] = 25_000_000L },
-            OperatorApprovals: new Dictionary<int, HashSet<int>> { [routerId] = new() { aliceId } });
+            OperatorApprovals: new Dictionary<int, HashSet<int>> { [routerId] = new() { aliceId } },
+            ScoreRouterIds: new HashSet<int> { routerId });
 
         var cg = factory.CreateCapacityGraph(bg, trustLookup,
             new FlowRequest { Source = Alice, Sink = Bob }, cached);
@@ -1015,7 +1018,8 @@ public class GraphFactoryTests
             WrapperToAvatar: new Dictionary<int, int>(),
             GroupRouters: new Dictionary<int, int> { [groupId] = routerId },
             ScoreGroupMintLimits: new Dictionary<(int, int), long> { [(groupId, tokenAId)] = 25_000_000L },
-            OperatorApprovals: null);
+            OperatorApprovals: null,
+            ScoreRouterIds: new HashSet<int> { routerId });
 
         var cg = factory.CreateCapacityGraph(bg, trustLookup,
             new FlowRequest { Source = Alice, Sink = Bob }, cached);
@@ -1024,6 +1028,82 @@ public class GraphFactoryTests
             "Null OperatorApprovals in cache leaves the per-request graph empty — production must populate the field at NetworkStateUpdaterService.cs lines 221/471/702.");
         Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.False,
             "With null cached approvals, even approved users lose score-router edges (C1 fail-CLOSED).");
+    }
+
+    /// <summary>
+    /// C2 regression: freshly-initialized score groups have an indexed GroupInitialized
+    /// event (and therefore a pathMintRouter) BEFORE any mint-limit row or operator
+    /// approval exists. The router must already be recognized as a score router so the
+    /// gate fires fail-CLOSED on unapproved sources; otherwise the user attempts a mint
+    /// path the contract immediately reverts.
+    /// </summary>
+    [Test]
+    public void GraphFactory_FreshlyInitializedScoreGroup_NoMintLimitYet_GateFiresClosed()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        mock.AddScoreRouter(ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        // intentionally NO AddScoreGroupMintLimit, NO AddOperatorApproval — mirrors
+        // the post-initialize / pre-first-mint window the C2 fix targets.
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob });
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.False,
+            "Freshly-initialized score router must be recognized (via ScoreRouterIds) and the gate must fail-CLOSED when no approval is present.");
+    }
+
+    /// <summary>
+    /// C2: a group with a custom router that is NOT a score-group router (no entry in
+    /// GroupInitialized) keeps its collateral edge — the operator-approval gate doesn't
+    /// apply. Pins the boundary between score and non-score groups.
+    /// </summary>
+    [Test]
+    public void GraphFactory_NonScoreGroupWithCustomRouter_EdgeKept()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddGroup(GroupG);
+        mock.AddGroupTrust(GroupG, TokenA);
+        mock.AddGroupRouter(GroupG, ScoreRouterAddr);
+        // No AddScoreRouter: this router is not in CrcV2_ScoreGroup_GroupInitialized.
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        mock.AddBalance(
+            AddressIdPool.IdOf(Alice.ToLowerInvariant()),
+            AddressIdPool.IdOf(TokenA.ToLowerInvariant()),
+            100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+
+        var cg = factory.CreateCapacityGraph(bg, trustLookup,
+            new FlowRequest { Source = Alice, Sink = Bob });
+
+        var tokenAId = AddressIdPool.IdOf(TokenA.ToLowerInvariant());
+        var groupId = AddressIdPool.IdOf(GroupG.ToLowerInvariant());
+        var poolId = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.Edges.Any(e => e.From == poolId && e.To == groupId && e.Token == tokenAId), Is.True,
+            "Non-score groups must not be subject to the score-router operator-approval gate.");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -16,6 +16,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<(string GroupAddress, string RouterAddress)> _groupRouters = new();
     private readonly List<(string GroupAddress, string CollateralToken, string AvailableLimit)> _scoreGroupMintLimits = new();
     private readonly List<(string Account, string Operator)> _operatorApprovals = new();
+    private readonly List<string> _scoreRouters = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
     private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
@@ -131,6 +132,17 @@ public class MockLoadGraph : ILoadGraph
     }
 
     /// <summary>
+    /// Register a score-group mint router. Mirrors the production source of truth
+    /// CrcV2_ScoreGroup.GroupInitialized.pathMintRouter — set once at initializeGroup,
+    /// immutable thereafter, distinct rows per (policy, group) collapse to a single
+    /// router via the production DISTINCT clause.
+    /// </summary>
+    public void AddScoreRouter(string routerAddress)
+    {
+        _scoreRouters.Add(routerAddress.ToLowerInvariant());
+    }
+
+    /// <summary>
     /// Add a consented flow flag using integer node ID.
     /// </summary>
     public void AddConsentedAvatar(int avatarId, bool hasConsentedFlow = true)
@@ -186,6 +198,8 @@ public class MockLoadGraph : ILoadGraph
         return _operatorApprovals.Where(row => filter.Contains(row.Account)).ToList();
     }
 
+    public IEnumerable<string> LoadScoreRouters() => _scoreRouters.Distinct().ToList();
+
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
     {
         return _consentedFlags;
@@ -228,6 +242,7 @@ public class MockLoadGraph : ILoadGraph
         _groupTrusts.Clear();
         _scoreGroupMintLimits.Clear();
         _operatorApprovals.Clear();
+        _scoreRouters.Clear();
         _consentedFlags.Clear();
         _registeredAvatars.Clear();
         _wrapperMappings.Clear();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -912,6 +912,46 @@ public class IncrementalLoadGraphTests
         Assert.That(results[0].HasConsentedFlow, Is.True);
     }
 
+    [Test]
+    public void LoadScoreRouters_DelegatesToInner()
+    {
+        // C2 regression: a missing override would silently fall through to the
+        // ILoadGraph default-empty implementation, leaving CapacityGraph.ScoreRouterIds
+        // empty and disabling the score-router gate in production.
+        const string router = "0xf1ff000000000000000000000000000000000077";
+        var stubInner = new StubLoadGraph();
+        stubInner.ScoreRouterAddresses.Add(router);
+
+        var incGraph = new IncrementalLoadGraph(
+            CreateBalanceState(), CreateTrustState(), CreateAvatarState(),
+            stubInner, new Settings(), 0);
+
+        var results = incGraph.LoadScoreRouters().ToList();
+
+        Assert.That(results, Is.EqualTo(new[] { router }));
+    }
+
+    [Test]
+    public void LoadOperatorApprovals_DelegatesToInner()
+    {
+        // C1 regression: a missing override would silently disable the operator-
+        // approval gate in production by returning the ILoadGraph default-empty list.
+        const string router = "0xf1ff000000000000000000000000000000000077";
+        const string avatar = "0xf1aa000000000000000000000000000000000088";
+        var stubInner = new StubLoadGraph();
+        stubInner.OperatorApprovalRows.Add((router, avatar));
+
+        var incGraph = new IncrementalLoadGraph(
+            CreateBalanceState(), CreateTrustState(), CreateAvatarState(),
+            stubInner, new Settings(), 0);
+
+        var results = incGraph.LoadOperatorApprovals(new[] { router }).ToList();
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Account.ToLowerInvariant(), Is.EqualTo(router));
+        Assert.That(results[0].Operator.ToLowerInvariant(), Is.EqualTo(avatar));
+    }
+
     /// <summary>
     /// Stub ILoadGraph for testing delegation.
     /// </summary>
@@ -921,6 +961,8 @@ public class IncrementalLoadGraphTests
         public List<(string GroupAddress, string TrustedToken)> GroupTrustEntries { get; } = new();
         public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; } = new();
         public List<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings { get; } = new();
+        public List<string> ScoreRouterAddresses { get; } = new();
+        public List<(string Account, string Operator)> OperatorApprovalRows { get; } = new();
 
         public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
             LoadV2Balances() => Enumerable.Empty<(string, int, int, bool, bool)>();
@@ -938,5 +980,14 @@ public class IncrementalLoadGraphTests
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
         public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
             => WrapperMappings;
+
+        public IEnumerable<string> LoadScoreRouters() => ScoreRouterAddresses;
+
+        public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+        {
+            var filter = new HashSet<string>(accounts.Select(a => a.ToLowerInvariant()));
+            return OperatorApprovalRows.Where(r => filter.Contains(r.Account.ToLowerInvariant()));
+        }
     }
+
 }

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -29,6 +29,7 @@
         <None Remove="Data\Queries\groupTrustQuery.sql" />
         <None Remove="Data\Queries\groupTrustQuery.fallback.sql" />
         <None Remove="Data\Queries\groupRouterQuery.sql" />
+        <None Remove="Data\Queries\scoreRoutersQuery.sql" />
         <None Remove="Data\Queries\consentedFlowQuery.sql" />
         <None Remove="Data\Queries\balanceFullStateQuery.sql" />
         <None Remove="Data\Queries\trustFullStateQuery.sql" />
@@ -50,6 +51,7 @@
         <EmbeddedResource Include="Data\Queries\groupTrustQuery.sql" />
         <EmbeddedResource Include="Data\Queries\groupTrustQuery.fallback.sql" />
         <EmbeddedResource Include="Data\Queries\groupRouterQuery.sql" />
+        <EmbeddedResource Include="Data\Queries\scoreRoutersQuery.sql" />
         <EmbeddedResource Include="Data\Queries\consentedFlowQuery.sql" />
         <EmbeddedResource Include="Data\Queries\balanceFullStateQuery.sql" />
         <EmbeddedResource Include="Data\Queries\trustFullStateQuery.sql" />

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -18,7 +18,14 @@ public record PathfinderGraphSnapshot(
     IReadOnlyList<string>? Organizations = null,
     IReadOnlyList<PathfinderGraphWrapperMappingRow>? WrapperMappings = null,
     IReadOnlyList<PathfinderGraphGroupRouterRow>? GroupRouters = null,
-    IReadOnlyList<PathfinderGraphScoreGroupMintLimitRow>? ScoreGroupMintLimits = null
+    IReadOnlyList<PathfinderGraphScoreGroupMintLimitRow>? ScoreGroupMintLimits = null,
+    IReadOnlyList<PathfinderGraphOperatorApprovalRow>? OperatorApprovals = null,
+    IReadOnlyList<string>? ScoreRouters = null
+);
+
+public record PathfinderGraphOperatorApprovalRow(
+    string Account,
+    string Operator
 );
 
 public record PathfinderGraphBalanceRow(
@@ -108,6 +115,12 @@ internal sealed class PathfinderGraphSnapshotDto
     [JsonPropertyName("wrapperMappings")]
     public List<PathfinderGraphWrapperMappingRow>? WrapperMappings { get; set; }
 
+    [JsonPropertyName("operatorApprovals")]
+    public List<PathfinderGraphOperatorApprovalRow>? OperatorApprovals { get; set; }
+
+    [JsonPropertyName("scoreRouters")]
+    public List<string>? ScoreRouters { get; set; }
+
     public PathfinderGraphSnapshot ToModel() => new(
         SchemaVersion,
         LastProcessedBlock,
@@ -121,5 +134,7 @@ internal sealed class PathfinderGraphSnapshotDto
         Organizations,
         WrapperMappings,
         GroupRouters,
-        ScoreGroupMintLimits);
+        ScoreGroupMintLimits,
+        OperatorApprovals,
+        ScoreRouters);
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -103,6 +103,27 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return (row.GroupAddress.ToLowerInvariant(), row.CollateralToken.ToLowerInvariant(), row.AvailableLimit);
     }
 
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var rows = _snapshot.OperatorApprovals ?? [];
+        if (rows.Count == 0)
+            yield break;
+        var filter = new HashSet<string>(accounts.Select(a => a.ToLowerInvariant()));
+        foreach (var row in rows)
+        {
+            var account = row.Account.ToLowerInvariant();
+            if (filter.Contains(account))
+                yield return (account, row.Operator.ToLowerInvariant());
+        }
+    }
+
+    public IEnumerable<string> LoadScoreRouters()
+    {
+        var rows = _snapshot.ScoreRouters ?? [];
+        foreach (var row in rows)
+            yield return row.ToLowerInvariant();
+    }
+
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()
     {
         var rows = _snapshot.ConsentedFlow ?? [];

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -148,6 +148,19 @@ public class IncrementalLoadGraph : ILoadGraph
         => _inner.LoadScoreGroupMintLimits();
 
     /// <summary>
+    /// Score-router set + ERC-1155 operator approvals are sourced from index tables that
+    /// the in-memory state doesn't shadow, so delegate to the inner DB-backed loader.
+    /// Without these overrides every base-snapshot build would inherit the
+    /// ILoadGraph default-empty implementations and silently disable the score-router
+    /// approval gate in production.
+    /// </summary>
+    public IEnumerable<string> LoadScoreRouters()
+        => _inner.LoadScoreRouters();
+
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+        => _inner.LoadOperatorApprovals(accounts);
+
+    /// <summary>
     /// Delegates to inner LoadGraph — consented flow table is small, fast query.
     /// </summary>
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -22,6 +22,7 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts,
         IReadOnlyList<(string GroupAddress, string RouterAddress)> GroupRouters,
         IReadOnlyList<(string GroupAddress, string CollateralToken, string AvailableLimit)> ScoreGroupMintLimits,
+        IReadOnlyList<string> ScoreRouters,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
         IReadOnlyList<string> RegisteredAvatars,
         IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings
@@ -39,6 +40,15 @@ namespace Circles.Pathfinder.Data
         IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts();
         IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters() => [];
         IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits() => [];
+
+        /// <summary>
+        /// Returns distinct ScoreGroupMintRouter addresses, taken from the
+        /// CrcV2_ScoreGroup.GroupInitialized event's pathMintRouter field. The event is
+        /// emitted exactly once per (policy, group) pair on initializeGroup and the
+        /// pathMintRouter is immutable thereafter, so each row's router is the canonical
+        /// score-router for its group. Empty by default for legacy mocks.
+        /// </summary>
+        IEnumerable<string> LoadScoreRouters() => [];
 
         /// <summary>
         /// Returns currently-active ERC-1155 operator approvals from the Hub for the given owner
@@ -328,13 +338,14 @@ namespace Circles.Pathfinder.Data
             var groupTrusts = LoadGroupTrustsInternal(connection, tx, scoreGroupTablesAvailable);
             var groupRouters = LoadGroupRoutersInternal(connection, tx, scoreGroupTablesAvailable);
             var scoreGroupMintLimits = LoadScoreGroupMintLimitsInternal(connection, tx, scoreGroupTablesAvailable);
+            var scoreRouters = LoadScoreRoutersInternal(connection, tx, scoreGroupTablesAvailable);
             var consentedFlags = LoadConsentedFlowFlagsInternal(connection, tx);
             var registeredAvatars = LoadRegisteredAvatarsInternal(connection, tx);
             var wrapperMappings = LoadWrapperMappingsInternal(connection, tx);
 
             tx.Commit();
 
-            return new LoadAllResult(balances, trust, groups, organizations, groupTrusts, groupRouters, scoreGroupMintLimits, consentedFlags, registeredAvatars, wrapperMappings);
+            return new LoadAllResult(balances, trust, groups, organizations, groupTrusts, groupRouters, scoreGroupMintLimits, scoreRouters, consentedFlags, registeredAvatars, wrapperMappings);
         }
 
         private List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
@@ -573,6 +584,54 @@ namespace Circles.Pathfinder.Data
                 results.Add((reader.GetString(0), reader.GetString(1)));
             }
 
+            return results;
+        }
+
+        public IEnumerable<string> LoadScoreRouters()
+        {
+            if (_settings.ScoreGroupMintPolicies.Length == 0)
+                return [];
+            if (!ScoreGroupTablesAvailable())
+                return [];
+
+            var query = LoadQueryFromResource("scoreRoutersQuery.sql");
+            var results = new List<string>(128);
+
+            var sw = Stopwatch.StartNew();
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(query, connection);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+                results.Add(reader.GetString(0));
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("score_routers", sw.Elapsed);
+            return results;
+        }
+
+        private List<string> LoadScoreRoutersInternal(
+            NpgsqlConnection connection,
+            NpgsqlTransaction tx,
+            bool scoreGroupTablesAvailable)
+        {
+            if (_settings.ScoreGroupMintPolicies.Length == 0 || !scoreGroupTablesAvailable)
+                return new List<string>(0);
+
+            var query = LoadQueryFromResource("scoreRoutersQuery.sql");
+            var results = new List<string>(128);
+
+            var sw = Stopwatch.StartNew();
+            using var command = new NpgsqlCommand(query, connection, tx);
+            command.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+            command.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+                results.Add(reader.GetString(0));
+
+            sw.Stop();
+            OnQueryCompleted?.Invoke("score_routers", sw.Elapsed);
             return results;
         }
 

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/scoreRoutersQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/scoreRoutersQuery.sql
@@ -1,0 +1,3 @@
+SELECT DISTINCT LOWER("pathMintRouter") AS router_address
+FROM "CrcV2_ScoreGroup_GroupInitialized"
+WHERE LOWER("emitter") = ANY(@scoreMintPolicies);

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -16,7 +16,8 @@ public sealed record CachedGroupData(
     Dictionary<int, int> WrapperToAvatar,
     Dictionary<int, int>? GroupRouters = null,
     Dictionary<(int GroupAddress, int CollateralToken), long>? ScoreGroupMintLimits = null,
-    Dictionary<int, HashSet<int>>? OperatorApprovals = null);
+    Dictionary<int, HashSet<int>>? OperatorApprovals = null,
+    HashSet<int>? ScoreRouterIds = null);
 
 public class CapacityGraph : IGraph<CapacityEdge>
 {
@@ -43,6 +44,15 @@ public class CapacityGraph : IGraph<CapacityEdge>
     /// (the operator) is not in this set for that router.
     /// </summary>
     public Dictionary<int, HashSet<int>> OperatorApprovals { get; } = new();
+
+    /// <summary>
+    /// Score-group mint routers, keyed by address ID. Source of truth: the
+    /// CrcV2_ScoreGroup.GroupInitialized event's pathMintRouter field (immutable
+    /// post-init). Used by IsScoreRouter and by AddTokenPoolOutEdges to recognize a
+    /// freshly-initialized score group even when no mint-limit rows or operator
+    /// approvals exist yet — both of which lag the initialize event in practice.
+    /// </summary>
+    public HashSet<int> ScoreRouterIds { get; } = new();
 
     // Track which tokens each group trusts
     public Dictionary<int, HashSet<int>> GroupTrustedTokens { get; } = new Dictionary<int, HashSet<int>>();

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -691,6 +691,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 foreach (var (cachedRouterId, operators) in cached.OperatorApprovals)
                     capacityGraph.OperatorApprovals[cachedRouterId] = new HashSet<int>(operators);
             }
+            if (cached.ScoreRouterIds != null)
+            {
+                foreach (var scoreRouterId in cached.ScoreRouterIds)
+                    capacityGraph.ScoreRouterIds.Add(scoreRouterId);
+            }
             foreach (var orgId in cached.OrganizationNodes)
                 capacityGraph.OrganizationNodes.Add(orgId);
             foreach (var (groupId, tokens) in cached.GroupTrustedTokens)
@@ -732,6 +737,18 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             int groupId = AddressIdPool.IdOf(groupAddress.ToLowerInvariant());
             int tokenId = AddressIdPool.IdOf(collateralToken.ToLowerInvariant());
             capacityGraph.ScoreGroupMintLimits[(groupId, tokenId)] = CirclesConverter.TruncateToInt64(parsedLimit);
+        }
+
+        // Load the canonical score-router set from CrcV2_ScoreGroup.GroupInitialized.
+        // The pathMintRouter field is immutable post-init, so this is the source of truth
+        // for "is this address a score router" — independent of whether mint-limit rows
+        // or operator approvals exist yet (both lag the initialize event).
+        foreach (var scoreRouterAddress in loadGraph.LoadScoreRouters())
+        {
+            if (string.IsNullOrWhiteSpace(scoreRouterAddress))
+                continue;
+            int scoreRouterId = AddressIdPool.IdOf(scoreRouterAddress.ToLowerInvariant());
+            capacityGraph.ScoreRouterIds.Add(scoreRouterId);
         }
 
         // Load ERC-1155 operator approvals granted BY the known group routers.
@@ -956,10 +973,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 // the edges are inherently source-dependent — strip them unconditionally so
                 // the shared snapshot can't emit reverting paths. Per-request filtered
                 // builds reconstruct these edges with proper source context.
-                // A group is a score group iff it has at least one per-collateral mint-limit row.
-                bool isScoreGroup = trustedTokens.Any(t => g.ScoreGroupMintLimits.ContainsKey((groupId, t)));
+                // Membership in ScoreRouterIds is the canonical signal — derived from
+                // CrcV2_ScoreGroup.GroupInitialized.pathMintRouter — so freshly-initialized
+                // groups with no mint-limit rows yet are still recognized and gated.
+                bool isScoreRouter = g.ScoreRouterIds.Contains(groupRouter);
                 bool operatorApproved =
-                    !isScoreGroup
+                    !isScoreRouter
                     || (sourceId.HasValue
                         && g.OperatorApprovals.TryGetValue(groupRouter, out var approvedOps)
                         && approvedOps.Contains(sourceId.Value));

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -135,26 +135,17 @@ public sealed class CapacityGraphContractState : IContractState
     }
 
     /// <summary>
-    /// True when the address is a known score-group mint router for some group in this graph.
-    /// Detected by membership in OperatorApprovals (populated only for score routers) or
-    /// by being the routing endpoint of a group that has per-collateral mint limits.
+    /// True when the address is a known score-group mint router. Backed by the
+    /// CapacityGraph.ScoreRouterIds set, which is populated from
+    /// CrcV2_ScoreGroup.GroupInitialized.pathMintRouter — the contract-level source of
+    /// truth. Freshly-initialized groups with no mint-limit rows or operator approvals
+    /// yet are still classified correctly (both lag the initialize event in practice).
     /// </summary>
     public bool IsScoreRouter(string address)
     {
         var lower = address.ToLowerInvariant();
         if (!AddressIdPool.TryIdOf(lower, out int id))
             return false;
-
-        if (_graph.OperatorApprovals.ContainsKey(id))
-            return true;
-
-        foreach (var (groupId, routerId) in _graph.GroupRouters)
-        {
-            if (routerId != id) continue;
-            if (_graph.GroupTrustedTokens.TryGetValue(groupId, out var tokens) &&
-                tokens.Any(t => _graph.ScoreGroupMintLimits.ContainsKey((groupId, t))))
-                return true;
-        }
-        return false;
+        return _graph.ScoreRouterIds.Contains(id);
     }
 }


### PR DESCRIPTION
## Summary

- Introduce `CapacityGraph.ScoreRouterIds` as the canonical score-router set, loaded from `CrcV2_ScoreGroup_GroupInitialized.pathMintRouter` (immutable post-init).
- Collapse `CapacityGraphContractState.IsScoreRouter` to an O(1) HashSet lookup; remove the two-path heuristic that had silent false negatives during the post-init / pre-first-mint window.
- Rekey the operator-approval gate predicate in `GraphFactory.AddTokenPoolOutEdges` from `ScoreGroupMintLimits` row presence (lagged) to `ScoreRouterIds` membership (canonical).
- Fix a latent regression that silently disabled the approval gate in production: `IncrementalLoadGraph` and `CacheLoadGraph` were missing `LoadScoreRouters` and `LoadOperatorApprovals` overrides and were falling through to the `ILoadGraph` default-empty implementations.
- Extend `PathfinderGraphSnapshot` DTO + `CacheLoadGraph` with `operatorApprovals` and `scoreRouters` channels; cache producers must populate these to enable the gate on cache-source deployments.

## Changes

- `Pathfinder/Graphs/CapacityGraph.cs` — `ScoreRouterIds` field; `CachedGroupData.ScoreRouterIds` 10th optional record field.
- `Pathfinder/Data/LoadGraph.cs` + `Pathfinder/Data/Queries/scoreRoutersQuery.sql` (new) — `LoadScoreRouters()` + Internal variant; `LoadAllResult.ScoreRouters` slot.
- `Pathfinder/Graphs/GraphFactory.cs` — populate `ScoreRouterIds` from DB and from cache; new gate predicate `isScoreRouter = ScoreRouterIds.Contains(groupRouter)`.
- `Pathfinder/Validation/CapacityGraphContractState.cs` — `IsScoreRouter` simplified.
- `Pathfinder.Host/State/NetworkStateUpdaterService.cs` — propagate `cap.ScoreRouterIds` at all three `CachedGroupData` construction sites.
- `Pathfinder/Data/IncrementalLoadGraph.cs` — explicit delegating overrides for `LoadScoreRouters` and `LoadOperatorApprovals`.
- `Pathfinder/Data/CacheLoadGraph.cs` + `Pathfinder/Data/CacheGraphModels.cs` — DTO extensions and overrides.
- Tests: 5 new in `GraphFactoryTests`, 3 new in `CapacityGraphContractStateTests`, 2 new in `IncrementalStateTests`; `MockLoadGraph.AddScoreRouter` helper + `LoadScoreRouters` override.

## Test plan

- [x] `dotnet test` — full solution green; pathfinder tests 997 passing (was 990), 0 failing.
- [x] `dotnet build` clean (0 errors, pre-existing warnings unchanged).
- [ ] Live staging: confirm freshly-initialized score group routes correctly through the operator-approval gate immediately after `initializeGroup` and before the first mint-limit row is written.
- [ ] Live staging: confirm `circles_findPath` for an approved source still yields a valid path through an existing score group.
- [ ] Cache-source deployments: coordinate with the cache producer to start emitting `operatorApprovals` and `scoreRouters` snapshot fields before relying on the gate there.