### PR TITLE
I-tier follow-ups: SQL pushdown, footgun overload, ApproveCRCRequired tests

### DIFF
--- a/src/Common/Circles.Common.Tests/ScoreGroupMintLimitReaderTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupMintLimitReaderTests.cs
@@ -1,0 +1,34 @@
+namespace Circles.Common.Tests;
+
+[TestFixture]
+public sealed class ScoreGroupMintLimitReaderTests
+{
+    [Test]
+    public void NormalizeFilter_Null_ReturnsNull()
+    {
+        Assert.That(ScoreGroupMintLimitReader.NormalizeFilter(null), Is.Null);
+    }
+
+    [Test]
+    public void NormalizeFilter_Whitespace_ReturnsNull()
+    {
+        Assert.That(ScoreGroupMintLimitReader.NormalizeFilter("   "), Is.Null);
+        Assert.That(ScoreGroupMintLimitReader.NormalizeFilter(""), Is.Null);
+    }
+
+    [Test]
+    public void NormalizeFilter_MixedCase_Lowercases()
+    {
+        Assert.That(
+            ScoreGroupMintLimitReader.NormalizeFilter("0x24c9BA1fB88533B0cD2aEa37DaD75B809eEcF2C0"),
+            Is.EqualTo("0x24c9ba1fb88533b0cd2aea37dad75b809eecf2c0"));
+    }
+
+    [Test]
+    public void NormalizeFilter_WrappedWhitespace_Trimmed()
+    {
+        Assert.That(
+            ScoreGroupMintLimitReader.NormalizeFilter("  0xABC  "),
+            Is.EqualTo("0xabc"));
+    }
+}

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -30,4 +30,8 @@
     <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Circles.Common.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -41,6 +41,7 @@ public static class ScoreGroupMintLimitReader
             WHERE (@maxBlock::bigint IS NULL OR g."blockNumber" <= @maxBlock)
               AND LOWER(g."mint") = ANY(@scoreMintPolicies)
               AND lsg.group_address IS NOT NULL
