### PR TITLE
feat(pathfinder): post-flow validator for score-group mint limits

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -37,6 +37,7 @@ public class HubContractValidatorTests
     {
         public string? Router { get; set; }
         public HashSet<string> Routers { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+        public HashSet<string> ScoreRouters { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> Groups { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<string> Consented { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public HashSet<(string Truster, string CirclesId)> Trusts { get; set; } = new();
@@ -44,10 +45,18 @@ public class HubContractValidatorTests
         public HashSet<string> Registered { get; set; } = new(StringComparer.OrdinalIgnoreCase);
         public bool RegisterAll { get; set; } = true; // Default: all considered registered
 
+        // Keys are lowercased (group, collateral) tuples. Null entries simulate "not cached"
+        // for Rule 12's fail-closed branch — distinct from "absent key" which returns null too,
+        // both mapping to GetScoreGroupMintLimit() == null at the interface level.
+        public Dictionary<(string Group, string Collateral), long> ScoreGroupMintLimits { get; set; }
+            = new();
+
         public string? RouterAddress => Router;
         public bool IsRouter(string address) =>
             (Router != null && string.Equals(Router, address, StringComparison.OrdinalIgnoreCase))
-            || Routers.Contains(address);
+            || Routers.Contains(address)
+            || ScoreRouters.Contains(address);
+        public bool IsScoreRouter(string address) => ScoreRouters.Contains(address);
         public bool IsGroup(string address) => Groups.Contains(address);
         public bool HasAdvancedUsageFlags(string address) => Consented.Contains(address);
         public bool IsRegistered(string address) => RegisterAll || Registered.Contains(address);
@@ -59,6 +68,14 @@ public class HubContractValidatorTests
         {
             if (TrustAll) return true;
             return Trusts.Contains((truster.ToLowerInvariant(), circlesId.ToLowerInvariant()));
+        }
+
+        public long? GetScoreGroupMintLimit(string group, string collateral)
+        {
+            return ScoreGroupMintLimits.TryGetValue(
+                (group.ToLowerInvariant(), collateral.ToLowerInvariant()), out var limit)
+                ? limit
+                : null;
         }
     }
 
@@ -944,5 +961,274 @@ public class HubContractValidatorTests
             AddressIdPool.StringOf(groupId),
             AddressIdPool.StringOf(untrustedId)), Is.False,
             "Group not trusting token should return false");
+    }
+
+    // ═══════════════════════════════════════════
+    // Rule 12: ScoreGroupMintLimitsHonored
+    // Mirrors OffchainScoreBasedMintPolicy.beforeMintPolicy's router branch:
+    // cumulative router→group deposits per (group, collateral) ≤ availableLimit.
+    //
+    // Units convention (mirrors production):
+    //   TransferPathStep.Value: wei (10^18 per CRC, per V2Pathfinder.cs:454)
+    //   ScoreGroupMintLimits cached value: 6-decimal CRC (10^6 per CRC,
+    //     per GraphFactory.cs:739 / CirclesConverter.TruncateToInt64)
+    // The validator inflates the cached limit to wei via BlowUpToBigInteger.
+    // Tests use whole-CRC values where possible: 1 CRC = 1_000_000 cached,
+    // 1 CRC = "1000000000000000000" as wei Value string.
+    // ═══════════════════════════════════════════
+
+    private const string Wei_0_4_CRC = "400000000000000000";   // 0.4 CRC in wei
+    private const string Wei_0_5_CRC = "500000000000000000";   // 0.5 CRC in wei
+    private const string Wei_1_0_CRC = "1000000000000000000";  // 1 CRC in wei
+    private const long Cached_0_5_CRC = 500_000L;              // 0.5 CRC at 6dp
+    private const long Cached_0_7_CRC = 700_000L;              // 0.7 CRC at 6dp
+    private const long Cached_1_0_CRC = 1_000_000L;            // 1 CRC at 6dp
+
+    [Test]
+    public void Rule12_SingleIntermediaryWithinLimit_Passes()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            ScoreGroupMintLimits = { [(GroupA.ToLowerInvariant(), Alice.ToLowerInvariant())] = Cached_1_0_CRC },
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, Alice, Wei_0_5_CRC),
+            Step(ScoreRouter, GroupA, Alice, Wei_0_5_CRC),
+            Step(GroupA, Bob, GroupA, Wei_0_5_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "0.5 CRC cumulative Alice-collateral ≤ 1 CRC availableLimit must pass.");
+    }
+
+    [Test]
+    public void Rule12_TwoIntermediariesSameCollateralOverLimit_FailsWithError()
+    {
+        // Same-token sharing case: both Bob and Carol push Alice-collateral
+        // through the score router into GroupA. They share the (GroupA, Alice)
+        // cap, and their cumulative deposit exceeds it. The violation must
+        // point at the SECOND deposit edge — the one that crosses the cap.
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            ScoreGroupMintLimits = { [(GroupA.ToLowerInvariant(), Alice.ToLowerInvariant())] = Cached_0_7_CRC },
+        };
+        // Two 0.4 CRC deposits → 0.8 CRC cumulative > 0.7 CRC cap
+        var steps = new[]
+        {
+            Step(Bob, ScoreRouter, Alice, Wei_0_4_CRC),       // edge 0
+            Step(ScoreRouter, GroupA, Alice, Wei_0_4_CRC),    // edge 1 — first router→group, within cap
+            Step(Carol, ScoreRouter, Alice, Wei_0_4_CRC),     // edge 2
+            Step(ScoreRouter, GroupA, Alice, Wei_0_4_CRC),    // edge 3 — second router→group, pushes over
+            Step(GroupA, Dave, GroupA, "800000000000000000"), // edge 4 — 0.8 CRC mint
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        var rule12 = violations.Where(v => v.Rule == "ScoreGroupMintLimitsHonored").ToList();
+        Assert.That(rule12.Count, Is.EqualTo(1),
+            "Exactly one violation per (group, collateral) bucket.");
+        Assert.That(rule12[0].Severity, Is.EqualTo("error"));
+        Assert.That(rule12[0].EdgeIndex, Is.EqualTo(3),
+            "Violation must point at the edge that pushes cumulative past the cap, not the bucket's first contributor.");
+        Assert.That(rule12[0].Message,
+            Does.Contain("800000000000000000")        // cumulative in wei
+            .And.Contain("700000000000000000"));      // limit inflated to wei
+    }
+
+    [Test]
+    public void Rule12_TwoIntermediariesIndependentCollateralsWithinLimits_Passes()
+    {
+        // Per-intermediary case: each intermediary contributes its own personal
+        // CRC token as collateral. (GroupA, Bob) and (GroupA, Carol) are
+        // independent rows on-chain, each with its own cap.
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            ScoreGroupMintLimits =
+            {
+                [(GroupA.ToLowerInvariant(), Bob.ToLowerInvariant())] = Cached_0_5_CRC,
+                [(GroupA.ToLowerInvariant(), Carol.ToLowerInvariant())] = Cached_0_5_CRC,
+            },
+        };
+        var steps = new[]
+        {
+            Step(Bob, ScoreRouter, Bob, Wei_0_4_CRC),
+            Step(ScoreRouter, GroupA, Bob, Wei_0_4_CRC),
+            Step(Carol, ScoreRouter, Carol, Wei_0_4_CRC),
+            Step(ScoreRouter, GroupA, Carol, Wei_0_4_CRC),
+            Step(GroupA, Dave, GroupA, "800000000000000000"),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Independent (group, intermediary-token) rows each at 0.4 of 0.5 CRC cap must pass.");
+    }
+
+    [Test]
+    public void Rule12_NoCachedLimitForScoreRouterEdge_FailsClosed()
+    {
+        // State-snapshot drift: a score-router→group edge exists but no
+        // availableLimit row was emitted. Refuse the path (chain would revert).
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            // ScoreGroupMintLimits intentionally empty
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, Alice, Wei_0_5_CRC),
+            Step(ScoreRouter, GroupA, Alice, Wei_0_5_CRC),
+            Step(GroupA, Bob, GroupA, Wei_0_5_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        var rule12 = violations.Where(v => v.Rule == "ScoreGroupMintLimitsHonored").ToList();
+        Assert.That(rule12.Count, Is.EqualTo(1));
+        Assert.That(rule12[0].Severity, Is.EqualTo("error"));
+        Assert.That(rule12[0].Message, Does.Contain("no availableLimit").Or.Contain("state-snapshot drift"));
+    }
+
+    [Test]
+    public void Rule12_NoScoreRouterEdges_NoOp()
+    {
+        // Base-group flows (regular router, no score router on path) must
+        // not be touched by Rule 12, regardless of whether any limits are
+        // cached. The validator scopes by IsScoreRouter().
+        var state = new MockContractState
+        {
+            Router = Router,
+            TrustAll = true,
+            Groups = { GroupA },
+        };
+        var steps = new[]
+        {
+            Step(Alice, Router, Alice, Wei_0_5_CRC),
+            Step(Router, GroupA, Alice, Wei_0_5_CRC),
+            Step(GroupA, Bob, GroupA, Wei_0_5_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Non-score routers must not trigger Rule 12.");
+    }
+
+    [Test]
+    public void Rule12_ExactLimitBoundary_Passes()
+    {
+        // Cumulative == limit (exact-edge boundary) — strict-greater compare,
+        // so this must pass. Regression: ensures we never silently switch
+        // to >= which would reject paths that the contract would accept.
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            ScoreGroupMintLimits = { [(GroupA.ToLowerInvariant(), Alice.ToLowerInvariant())] = Cached_1_0_CRC },
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, Alice, Wei_1_0_CRC),
+            Step(ScoreRouter, GroupA, Alice, Wei_1_0_CRC), // exactly == 1 CRC limit
+            Step(GroupA, Bob, GroupA, Wei_1_0_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        Assert.That(violations, Is.Empty, "Cumulative == limit must pass (strict-greater compare).");
+    }
+
+    [Test]
+    public void Rule12_UnparseableValueOnScoreRouterEdge_FailsWithError()
+    {
+        // Silent-failure guard: BigInteger.TryParse failures on score-router
+        // edges must surface as a Rule 12 violation, not slip past via
+        // "continue". Rule 1 doesn't catch non-empty junk strings.
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            ScoreGroupMintLimits = { [(GroupA.ToLowerInvariant(), Alice.ToLowerInvariant())] = Cached_1_0_CRC },
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, Alice, "not-a-number"),
+            Step(ScoreRouter, GroupA, Alice, "0xdeadbeef"),
+            Step(GroupA, Bob, GroupA, Wei_0_5_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        var rule12 = violations.Where(v => v.Rule == "ScoreGroupMintLimitsHonored").ToList();
+        Assert.That(rule12.Any(v => v.Message.Contains("unparseable")), Is.True,
+            "Unparseable Value on a score-router→group edge must produce a Rule 12 error.");
+    }
+
+    [Test]
+    public void Rule12_WrapperTokenOwnerKeyedAsRaw_MatchesGraphFactory()
+    {
+        // Regression: Rule 12 must NOT resolve wrapper→underlying. The
+        // ScoreGroupMintLimits cache is keyed by raw token id (matching
+        // GraphFactory.cs:999 + GraphFactory.cs:1032). If a wrapper ever
+        // appeared as TokenOwner on a score-router→group hop, the cache
+        // lookup must use the wrapper address directly so it matches what
+        // GraphFactory stored. Resolving here would create a spurious
+        // "no availableLimit cached" fail-close.
+        const string WrapperAddr = "0x0000000000000000000000000000000000000088";
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            TrustAll = true,
+            Groups = { GroupA },
+            Wrappers = { [WrapperAddr] = Alice }, // wrapper→underlying mapping exists…
+            ScoreGroupMintLimits =
+            {
+                // …but the cache is keyed under the WRAPPER address, not Alice.
+                [(GroupA.ToLowerInvariant(), WrapperAddr.ToLowerInvariant())] = Cached_1_0_CRC,
+            },
+        };
+        var steps = new[]
+        {
+            Step(Alice, ScoreRouter, WrapperAddr, Wei_0_5_CRC),
+            Step(ScoreRouter, GroupA, WrapperAddr, Wei_0_5_CRC),
+            Step(GroupA, Bob, GroupA, Wei_0_5_CRC),
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateScoreGroupMintLimits(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Wrapper-keyed lookup must succeed without wrapper resolution; " +
+            "if Rule 12 resolved to Alice, the lookup would miss and fail-close.");
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -159,4 +159,27 @@ public sealed class CapacityGraphContractState : IContractState
             return false;
         return _graph.ScoreRouterIds.Contains(id);
     }
+
+    /// <summary>
+    /// Read the cached availableLimit for (group, collateral) from
+    /// CapacityGraph.ScoreGroupMintLimits, sourced via
+    /// circles_getScoreGroupMintLimits → LoadGraph.LoadScoreGroupMintLimits.
+    /// Returns null when the tuple has no cached entry (state-snapshot drift,
+    /// non-score group, or unknown address) — Rule 12 maps null → fail-closed
+    /// for score-router→group edges.
+    /// </summary>
+    public long? GetScoreGroupMintLimit(string group, string collateral)
+    {
+        var groupLower = group.ToLowerInvariant();
+        var collateralLower = collateral.ToLowerInvariant();
+
+        if (!AddressIdPool.TryIdOf(groupLower, out int groupId))
+            return null;
+        if (!AddressIdPool.TryIdOf(collateralLower, out int collateralId))
+            return null;
+
+        return _graph.ScoreGroupMintLimits.TryGetValue((groupId, collateralId), out var limit)
+            ? limit
+            : null;
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Numerics;
+using Circles.Common;
 using Circles.Common.Dto;
 
 namespace Circles.Pathfinder.Validation;
@@ -12,7 +13,7 @@ namespace Circles.Pathfinder.Validation;
 public static class HubContractValidator
 {
     /// <summary>
-    /// Run all 11 validation rules against the transfer path.
+    /// Run all 12 validation rules against the transfer path.
     /// </summary>
     /// <param name="steps">The transfer steps produced by the pathfinder.</param>
     /// <param name="source">The sender address.</param>
@@ -41,6 +42,7 @@ public static class HubContractValidator
         ValidateCollateralBeforeMint(filtered, state, violations);
         ValidateNoDuplicateEdges(filtered, violations);
         ValidateNoSelfTransfers(filtered, sink, violations);
+        ValidateScoreGroupMintLimits(filtered, state, violations);
 
         bool isValid = !violations.Any(v => v.Severity == "error");
         return new ValidationResult(isValid, violations);
@@ -632,6 +634,139 @@ public static class HubContractValidator
                     "NoSelfTransfers",
                     $"Edge {i}: self-transfer at '{from}'",
                     i, "warning"));
+            }
+        }
+    }
+
+    // ────────────────────────────────────────────
+    // Rule 12: ScoreGroupMintLimitsHonored
+    //
+    // OffchainScoreBasedMintPolicy.beforeMintPolicy router-branch math
+    // (OffchainScoreBasedMintPolicy.sol:237-249):
+    //
+    //   currentLimit = historicalSupplyOnToday(collateral)
+    //                + getMintedAmountOnToday(group, collateral)
+    //                − HUB.balanceOf(treasury, collateral)
+    //
+    // The mapping is keyed on (group, collateral) only — there is no
+    // per-intermediary accounting. Under typical usage where each
+    // intermediary supplies its own personal CRC token as collateral,
+    // (group, intermediary-token) maps 1:1 to a per-intermediary cap.
+    // In the rare case of two intermediaries supplying the same
+    // third-party token, they share a single cap.
+    //
+    // The pathfinder encodes this constraint at graph-build time as a
+    // single TokenPool(collateral)→group capacity edge (GraphFactory.cs:
+    // 999-1040, CapacityGraph.cs:37) sized to availableLimit. Rule 12
+    // is the post-flow second reader: any future encoding regression
+    // that returns a path whose cumulative Router→Group deposits exceed
+    // the cached availableLimit gets caught HERE instead of reverting
+    // on-chain during operateFlowMatrix.
+    //
+    // Scope: only edges where (from = score router) AND (to = group).
+    // Base-group routers and non-router from-vertices are out of scope.
+    //
+    // Units: TransferPathStep.Value is wei (10^18 base, per its DTO doc
+    // and V2Pathfinder.cs:454 via CirclesConverter.BlowUpToUInt256).
+    // CapacityGraph.ScoreGroupMintLimits stores values truncated to
+    // 6-decimal CRC (long) at GraphFactory.cs:739 via TruncateToInt64.
+    // We re-inflate the cached limit to wei via BlowUpToBigInteger before
+    // comparison so both operands share the same unit.
+    //
+    // Collateral keying: matches GraphFactory.cs:999 + GraphFactory.cs:1032
+    // exactly — raw TokenOwner address, no wrapper resolution. The
+    // ScoreGroupMintLimits cache is keyed on avatar addresses (per
+    // ScoreGroupMintLimits.cs BaseRowsSql joining V_CrcV2_TrustRelations
+    // → V_CrcV2_Avatars), so groups only trust avatars, not wrapper
+    // contracts — wrappers cannot appear as TokenOwner on a
+    // score-router→group hop. Resolving wrappers here would create
+    // a key mismatch with the cache and spuriously fail-close.
+    //
+    // Failure modes (all emitted as "error" — chain would revert):
+    //   - unparseable Value → reject (Rule 1 doesn't catch non-empty junk)
+    //   - cumulative > limit → reject (emitted on the EDGE that pushes
+    //     the running sum past the cap, not the bucket's first contributor)
+    //   - score-router→group hop with no cached limit → reject
+    //     (state-snapshot drift; safer to refuse than emit a chain-reverting path)
+    // ────────────────────────────────────────────
+    internal static void ValidateScoreGroupMintLimits(
+        IReadOnlyList<TransferPathStep> steps,
+        IContractState state,
+        List<ValidationViolation> violations)
+    {
+        var cumulative = new Dictionary<(string Group, string Collateral), BigInteger>();
+        var bucketAlreadyViolated = new HashSet<(string Group, string Collateral)>();
+
+        for (int i = 0; i < steps.Count; i++)
+        {
+            var from = steps[i].From.ToLowerInvariant();
+            var to = steps[i].To.ToLowerInvariant();
+
+            if (!state.IsScoreRouter(from) || !state.IsGroup(to))
+                continue;
+
+            // Score-router→group edges MUST carry a parseable Value.
+            // Rule 1 catches zero/empty but not negative or junk strings,
+            // so Rule 12 emits its own diagnostic within its own scope
+            // rather than rely on Rule 1's narrower checks.
+            if (!BigInteger.TryParse(steps[i].Value, out var flow))
+            {
+                violations.Add(new ValidationViolation(
+                    "ScoreGroupMintLimitsHonored",
+                    $"Edge {i}: score-router→group has unparseable Value '{steps[i].Value}' — refusing path",
+                    i, "error"));
+                continue;
+            }
+            if (flow == 0)
+                continue; // Zero is Rule 1's domain; no point double-reporting
+            if (flow < 0)
+            {
+                // Unreachable from BlowUpToUInt256 (unsigned), but a manually-constructed
+                // step could carry a negative — surface within Rule 12's scope rather
+                // than slip past as silent skip.
+                violations.Add(new ValidationViolation(
+                    "ScoreGroupMintLimitsHonored",
+                    $"Edge {i}: score-router→group has negative Value '{steps[i].Value}' — refusing path",
+                    i, "error"));
+                continue;
+            }
+
+            var collateral = steps[i].TokenOwner.ToLowerInvariant();
+            var key = (to, collateral);
+
+            cumulative.TryGetValue(key, out var current);
+            var next = current + flow;
+            cumulative[key] = next;
+
+            // Emit at most one violation per (group, collateral) bucket — the
+            // first edge that pushes the running sum past the cap.
+            if (bucketAlreadyViolated.Contains(key))
+                continue;
+
+            var cachedLimit = state.GetScoreGroupMintLimit(to, collateral);
+            if (cachedLimit == null)
+            {
+                violations.Add(new ValidationViolation(
+                    "ScoreGroupMintLimitsHonored",
+                    $"Edge {i}: score router → group '{to}' deposits collateral '{collateral}' " +
+                    "but no availableLimit is cached (state-snapshot drift) — refusing path",
+                    i, "error"));
+                bucketAlreadyViolated.Add(key);
+                continue;
+            }
+
+            // Inflate 6-decimal-CRC long back to wei to match Value's unit.
+            var limitWei = CirclesConverter.BlowUpToBigInteger(cachedLimit.Value);
+            if (next > limitWei)
+            {
+                violations.Add(new ValidationViolation(
+                    "ScoreGroupMintLimitsHonored",
+                    $"Edge {i}: cumulative score-router→group mint for " +
+                    $"(group={to}, collateral={collateral}) is {next} wei, " +
+                    $"exceeds on-chain availableLimit {limitWei} wei " +
+                    $"(cached as {cachedLimit.Value} at 6-decimal CRC precision)",
+                    i, "error"));
+                bucketAlreadyViolated.Add(key);
             }
         }
     }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
