### PR TITLE
feat(pathfinder): restrict ScoreGroup CRC to terminal mint edge (wrapped-only)

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1877,4 +1877,238 @@ public class GraphFactoryTests
     }
 
     #endregion
+
+    #region ScoreGroup wrapped-only guards
+
+    // ScoreGroup CRC is wrapped-only by design: the unwrapped ERC1155 may appear
+    // ONLY on the terminal Group→sink mint edge (recipient wraps off-graph). It
+    // must never be delivered to a non-sink intermediary, never sit as a holder
+    // balance, and never be forwarded transitively. A group is a "score group"
+    // iff its router is in ScoreRouterIds (canonical, immutable post-init).
+
+    private static readonly string ScoreGroupSg = "0xf15c000000000000000000000000000000000021";
+    private static readonly string Carol = "0xf1cc000000000000000000000000000000000004";
+
+    /// <summary>Builds a HelperMock whose GroupSg is a score group collateralised by TokenA.</summary>
+    private static HelperMock MakeScoreGroupMock()
+    {
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddRegisteredAvatar(Carol);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddRegisteredAvatar(ScoreGroupSg);
+        mock.AddGroup(ScoreGroupSg);
+        mock.AddGroupTrust(ScoreGroupSg, TokenA);
+        mock.AddGroupRouter(ScoreGroupSg, ScoreRouterAddr);
+        mock.AddScoreRouter(ScoreRouterAddr);
+        mock.AddTrust(ScoreRouterAddr, TokenA);
+        mock.AddScoreGroupMintLimit(ScoreGroupSg, TokenA, "25000000000000000000");
+        mock.AddOperatorApproval(ScoreRouterAddr, Alice);
+        return mock;
+    }
+
+    [Test]
+    public void ScoreGroupCrc_MintedOnlyToSink_NotToNonSinkTruster()
+    {
+        // Alice (collateral holder) → Bob (sink). Bob and Carol both trust the
+        // score group's CRC, but only the sink may receive the freshly minted
+        // unwrapped ERC1155 — Carol (a non-sink intermediary) must not.
+        var mock = MakeScoreGroupMock();
+        mock.AddTrust(Bob, ScoreGroupSg);
+        mock.AddTrust(Carol, ScoreGroupSg);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Bob,
+            ToTokens = new List<string> { ScoreGroupSg }
+        };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int sgId = AddressIdPool.IdOf(ScoreGroupSg);
+        int bobId = AddressIdPool.IdOf(Bob);
+        int carolId = AddressIdPool.IdOf(Carol);
+
+        Assert.That(cg.IsScoreGroup(sgId), Is.True,
+            "GroupSg's router is a score router → it must be recognised as a score group.");
+
+        var toSink = cg.Edges.Where(e => e.From == sgId && e.To == bobId && e.Token == sgId).ToList();
+        Assert.That(toSink.Count, Is.EqualTo(1),
+            "The terminal Group→sink mint edge for the score-group CRC must exist.");
+
+        var toCarol = cg.Edges.Where(e => e.From == sgId && e.To == carolId && e.Token == sgId).ToList();
+        Assert.That(toCarol.Count, Is.EqualTo(0),
+            "Score-group CRC must NOT be minted to a non-sink intermediary.");
+    }
+
+    [Test]
+    public void RegularGroupCrc_StillMintedToNonSinkTruster_NegativeControl()
+    {
+        // Identical topology but GroupG is a REGULAR group (no score router).
+        // The guard must not affect it: Group→Carol (non-sink) still exists.
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddRegisteredAvatar(Carol);
+        mock.AddRegisteredAvatar(TokenA);
+        mock.AddRegisteredAvatar(GroupG);
+        mock.AddGroup(GroupG);
+        mock.AddTrust(Bob, GroupG);
+        mock.AddTrust(Carol, GroupG);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int groupId = AddressIdPool.IdOf(GroupG);
+        int carolId = AddressIdPool.IdOf(Carol);
+
+        Assert.That(cg.IsScoreGroup(groupId), Is.False,
+            "A group with no score router must not be treated as a score group.");
+        var toCarol = cg.Edges.Where(e => e.From == groupId && e.To == carolId && e.Token == groupId).ToList();
+        Assert.That(toCarol.Count, Is.EqualTo(1),
+            "Regular group CRC remains transitively mintable to non-sink trusters (unchanged behaviour).");
+    }
+
+    [Test]
+    public void ScoreGroupCrc_HolderBalance_NotRoutable()
+    {
+        // Bob already holds the score group's unwrapped CRC. It must not become
+        // routing liquidity: no Holder→TokenPool edge, no pool node at all.
+        var mock = MakeScoreGroupMock();
+        mock.AddBalance(AddressIdPool.IdOf(Bob), AddressIdPool.IdOf(ScoreGroupSg), 5_000_000);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest { Source = Alice, Sink = Carol };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int sgId = AddressIdPool.IdOf(ScoreGroupSg);
+        int bobId = AddressIdPool.IdOf(Bob);
+        int sgPool = AddressIdPool.TokenPoolIdOf(sgId);
+
+        Assert.That(cg.Nodes.ContainsKey(sgPool), Is.False,
+            "No TokenPool node may be created for an unwrapped score-group CRC balance.");
+        var holderEdges = cg.Edges.Where(e => e.From == bobId && e.Token == sgId).ToList();
+        Assert.That(holderEdges.Count, Is.EqualTo(0),
+            "A holder of unwrapped score-group CRC must have no outgoing routable edge for it.");
+    }
+
+    [Test]
+    public void RegularGroupCrc_HolderBalance_Routable_NegativeControl()
+    {
+        // Counterpart: a regular group's CRC held by Bob IS routable (pool node
+        // + holder edge present), proving the holder guard is score-group-scoped.
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddRegisteredAvatar(GroupG);
+        mock.AddGroup(GroupG);
+        mock.AddBalance(AddressIdPool.IdOf(Bob), AddressIdPool.IdOf(GroupG), 5_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int groupId = AddressIdPool.IdOf(GroupG);
+        int bobId = AddressIdPool.IdOf(Bob);
+        int gPool = AddressIdPool.TokenPoolIdOf(groupId);
+
+        Assert.That(cg.Nodes.ContainsKey(gPool), Is.True,
+            "Regular group CRC balances still create a TokenPool node.");
+        var holderEdges = cg.Edges.Where(e => e.From == bobId && e.To == gPool && e.Token == groupId).ToList();
+        Assert.That(holderEdges.Count, Is.EqualTo(1),
+            "Regular group CRC remains routable from a holder (unchanged behaviour).");
+    }
+
+    [Test]
+    public void SelfMintViaPath_ScoreGroup_VirtualSinkFallbackSurvivesGuards()
+    {
+        // The wrapped-only guards must NOT break legitimate self-mint
+        // (source==sink, toTokens=[scoreGroup]). The Group→virtualSink fallback
+        // (PR #397) resolves to Group→sink, the one permitted terminal edge.
+        var mock = MakeScoreGroupMock();
+        mock.AddTrust(Alice, ScoreGroupSg); // recipient trusts SG so it survives the sink-side filter
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest
+        {
+            Source = Alice,
+            Sink = Alice,
+            ToTokens = new List<string> { ScoreGroupSg }
+        };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int sgId = AddressIdPool.IdOf(ScoreGroupSg);
+        int tokenAId = AddressIdPool.IdOf(TokenA);
+        int sgPool = AddressIdPool.TokenPoolIdOf(tokenAId);
+
+        Assert.That(cg.VirtualSinkAddress, Is.Not.Null,
+            "Self-mint must still produce a surviving virtual sink under the guards.");
+        int vSink = cg.VirtualSinkAddress!.Value;
+
+        var fallback = cg.Edges.Where(e => e.From == sgId && e.To == vSink && e.Token == sgId).ToList();
+        Assert.That(fallback.Count, Is.EqualTo(1),
+            "Group→virtualSink self-mint fallback must still fire for a score group.");
+
+        var capEdge = cg.Edges.Single(e => e.From == sgPool && e.To == sgId && e.Token == tokenAId);
+        Assert.That(capEdge.InitialCapacity, Is.EqualTo(25_000_000),
+            "Collateral mint inflow (pool(collateral)→group) is unaffected by the guards.");
+    }
+
+    [Test]
+    public void ScoreGroupReusingStandardRouter_DoesNotMisflagRegularGroups()
+    {
+        // Catastrophic-misfire guard: if a score group is ever initialized with
+        // the STANDARD group router as its pathMintRouter, ScoreRouterIds would
+        // contain the standard router id. Every regular group is assigned that
+        // same router, so without the RouterNode exclusion in IsScoreGroup the
+        // wrap-only guard would strip ALL regular-group routing. Verify the
+        // exclusion holds: a regular group on the standard router stays routable.
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddRegisteredAvatar(GroupG);
+        mock.AddGroup(GroupG);
+        // Regular group explicitly on the standard router (mirrors prod
+        // groupRouterQuery.sql ELSE @standardRouter behaviour).
+        mock.AddGroupRouter(GroupG, RouterAddr);
+        // Simulate the adverse on-chain fact: standard router shows up as a score
+        // router (a score group somewhere used it as pathMintRouter).
+        mock.AddScoreRouter(RouterAddr);
+        mock.AddTrust(Bob, GroupG); // Bob is a non-sink truster
+
+        var factory = new GraphFactory(RouterAddr, mock);
+        var bg = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        var request = new FlowRequest { Source = Alice, Sink = Carol };
+        var cg = factory.CreateCapacityGraph(bg, trustLookup, request);
+
+        int groupId = AddressIdPool.IdOf(GroupG);
+        int bobId = AddressIdPool.IdOf(Bob);
+
+        Assert.That(cg.IsScoreGroup(groupId), Is.False,
+            "A group on the standard router must NEVER be treated as a score group, " +
+            "even if the standard router id leaked into ScoreRouterIds.");
+        var toBob = cg.Edges.Where(e => e.From == groupId && e.To == bobId && e.Token == groupId).ToList();
+        Assert.That(toBob.Count, Is.EqualTo(1),
+            "Regular-group routing must survive a standard-router/score-router collision.");
+    }
+
+    #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -131,6 +131,33 @@ public class CapacityGraph : IGraph<CapacityEdge>
     public bool IsOrganization(int nodeAddress) => OrganizationNodes.Contains(nodeAddress);
     public bool IsRouter(int nodeAddress) => RouterNodes.Contains(nodeAddress);
 
+    /// <summary>
+    /// True when <paramref name="nodeAddress"/> is a score-group avatar (its CRC
+    /// token id == the avatar address). Derived from the canonical ScoreRouterIds
+    /// set (sourced from CrcV2_ScoreGroup.GroupInitialized.pathMintRouter, immutable
+    /// post-init, does not lag mint-limit rows) joined via the group→router map —
+    /// the same signal AddTokenPoolOutEdges uses to recognize a score router. No
+    /// separate propagation path, so every graph-load mode (per-request DB, cached,
+    /// cache snapshot, incremental) gets it for free once GroupRouters and
+    /// ScoreRouterIds are populated.
+    ///
+    /// ScoreGroup CRC is wrapped-only by design: the unwrapped ERC1155 may appear
+    /// solely on the terminal Group→sink mint edge — never as a holder balance or a
+    /// transient hop. The graph-construction guards consult this predicate.
+    ///
+    /// The standard group router (<see cref="RouterNode"/>) is explicitly excluded:
+    /// every regular group is assigned the standard router, so if a score group were
+    /// ever initialized with the standard router as its pathMintRouter, ScoreRouterIds
+    /// would contain it and this predicate would fire for ALL regular groups, silently
+    /// stripping their routing. A score group that genuinely reused the standard router
+    /// is anyway indistinguishable from a regular group here, so excluding it is the
+    /// safe, non-lossy choice. A collision is logged at load (see GraphFactory).
+    /// </summary>
+    public bool IsScoreGroup(int nodeAddress) =>
+        GroupRouters.TryGetValue(nodeAddress, out var routerId)
+        && routerId != RouterNode
+        && ScoreRouterIds.Contains(routerId);
+
     public int RouterForGroup(int groupAddress)
     {
         if (GroupRouters.TryGetValue(groupAddress, out var routerAddress))

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -751,6 +751,22 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             capacityGraph.ScoreRouterIds.Add(scoreRouterId);
         }
 
+        // A score group must deploy its own pathMintRouter. If one is ever
+        // initialized with the standard group router, IsScoreGroup excludes it
+        // (otherwise every regular group would be misflagged and silently
+        // stripped). Surface the misconfiguration loudly — the wrap-only guard
+        // is inert for that group until it is redeployed with a dedicated router.
+        if (capacityGraph.RouterNode is { } stdRouterId
+            && capacityGraph.ScoreRouterIds.Contains(stdRouterId))
+        {
+            _logger.LogError(
+                "Score router collision: a ScoreGroup.GroupInitialized event uses the standard " +
+                "group router {Router} as pathMintRouter. IsScoreGroup excludes the standard " +
+                "router, so the wrapped-only guard is INERT for any such group. Redeploy the " +
+                "score group with a dedicated ScoreGroupMintRouter.",
+                AddressIdPool.StringOf(stdRouterId));
+        }
+
         // Load ERC-1155 operator approvals granted BY the known group routers.
         // These gate Avatar→Router edges: Hub.operateFlowMatrix reverts if the caller
         // (operator/msg.sender) is not approved by the Router that holds tokens on the path.
@@ -866,6 +882,10 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             if (isSource && excludedFromTokensFilter.Count > 0 && excludedFromTokensFilter.Contains(bn.Token)) continue;
             if (bn.IsWrapped && !(req?.WithWrap ?? false)) continue;
             if (bn.IsWrapped && !isSource) continue;
+            // ScoreGroup CRC is wrapped-only: the unwrapped ERC1155 must never be a
+            // routable holder balance (no source spend, no transient forwarding). It
+            // may exist only on the terminal Group→sink mint edge.
+            if (g.IsScoreGroup(bn.Token)) continue;
 
             // ensure the pool node exists
             g.AddTokenNode(bn.Token);
@@ -903,6 +923,8 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
             if (sb.IsWrapped && !(req?.WithWrap ?? false)) continue;
             if (sb.IsWrapped && !isSource) continue;
+            // ScoreGroup CRC is wrapped-only — never a routable (simulated) balance.
+            if (g.IsScoreGroup(sb.TokenId)) continue;
 
             g.AddTokenNode(sb.TokenId);
             int pool = AddressIdPool.TokenPoolIdOf(sb.TokenId);
@@ -1027,6 +1049,14 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             int pool = AddressIdPool.TokenPoolIdOf(token);
             if (!g.Nodes.ContainsKey(pool)) continue; // no supply -> no out-edges
 
+            // Defense-in-depth safety net (normally a no-op): a score-group CRC
+            // pool node is never created in the first place (guards in the
+            // holder/simulated balance loops skip it), so this branch is not the
+            // primary enforcement — it only matters if those upstream guards are
+            // ever weakened. Collateral mint inflow (pool(collateral)→group) is
+            // unaffected: its token is member collateral, never a score-group id.
+            if (g.IsScoreGroup(token)) continue;
+
             foreach (var a in acceptors)
             {
                 var capacity = g.ScoreGroupMintLimits.TryGetValue((a, token), out var availableLimit)
@@ -1058,8 +1088,16 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 int pool = AddressIdPool.TokenPoolIdOf(t);
                 if (g.Nodes.ContainsKey(pool))
                 {
-                    g.AddCapacityEdge(pool, virtualSink.Value, t, long.MaxValue);
-                    continue;
+                    // Defense-in-depth: a score-group CRC pool node must never
+                    // exist (upstream guards prevent it). If one ever did, do NOT
+                    // route it transiently via pool→virtualSink — fall through to
+                    // the Group→virtualSink self-mint terminal, the only permitted
+                    // appearance of the unwrapped score-group ERC1155.
+                    if (!g.IsScoreGroup(t))
+                    {
+                        g.AddCapacityEdge(pool, virtualSink.Value, t, long.MaxValue);
+                        continue;
+                    }
                 }
 
                 if (g.IsGroup(t))
@@ -1080,6 +1118,12 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         HashSet<int> toTokensFilter,
         HashSet<int> excludedToTokensFilter)
     {
+        // Observability for the hard-wired (no kill-switch) wrap-only guard: a
+        // sudden spike here vs. the known score-group count signals a misfire
+        // (e.g. the standard-router collision IsScoreGroup guards against).
+        int scoreGroupNonSinkSkipped = 0;
+        var scoreGroupsGuarded = new HashSet<int>();
+
         foreach (var groupId in g.GroupNodes)
         {
             // Each group mints its own token (the group address IS the token address)
@@ -1096,6 +1140,18 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 if (trustedTokens.Contains(groupToken))
                 {
                     bool isSink = sinkId.HasValue && truster == sinkId.Value;
+                    // ScoreGroup CRC is wrapped-only: the unwrapped ERC1155 may be
+                    // minted ONLY directly to the final recipient (sink), who wraps
+                    // it off-graph. No Group→intermediary delivery, no transient
+                    // forwarding. In the sink-less shared snapshot this fails closed
+                    // (no score-group mint edges); per-request filtered builds
+                    // reconstruct them with proper sink context.
+                    if (g.IsScoreGroup(groupId) && !isSink)
+                    {
+                        scoreGroupNonSinkSkipped++;
+                        scoreGroupsGuarded.Add(groupId);
+                        continue;
+                    }
                     if (isSink && toTokensFilter.Count > 0 && !toTokensFilter.Contains(groupToken))
                         continue;
                     if (isSink && excludedToTokensFilter.Count > 0 && excludedToTokensFilter.Contains(groupToken))
@@ -1111,6 +1167,11 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 g.AddCapacityEdge(groupId, avatar, groupToken, long.MaxValue);
             }
         }
+
+        if (scoreGroupNonSinkSkipped > 0)
+            _logger.LogInformation(
+                "Wrapped-only guard: dropped {Count} non-sink Group→avatar mint edges across {Groups} score group(s)",
+                scoreGroupNonSinkSkipped, scoreGroupsGuarded.Count);
     }
 
     private void RemoveTokenSelfLoopsForSwap(


### PR DESCRIPTION
## Summary

ScoreGroup CRC is wrapped-only by design: the unwrapped ERC1155 must never be
held by an avatar or transitively transferred. It may appear in the pathfinder
flow graph **only** on the terminal `Group→sink` mint edge — the recipient wraps
it off-graph. Regular (non-score) groups are unaffected.

## Changes

- **`CapacityGraph.IsScoreGroup`** — derived predicate: a group whose router is
  in the canonical `ScoreRouterIds` set (sourced from
  `CrcV2_ScoreGroup.GroupInitialized.pathMintRouter`, immutable post-init). No
  new query or propagation path — reuses data already loaded in every graph
  mode. The standard group router is explicitly excluded, so a score group that
  ever reused it cannot misflag every regular group; such a collision is logged
  at load.
- **Four graph-construction guards in `GraphFactory`**:
  1. `AddGroupMintingEdges` — score-group `Group→avatar` edge only when the
     avatar is the sink (fails closed in the sink-less shared snapshot;
     per-request builds reconstruct with sink context).
  2. `AddHolderToTokenEdges_Pooled` — skip score-group token balances.
  3. `AddSimulatedBalances_Pooled` — same for simulated balances.
  4. `AddTokenPoolOutEdges` — skip score-group token in the pool out-edge loop;
     the `pool→virtualSink` branch is also guarded (defense-in-depth).
- **Preserved**: the `Group→virtualSink` self-mint terminal and the
  `pool(collateral)→group` mint inflow.
- **Observability**: aggregate drop count logged for the guard (it is
  hard-wired with no kill-switch).

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] Full pathfinder suite — **1020 pass, 0 fail**
- [x] 6 new `GraphFactoryTests`: mint-only-to-sink, holder-balance not routable,
      self-mint fallback survives, two regular-group negative controls, and a
      standard-router/score-router collision regression
- [ ] Staging: self-mint `findPath` (source==sink, toTokens=[score group])
      still returns non-zero flow via collateral→Group→sink
- [ ] Staging: a multi-hop request cannot forward the unwrapped score-group
      token through an intermediary