+              AND (@groupAddressFilter::text IS NULL OR g."group" = @groupAddressFilter)
         ),
         group_tokens AS (
             SELECT
@@ -51,6 +52,7 @@ public static class ScoreGroupMintLimitReader
             FROM score_groups sg
             INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = sg.group_address
             INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
+            WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
         ),
         token_supply AS (
             SELECT
@@ -107,7 +109,9 @@ public static class ScoreGroupMintLimitReader
         double safetyMargin,
         int commandTimeoutSeconds,
         long? maxBlock = null,
-        NpgsqlTransaction? transaction = null)
+        NpgsqlTransaction? transaction = null,
+        string? groupAddressFilter = null,
+        string? collateralTokenFilter = null)
     {
         var policies = scoreMintPolicies
             .Select(x => x.Trim().ToLowerInvariant())
@@ -118,7 +122,14 @@ public static class ScoreGroupMintLimitReader
         if (policies.Length == 0)
             return [];
 
-        var baseRows = ReadBaseRows(connection, policies, commandTimeoutSeconds, maxBlock, transaction);
+        var baseRows = ReadBaseRows(
+            connection,
+            policies,
+            commandTimeoutSeconds,
+            maxBlock,
+            transaction,
+            NormalizeFilter(groupAddressFilter),
+            NormalizeFilter(collateralTokenFilter));
         return ReadFromBaseRows(
             connection,
             policies,
@@ -128,6 +139,14 @@ public static class ScoreGroupMintLimitReader
             commandTimeoutSeconds,
             maxBlock,
             transaction);
+    }
+
+    internal static string? NormalizeFilter(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        return value.Trim().ToLowerInvariant();
     }
 
     public static IReadOnlyList<ScoreGroupMintLimitRow> ReadFromBaseRows(
@@ -193,13 +212,17 @@ public static class ScoreGroupMintLimitReader
         string[] policies,
         int commandTimeoutSeconds,
         long? maxBlock,
-        NpgsqlTransaction? transaction)
+        NpgsqlTransaction? transaction,
+        string? groupAddressFilter = null,
+        string? collateralTokenFilter = null)
     {
         var rows = new List<ScoreGroupMintLimitBaseRow>();
         using var command = new NpgsqlCommand(BaseRowsSql, connection, transaction);
         command.CommandTimeout = commandTimeoutSeconds;
         command.Parameters.AddWithValue("scoreMintPolicies", policies);
         AddMaxBlockParameter(command, maxBlock);
+        AddTextFilterParameter(command, "groupAddressFilter", groupAddressFilter);
+        AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
 
         using var reader = command.ExecuteReader();
         while (reader.Read())
@@ -294,5 +317,11 @@ public static class ScoreGroupMintLimitReader
     {
         var parameter = command.Parameters.Add("maxBlock", NpgsqlDbType.Bigint);
         parameter.Value = (object?)maxBlock ?? DBNull.Value;
+    }
+
+    private static void AddTextFilterParameter(NpgsqlCommand command, string name, string? value)
+    {
+        var parameter = command.Parameters.Add(name, NpgsqlDbType.Text);
+        parameter.Value = (object?)value ?? DBNull.Value;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -51,10 +51,11 @@ public class HubContractValidatorTests
         public Dictionary<(string Group, string Collateral), long> ScoreGroupMintLimits { get; set; }
             = new();
 
-        // (account, operator) tuples lowercased. When the set is non-empty the mock switches to
-        // strict mode: returns true only for explicit entries. Empty set falls back to the
-        // interface default (true) so tests that don't care about approvals don't have to seed.
+        // (account, operator) tuples lowercased. Membership grants approval — but only when
+        // StrictApprovals is true. Default behavior is permissive (returns true regardless),
+        // matching the IContractState default so existing tests don't have to seed anything.
         public HashSet<(string Account, string Operator)> Approvals { get; set; } = new();
+        public bool StrictApprovals { get; set; }
 
         public string? RouterAddress => Router;
         public bool IsRouter(string address) =>
@@ -85,7 +86,7 @@ public class HubContractValidatorTests
 
         public bool IsApprovedForAll(string account, string @operator)
         {
-            if (Approvals.Count == 0) return true;
+            if (!StrictApprovals) return true;
             return Approvals.Contains((account.ToLowerInvariant(), @operator.ToLowerInvariant()));
         }
     }
@@ -368,9 +369,7 @@ public class HubContractValidatorTests
             Router = Router,
             ScoreRouters = { ScoreRouter },
             Trusts = { (ScoreRouter.ToLowerInvariant(), Alice.ToLowerInvariant()) },
-            // Approvals seeded with a dummy unrelated entry so the set is non-empty
-            // and the mock switches to strict mode (instead of the permissive default).
-            Approvals = { (Router, Carol.ToLowerInvariant()) },
+            StrictApprovals = true,
         };
         var steps = new[] { Step(Alice, ScoreRouter, Alice) };
         var violations = new List<ValidationViolation>();
@@ -389,7 +388,7 @@ public class HubContractValidatorTests
             Router = Router,
             // Router is the standard router but NOT a score router.
             Trusts = { (Router, Alice.ToLowerInvariant()) },
-            Approvals = { (Router, Carol.ToLowerInvariant()) }, // strict mode, Alice not approved
+            StrictApprovals = true, // Alice not in Approvals → unapproved, but Router is not a score router.
         };
         var steps = new[] { Step(Alice, Router, Alice) };
         var violations = new List<ValidationViolation>();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -194,7 +194,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Bob, Alice) }; // Alice sends Alice-token to Bob
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Is.Empty);
     }
 
@@ -204,7 +204,7 @@ public class HubContractValidatorTests
         var state = new MockContractState { Router = Router }; // No trusts, TrustAll=false
         var steps = new[] { Step(Alice, Bob, Alice) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations.Count, Is.EqualTo(1));
         Assert.That(violations[0].Rule, Is.EqualTo("IsPermittedFlow"));
     }
@@ -220,7 +220,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Bob, Carol) }; // Consented: checks From trusts To
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Is.Empty);
     }
 
@@ -235,7 +235,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Bob, Carol) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations.Any(v => v.Message.Contains("advancedUsageFlags")), Is.True);
     }
 
@@ -250,7 +250,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Bob, Carol) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations.Any(v => v.Message.Contains("does not trust")), Is.True);
     }
 
@@ -264,7 +264,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Router, GroupA, Alice) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Is.Empty, "Router→Group should bypass isPermittedFlow (internal group mint)");
     }
 
@@ -278,7 +278,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Router, Alice) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Is.Empty, "Avatar→Router should pass when Router trusts tokenOwner");
     }
 
