### PR TITLE
fix(pathfinder): fail-closed IsApprovedForAll when score routers indexed

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -42,6 +42,20 @@ public class NetworkStateUpdaterService : BackgroundService
     private CacheLoadGraph? _cacheLoadGraph;
     private string? _cacheGraphEtag;
 
+    // C3: log score-policy posture on each transition so an operator can read the log
+    // and reconstruct boot → indexer-catchup → healthy progression without a metric
+    // dashboard. Initial state is NotLogged so the first observation always emits one
+    // log batch; subsequent identical observations are suppressed.
+    private ScorePolicyDiagnosticState _scorePolicyState = ScorePolicyDiagnosticState.NotLogged;
+
+    private enum ScorePolicyDiagnosticState
+    {
+        NotLogged,
+        FailOpenNoRouters,      // policy configured but no GroupInitialized event indexed yet
+        FailClosedNoApprovals,  // routers indexed but no ApprovalForAll events indexed yet
+        Healthy                  // routers + approvals both present
+    }
+
     public NetworkStateUpdaterService(NetworkState networkState,
         Circles.Pathfinder.Host.Settings settings,
         ILogger<NetworkStateUpdaterService> log,
@@ -145,6 +159,7 @@ public class NetworkStateUpdaterService : BackgroundService
                     GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
                     GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
                     GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
+                    TryLogScorePolicyDiagnostic(currentSnap.Base);
                 }
 
                 GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
@@ -661,6 +676,7 @@ public class NetworkStateUpdaterService : BackgroundService
                 GraphUpdateMetrics.ConsentedAvatarCount.Set(currentSnap.Base.ConsentedAvatars.Count);
                 GraphUpdateMetrics.RouterTrustCoverageTotal.Set(currentSnap.Base.TotalGroupTokenEdges);
                 GraphUpdateMetrics.RouterTrustFilteredCount.Set(currentSnap.Base.RouterFilteredEdges);
+                TryLogScorePolicyDiagnostic(currentSnap.Base);
             }
             GraphUpdateMetrics.AddressPoolSize.Set(AddressIdPool.Count);
 
@@ -852,6 +868,57 @@ public class NetworkStateUpdaterService : BackgroundService
         {
             GraphUpdateMetrics.MatViewRefreshErrors.WithLabels(viewName).Inc();
             _log.LogWarning(ex, "Failed to refresh materialized view {View} — stale data until next refresh", viewName);
+        }
+    }
+
+    /// <summary>
+    /// C3 observability: log the score-policy posture on each transition so an operator
+    /// can read the log and reconstruct boot → catchup → healthy progression. Fires when
+    /// either local <c>ScoreGroupMintPolicies</c> is configured OR the cache has
+    /// materialized at least one score router (the cache producer can ship routers
+    /// independently of local config under <c>USE_CACHE_GRAPH_SOURCE</c>; either signal
+    /// means the gate is live). No-op when both are empty — gate stays legacy fail-OPEN
+    /// and there's nothing to surface. INFO on every transition; WARN only when the
+    /// posture is non-Healthy (so chronic indexer lag stays loud, but a node that boots
+    /// healthy logs exactly one info line).
+    /// </summary>
+    private void TryLogScorePolicyDiagnostic(CapacityGraph baseGraph)
+    {
+        var policiesConfigured = _settings.ScoreGroupMintPolicies.Length > 0;
+        var routersIndexed = baseGraph.ScoreRouterIds.Count > 0;
+        if (!policiesConfigured && !routersIndexed)
+            return;
+
+        ScorePolicyDiagnosticState newState =
+            !routersIndexed                            ? ScorePolicyDiagnosticState.FailOpenNoRouters
+            : baseGraph.OperatorApprovals.Count == 0   ? ScorePolicyDiagnosticState.FailClosedNoApprovals
+            :                                            ScorePolicyDiagnosticState.Healthy;
+
+        if (newState == _scorePolicyState) return;
+        var previousState = _scorePolicyState;
+        _scorePolicyState = newState;
+
+        _log.LogInformation(
+            "Score-policy posture {NewState} (was {PreviousState}): {PolicyCount} policies configured, {RouterCount} routers indexed, {ApprovalCount} operator approvals indexed",
+            newState, previousState,
+            _settings.ScoreGroupMintPolicies.Length,
+            baseGraph.ScoreRouterIds.Count,
+            baseGraph.OperatorApprovals.Count);
+
+        if (newState == ScorePolicyDiagnosticState.FailOpenNoRouters)
+        {
+            _log.LogWarning(
+                "Score-policy gate FAIL-OPEN: ScoreRouterIds empty — no CrcV2_ScoreGroup.GroupInitialized events indexed yet. " +
+                "Either no score groups exist OR the indexer is behind. " +
+                "ApproveCRCRequired will not fire until at least one router is indexed.");
+        }
+        else if (newState == ScorePolicyDiagnosticState.FailClosedNoApprovals)
+        {
+            _log.LogWarning(
+                "Score-policy gate FAIL-CLOSED: {RouterCount} routers indexed but OperatorApprovals empty — " +
+                "indexer likely behind on approval events. " +
+                "ApproveCRCRequired will drop all router edges until approvals catch up.",
+                baseGraph.ScoreRouterIds.Count);
         }
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphContractStateTests.cs
@@ -7,9 +7,9 @@ namespace Circles.Pathfinder.Tests;
 /// <summary>
 /// Unit tests for CapacityGraphContractState — the bridge from the runtime CapacityGraph
 /// to IContractState consumed by HubContractValidator. Pins the IsApprovedForAll lookup
-/// direction (account=router → operator=avatar) and the behaviors that C3 will later
-/// tighten (fail-open on empty approvals is current behavior; documented but not changed
-/// here).
+/// direction (account=router → operator=avatar) and the C3 fail-closed-when-routers-
+/// indexed semantics: empty OperatorApprovals is permissive ONLY in builds with no
+/// score-group policy active (ScoreRouterIds empty).
 /// </summary>
 [TestFixture, Parallelizable]
 public class CapacityGraphContractStateTests
@@ -52,16 +52,57 @@ public class CapacityGraphContractStateTests
     }
 
     [Test]
