### PR TITLE
fix(pathfinder): return retryable 503 instead of 500 during graph warmup

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -175,8 +175,22 @@ internal sealed class FindPathHandler(
 
             if (balanceGraph is null)
             {
+                // Transient warmup (post-restart / reorg / upstream not ready), not a
+                // client error — 503 so load balancers drain & clients retry.
+                FindPathMetrics.SolverStatusTotal.WithLabels("not_ready").Inc();
                 log.LogWarning("Graphs not ready");
-                return Results.BadRequest("Graphs are not loaded yet.");
+                return Results.Json(new { error = "Graphs are not loaded yet." },
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
+            }
+
+            if (!pool.HasCurrentSnapshot)
+            {
+                // Same predicate as GraphReadinessHealthCheck (/ready). Without this
+                // gate, pool.Rent throws InvalidOperationException → generic catch → 500
+                // for a recoverable warmup state.
+                FindPathMetrics.SolverStatusTotal.WithLabels("not_ready").Inc();
+                log.LogWarning("Capacity graph snapshot not ready — returning 503 (warmup)");
+                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
             }
 
             using var h = await pool.Rent(request, balanceGraph, trustGraph);
@@ -343,6 +357,21 @@ internal sealed class FindPathHandler(
                 graphBlock, sw.ElapsedMilliseconds, 400,
                 request.WithWrap ?? false, request.QuantizedMode ?? false, "bad_request");
             return Results.BadRequest(ex.Message);
+        }
+        catch (GraphNotReadyException ex)
+        {
+            // Backstops the check-then-Rent TOCTOU window after the
+            // HasCurrentSnapshot gate above. Scoped to the dedicated
+            // GraphNotReadyException so genuine InvalidOperationExceptions from
+            // the solver still surface as 500 via the generic catch below.
+            FindPathMetrics.SolverStatusTotal.WithLabels("not_ready").Inc();
+            log.LogWarning(ex,
+                "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} error={Error}",
+                route, safeSource, safeSink, safeTargetFlow,
+                "", 0, request.MaxTransfers ?? -1,
+                graphBlock, sw.ElapsedMilliseconds, 503,
+                request.WithWrap ?? false, request.QuantizedMode ?? false, "not_ready");
+            return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CapacityGraphPoolTests.cs
@@ -103,17 +103,18 @@ public class CapacityGraphPoolTests
     }
 
     // ----------------------------------------------------------------
-    // 3. Rent before snapshot loaded throws InvalidOperationException
+    // 3. Rent before snapshot loaded throws GraphNotReadyException
+    //    (a recoverable warmup signal, distinct from a solver fault)
     // ----------------------------------------------------------------
 
     [Test]
-    public void Rent_BeforeSnapshotLoaded_ThrowsInvalidOperation()
+    public void Rent_BeforeSnapshotLoaded_ThrowsGraphNotReady()
     {
         var pool = CreatePool();
         var (balances, trust) = BuildMinimalInputs();
         var request = new FlowRequest();
 
-        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () =>
+        var ex = Assert.ThrowsAsync<GraphNotReadyException>(async () =>
         {
             await pool.Rent(request, balances, trust);
         });

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HttpEndpointTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HttpEndpointTests.cs
@@ -120,17 +120,19 @@ public class HttpEndpointTests
     }
 
     [Test]
-    public async Task FindMaxFlow_GraphsNotReady_Returns400()
+    public async Task FindMaxFlow_GraphsNotReady_Returns503()
     {
+        // Warmup is a transient server-side state, not a client error — must be a
+        // retryable 503 so load balancers drain the node, never 500/400.
         var resp = await _client!.GetAsync(
             $"/findMaxFlow?from={ValidAddr(1)}&to={ValidAddr(2)}&amount=100");
-        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
         var body = await resp.Content.ReadAsStringAsync();
         Assert.That(body, Does.Contain("Graphs are not loaded"));
     }
 
     [Test]
-    public async Task FindMaxFlow_TooManySimulatedBalances_Returns400()
+    public async Task FindMaxFlow_FewSimulatedBalances_PassesValidationThen503()
     {
         // The GET endpoint accepts simulatedBalances as a query param JSON string.
         // 1001 entries with full addresses would exceed URI length limits, so we test
@@ -141,8 +143,9 @@ public class HttpEndpointTests
 
         var resp = await _client!.GetAsync(
             $"/findMaxFlow?from={ValidAddr(1)}&to={ValidAddr(2)}&amount=100&simulatedBalances={Uri.EscapeDataString(json)}");
-        // With 1 entry, should pass validation and fail on "graphs not loaded"
-        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        // With 1 entry, should pass size validation and fall through to the
+        // transient "graphs not loaded" warmup state → retryable 503.
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
         var body = await resp.Content.ReadAsStringAsync();
         Assert.That(body, Does.Contain("Graphs are not loaded"));
     }
@@ -180,11 +183,11 @@ public class HttpEndpointTests
     }
 
     [Test]