@@ -292,7 +292,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Alice, Router, Alice) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Has.Count.EqualTo(1));
         Assert.That(violations[0].Message, Does.Contain("Avatar→Router"));
         Assert.That(violations[0].Message, Does.Contain("does not trust token owner"));
@@ -310,7 +310,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Router, Alice, Bob) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Is.Empty, "Router→NonGroup should use standard validation and pass when trusted");
     }
 
@@ -324,7 +324,7 @@ public class HubContractValidatorTests
         };
         var steps = new[] { Step(Router, Alice, Bob) };
         var violations = new List<ValidationViolation>();
-        HubContractValidator.ValidateIsPermittedFlow(steps, state, violations);
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Has.Count.EqualTo(1), "Router→NonGroup with no trust should fail standard validation");
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -51,6 +51,11 @@ public class HubContractValidatorTests
         public Dictionary<(string Group, string Collateral), long> ScoreGroupMintLimits { get; set; }
             = new();
 
+        // (account, operator) tuples lowercased. When the set is non-empty the mock switches to
+        // strict mode: returns true only for explicit entries. Empty set falls back to the
+        // interface default (true) so tests that don't care about approvals don't have to seed.
+        public HashSet<(string Account, string Operator)> Approvals { get; set; } = new();
+
         public string? RouterAddress => Router;
         public bool IsRouter(string address) =>
             (Router != null && string.Equals(Router, address, StringComparison.OrdinalIgnoreCase))
@@ -76,6 +81,12 @@ public class HubContractValidatorTests
                 (group.ToLowerInvariant(), collateral.ToLowerInvariant()), out var limit)
                 ? limit
                 : null;
+        }
+
+        public bool IsApprovedForAll(string account, string @operator)
+        {
+            if (Approvals.Count == 0) return true;
+            return Approvals.Contains((account.ToLowerInvariant(), @operator.ToLowerInvariant()));
         }
     }
 
@@ -326,6 +337,65 @@ public class HubContractValidatorTests
         var violations = new List<ValidationViolation>();
         HubContractValidator.ValidateIsPermittedFlow(steps, source: "", state, violations);
         Assert.That(violations, Has.Count.EqualTo(1), "Router→NonGroup with no trust should fail standard validation");
+    }
+
+    // ═══════════════════════════════════════════
+    // Rule: ApproveCRCRequired (Avatar→ScoreRouter requires ERC-1155 operator approval)
+    // ═══════════════════════════════════════════
+
+    [Test]
+    public void ApproveCRCRequired_ScoreRouterEdge_WithApproval_DoesNotEmit()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            Trusts = { (ScoreRouter.ToLowerInvariant(), Alice.ToLowerInvariant()) },
+            Approvals = { (ScoreRouter.ToLowerInvariant(), Alice.ToLowerInvariant()) },
+        };
+        var steps = new[] { Step(Alice, ScoreRouter, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: Alice, state, violations);
+        Assert.That(violations.Any(v => v.Rule == "ApproveCRCRequired"), Is.False,
+            "ApproveCRCRequired must not fire when ScoreRouter has approved source");
+    }
+
+    [Test]
+    public void ApproveCRCRequired_ScoreRouterEdge_WithoutApproval_Emits()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            ScoreRouters = { ScoreRouter },
+            Trusts = { (ScoreRouter.ToLowerInvariant(), Alice.ToLowerInvariant()) },
+            // Approvals seeded with a dummy unrelated entry so the set is non-empty
+            // and the mock switches to strict mode (instead of the permissive default).
+            Approvals = { (Router, Carol.ToLowerInvariant()) },
+        };
+        var steps = new[] { Step(Alice, ScoreRouter, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: Alice, state, violations);
+        var violation = violations.SingleOrDefault(v => v.Rule == "ApproveCRCRequired");
+        Assert.That(violation, Is.Not.Null, "ApproveCRCRequired must fire when ScoreRouter has no approval for source");
+        Assert.That(violation!.Message, Does.Contain("setApprovalForCRC"),
+            "Message should guide the SDK to call setApprovalForCRC");
+    }
+
+    [Test]
+    public void ApproveCRCRequired_NonScoreRouterEdge_NoEmission_EvenWithoutApproval()
+    {
+        var state = new MockContractState
+        {
+            Router = Router,
+            // Router is the standard router but NOT a score router.
+            Trusts = { (Router, Alice.ToLowerInvariant()) },
+            Approvals = { (Router, Carol.ToLowerInvariant()) }, // strict mode, Alice not approved
+        };
+        var steps = new[] { Step(Alice, Router, Alice) };
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateIsPermittedFlow(steps, source: Alice, state, violations);
+        Assert.That(violations.Any(v => v.Rule == "ApproveCRCRequired"), Is.False,
+            "ApproveCRCRequired is scoped to score-router edges; standard routers must not trip it");
     }
 
     // ═══════════════════════════════════════════

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -368,12 +368,6 @@ public static class HubContractValidator
     // ────────────────────────────────────────────
     internal static void ValidateIsPermittedFlow(
         IReadOnlyList<TransferPathStep> steps,
-        IContractState state,
-        List<ValidationViolation> violations)
-        => ValidateIsPermittedFlow(steps, source: string.Empty, state, violations);
-
-    internal static void ValidateIsPermittedFlow(
-        IReadOnlyList<TransferPathStep> steps,
         string source,
         IContractState state,
         List<ValidationViolation> violations)

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
@@ -33,18 +33,17 @@ public partial class CirclesRpcModule : ICirclesRpcModule
             policies,
             targetTimestamp: null,
             safetyMargin: 1.0,