-    public void IsApprovedForAll_EmptyApprovals_ReturnsTrue_CurrentBehavior()
+    public void IsApprovedForAll_EmptyApprovals_FailOpen_WhenNoScoreRouters()
     {
-        // Pins the current fail-open default: with no OperatorApprovals at all, the gate
-        // is assumed inapplicable (legacy behavior — only score-group policies populate
-        // approvals). C3 will tighten this to fail-closed when score policies are
-        // configured; this test documents the pre-C3 state so the change is visible.
+        // Legacy semantics preserved: when ScoreRouterIds is empty (no score-group
+        // policy active OR indexer hasn't seen any GroupInitialized event yet), absence
+        // of approval data means "rule inapplicable" → permissive. This keeps non-score-
+        // group CRC paths working in builds that don't run a score policy at all.
         var g = new CapacityGraph();
         var state = new CapacityGraphContractState(g);
 
         Assert.That(state.IsApprovedForAll(ScoreRouter, Alice), Is.True);
+    }
+
+    [Test]
+    public void IsApprovedForAll_EmptyApprovals_FailClosed_WhenScoreRoutersIndexed()
+    {
+        // C3: once the cache has seen at least one CrcV2_ScoreGroup.GroupInitialized
+        // event (ScoreRouterIds non-empty), an empty OperatorApprovals dict means
+        // "indexer behind on approval events", not "nobody approved anything". Must
+        // drop the edge — otherwise the pathfinder returns paths that revert at the
+        // policy hook on-chain.
+        // Argument order matches production: HubContractValidator passes (router, avatar)
+        // i.e. account=router, operator=avatar (OperatorApprovals is keyed router→avatars).
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        var g = new CapacityGraph();
+        g.ScoreRouterIds.Add(routerId);
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsApprovedForAll(ScoreRouter, Alice), Is.False,
+            "Score routers are known but no approvals indexed — must fail closed.");
+    }
+
+    [Test]
+    public void IsApprovedForAll_UnknownAccount_FailClosed_WhenScoreRoutersIndexed()
+    {
+        // C3: second fail-open branch. When the account address isn't in AddressIdPool
+        // it cannot possibly have an approval entry; under an active score policy this
+        // must also drop the edge rather than wave it through. Uses a fresh address
+        // that has not been interned by any earlier test to exercise the TryIdOf-miss
+        // path.
+        var unknownAccount = "0xf2ee000000000000000000000000000000000099";
+        int routerId = AddressIdPool.IdOf(ScoreRouter);
+        int aliceId = AddressIdPool.IdOf(Alice);
+        var g = new CapacityGraph();
+        g.ScoreRouterIds.Add(routerId);
+        // Populate approvals so the first guard (empty dict) is skipped — we want to
+        // reach the AddressIdPool.TryIdOf(account) miss specifically.
+        g.OperatorApprovals[routerId] = new HashSet<int> { aliceId };
+        var state = new CapacityGraphContractState(g);
+
+        Assert.That(state.IsApprovedForAll(unknownAccount, ScoreRouter), Is.False,
+            "Account not in AddressIdPool under an active score policy must fail closed.");
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -112,20 +112,31 @@ public sealed class CapacityGraphContractState : IContractState
     }
 
     /// <summary>
