### PR TITLE
feat(score-group): index ScoreGroupInitialized + OptOutStatusChanged

### DIFF
--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -65,6 +65,34 @@ public record RouterMinted(
     UInt256 Amount,
     UInt256 CurrentAvailableLimit) : IIndexEvent;
 
+// Emitted by the ScoreGroup contract itself in its constructor. `Emitter` is
+// the ScoreGroup contract address; we don't carry a separate `group` column
+// because the emitter IS the group identity here.
+public record ScoreGroupInitialized(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string MetadataManager,
+    string MintRouter,
+    string Treasury,
+    string StableErc20,
+    string DemurrageErc20) : IIndexEvent;
+
+// Emitted by the ScoreGroup contract when a human avatar opts out of (or back
+// into) the group's scoring. `Emitter` is the ScoreGroup contract address.
+public record OptOutStatusChanged(
+    long BlockNumber,
+    long Timestamp,
+    int TransactionIndex,
+    int LogIndex,
+    string TransactionHash,
+    string Emitter,
+    string Member,
+    bool OptedOut) : IIndexEvent;
+
 public class DatabaseSchema : BaseDatabaseSchema
 {
     public static readonly EventSchema GroupInitialized = WithEmitterColumn(EventSchema.FromSolidity(
@@ -86,6 +114,14 @@ public class DatabaseSchema : BaseDatabaseSchema
     public static readonly EventSchema RouterMinted = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
         "event RouterMinted(address indexed group,uint256 indexed collateral,uint256 amount,uint256 currentAvailableLimit)"));
+
+    public static readonly EventSchema ScoreGroupInitialized = WithEmitterColumn(EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event ScoreGroupInitialized(address indexed metadataManager,address indexed mintRouter,address indexed treasury,address stableERC20,address demurrageERC20)"));
+
+    public static readonly EventSchema OptOutStatusChanged = WithEmitterColumn(EventSchema.FromSolidity(
+        "CrcV2_ScoreGroup",
+        "event OptOutStatusChanged(address indexed member,bool optedOut)"));
 
     private static EventSchema WithEmitterColumn(EventSchema schema)
     {
@@ -159,6 +195,31 @@ public class DatabaseSchema : BaseDatabaseSchema
                 ("collateral", e => (BigInteger)e.Collateral),
                 ("amount", e => (BigInteger)e.Amount),
                 ("currentAvailableLimit", e => (BigInteger)e.CurrentAvailableLimit)
+            ]);
+
+        AddMappings<ScoreGroupInitialized>(
+            ns: "CrcV2_ScoreGroup",
+            table: "ScoreGroupInitialized",
+            eventSchema: ScoreGroupInitialized,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("metadataManager", e => e.MetadataManager),
+                ("mintRouter", e => e.MintRouter),
+                ("treasury", e => e.Treasury),
+                ("stableERC20", e => e.StableErc20),
+                ("demurrageERC20", e => e.DemurrageErc20)
+            ]);
+
+        AddMappings<OptOutStatusChanged>(
+            ns: "CrcV2_ScoreGroup",
+            table: "OptOutStatusChanged",
+            eventSchema: OptOutStatusChanged,
+            databaseFieldMap:
+            [
+                ("emitter", e => e.Emitter),
+                ("member", e => e.Member),
+                ("optedOut", e => e.OptedOut)
             ]);
     }
 }

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
@@ -16,24 +16,36 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
     private static readonly Hash256 HistoricalSupplyTopic = new(DatabaseSchema.HistoricalSupply.Topic);
     private static readonly Hash256 PersonalMintedTopic = new(DatabaseSchema.PersonalMinted.Topic);
     private static readonly Hash256 RouterMintedTopic = new(DatabaseSchema.RouterMinted.Topic);
+    private static readonly Hash256 ScoreGroupInitializedTopic = new(DatabaseSchema.ScoreGroupInitialized.Topic);
+    private static readonly Hash256 OptOutStatusChangedTopic = new(DatabaseSchema.OptOutStatusChanged.Topic);
 
     public static readonly RollbackCache<Address, object?> ScoreGroupPolicies = new("ScoreGroupPolicies");
 
