### PR TITLE
feat(cache): emit scoreRouters + operatorApprovals in pathfinder graph snapshot

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -106,6 +106,38 @@ public class PathfinderGraphControllerTests
         response.Groups.Should().NotBeNull();
         response.GroupTrusts.Should().NotBeNull();
         response.ConsentedFlow.Should().NotBeNull();
+        // C3 fail-closed gate inputs — must be in the default snapshot so
+        // CapacityGraphContractState.IsApprovedForAll has the data it needs.
+        response.ScoreRouters.Should().NotBeNull();
+        response.OperatorApprovals.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void GetGraph_ScoreRouters_AreEmpty_WhenNoDataSourceConfigured()
+    {
+        // Unit test constructor passes _dataSource = null. Builder must no-op gracefully:
+        // emit empty list (section requested), not null and not throw.
+        var controller = CreateController();
+
+        var result = controller.GetGraph(include: "scorerouters,operatorapprovals");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ScoreRouters.Should().NotBeNull().And.BeEmpty();
+        response.OperatorApprovals.Should().NotBeNull().And.BeEmpty();
+        response.Trust.Should().BeNull();
+        response.Groups.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetGraph_ScoreRouters_OmittedWhenNotInInclude()
+    {
+        var controller = CreateController();
+
+        var result = controller.GetGraph(include: "balances");
+        var response = ((OkObjectResult)result.Result!).Value as PathfinderGraphResponse;
+
+        response!.ScoreRouters.Should().BeNull();
+        response.OperatorApprovals.Should().BeNull();
     }
 
     [Fact]

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -185,7 +185,11 @@ public record PathfinderGraphResponse(
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
     IReadOnlyList<PathfinderWrapperMappingRow>? WrapperMappings,
     [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
-    IReadOnlyList<PathfinderScoreGroupMintLimitRow>? ScoreGroupMintLimits
+    IReadOnlyList<PathfinderScoreGroupMintLimitRow>? ScoreGroupMintLimits,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<string>? ScoreRouters,
+    [property: System.Text.Json.Serialization.JsonIgnore(Condition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyList<PathfinderOperatorApprovalRow>? OperatorApprovals
 );
 
 public record PathfinderBalanceRow(
@@ -229,4 +233,9 @@ public record PathfinderConsentedFlowRow(
 public record PathfinderWrapperMappingRow(
     string WrapperAddress,
     string UnderlyingAvatar
+);
+
+public record PathfinderOperatorApprovalRow(
+    string Account,
+    string Operator
 );

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -120,6 +120,14 @@ public class PathfinderGraphController : ControllerBase
             var avatarToWrappers = sections.Contains("trust")
                 ? BuildAvatarToWrappersIndex()
                 : null;
+            // All historical distinct routers across all score-group policies (matches DB-source
+            // scoreRoutersQuery.sql, NOT just the per-group-latest in indexedScoreGroupRouters).
+            // If a group re-initialises with a new router, both old and new must appear so the
+            // C3 gate can resolve approvals for either; deriving from indexedScoreGroupRouters
+            // alone would drop retired routers and silently fail-OPEN their approvals.
+            var allScoreRouters = sections.Contains("scorerouters") || sections.Contains("operatorapprovals")
+                ? LoadAllScoreRouters(lastBlock)
+                : [];
 
             var response = new PathfinderGraphResponse(
                 SchemaVersion: SchemaVersion,
@@ -136,11 +144,17 @@ public class PathfinderGraphController : ControllerBase
                 WrapperMappings: sections.Contains("wrappermappings") ? BuildWrapperMappings(registrations) : null,
                 ScoreGroupMintLimits: sections.Contains("scoregroupmintlimits")
                     ? BuildScoreGroupMintLimits(registrations, routerGroups!, indexedScoreGroupRouters, lastBlock)
+                    : null,
+                ScoreRouters: sections.Contains("scorerouters")
+                    ? allScoreRouters
+                    : null,
+                OperatorApprovals: sections.Contains("operatorapprovals")
+                    ? BuildOperatorApprovals(allScoreRouters, lastBlock)
                     : null
             );
 
             _logger.LogDebug(
-                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}, orgs={Orgs}, wrappers={Wrappers}",
+                "Pathfinder graph snapshot: block={Block}, balances={Balances}, trust={Trust}, groups={Groups}, groupTrusts={GroupTrusts}, consent={Consent}, avatars={Avatars}, orgs={Orgs}, wrappers={Wrappers}, scoreRouters={ScoreRouters}, operatorApprovals={OperatorApprovals}",
                 lastBlock,
                 response.Balances?.Count ?? 0,
                 response.Trust?.Count ?? 0,
@@ -149,7 +163,9 @@ public class PathfinderGraphController : ControllerBase
                 response.ConsentedFlow?.Count ?? 0,
                 response.Avatars?.Count ?? 0,
                 response.Organizations?.Count ?? 0,
-                response.WrapperMappings?.Count ?? 0);
+                response.WrapperMappings?.Count ?? 0,
+                response.ScoreRouters?.Count ?? 0,
+                response.OperatorApprovals?.Count ?? 0);
 
             return Ok(response);
         }
@@ -163,7 +179,7 @@ public class PathfinderGraphController : ControllerBase
     private static HashSet<string> ParseInclude(string? include)
     {
         if (string.IsNullOrWhiteSpace(include))
-            return new HashSet<string> { "balances", "trust", "groups", "grouprouters", "grouptrusts", "scoregroupmintlimits", "consentedflow", "avatars", "organizations", "wrappermappings" };
+            return new HashSet<string> { "balances", "trust", "groups", "grouprouters", "grouptrusts", "scoregroupmintlimits", "consentedflow", "avatars", "organizations", "wrappermappings", "scorerouters", "operatorapprovals" };
 
         return new HashSet<string>(
             include.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
@@ -398,6 +414,106 @@ public class PathfinderGraphController : ControllerBase
                 row.CollateralToken,
                 row.AvailableLimit))
             .ToList();
+    }
+
+    /// <summary>
+    /// All distinct score-router addresses ever emitted by CrcV2_ScoreGroup_GroupInitialized
+    /// across the configured score-group mint policies, bounded by lastBlock for snapshot reproducibility.
+    /// Mirrors the DB-source scoreRoutersQuery.sql so cache-source and DB-source feed the same
+    /// router universe into the C3 fail-closed gate, including retired routers from re-initialisations.
+    /// </summary>
+    private List<string> LoadAllScoreRouters(long lastBlock)
+    {
+        if (_dataSource == null || ScoreGroupMintPolicies.Count == 0)
+            return [];
+
+        const string sql = """
+            SELECT DISTINCT LOWER("pathMintRouter") AS router
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE "blockNumber" <= @lastBlock
+              AND LOWER("emitter") = ANY(@scoreMintPolicies);
+            """;
+
+        try
+        {
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("lastBlock", lastBlock);
+            command.Parameters.AddWithValue("scoreMintPolicies", ScoreGroupMintPolicies.ToArray());
+            command.CommandTimeout = 60;
+
+            var result = new List<string>();
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                var router = reader.GetString(0);
+                if (!string.IsNullOrEmpty(router))
+                    result.Add(router);
+            }
+            return result;
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            _logger.LogWarning(
+                ex,
+                "Score-group router table is not available yet; score routers omitted from the pathfinder graph snapshot");
+            return [];
+        }
+    }
+
+    /// <summary>
+    /// Operator-approval pairs filtered to score-router accounts only. Matches the DB-source
+    /// CrcV2_ApprovalForAll DISTINCT-ON-(account, operator) projection used by LoadGraph.LoadOperatorApprovals,
+    /// bounded by lastBlock to keep snapshots reproducible.
+    /// </summary>
+    private List<PathfinderOperatorApprovalRow> BuildOperatorApprovals(
+        IReadOnlyList<string> scoreRouters,
+        long lastBlock)
+    {
+        if (_dataSource == null || scoreRouters.Count == 0)
+            return [];
+
+        const string sql = """
+            SELECT account, operator FROM (
+                SELECT DISTINCT ON (LOWER("account"), LOWER("operator"))
+                    LOWER("account") AS account,
+                    LOWER("operator") AS operator,
+                    "approved" AS approved
+                FROM "CrcV2_ApprovalForAll"
+                WHERE "blockNumber" <= @lastBlock
+                  AND LOWER("account") = ANY(@accounts)
+                ORDER BY LOWER("account"), LOWER("operator"),
+                         "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+            ) latest
+            WHERE approved = true;
+            """;
+
+        try
+        {
+            using var connection = _dataSource.OpenConnection();
+            using var command = new NpgsqlCommand(sql, connection);
+            command.Parameters.AddWithValue("lastBlock", lastBlock);
+            command.Parameters.AddWithValue("accounts", scoreRouters.ToArray());
+            command.CommandTimeout = 60;
+
+            var result = new List<PathfinderOperatorApprovalRow>(64);
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                result.Add(new PathfinderOperatorApprovalRow(
+                    Account: reader.GetString(0),
+                    Operator: reader.GetString(1)));
+            }
+
+            return result;
+        }
+        catch (PostgresException ex) when (ex.SqlState == PostgresErrorCodes.UndefinedTable)
+        {
+            _logger.LogWarning(
+                ex,
+                "CrcV2_ApprovalForAll table is not available yet; operator approvals omitted from the pathfinder graph snapshot");
+            return [];
+        }
     }
 
     private Dictionary<string, string> LoadIndexedScoreGroupRouters(long lastBlock)