-    /// Hub.isApprovedForAll(account, operator). Permissive when no approval data is loaded —
-    /// the GraphFactory only populates OperatorApprovals when a score-group policy is
-    /// configured, so absence here means the rule is not applicable in this build.
+    /// Hub.isApprovedForAll(account, operator). Fail-closed when ScoreRouterIds is non-empty —
+    /// at least one CrcV2_ScoreGroup.GroupInitialized event has been indexed, so a score
+    /// policy is live and missing approval data must be treated as "not indexed yet", not
+    /// "no approvals exist". Legacy permissive behavior is preserved only when no score
+    /// routers are known to the cache (no policy active or indexer hasn't caught up — the
+    /// policy isn't in force regardless).
+    ///
+    /// DB-source mode: LoadGraph.LoadScoreRouters early-returns on empty ScoreGroupMintPolicies,
+    /// so ScoreRouterIds.Count &gt; 0 implies a policy is configured locally.
+    /// Cache-source mode: CacheLoadGraph.LoadScoreRouters yields whatever the upstream cache
+    /// producer ships, independent of local config. The gate therefore trusts the materialized
+    /// cache: if routers are present, treat the policy as in force regardless of local env.
     /// </summary>
     public bool IsApprovedForAll(string account, string @operator)
     {
+        var scoreRoutersActive = _graph.ScoreRouterIds.Count > 0;
+
         if (_graph.OperatorApprovals.Count == 0)
-            return true;
+            return !scoreRoutersActive;
 
         var accountLower = account.ToLowerInvariant();
         var operatorLower = @operator.ToLowerInvariant();
 
         if (!AddressIdPool.TryIdOf(accountLower, out int accountId))
-            return true;
+            return !scoreRoutersActive;
 
         if (!AddressIdPool.TryIdOf(operatorLower, out int operatorId))
             return false;


### PR DESCRIPTION
## Summary

C3 of the C1→C5 score-policy hardening series. Closes the last fail-OPEN in `IsApprovedForAll`: when `OperatorApprovals` is empty or `account` isn't in `AddressIdPool`, the gate now returns `false` if at least one score router is known to the cache (`ScoreRouterIds.Count > 0`). Legacy permissive behavior is preserved only when no routers are indexed — i.e. when the policy isn't in force.

Builds on `4cd610be` (C1: approvals wired through cached snapshots) and `a712c990` (C2: `ScoreRouterIds` source-of-truth from `CrcV2_ScoreGroup.GroupInitialized.pathMintRouter`).

## Changes

- **`CapacityGraphContractState.cs`** — `IsApprovedForAll` derives `scoreRoutersActive = _graph.ScoreRouterIds.Count > 0`; both prior `return true` exits become `return !scoreRoutersActive`. Mirrors the fail-closed pattern from `IsRegistered` (same file, ~lines 84-93). The `IContractState` constructor remains `(graph)`-only — no DI ripple.
- **`NetworkStateUpdaterService.cs`** — transition-aware diagnostic in `TryLogScorePolicyDiagnostic`. Tracks a `ScorePolicyDiagnosticState` enum (`NotLogged` → `FailOpenNoRouters` / `FailClosedNoApprovals` / `Healthy`). Logs INFO on every state transition and WARN on non-`Healthy` states. Fires when EITHER local `ScoreGroupMintPolicies` is configured OR `ScoreRouterIds` is non-empty (so cache-source mode populating routers without local config still surfaces in logs).
- **`CapacityGraphContractStateTests.cs`** — rename C2 pinning test to `IsApprovedForAll_EmptyApprovals_FailOpen_WhenNoScoreRouters` (legacy semantics preserved); add `_FailClosed_WhenScoreRoutersIndexed` (empty-approvals branch) and `_UnknownAccount_FailClosed_WhenScoreRoutersIndexed` (defensive coverage of the address-pool-miss branch).

## Intentionally NOT in scope

- The graph-build edge-filter at `GraphFactory.cs:980-984` is a separate gate (C1's territory); it independently drops edges via raw `OperatorApprovals.TryGetValue`. C3 is the validator-side audit gate (`HubContractValidator.cs:432`).
- The broad `catch (Exception)` in `V2Pathfinder.cs:496-502` that swallows `HubContractValidator.Validate` exceptions into `ValidatorException=true` is pre-existing and not addressed here.
- Cache-producer DTO additions (`operatorApprovals`, `scoreRouters` JSON fields) are tracked separately and require the cache-service team. The new docstring on `IsApprovedForAll` acknowledges the asymmetry.

## Test plan

- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests` — 999 passed / 0 failed / 270 skipped (was 997 on staging tip; +2 net new tests, +1 rename).
- [ ] Post-merge: redeploy `staging` to `staging1`/`staging2` via the `pathfinder` ansible role. Tail logs and confirm the new `Score-policy posture …` INFO line fires on first snapshot. On a node configured with `V2_SCORE_GROUP_MINT_POLICIES` and a known approved (account, router) pair, confirm `findPath` returns a non-empty `transfers`. On a known unapproved (account, router) pair against the same router, confirm `maxFlow=0`.
- [ ] Confirm `circles_getScoreGroupMintLimits` regression-clean.

## Caller surface

Only call site of `IsApprovedForAll`: `HubContractValidator.cs:432` —
`state.IsScoreRouter(to) && !state.IsApprovedForAll(to, sourceLower)`.
Pre-guarded by `IsScoreRouter(to)`, so the new strict semantics only apply
to paths that already touch an indexed score router; non-score-router
flows are unaffected.