-    public IRollbackCache[] Caches { get; } = [ScoreGroupPolicies];
+    // Tracks ScoreGroup contract addresses (the groups themselves, not the
+    // policies). Populated from `GroupInitialized.group` rows at startup and
+    // extended at runtime when a new GroupInitialized event is parsed.
+    // ScoreGroup contracts emit ScoreGroupInitialized + OptOutStatusChanged
+    // themselves, so we need this address set in addition to the policy set.
+    public static readonly RollbackCache<Address, object?> ScoreGroupContracts = new("ScoreGroupContracts");
+
+    public IRollbackCache[] Caches { get; } = [ScoreGroupPolicies, ScoreGroupContracts];
 
     public Task InitCaches(InterfaceLogger logger, IDatabase database, Settings settings)
     {
-        var seed = policyAddresses.ToDictionary(a => a, _ => (object?)null);
+        var policySeed = policyAddresses.ToDictionary(a => a, _ => (object?)null);
+        var groupSeed = new Dictionary<Address, object?>();
 
-        var query = new Select("CrcV2_ScoreGroup", "GroupInitialized", ["emitter"], [], [], int.MaxValue, false,
+        var query = new Select("CrcV2_ScoreGroup", "GroupInitialized", ["emitter", "group"], [], [], int.MaxValue, false,
             int.MaxValue);
         foreach (var row in database.Select(query.ToSql(database)).Rows)
         {
-            seed[new Address(row[0]?.ToString() ?? throw new InvalidOperationException("Score group policy address is null"))] = null;
+            policySeed[new Address(row[0]?.ToString() ?? throw new InvalidOperationException("Score group policy address is null"))] = null;
+            groupSeed[new Address(row[1]?.ToString() ?? throw new InvalidOperationException("Score group address is null"))] = null;
         }
 
-        ScoreGroupPolicies.Seed(seed);
-        logger.Info($" * Cached {seed.Count} score group mint policy contracts");
+        ScoreGroupPolicies.Seed(policySeed);
+        ScoreGroupContracts.Seed(groupSeed);
+        logger.Info($" * Cached {policySeed.Count} score group mint policy contracts and {groupSeed.Count} score group contracts");
 
         return Task.CompletedTask;
     }
@@ -55,31 +67,51 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
         LogEntry log,
         int logIndex)
     {
-        if (log.Topics.Length == 0 || !ScoreGroupPolicies.ContainsKey(log.Address))
+        if (log.Topics.Length == 0)
         {
             yield break;
         }
 
         var topic = log.Topics[0];
-        if (topic == GroupInitializedTopic)
+
+        // Policy contracts emit: GroupInitialized / MerkleRootUpdated /
+        // HistoricalSupply / PersonalMinted / RouterMinted.
+        if (ScoreGroupPolicies.ContainsKey(log.Address))
         {
-            yield return ParseGroupInitialized(block, receipt, log, logIndex);
+            if (topic == GroupInitializedTopic)
+            {
+                yield return ParseGroupInitialized(block, receipt, log, logIndex);
+            }
+            else if (topic == MerkleRootUpdatedTopic)
+            {
+                yield return ParseMerkleRootUpdated(block, receipt, log, logIndex);
+            }
+            else if (topic == HistoricalSupplyTopic)
+            {
+                yield return ParseHistoricalSupply(block, receipt, log, logIndex);
+            }
+            else if (topic == PersonalMintedTopic)
+            {
+                yield return ParsePersonalMinted(block, receipt, log, logIndex);
+            }
+            else if (topic == RouterMintedTopic)
+            {
+                yield return ParseRouterMinted(block, receipt, log, logIndex);
+            }
+            yield break;
         }
-        else if (topic == MerkleRootUpdatedTopic)
+
+        // ScoreGroup contracts emit: ScoreGroupInitialized / OptOutStatusChanged.
+        if (ScoreGroupContracts.ContainsKey(log.Address))
         {
-            yield return ParseMerkleRootUpdated(block, receipt, log, logIndex);
-        }
-        else if (topic == HistoricalSupplyTopic)
-        {
-            yield return ParseHistoricalSupply(block, receipt, log, logIndex);
-        }
-        else if (topic == PersonalMintedTopic)
-        {
-            yield return ParsePersonalMinted(block, receipt, log, logIndex);
-        }
-        else if (topic == RouterMintedTopic)
-        {
-            yield return ParseRouterMinted(block, receipt, log, logIndex);
+            if (topic == ScoreGroupInitializedTopic)
+            {
+                yield return ParseScoreGroupInitialized(block, receipt, log, logIndex);
+            }
+            else if (topic == OptOutStatusChangedTopic)
+            {
+                yield return ParseOptOutStatusChanged(block, receipt, log, logIndex);
+            }
         }
     }
 