-    public async Task FindPath_Get_GraphsNotReady_Returns400()
+    public async Task FindPath_Get_GraphsNotReady_Returns503()
     {
         var resp = await _client!.GetAsync(
             $"/findPath?from={ValidAddr(1)}&to={ValidAddr(2)}&amount=100");
-        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
         var body = await resp.Content.ReadAsStringAsync();
         Assert.That(body, Does.Contain("Graphs are not loaded"));
     }
@@ -289,7 +292,7 @@ public class HttpEndpointTests
     }
 
     [Test]
-    public async Task FindPath_Post_GraphsNotReady_Returns400()
+    public async Task FindPath_Post_GraphsNotReady_Returns503()
     {
         var request = new FlowRequest
         {
@@ -299,7 +302,7 @@ public class HttpEndpointTests
         };
 
         var resp = await _client!.PostAsJsonAsync("/findPath", request);
-        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+        Assert.That(resp.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
         var body = await resp.Content.ReadAsStringAsync();
         Assert.That(body, Does.Contain("Graphs are not loaded"));
     }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -56,7 +56,7 @@ public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph
         // Single volatile read — snapshot and groupData are always consistent.
         var state = _state;
         if (state == null)
-            throw new InvalidOperationException("No capacity graph available yet.");
+            throw new GraphNotReadyException("No capacity graph available yet.");
 
         if (RequestNeedsFiltering(r))
         {
@@ -178,3 +178,13 @@ public readonly struct CapacityGraphHandle(CapacityGraph g) : IDisposable
         // GC reclaims when no longer referenced.
     }
 }
+
+/// <summary>
+/// Thrown when the capacity-graph snapshot has not been loaded yet (warmup,
+/// post-restart, reorg). A recoverable, retryable condition — distinct from a
+/// solver/data fault. Derives from InvalidOperationException only for
+/// backward-compatible fallthrough; the request path catches this exact type
+/// and maps it to HTTP 503 so genuine InvalidOperationExceptions from the
+/// solver still surface as 500.
+/// </summary>
+public sealed class GraphNotReadyException(string message) : InvalidOperationException(message);


### PR DESCRIPTION
## Summary

When the pathfinder's `CapacityGraphPool` snapshot is not yet loaded (post-restart, reorg, or an upstream dependency not ready), `findPath` requests threw `InvalidOperationException` at `CapacityGraphPool.Rent()`, which was caught by the generic exception handler in `FindPathHandler.ExecuteWithGuard` and returned **HTTP 500**.

A warming-up node is a recoverable, retryable condition — not a server fault. Returning 500 causes load balancers and clients to treat a self-healing node as broken instead of draining/retrying. The correct response is **503 Service Unavailable**, which is already what `/ready` returns for the same condition via `GraphReadinessHealthCheck` (`pool.HasCurrentSnapshot`). The request path simply did not check the same predicate.

## Changes

- `FindPathHandler.ExecuteWithGuard`: gate `!pool.HasCurrentSnapshot` → 503 before `pool.Rent()` (same predicate as `/ready`).
- Change the adjacent `balanceGraph is null` branch from 400 to 503 (same transient warmup class; retains the explanatory response body).
- Introduce `GraphNotReadyException : InvalidOperationException`, thrown only at the single genuine not-ready site (`CapacityGraphPool.Rent`). Narrow the request-path catch to that exact type so genuine `InvalidOperationException`s originating in the solver still surface as 500 (previously a broad `catch (InvalidOperationException)` could have masked them as retryable 503).
- New metric label `circles_..._solver_status_total{status="not_ready"}` to distinguish warmup rejections from real errors.

A single guard in the shared handler covers `GET /findMaxFlow`, `GET /findPath`, and `POST /findPath`. The `X-Max-Block-Number` historical path is unaffected (it does not use the pool).

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `HttpEndpointTests` warmup assertions flipped 400 → 503 across all three endpoints
- [x] `CapacityGraphPoolTests` throw-type assertion updated to the precise `GraphNotReadyException`
- [x] Full pathfinder suite: 1014 passed, 0 failed, 270 skipped (environment-dependent)
- [ ] Post-deploy: hit a freshly-restarted node during its warmup window — must return 503, never 500; succeeds once the snapshot loads