@@ -60,4 +60,22 @@ public interface IContractState
     /// Used to scope the approveCRC rule so it only fires for score-router edges.
     /// </summary>
     bool IsScoreRouter(string address) => false;
+
+    /// <summary>
+    /// circles_getScoreGroupMintLimits view: cached `availableLimit` per
+    /// (group, collateral) tuple, mirroring OffchainScoreBasedMintPolicy.sol's
+    /// router-branch math: `historicalSupplyOnToday(collateral)
+    /// + getMintedAmountOnToday(group, collateral) − HUB.balanceOf(treasury, collateral)`.
+    ///
+    /// The mapping is keyed on (group, collateral) only — there is no per-intermediary
+    /// accounting on-chain — so under the typical "intermediary mints with own token"
+    /// pattern, each (group, intermediary-token) row IS effectively per-intermediary;
+    /// only in the rare case of two intermediaries supplying the same third-party
+    /// collateral do they share a row.
+    ///
+    /// Returns null when no entry is cached. Rule 12 fails-closed on null when the
+    /// edge looks like a score-router→group hop, preventing chain-reverting paths
+    /// from leaking through during indexer drift.
+    /// </summary>
+    long? GetScoreGroupMintLimit(string group, string collateral) => null;
 }


### PR DESCRIPTION
## Summary