@@ -88,6 +120,10 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
         var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
         var manager = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[2].Bytes);
         var router = new Address(log.Data.Slice(12, 20)).ToLowerHex();
+
+        // Track this score group so a subsequent ScoreGroupInitialized or
+        // OptOutStatusChanged log emitted by it gets indexed.
+        ScoreGroupContracts.Add(block.Number, new Address(group), null);
 
         return new GroupInitialized(
             block.Number,
@@ -179,6 +215,56 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
             Uint(log.Topics[2].Bytes),
             Uint(data.Slice(0, 32)),
             Uint(data.Slice(32, 32)));
+    }
+
+    private static ScoreGroupInitialized ParseScoreGroupInitialized(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        // event ScoreGroupInitialized(
+        //     address indexed metadataManager,
+        //     address indexed mintRouter,
+        //     address indexed treasury,
+        //     address stableERC20,
+        //     address demurrageERC20
+        // );
+        var metadataManager = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var mintRouter = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[2].Bytes);
+        var treasury = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[3].Bytes);
+        var data = log.Data.AsSpan();
+        // Each address is right-padded to 32 bytes in event data — last 20 bytes are the address.
+        var stableErc20 = new Address(data.Slice(12, 20).ToArray()).ToLowerHex();
+        var demurrageErc20 = new Address(data.Slice(44, 20).ToArray()).ToLowerHex();
+
+        return new ScoreGroupInitialized(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            metadataManager,
+            mintRouter,
+            treasury,
+            stableErc20,
+            demurrageErc20);
+    }
+
+    private static OptOutStatusChanged ParseOptOutStatusChanged(Block block, TxReceipt receipt, LogEntry log, int logIndex)
+    {
+        // event OptOutStatusChanged(address indexed member, bool optedOut);
+        var member = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var data = log.Data.AsSpan();
+        // bool is encoded as a 32-byte word; non-zero last byte → true.
+        var optedOut = data.Length >= 32 && data[31] != 0;
+
+        return new OptOutStatusChanged(
+            block.Number,
+            (long)block.Timestamp,
+            receipt.Index,
+            logIndex,
+            receipt.TxHash!.ToString(),
+            log.Address.ToLowerHex(),
+            member,
+            optedOut);
     }
 
     private static UInt256 Uint(ReadOnlySpan<byte> bytes) => new(bytes, true);


### PR DESCRIPTION
## Summary
- Add two new event tables emitted by the ScoreGroup contract itself (not the mint policy): `CrcV2_ScoreGroup_ScoreGroupInitialized` (one-shot constructor event with metadataManager, mintRouter, treasury, stableERC20, demurrageERC20) and `CrcV2_ScoreGroup_OptOutStatusChanged` (per-avatar opt-out flag changes).
- New `ScoreGroupContracts` RollbackCache tracks ScoreGroup contract addresses. Seeded at startup from the existing `GroupInitialized.group` column so a reindex catches historical emissions; extended at runtime when the policy emits a new `GroupInitialized`.
- `ParseLog` dispatches on the address set: policy address → policy events; ScoreGroup address → group-self events. Existing five event tables are unchanged.

## Operator action at cutover
- Add both new table names to `REINDEX_TABLES` on each pgaf-gnosis primary.
- `REINDEX_FROM_BLOCK` must cover the ScoreGroup contract deployment blocks (typically a handful of blocks before the policy's `GroupInitialized` event for the same group). The buffer used in the prior reindex (block 46230000) covers all currently-deployed groups.

## Test plan
- [x] dotnet build Circles.sln — 0 errors
- [x] Circles.Common.Tests — 97/97
- [x] Circles.Index.CirclesV2.Tests — 98/98