### PR TITLE
feat(score-group): multi-sub-treasury sum + HistoricalSupply/MerkleRootUpdated ABI bump

### DIFF
--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -39,22 +39,16 @@ public class PathfinderGraphController : ControllerBase
             .ToHashSet();
 
     /// <summary>
-    /// Score-group treasury "aggregator" → sub-treasury address list. Mirrors the
-    /// <c>SCORE_TREASURY_SUBTREASURIES</c> env parsed by <see cref="Settings"/>; this
-    /// controller reads env directly because the Cache service does not consume
-    /// <c>Circles.Common.Settings</c>. Format: <c>agg:sub1,sub2;agg:sub3,sub4</c>.
+    /// Score-group treasury "aggregator" → sub-treasury address list. Same env
+    /// (<c>SCORE_TREASURY_SUBTREASURIES</c>) and validated parser as the pathfinder
+    /// and indexer; the Cache service reads it directly because it does not link
+    /// <c>Circles.Common.Settings</c>, but routes through the same validator so
+    /// malformed-env operator-typos fail-fast everywhere uniformly.
     /// </summary>
     private static readonly Dictionary<string, string[]> ScoreTreasurySubTreasuries =
-        (Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES") ?? "")
-            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(entry => entry.Split(':', 2))
-            .Where(parts => parts.Length == 2)
-            .ToDictionary(
-                parts => parts[0].Trim().ToLowerInvariant(),
-                parts => parts[1]
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .Select(addr => addr.ToLowerInvariant())
-                    .ToArray());
+        Circles.Common.EnvParsers.ParseAggregatorMap(
+            "SCORE_TREASURY_SUBTREASURIES",
+            Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES"));
 
     private static readonly string BaseGroupRouter =
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.Trim().ToLowerInvariant()
@@ -727,13 +721,25 @@ public class PathfinderGraphController : ControllerBase
         if (balance <= 0)
             return BigInteger.Zero;
 
+        var attoBalance = CirclesConverter.CirclesToAttoCircles(balance);
+
         if (!_caches.V2LastActivity.TryGetValue(balanceKey, out var lastActivity) ||
             lastActivity < V2InflationDayZero)
         {
-            return BigInteger.Zero;
+            // Cache anomaly: a positive balance is recorded but the
+            // last-activity cache has no entry. Returning zero here silently
+            // erases the balance from any downstream sum — including the
+            // score-group treasury sum below, where missing balance means
+            // the mint-cap formula over-approves. Fall back to the
+            // un-demurraged inflationary balance (an upper bound, since
+            // demurrage only ever decreases the value); biases treasury
+            // sums HIGH, biases the mint cap LOW, which is the safer side.
+            _logger.LogWarning(
+                "DemurrageCachedV2Balance: V2LastActivity missing for key {Key}; using un-demurraged inflationary balance as conservative upper bound",
+                balanceKey);
+            return attoBalance;
         }
 
-        var attoBalance = CirclesConverter.CirclesToAttoCircles(balance);
         var targetDay = CirclesConverter.DayFromTimestamp(DateTimeOffset.UtcNow, V2InflationDayZero);
         var lastActivityDay = (ulong)(lastActivity - V2InflationDayZero) / (ulong)SecondsPerDay;
         var daysDelta = targetDay > lastActivityDay ? targetDay - lastActivityDay : 0;

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -38,6 +38,24 @@ public class PathfinderGraphController : ControllerBase
             .Select(x => x.ToLowerInvariant())
             .ToHashSet();
 
+    /// <summary>
+    /// Score-group treasury "aggregator" → sub-treasury address list. Mirrors the
+    /// <c>SCORE_TREASURY_SUBTREASURIES</c> env parsed by <see cref="Settings"/>; this
+    /// controller reads env directly because the Cache service does not consume
+    /// <c>Circles.Common.Settings</c>. Format: <c>agg:sub1,sub2;agg:sub3,sub4</c>.
+    /// </summary>
+    private static readonly Dictionary<string, string[]> ScoreTreasurySubTreasuries =
+        (Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES") ?? "")
+            .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(entry => entry.Split(':', 2))
+            .Where(parts => parts.Length == 2)
+            .ToDictionary(
+                parts => parts[0].Trim().ToLowerInvariant(),
+                parts => parts[1]
+                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                    .Select(addr => addr.ToLowerInvariant())
+                    .ToArray());
+
     private static readonly string BaseGroupRouter =
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.Trim().ToLowerInvariant()
         ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -673,9 +691,23 @@ public class PathfinderGraphController : ControllerBase
             if (!groupMetadata.TryGetValue(group, out var metadata))
                 continue;
 
+            // When the on-chain treasury is a ScoreTreasury aggregator that doesn't
+            // custody tokens (forwards them to score-keyed sub-treasuries), the
+            // override list provides the actual holders. Sum balances across them;
+            // legacy single-treasury groups fall through to the original lookup.
+            var effectiveTreasuries =
+                ScoreTreasurySubTreasuries.TryGetValue(metadata.Treasury, out var subs) && subs.Length > 0
+                    ? subs
+                    : [metadata.Treasury];
+
             foreach (var token in tokens)
             {
-                accountTokenBalances.TryGetValue((metadata.Treasury, token), out var treasuryBalance);
+                BigInteger treasuryBalance = BigInteger.Zero;
+                foreach (var treasury in effectiveTreasuries)
+                {
+                    if (accountTokenBalances.TryGetValue((treasury, token), out var bal))
+                        treasuryBalance += bal;
+                }
                 tokenSupply.TryGetValue(token, out var currentSupply);
 
                 rows.Add(new ScoreGroupMintLimitBaseRow(

--- a/src/Common/Circles.Common/EnvParsers.cs
+++ b/src/Common/Circles.Common/EnvParsers.cs
@@ -1,0 +1,76 @@
+using System.Text.RegularExpressions;
+
+namespace Circles.Common;
+
+/// <summary>
+/// Shared env-variable parsers reused across the plugin, pathfinder, and cache
+/// service. Centralizing parsing prevents subtle behavioral drift between the
+/// per-service copies (e.g. <c>IsNullOrEmpty</c> vs <c>RemoveEmptyEntries</c>)
+/// and ensures every consumer applies the same address-shape validation.
+/// </summary>
+public static class EnvParsers
+{
+    private static readonly Regex AddressRegex =
+        new(@"^0x[0-9a-f]{40}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parses an aggregator → sub-address map from a single environment variable.
+    /// Format: <c>agg:sub1,sub2;agg2:sub3,sub4</c>. Whitespace is trimmed around
+    /// each segment. All addresses are normalized to lowercase and validated
+    /// against <c>^0x[0-9a-f]{40}$</c>; malformed entries throw immediately so
+    /// operator typos surface at startup rather than silently degrading to
+    /// single-treasury behavior in production (which over-approves mint caps).
+    /// </summary>
+    /// <param name="envName">Name of the env var (for error messages).</param>
+    /// <param name="raw">Raw env value, or null/empty (returns empty dict).</param>
+    /// <returns>Validated map; empty dict if <paramref name="raw"/> is unset.</returns>
+    public static Dictionary<string, string[]> ParseAggregatorMap(string envName, string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+            return new Dictionary<string, string[]>();
+
+        var result = new Dictionary<string, string[]>();
+        var entries = raw.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var entry in entries)
+        {
+            var parts = entry.Split(':', 2);
+            if (parts.Length != 2)
+            {
+                throw new InvalidOperationException(
+                    $"{envName}: entry '{entry}' is malformed; expected 'aggregator:sub1,sub2'");
+            }
+
+            var aggregator = parts[0].Trim().ToLowerInvariant();
+            if (!AddressRegex.IsMatch(aggregator))
+            {
+                throw new InvalidOperationException(
+                    $"{envName}: aggregator '{parts[0]}' is not a 0x-prefixed 40-char hex address");
+            }
+
+            var subs = parts[1]
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(addr => addr.ToLowerInvariant())
+                .ToArray();
+            if (subs.Length == 0)
+            {
+                throw new InvalidOperationException(
+                    $"{envName}: aggregator '{aggregator}' has no sub-addresses");
+            }
+            foreach (var sub in subs)
+            {
+                if (!AddressRegex.IsMatch(sub))
+                {
+                    throw new InvalidOperationException(
+                        $"{envName}: sub-address '{sub}' under '{aggregator}' is not a 0x-prefixed 40-char hex address");
+                }
+            }
+
+            if (!result.TryAdd(aggregator, subs))
+            {
+                throw new InvalidOperationException(
+                    $"{envName}: aggregator '{aggregator}' appears more than once");
+            }
+        }
+        return result;
+    }
+}

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -21,6 +21,17 @@ public static class ScoreGroupMintLimitReader
 {
     private const uint InflationDayZeroUnix = 1_602_720_000;
 
+    /// <summary>
+    /// Base-rows SQL. Each score group's "treasury" (as recorded in
+    /// <c>CrcV2_RegisterGroup.treasury</c>) is expanded into one or more
+    /// effective treasury addresses via the <c>treasury_overrides</c> CTE.
+    /// When the on-chain treasury is a <c>ScoreTreasury</c> router/splitter
+    /// (does not custody collateral itself but forwards to score-keyed
+    /// sub-treasuries), the override list contains the sub-treasuries that
+    /// actually hold tokens. Groups not in the override map fall back to
+    /// single-treasury behavior — the override list defaults to
+    /// <c>ARRAY[treasury]</c>.
+    /// </summary>
     private const string BaseRowsSql = """
         WITH latest_score_group AS (
             SELECT DISTINCT ON ("group")
@@ -43,14 +54,31 @@ public static class ScoreGroupMintLimitReader
               AND lsg.group_address IS NOT NULL
               AND (@groupAddressFilter::text IS NULL OR g."group" = @groupAddressFilter)
         ),
-        group_tokens AS (
+        treasury_overrides AS (
+            SELECT
+                LOWER(agg) AS aggregator,
+                string_to_array(LOWER(subs_csv), ',') AS subs
+            FROM unnest(
+                @subTreasuryAggregators::text[],
+                @subTreasuryLists::text[]
+            ) AS u(agg, subs_csv)
+        ),
+        effective_treasuries AS (
             SELECT
                 sg.group_address,
-                sg.treasury,
                 sg.policy,
-                t.trustee AS trusted_token
+                COALESCE(o.subs, ARRAY[sg.treasury]::text[]) AS treasuries
             FROM score_groups sg
-            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = sg.group_address
+            LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury
+        ),
+        group_tokens AS (
+            SELECT
+                et.group_address,
+                et.treasuries,
+                et.policy,
+                t.trustee AS trusted_token
+            FROM effective_treasuries et
+            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = et.group_address
             INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
             WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
         ),
@@ -67,26 +95,33 @@ public static class ScoreGroupMintLimitReader
             gt.group_address,
             gt.trusted_token,
             gt.policy,
-            COALESCE(tb."demurragedTotalBalance", 0)::text AS treasury_balance,
+            COALESCE((
+                SELECT SUM(b."demurragedTotalBalance")
+                FROM "V_CrcV2_BalancesByAccountAndToken" b
+                WHERE b.account = ANY(gt.treasuries)
+                  AND b."tokenAddress" = gt.trusted_token
+            ), 0)::text AS treasury_balance,
             COALESCE(ts.current_supply, '0') AS current_supply
         FROM group_tokens gt
-        LEFT JOIN "V_CrcV2_BalancesByAccountAndToken" tb
-            ON tb.account = gt.treasury
-           AND tb."tokenAddress" = gt.trusted_token
         LEFT JOIN token_supply ts
             ON ts."tokenAddress" = gt.trusted_token;
         """;
 
+    // HistoricalSupply is now per-(group, collateral) in the prod contract — the
+    // event added `address indexed group`, so a single policy serving multiple
+    // groups (via initializeGroup) tracks supply scoped to each group rather
+    // than conflating them. DISTINCT ON / ORDER BY must include "group".
     private const string HistoricalSql = """
-        SELECT DISTINCT ON (LOWER("emitter"), "collateral")
+        SELECT DISTINCT ON (LOWER("emitter"), "group", "collateral")
             LOWER("emitter") AS policy,
+            LOWER("group") AS group_address,
             "collateral"::text AS collateral,
             "supply"::text AS supply,
             "day"::text AS day
         FROM "CrcV2_ScoreGroup_HistoricalSupply"
         WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
           AND (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
-        ORDER BY LOWER("emitter"), "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
+        ORDER BY LOWER("emitter"), "group", "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
         """;
 
     private const string PersonalSql = """
@@ -111,7 +146,8 @@ public static class ScoreGroupMintLimitReader
         long? maxBlock = null,
         NpgsqlTransaction? transaction = null,
         string? groupAddressFilter = null,
-        string? collateralTokenFilter = null)
+        string? collateralTokenFilter = null,
+        IReadOnlyDictionary<string, string[]>? subTreasuryOverrides = null)
     {
         var policies = scoreMintPolicies
             .Select(x => x.Trim().ToLowerInvariant())
@@ -129,7 +165,8 @@ public static class ScoreGroupMintLimitReader
             maxBlock,
             transaction,
             NormalizeFilter(groupAddressFilter),
-            NormalizeFilter(collateralTokenFilter));
+            NormalizeFilter(collateralTokenFilter),
+            subTreasuryOverrides);
         return ReadFromBaseRows(
             connection,
             policies,
@@ -183,7 +220,7 @@ public static class ScoreGroupMintLimitReader
             var currentSupply = row.CurrentSupply;
             var collateralId = AddressToTokenId(collateralToken);
 
-            var historicalSupply = historical.TryGetValue((policy, collateralId), out var historicalState)
+            var historicalSupply = historical.TryGetValue((policy, group, collateralId), out var historicalState)
                 ? DiscountToTargetDay(historicalState.Amount, historicalState.Day, targetDay)
                 : currentSupply;
 
@@ -214,12 +251,29 @@ public static class ScoreGroupMintLimitReader
         long? maxBlock,
         NpgsqlTransaction? transaction,
         string? groupAddressFilter = null,
-        string? collateralTokenFilter = null)
+        string? collateralTokenFilter = null,
+        IReadOnlyDictionary<string, string[]>? subTreasuryOverrides = null)
     {
+        // Flatten the override dict into two parallel text[] arrays so the SQL
+        // CTE can unnest them. Empty input keeps every group on its single
+        // RegisterGroup-recorded treasury via the COALESCE fallback inside the
+        // SQL. All addresses lowercased to match the score_groups CTE keys.
+        var overridePairs = (subTreasuryOverrides ?? new Dictionary<string, string[]>())
+            .Where(kv => kv.Value.Length > 0)
+            .ToArray();
+        var subTreasuryAggregators = overridePairs
+            .Select(kv => kv.Key.Trim().ToLowerInvariant())
+            .ToArray();
+        var subTreasuryLists = overridePairs
+            .Select(kv => string.Join(",", kv.Value.Select(addr => addr.Trim().ToLowerInvariant())))
+            .ToArray();
+
         var rows = new List<ScoreGroupMintLimitBaseRow>();
         using var command = new NpgsqlCommand(BaseRowsSql, connection, transaction);
         command.CommandTimeout = commandTimeoutSeconds;
         command.Parameters.AddWithValue("scoreMintPolicies", policies);
+        command.Parameters.AddWithValue("subTreasuryAggregators", subTreasuryAggregators);
+        command.Parameters.AddWithValue("subTreasuryLists", subTreasuryLists);
         AddMaxBlockParameter(command, maxBlock);
         AddTextFilterParameter(command, "groupAddressFilter", groupAddressFilter);
         AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
@@ -243,14 +297,14 @@ public static class ScoreGroupMintLimitReader
         return rows;
     }
 
-    private static Dictionary<(string Policy, string Collateral), (BigInteger Amount, ulong Day)> ReadHistorical(
+    private static Dictionary<(string Policy, string Group, string Collateral), (BigInteger Amount, ulong Day)> ReadHistorical(
         NpgsqlConnection connection,
         string[] policies,
         int commandTimeoutSeconds,
         long? maxBlock,
         NpgsqlTransaction? transaction)
     {
-        var result = new Dictionary<(string, string), (BigInteger, ulong)>();
+        var result = new Dictionary<(string, string, string), (BigInteger, ulong)>();
         using var command = new NpgsqlCommand(HistoricalSql, connection, transaction);
         command.CommandTimeout = commandTimeoutSeconds;
         command.Parameters.AddWithValue("scoreMintPolicies", policies);
@@ -259,9 +313,10 @@ public static class ScoreGroupMintLimitReader
         using var reader = command.ExecuteReader();
         while (reader.Read())
         {
-            result[(reader.GetString(0), reader.GetString(1))] = (
-                ParseBigInteger(reader.GetString(2)),
-                ParseUInt64(reader.GetString(3)));
+            // policy | group_address | collateral | supply | day
+            result[(reader.GetString(0), reader.GetString(1).ToLowerInvariant(), reader.GetString(2))] = (
+                ParseBigInteger(reader.GetString(3)),
+                ParseUInt64(reader.GetString(4)));
         }
 
         return result;

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -44,15 +44,15 @@ public static class ScoreGroupMintLimitReader
         ),
         score_groups AS (
             SELECT
-                g."group" AS group_address,
+                LOWER(g."group") AS group_address,
                 LOWER(g."treasury") AS treasury,
                 LOWER(COALESCE(lsg.policy, g."mint")) AS policy
             FROM "CrcV2_RegisterGroup" g
-            LEFT JOIN latest_score_group lsg ON lsg.group_address = g."group"
+            LEFT JOIN latest_score_group lsg ON LOWER(lsg.group_address) = LOWER(g."group")
             WHERE (@maxBlock::bigint IS NULL OR g."blockNumber" <= @maxBlock)
               AND LOWER(g."mint") = ANY(@scoreMintPolicies)
               AND lsg.group_address IS NOT NULL
-              AND (@groupAddressFilter::text IS NULL OR g."group" = @groupAddressFilter)
+              AND (@groupAddressFilter::text IS NULL OR LOWER(g."group") = @groupAddressFilter)
         ),
         treasury_overrides AS (
             SELECT
@@ -125,16 +125,16 @@ public static class ScoreGroupMintLimitReader
         """;
 
     private const string PersonalSql = """
-        SELECT DISTINCT ON (LOWER("emitter"), "group", "collateral")
+        SELECT DISTINCT ON (LOWER("emitter"), LOWER("group"), "collateral")
             LOWER("emitter") AS policy,
-            "group" AS group_address,
+            LOWER("group") AS group_address,
             "collateral"::text AS collateral,
             "mintedAmountOnToday"::text AS minted_amount,
             "day"::text AS day
         FROM "CrcV2_ScoreGroup_PersonalMinted"
         WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
           AND (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
-        ORDER BY LOWER("emitter"), "group", "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
+        ORDER BY LOWER("emitter"), LOWER("group"), "collateral", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC;
         """;
 
     public static IReadOnlyList<ScoreGroupMintLimitRow> Read(

--- a/src/Common/Circles.Common/Settings.cs
+++ b/src/Common/Circles.Common/Settings.cs
@@ -242,6 +242,33 @@ public class Settings
             .ToArray()
         ?? [];
 
+    /// <summary>
+    /// Maps a score-group "treasury" (as recorded in <c>CrcV2_RegisterGroup.treasury</c>) to one
+    /// or more sub-treasury addresses that actually hold collateral. Required when the on-chain
+    /// treasury is a <c>ScoreTreasury</c> router/splitter that forwards tokens to score-keyed
+    /// sub-treasuries rather than custody-ing them itself; without this mapping
+    /// <see cref="Hub.balanceOf(treasury, collateral)"/> returns 0 and the mint-cap formula
+    /// over-approves every router/migration mint.
+    ///
+    /// Format: semicolon-separated entries; each entry is <c>aggregator:sub1,sub2[,...]</c>.
+    /// Example: <c>0xbee55b27...:0xe7dc5fae...,0x4b767d10...</c>. All addresses are normalized to
+    /// lowercase. Aggregators not in this map fall back to single-treasury behavior (legacy
+    /// base groups stay correct).
+    /// </summary>
+    public readonly Dictionary<string, string[]> ScoreTreasurySubTreasuries =
+        Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES")?.Split(';')
+            .Select(entry => entry.Trim())
+            .Where(entry => !string.IsNullOrEmpty(entry))
+            .Select(entry => entry.Split(':', 2))
+            .Where(parts => parts.Length == 2)
+            .ToDictionary(
+                parts => parts[0].Trim().ToLowerInvariant(),
+                parts => parts[1].Split(',')
+                    .Select(addr => addr.Trim().ToLowerInvariant())
+                    .Where(addr => !string.IsNullOrWhiteSpace(addr))
+                    .ToArray())
+        ?? new Dictionary<string, string[]>();
+
     public readonly string BaseGroupDeployer =
         Environment.GetEnvironmentVariable("BASE_GROUP_DEPLOYER")?.ToLowerInvariant()
         ?? "0xd0b5bd9962197beac4cba24244ec3587f19bd06d";

--- a/src/Common/Circles.Common/Settings.cs
+++ b/src/Common/Circles.Common/Settings.cs
@@ -256,18 +256,9 @@ public class Settings
     /// base groups stay correct).
     /// </summary>
     public readonly Dictionary<string, string[]> ScoreTreasurySubTreasuries =
-        Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES")?.Split(';')
-            .Select(entry => entry.Trim())
-            .Where(entry => !string.IsNullOrEmpty(entry))
-            .Select(entry => entry.Split(':', 2))
-            .Where(parts => parts.Length == 2)
-            .ToDictionary(
-                parts => parts[0].Trim().ToLowerInvariant(),
-                parts => parts[1].Split(',')
-                    .Select(addr => addr.Trim().ToLowerInvariant())
-                    .Where(addr => !string.IsNullOrWhiteSpace(addr))
-                    .ToArray())
-        ?? new Dictionary<string, string[]>();
+        EnvParsers.ParseAggregatorMap(
+            "SCORE_TREASURY_SUBTREASURIES",
+            Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES"));
 
     public readonly string BaseGroupDeployer =
         Environment.GetEnvironmentVariable("BASE_GROUP_DEPLOYER")?.ToLowerInvariant()

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -23,7 +23,9 @@ public record MerkleRootUpdated(
     string TransactionHash,
     string Emitter,
     string Group,
-    byte[] NewMerkleRoot) : IIndexEvent;
+    byte[] NewMerkleRoot,
+    byte[] PreviousRoot,
+    UInt256 UpdateBlockNumber) : IIndexEvent;
 
 public record HistoricalSupply(
     long BlockNumber,
@@ -32,6 +34,7 @@ public record HistoricalSupply(
     int LogIndex,
     string TransactionHash,
     string Emitter,
+    string Group,
     UInt256 Collateral,
     UInt256 Supply,
     UInt256 Day) : IIndexEvent;
@@ -70,11 +73,11 @@ public class DatabaseSchema : BaseDatabaseSchema
 
     public static readonly EventSchema MerkleRootUpdated = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot)"));
+        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot,bytes32 previousRoot,uint256 updateBlockNumber)"));
 
     public static readonly EventSchema HistoricalSupply = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event HistoricalSupply(uint256 indexed collateral,uint256 supply,uint256 day)"));
+        "event HistoricalSupply(address indexed group,uint256 indexed collateral,uint256 supply,uint256 day)"));
 
     public static readonly EventSchema PersonalMinted = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
@@ -112,7 +115,9 @@ public class DatabaseSchema : BaseDatabaseSchema
             [
                 ("emitter", e => e.Emitter),
                 ("group", e => e.Group),
-                ("newMerkleRoot", e => e.NewMerkleRoot)
+                ("newMerkleRoot", e => e.NewMerkleRoot),
+                ("previousRoot", e => e.PreviousRoot),
+                ("updateBlockNumber", e => (BigInteger)e.UpdateBlockNumber)
             ]);
 
         AddMappings<HistoricalSupply>(
@@ -122,6 +127,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             databaseFieldMap:
             [
                 ("emitter", e => e.Emitter),
+                ("group", e => e.Group),
                 ("collateral", e => (BigInteger)e.Collateral),
                 ("supply", e => (BigInteger)e.Supply),
                 ("day", e => (BigInteger)e.Day)

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
@@ -103,7 +103,11 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
 
     private static MerkleRootUpdated ParseMerkleRootUpdated(Block block, TxReceipt receipt, LogEntry log, int logIndex)
     {
+        // event MerkleRootUpdated(address indexed group, bytes32 newMerkleRoot,
+        //                         bytes32 previousRoot, uint256 updateBlockNumber)
+        // 96 unindexed bytes: newMerkleRoot | previousRoot | updateBlockNumber.
         var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var data = log.Data.AsSpan();
 
         return new MerkleRootUpdated(
             block.Number,
@@ -113,11 +117,17 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
             receipt.TxHash!.ToString(),
             log.Address.ToLowerHex(),
             group,
-            log.Data.ToArray());
+            data.Slice(0, 32).ToArray(),
+            data.Slice(32, 32).ToArray(),
+            Uint(data.Slice(64, 32)));
     }
 
     private static HistoricalSupply ParseHistoricalSupply(Block block, TxReceipt receipt, LogEntry log, int logIndex)
     {
+        // event HistoricalSupply(address indexed group, uint256 indexed collateral,
+        //                        uint256 supply, uint256 day)
+        // Topic shift: topic[1] was collateral, now group; topic[2] is collateral.
+        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
         var data = log.Data.AsSpan();
 
         return new HistoricalSupply(
@@ -127,7 +137,8 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
             logIndex,
             receipt.TxHash!.ToString(),
             log.Address.ToLowerHex(),
-            Uint(log.Topics[1].Bytes),
+            group,
+            Uint(log.Topics[2].Bytes),
             Uint(data.Slice(0, 32)),
             Uint(data.Slice(32, 32)));
     }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -648,7 +648,8 @@ namespace Circles.Pathfinder.Data
                 _settings.ScoreGroupMintPolicies,
                 _settings.TargetDemurrageTimestamp,
                 _settings.DemurrageSafetyMargin,
-                _settings.PathfinderGroupTimeoutSeconds);
+                _settings.PathfinderGroupTimeoutSeconds,
+                subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries);
 
             sw.Stop();
             OnQueryCompleted?.Invoke("score_group_mint_limits", sw.Elapsed);
@@ -712,7 +713,8 @@ namespace Circles.Pathfinder.Data
                 _settings.TargetDemurrageTimestamp,
                 _settings.DemurrageSafetyMargin,
                 _settings.PathfinderGroupTimeoutSeconds,
-                transaction: tx);
+                transaction: tx,
+                subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries);
 
             sw.Stop();
             OnQueryCompleted?.Invoke("score_group_mint_limits", sw.Elapsed);

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -151,4 +151,27 @@ public class Settings
             .Where(x => !string.IsNullOrWhiteSpace(x))
             .ToArray()
         ?? [];
+
+    /// <summary>
+    /// Score-group treasury "aggregator" → sub-treasury address list. Required
+    /// when the on-chain treasury is a ScoreTreasury router/splitter that
+    /// forwards collateral to score-keyed sub-treasuries rather than custody-ing
+    /// it itself. Without this mapping <c>Hub.balanceOf(treasury, collateral)</c>
+    /// returns 0 and the mint-cap formula over-approves router/migration mints.
+    /// Format: <c>aggregator:sub1,sub2;aggregator:sub3,sub4</c>; addresses are
+    /// lowercased. Aggregators not in this map keep single-treasury behavior.
+    /// </summary>
+    public Dictionary<string, string[]> ScoreTreasurySubTreasuries { get; set; } =
+        Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES")?.Split(';')
+            .Select(entry => entry.Trim())
+            .Where(entry => !string.IsNullOrEmpty(entry))
+            .Select(entry => entry.Split(':', 2))
+            .Where(parts => parts.Length == 2)
+            .ToDictionary(
+                parts => parts[0].Trim().ToLowerInvariant(),
+                parts => parts[1].Split(',')
+                    .Select(addr => addr.Trim().ToLowerInvariant())
+                    .Where(addr => !string.IsNullOrWhiteSpace(addr))
+                    .ToArray())
+        ?? new Dictionary<string, string[]>();
 }

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -162,16 +162,7 @@ public class Settings
     /// lowercased. Aggregators not in this map keep single-treasury behavior.
     /// </summary>
     public Dictionary<string, string[]> ScoreTreasurySubTreasuries { get; set; } =
