### PR TITLE
feat(pathfinder): expose validation diagnostics + fail-closed on validator exception

### DIFF
--- a/src/Common/Circles.Common.Tests/MaxFlowResponseSerializationTests.cs
+++ b/src/Common/Circles.Common.Tests/MaxFlowResponseSerializationTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using Circles.Common.Dto;
+
+namespace Circles.Common.Tests;
+
+[TestFixture]
+public sealed class MaxFlowResponseSerializationTests
+{
+    private static string Serialize(MaxFlowResponse r) =>
+        JsonSerializer.Serialize(r);
+
+    [Test]
+    public void HealthyResponse_OmitsValidationFields()
+    {
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>());
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Not.Contain("validationErrors"));
+        Assert.That(json, Does.Not.Contain("validationViolationRules"));
+        Assert.That(json, Does.Not.Contain("validatorException"));
+    }
+
+    [Test]
+    public void ValidationErrorsNonZero_SerializesCount()
+    {
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidationErrors = 2,
+            ValidationViolationRules = new[] { "ScoreGroupMintLimitsHonored", "ApproveCRCRequired" }
+        };
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Contain("\"validationErrors\":2"));
+        Assert.That(json, Does.Contain("\"validationViolationRules\""));
+        Assert.That(json, Does.Contain("ScoreGroupMintLimitsHonored"));
+        Assert.That(json, Does.Contain("ApproveCRCRequired"));
+    }
+
+    [Test]
+    public void ValidatorExceptionTrue_SerializesFlag()
+    {
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidatorException = true
+        };
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Contain("\"validatorException\":true"));
+    }
+
+    [Test]
+    public void NullViolationRules_Omitted_EvenWhenErrorsNonZero()
+    {
+        // Defensive shape: an "exception" path may set ValidationErrors without populating
+        // the rule list. The list field must stay absent rather than serializing as null.
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidationErrors = 1,
+            ValidationViolationRules = null
+        };
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Contain("\"validationErrors\":1"));
+        Assert.That(json, Does.Not.Contain("validationViolationRules"));
+    }
+
+    [Test]
+    public void EmptyViolationRulesList_SerializesAsEmptyArray()
+    {
+        // Pins the load-bearing invariant documented on the property: producers are
+        // expected to leave ValidationViolationRules null when zero violations occur.
+        // An empty list WILL appear on the wire as []; this test makes that explicit so
+        // an upstream change from `null` → `new List<string>()` is caught immediately.
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidationViolationRules = new List<string>()
+        };
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Contain("\"validationViolationRules\":[]"));
+    }
+
+    [Test]
+    public void ValidatorExceptionOnly_OmitsValidationErrorsZeroField()
+    {
+        // The "validator threw, errors stayed at default 0" combination produces a wire
+        // shape with validatorException:true and no validationErrors field. Pinning this
+        // so callers can distinguish "validator ran cleanly" (no fields) from "validator
+        // threw" (validatorException:true alone).
+        var r = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidatorException = true
+            // ValidationErrors stays default 0 — omitted by WhenWritingDefault
+        };
+        var json = Serialize(r);
+
+        Assert.That(json, Does.Contain("\"validatorException\":true"));
+        Assert.That(json, Does.Not.Contain("validationErrors"));
+        Assert.That(json, Does.Not.Contain("validationViolationRules"));
+    }
+
+    [Test]
+    public void RoundTrip_PreservesValidationFields()
+    {
+        // Pins both wire-name mapping and the deserialize path so the DTO can be consumed
+        // by both producers and consumers (e.g. the integration tests that deserialize
+        // MaxFlowResponse out of a JSON-RPC envelope).
+        var original = new MaxFlowResponse("0", new List<TransferPathStep>())
+        {
+            ValidationErrors = 2,
+            ValidationViolationRules = new[] { "ScoreGroupMintLimitsHonored", "ApproveCRCRequired" },
+            ValidatorException = true
+        };
+        var json = Serialize(original);
+        var roundTripped = JsonSerializer.Deserialize<MaxFlowResponse>(json);
+
+        Assert.That(roundTripped, Is.Not.Null);
+        Assert.That(roundTripped!.ValidationErrors, Is.EqualTo(2));
+        Assert.That(roundTripped.ValidationViolationRules, Is.EquivalentTo(original.ValidationViolationRules!));
+        Assert.That(roundTripped.ValidatorException, Is.True);
+    }
+}

--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -80,24 +80,31 @@ public class MaxFlowResponse
     public string? ReqId { get; set; }
 
     /// <summary>
-    /// Canary: number of Hub.sol rule violations detected by HubContractValidator.
-    /// Non-zero means the pathfinder produced output that would revert on-chain.
-    /// Not serialized — used internally for metrics.
+    /// Number of Hub.sol rule violations detected by HubContractValidator. When non-zero,
+    /// the pathfinder produced output that would have reverted on-chain and the response's
+    /// transfers have been replaced with the empty path by the safety net. Serialized only
+    /// when non-zero so callers can self-diagnose path rejections without log access.
     /// </summary>