-            commandTimeoutSeconds: _settings.DatabaseQueryTimeoutSeconds);
+            commandTimeoutSeconds: _settings.DatabaseQueryTimeoutSeconds,
+            groupAddressFilter: group,
+            collateralTokenFilter: collateralFilter);
 
-        var filtered = rows
-            .Where(row => string.Equals(row.GroupAddress, group, StringComparison.OrdinalIgnoreCase))
-            .Where(row => collateralFilter == null
-                          || string.Equals(row.CollateralToken, collateralFilter, StringComparison.OrdinalIgnoreCase))
+        var rpcRows = rows
             .Select(row => new ScoreGroupMintLimitRpcRow(
                 row.GroupAddress,
                 row.CollateralToken,
                 row.AvailableLimit))
             .ToArray();
 
-        return new ScoreGroupMintLimitsResponse(group, filtered);
+        return new ScoreGroupMintLimitsResponse(group, rpcRows);
     }
 }


### PR DESCRIPTION
## Summary

Three review-flagged improvements from the earlier PR #388/#23 series, none of which change runtime behavior:

- Push group/collateral filters from in-memory `.Where()` into the SQL of `circles_getScoreGroupMintLimits` so the RPC no longer materializes the full policy row matrix per call. Optional, parameterized, default-null — existing callers (LoadGraph) unchanged.
- Remove the source-less `ValidateIsPermittedFlow` overload that silently defaulted source to `""` and masked `ApproveCRCRequired` emission. Forces explicit source from every caller. The single production caller already passes a real source; the 10 test call sites pass `source: \"\"`.
- Three new tests for `ApproveCRCRequired` emission: with approval, without approval, and standard-router scoping. Mock fixture extended with an explicit `StrictApprovals` toggle to keep the strict/permissive mode separate from approval-set membership.

## Changes

- `src/Common/Circles.Common/ScoreGroupMintLimits.cs` — `Read()` gains optional `groupAddressFilter` / `collateralTokenFilter` params; `BaseRowsSql` gains two `IS NULL OR column = @param` predicates in the `score_groups` and `group_tokens` CTEs.
- `src/Common/Circles.Common/Circles.Common.csproj` — `InternalsVisibleTo(\"Circles.Common.Tests\")` so the new `NormalizeFilter` seam can be unit-tested without widening the public API.
- `src/Common/Circles.Common.Tests/ScoreGroupMintLimitReaderTests.cs` — 4 unit tests for `NormalizeFilter` (null/whitespace/case/trim).
- `src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs` — drop the post-query LINQ filter; pass user inputs through to SQL.
- `src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs` — remove the source-less overload.
- `src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs` — 10 call-site updates + 3 new tests + `StrictApprovals` toggle on `MockContractState`.

## Test plan

- [x] `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj` — 1010/0/270, +3 over the pre-change baseline.
- [x] `dotnet test src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj` — 97/0/0, +4 over the pre-change baseline.
- [x] `dotnet build src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj` clean.
- [ ] Once merged, run `circles_getScoreGroupMintLimits(group, collateral)` against a populated environment and confirm row counts match the prior unfiltered+LINQ result.