-        Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES")?.Split(';')
-            .Select(entry => entry.Trim())
-            .Where(entry => !string.IsNullOrEmpty(entry))
-            .Select(entry => entry.Split(':', 2))
-            .Where(parts => parts.Length == 2)
-            .ToDictionary(
-                parts => parts[0].Trim().ToLowerInvariant(),
-                parts => parts[1].Split(',')
-                    .Select(addr => addr.Trim().ToLowerInvariant())
-                    .Where(addr => !string.IsNullOrWhiteSpace(addr))
-                    .ToArray())
-        ?? new Dictionary<string, string[]>();
+        Circles.Common.EnvParsers.ParseAggregatorMap(
+            "SCORE_TREASURY_SUBTREASURIES",
+            Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES"));
 }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
@@ -35,7 +35,8 @@ public partial class CirclesRpcModule : ICirclesRpcModule
             safetyMargin: 1.0,
             commandTimeoutSeconds: _settings.DatabaseQueryTimeoutSeconds,
             groupAddressFilter: group,
-            collateralTokenFilter: collateralFilter);
+            collateralTokenFilter: collateralFilter,
+            subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries);
 
         var rpcRows = rows
             .Select(row => new ScoreGroupMintLimitRpcRow(


### PR DESCRIPTION
## Summary

Three coordinated changes that align the indexer + pathfinder + cache service with the prod score-group contract surface:

- **Multi-sub-treasury balance sum.** New env \`SCORE_TREASURY_SUBTREASURIES\` maps each on-chain \`treasury\` (recorded in \`CrcV2_RegisterGroup.treasury\`) to one or more sub-treasury addresses that actually custody collateral. Required when the on-chain treasury is a \`ScoreTreasury\` router/splitter that forwards tokens to score-keyed sub-treasuries rather than custody-ing them; without the override \`Hub.balanceOf(treasury, collateral)\` returns 0 and the mint-cap formula over-approves router/migration mints by the full collateral supply. \`ScoreGroupMintLimits.cs:BaseRowsSql\` adds a \`treasury_overrides\`/\`effective_treasuries\` CTE pair and sums balances across the array via a correlated subquery. Cache-service's in-memory path mirrors the same logic.
- **\`HistoricalSupply\` event ABI bump.** First param gains \`address indexed group\`. Topic shift: topic[1] was \`collateral\`, now \`group\`; topic[2] is \`collateral\`. DB column + record type extended; \`ScoreGroupMintLimits\` re-keys historical map on \`(policy, group, collateral)\` because one policy can serve multiple groups.
- **\`MerkleRootUpdated\` event ABI bump.** Gains two new unindexed fields: \`previousRoot\` (bytes32) and \`updateBlockNumber\` (uint256). DB columns + record type + log parser data slicing extended.

Audit follow-ups in the trailing commit: shared validated \`EnvParsers.ParseAggregatorMap\` collapses three duplicate parsers into one with regex address validation + fail-loud on malformed entries (prevents operator-typo over-approval), \`DemurrageCachedV2Balance\` falls back to un-demurraged inflationary balance with a warning instead of silently returning zero when \`V2LastActivity\` is missing (prevents over-approval via excluded sub-treasury balance), defensive \`LOWER(\"group\")\` on the score_groups CTE join and PersonalSql.

## Deployment notes

Plugin schema does not auto-migrate. At deploy time per pgaf primary:
1. \`DROP TABLE\` the five \`CrcV2_ScoreGroup_*\` tables.
2. Deploy plugin with new env: \`V2_SCORE_GROUP_MINT_POLICIES\`, \`SCORE_TREASURY_SUBTREASURIES\`, \`REINDEX_TABLES=CrcV2_ScoreGroup_…\`, and \`REINDEX_FROM_BLOCK\` bracketing the new policy's deploy block.
3. Plugin recreates tables with the new schema and re-emits events from chain (filtered to the configured policy list).

## Test plan

- [x] \`dotnet build Circles.sln\` clean
- [x] \`Circles.Common.Tests\` 97/97 pass
- [x] \`Circles.Index.CirclesV2.Tests\` 98/98 pass
- [ ] Staging: drop + redeploy + reindex; \`circles_getScoreGroupMintLimits(\"<new prod group>\")\` returns finite caps; cross-check against on-chain \`ScoreTreasury.balanceOfCollateral(<tokenId>)\` to confirm the SQL sum matches the contract view.