-    [JsonIgnore]
+    [JsonPropertyName("validationErrors")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public int ValidationErrors { get; set; }
 
     /// <summary>
-    /// Canary: rule names of validation violations, for per-rule metric labeling.
-    /// Not serialized — used internally for metrics.
+    /// Hub.sol rule names of each detected violation (duplicates are removed by
+    /// HubContractValidator before assignment). Serialized when not null. The producer is
+    /// expected to leave this null when there are zero violations rather than assigning
+    /// an empty list; an empty list would appear on the wire as `[]`.
     /// </summary>
-    [JsonIgnore]
+    [JsonPropertyName("validationViolationRules")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public IReadOnlyList<string>? ValidationViolationRules { get; set; }
 
     /// <summary>
-    /// Canary: true if HubContractValidator threw an exception (validator bug, not pathfinder bug).
+    /// True if HubContractValidator threw an unexpected exception (validator bug, not
+    /// pathfinder bug). Serialized only when true.
     /// </summary>
-    [JsonIgnore]
+    [JsonPropertyName("validatorException")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool ValidatorException { get; set; }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -196,11 +196,13 @@ internal sealed class FindPathHandler(
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
 
-                // Path audit: when HubContractValidator detected Hub.sol rule violations,
-                // the produced path would revert on-chain. Record metrics, log, then replace
-                // the broken transfers with the canonical empty response so the wallet can't
-                // submit a doomed tx. The API contract still returns MaxFlowResponse — never errors.
-                if (mfr.ValidationErrors > 0)
+                // Path audit: when HubContractValidator detected Hub.sol rule violations OR
+                // threw an unexpected exception, the produced path is unsafe (would either
+                // revert on-chain or could not be vouched for). Record metrics, log, then
+                // replace the broken transfers with the canonical empty response so the
+                // wallet can't submit a doomed tx. The API contract still returns
+                // MaxFlowResponse — never errors.
+                if (mfr.ValidationErrors > 0 || mfr.ValidatorException)
                 {
                     FindPathMetrics.PathAuditViolationsTotal.WithLabels("any").Inc();
                     if (mfr.ValidationViolationRules != null)
@@ -208,12 +210,14 @@ internal sealed class FindPathHandler(
                         foreach (var rule in mfr.ValidationViolationRules)
                             FindPathMetrics.PathAuditViolationsTotal.WithLabels(rule).Inc();
                     }
+                    if (mfr.ValidatorException)
+                        FindPathMetrics.PathAuditViolationsTotal.WithLabels("ValidatorException").Inc();
 
                     log.LogError(
-                        "Path audit: Hub.sol rule violations detected — replacing path with empty response. " +
-                        "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}",
+                        "Path audit: validator rejected response — replacing path with empty response. " +
+                        "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}, ValidatorException={ValidatorException}",
                         safeSource, safeSink, mfr.GraphBlock,
-                        mfr.Transfers?.Count ?? 0, mfr.ValidationErrors);
+                        mfr.Transfers?.Count ?? 0, mfr.ValidationErrors, mfr.ValidatorException);
 
                     FindPathMetrics.PathAuditBlockedTotal.WithLabels("any").Inc();
                     if (mfr.ValidationViolationRules != null)
@@ -221,11 +225,14 @@ internal sealed class FindPathHandler(
                         foreach (var rule in mfr.ValidationViolationRules)
                             FindPathMetrics.PathAuditBlockedTotal.WithLabels(rule).Inc();
                     }
+                    if (mfr.ValidatorException)
+                        FindPathMetrics.PathAuditBlockedTotal.WithLabels("ValidatorException").Inc();
 
                     var emptyResponse = new MaxFlowResponse("0", new List<TransferPathStep>(), null)
                     {
                         ReqId = mfr.ReqId,
                         GraphBlock = mfr.GraphBlock,
+                        ConsentDroppedPaths = mfr.ConsentDroppedPaths,
                         ValidationErrors = mfr.ValidationErrors,
                         ValidationViolationRules = mfr.ValidationViolationRules,
                         ValidatorException = mfr.ValidatorException
@@ -408,8 +415,9 @@ internal sealed class FindPathHandler(
                 if (mfr.ConsentDroppedPaths > 0)
                     FindPathMetrics.ConsentPathsDroppedTotal.Inc(mfr.ConsentDroppedPaths);
 
-                // Track Hub.sol rule violations (same as live path) — and replace with empty.
-                if (mfr.ValidationErrors > 0)
+                // Track Hub.sol rule violations or validator exceptions (same as live path)
+                // — and replace with empty.
+                if (mfr.ValidationErrors > 0 || mfr.ValidatorException)
                 {
                     FindPathMetrics.PathAuditViolationsTotal.WithLabels("any").Inc();
                     if (mfr.ValidationViolationRules != null)
@@ -417,12 +425,14 @@ internal sealed class FindPathHandler(
                         foreach (var rule in mfr.ValidationViolationRules)
                             FindPathMetrics.PathAuditViolationsTotal.WithLabels(rule).Inc();
                     }
+                    if (mfr.ValidatorException)
+                        FindPathMetrics.PathAuditViolationsTotal.WithLabels("ValidatorException").Inc();
 
                     log.LogError(
-                        "Historical path audit: Hub.sol rule violations — replacing path with empty response. " +
-                        "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}",
+                        "Historical path audit: validator rejected response — replacing path with empty response. " +
+                        "Source={Source}, Sink={Sink}, Block={Block}, Steps={Steps}, Errors={Errors}, ValidatorException={ValidatorException}",
                         safeSource, safeSink, blockNumber,
-                        mfr.Transfers?.Count ?? 0, mfr.ValidationErrors);
+                        mfr.Transfers?.Count ?? 0, mfr.ValidationErrors, mfr.ValidatorException);
 
                     FindPathMetrics.PathAuditBlockedTotal.WithLabels("any").Inc();
                     if (mfr.ValidationViolationRules != null)
@@ -430,11 +440,14 @@ internal sealed class FindPathHandler(
                         foreach (var rule in mfr.ValidationViolationRules)
                             FindPathMetrics.PathAuditBlockedTotal.WithLabels(rule).Inc();
                     }
+                    if (mfr.ValidatorException)
+                        FindPathMetrics.PathAuditBlockedTotal.WithLabels("ValidatorException").Inc();
 
                     var emptyResponse = new MaxFlowResponse("0", new List<TransferPathStep>(), null)
                     {
                         ReqId = mfr.ReqId,
                         GraphBlock = mfr.GraphBlock,
+                        ConsentDroppedPaths = mfr.ConsentDroppedPaths,
                         ValidationErrors = mfr.ValidationErrors,
                         ValidationViolationRules = mfr.ValidationViolationRules,
                         ValidatorException = mfr.ValidatorException


### PR DESCRIPTION
## Summary

- Relaxes `[JsonIgnore]` to `JsonIgnoreCondition.WhenWritingDefault` (and `WhenWritingNull` for the list) on `ValidationErrors`, `ValidationViolationRules`, and `ValidatorException` in `MaxFlowResponse` so the JSON-RPC response surfaces Hub.sol rule violations and validator exceptions to callers without log access. Healthy responses are byte-identical (omitted-when-default), so this is additive.
- Closes a latent safety-net hole in `FindPathHandler`: previously transfers were replaced with the empty response only when `ValidationErrors > 0`. When the validator threw, `ValidatorException` was set but transfers were returned verbatim — a potentially chain-reverting path could reach the wallet. Gate now uses `ValidationErrors > 0 || ValidatorException`. Both live + historical (`X-Max-Block-Number`) paths fixed.
- Adds `ValidatorException` label to `circles_path_audit_violations_total` and `circles_path_audit_blocked_total` so the exception case is metric-distinct from rule violations.
- Propagates `ConsentDroppedPaths` through the empty-response copy so the consent diagnostic isn't silently dropped under safety-net replacement.

## Wire-shape contract (new tests pin all paths)

| State | `validationErrors` | `validationViolationRules` | `validatorException` |
|---|---|---|---|
| Healthy | omitted | omitted | omitted |
| 1+ rule violation | `N` | `["RuleA", ...]` | omitted |
| Validator threw | omitted | omitted | `true` |
| Both (exception during rule eval) | `N` | `[...]` | `true` |

Producer contract: `ValidationViolationRules` must be left `null` (not `new List<string>()`) when zero violations occur. The empty-list edge is explicitly tested so an upstream regression is caught.

## Test plan

- [x] `dotnet test Circles.Common.Tests` — 90/90 pass (incl. 7 new serialization tests)
- [x] `dotnet test Circles.Pathfinder.Tests --filter "FullyQualifiedName~HubContractValidator|FullyQualifiedName~PathAudit|FullyQualifiedName~SafetyNet"` — 64/64 pass
- [x] `dotnet test Circles.Rpc.Host.Tests --filter "FullyQualifiedName~OpenRpcGenerator"` — 8/8 pass (schema additive, no snapshot tests pin shape)
- [x] `dotnet build Circles.Pathfinder.Host` — clean

## Deploy plan

Rolling deploy after merge: `make deploy-gnosis SERVICE=pathfinder ENV=staging`. No DB migration, no nethermind/EL restart, no indexer/cache-service touched.

## Known follow-ups (out of scope)

- HubContractValidator's `catch (Exception ex)` collapses all exception types to a single boolean; could add `WithLabels(ex.GetType().Name)` and rethrow fatal types (OOM, ThreadAbort, OperationCanceled).
- Validator skips entirely when `ctx.Transfers.Count == 0` (`V2Pathfinder.cs:470`); empty-path responses produce no audit signal.