### PR DESCRIPTION
## Summary

- Extends `/api/pathfinder/graph` with `scoreRouters` (distinct routers across all `CrcV2_ScoreGroup_GroupInitialized` rows for configured score-group policies) and `operatorApprovals` (DISTINCT-ON-(account, operator) latest approval state from `CrcV2_ApprovalForAll`, filtered to score-router accounts).
- Both fields mirror the DB-source semantics in `LoadGraph.LoadScoreRouters` and `LoadGraph.LoadOperatorApprovals` so cache-source and DB-source feed the C3 fail-closed approval gate the same router universe and approval set.
- New fields are nullable + `JsonIgnore` when null; included in the default include-set so existing callers get them without changes.

## Why

`CapacityGraphContractState.IsApprovedForAll` is fail-closed when `ScoreRouterIds` is non-empty (PR #390). Cache-source `CacheLoadGraph` already deserialises `scoreRouters` and `operatorApprovals` from this DTO, but the producer side never populated them — so any pathfinder running on cache snapshots sees `ScoreRouterIds.Count == 0` and the gate degrades to legacy fail-OPEN. With score-group policies configured, this means router-mediated mint paths can be returned even when the underlying approval is missing.

## Test plan

- [x] `dotnet test` — cache-service 226/0 + 26 skipped (testcontainers-gated); pathfinder 999/0 + 270 skipped.
- [x] New unit tests cover default-include, no-data-source empty behavior, and include-omission.
- [ ] Post-deploy on staging: `Score-policy posture` log on pathfinder transitions to steady `Healthy` (previously oscillating `FailOpenNoRouters → Healthy → FailOpenNoRouters` on cache-service restarts).
- [ ] End-to-end: known approved (user, score-router) returns non-empty `transfers`; known unapproved pair returns `maxFlow=0`.