Adds **Rule 12 ScoreGroupMintLimitsHonored** to `HubContractValidator` — a post-flow second-reader that asserts cumulative score-router→group deposits per `(group, collateral)` ≤ the cached `availableLimit` from `circles_getScoreGroupMintLimits`.

Mirrors `OffchainScoreBasedMintPolicy.beforeMintPolicy` router-branch math:

```
currentLimit = historicalSupplyOnToday(collateral)
             + getMintedAmountOnToday(group, collateral)
             − HUB.balanceOf(treasury, collateral)
```

Defense-in-depth: today, the only guarantee that pathfinder output respects per-`(group, collateral)` caps is the solver-time edge constraint built at `GraphFactory.cs:1032-1038`. Any future encoding regression would silently emit chain-reverting paths. Rule 12 catches that class of bug post-flow, with an actionable diagnostic.

## What changed

- `IContractState` gains `long? GetScoreGroupMintLimit(string group, string collateral)` (default `null`). Implemented by `CapacityGraphContractState` against `CapacityGraph.ScoreGroupMintLimits`.
- `HubContractValidator.ValidateScoreGroupMintLimits` walks the transfer steps; for each `IsScoreRouter(from) && IsGroup(to)` edge, accumulates flow per `(group, collateral)`, and emits an `error` violation when the first edge of a bucket pushes cumulative past `BlowUpToBigInteger(cachedLimit)`.
- Wired into `Validate()` as the final rule in the chain.

