### PR TITLE
fix(pathfinder): unify warmup-503 response body across three not-ready paths

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -179,18 +179,20 @@ internal sealed class FindPathHandler(
                 // client error — 503 so load balancers drain & clients retry.
                 FindPathMetrics.SolverStatusTotal.WithLabels("not_ready").Inc();
                 log.LogWarning("Graphs not ready");
-                return Results.Json(new { error = "Graphs are not loaded yet." },
+                return Results.Text("Graphs are not loaded yet.",
                     statusCode: StatusCodes.Status503ServiceUnavailable);
             }
 
             if (!pool.HasCurrentSnapshot)
             {
-                // Same predicate as GraphReadinessHealthCheck (/ready). Without this
-                // gate, pool.Rent throws InvalidOperationException → generic catch → 500
-                // for a recoverable warmup state.
+                // Mirrors the capacity-graph leg of /ready (GraphReadinessHealthCheck
+                // also checks AccountTrusts; here we only need pool state). Without
+                // this gate, pool.Rent throws InvalidOperationException → generic
+                // catch → 500 for a recoverable warmup state.
                 FindPathMetrics.SolverStatusTotal.WithLabels("not_ready").Inc();
                 log.LogWarning("Capacity graph snapshot not ready — returning 503 (warmup)");
-                return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+                return Results.Text("Graphs are not loaded yet.",
+                    statusCode: StatusCodes.Status503ServiceUnavailable);
             }
 
             using var h = await pool.Rent(request, balanceGraph, trustGraph);
@@ -371,7 +373,8 @@ internal sealed class FindPathHandler(
                 "", 0, request.MaxTransfers ?? -1,
                 graphBlock, sw.ElapsedMilliseconds, 503,
                 request.WithWrap ?? false, request.QuantizedMode ?? false, "not_ready");
-            return Results.StatusCode(StatusCodes.Status503ServiceUnavailable);
+            return Results.Text("Graphs are not loaded yet.",
+                statusCode: StatusCodes.Status503ServiceUnavailable);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {


### PR DESCRIPTION
## Summary

Follow-up to #398. Three gates can return 503 during graph warmup:
- `balanceGraph is null` (pre-Rent)
- `!pool.HasCurrentSnapshot` (pre-Rent)
- `GraphNotReadyException` catch (TOCTOU backstop)

Pre-fix, the first returns a JSON body; the other two return a bare status code. Same state class, two different response shapes.

This change unifies all three on `Results.Text("Graphs are not loaded yet.", statusCode: 503)` so the public contract is consistent regardless of which gate trips.

Also tightens the `HasCurrentSnapshot` gate comment — it mirrors only the capacity-graph leg of `/ready` (`GraphReadinessHealthCheck` also checks `AccountTrusts`), not the full predicate.

## Test plan

- [x] Build clean (0 errors).
- [x] HttpEndpointTests + CapacityGraphPoolTests: 41/41 pass.
- [ ] Post-deploy: hit warmup window with two requests that hit different gates (one without any snapshot loaded → `balanceGraph` null; one mid-load → `HasCurrentSnapshot` false). Both must return identical text/plain body `Graphs are not loaded yet.` with status 503.