## Correctness notes

- **Units**: `TransferPathStep.Value` is wei; the cache stores `TruncateToInt64` 6-decimal CRC. The validator inflates the cached limit back to wei via `CirclesConverter.BlowUpToBigInteger` before the `BigInteger` compare. Tests use realistic wei strings (`1000000000000000000` = 1 CRC) and `1_000_000` cache values.
- **Collateral keying**: raw `TokenOwner` address, no wrapper resolution. Matches `GraphFactory.cs:999` and `GraphFactory.cs:1032`, which key edges on the raw token, and the cache producer's `ScoreGroupMintLimits.cs BaseRowsSql` which keys on avatar addresses from `V_CrcV2_TrustRelations`. Wrappers cannot appear as `TokenOwner` on a score-router→group hop (groups trust avatars, not wrapper contracts).
- **Failure scope**: edge-level diagnostic points at the crossing edge (the first one that pushes cumulative past the cap), not the bucket's first contributor.
- **Silent-failure hardening**: unparseable or negative `Value` on a score-router→group edge surfaces as a Rule 12 violation rather than `continue`-skip (`Rule 1` only catches empty/`"0"`).
- **Fail-closed**: missing `availableLimit` for a score-router→group edge emits an explicit `state-snapshot drift` error.

## Tests

8 unit cases in `HubContractValidatorTests`:
1. Single intermediary within limit → pass.
2. Two intermediaries, shared collateral, cumulative over limit → fail (asserts `EdgeIndex` is the crossing edge).
3. Two intermediaries, independent collaterals, each within its own cap → pass.
4. Score-router→group edge with no cached limit → fail-closed.
5. Non-score-router edges → no-op.
6. Cumulative == limit (exact boundary, strict-greater compare) → pass.
7. Unparseable `Value` on score-router edge → Rule 12 error.
8. Wrapper as `TokenOwner` with cache keyed by wrapper address → pass (locks in no-wrapper-resolution behavior).

## Test plan

- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj --filter 'FullyQualifiedName~HubContractValidatorTests'` — 64/0, +3 vs prior.
- [x] Full non-Anvil pathfinder suite — 987/0/144-skipped.
- [x] `dotnet build` — 0 errors, pre-existing warnings only.
- [ ] Post-deploy on staging: no spurious `ScoreGroupMintLimitsHonored` errors on known-good paths (Rule 12 should be silent on every Healthy traffic until the encoding regresses).
- [ ] Post-deploy on staging: a synthetic over-limit max-flow returns the expected Rule 12 violation in the path-audit log.