### PR TITLE
fix(pathfinder): skip simulation canary for withWrap=true requests

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -56,6 +56,13 @@ internal sealed class SimulationCanaryService : BackgroundService
         "circles_canary_simulation_queue_dropped_total",
         "Work items dropped because the simulation queue was full");
 
+    private static readonly Counter SimulationSkipped = Metrics.CreateCounter(
+        "circles_canary_simulation_skipped_total",
+        "Work items skipped before enqueue, by reason",
+        new CounterConfiguration { LabelNames = new[] { "reason" } });
+
+    public static void RecordSkipped(string reason) => SimulationSkipped.WithLabels(reason).Inc();
+
     public SimulationCanaryService(
         Settings settings,
         ILogger<SimulationCanaryService> log,

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -260,9 +260,15 @@ internal sealed class FindPathHandler(
                     FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
 
                 // Simulation canary: enqueue for async eth_call validation.
-                // Skip when: simulated balances/trusts (not real state), or source is a Group/Organization
-                // (Hub.sol operateFlowMatrix requires isApprovedForAll(source, msg.sender).
-                // Groups/Orgs don't self-approve — canary would get OperatorNotApprovedForSource).
+                // Skip when:
+                //   - simulated balances/trusts (not real state),
+                //   - source is a Group/Organization (Hub.sol operateFlowMatrix requires
+                //     isApprovedForAll(source, msg.sender); Groups/Orgs don't self-approve →
+                //     false-positive OperatorNotApprovedForSource),
+                //   - withWrap=true (SDK prepends Wrapper.unwrap() before operateFlowMatrix;
+                //     canary's eth_call only replays operateFlowMatrix and sees zero ERC1155
+                //     balance → false-positive ERC1155InsufficientBalance. Full fix tracked
+                //     as the unwrap-prefix simulation follow-up).
                 bool hasSimulated = (request.SimulatedBalances?.Count > 0)
                                     || (request.SimulatedTrusts?.Count > 0)
                                     || (request.SimulatedConsentedAvatars?.Count > 0);
@@ -275,12 +281,15 @@ internal sealed class FindPathHandler(
                                           || h.Graph.IsOrganization(sourceId);
                 }
 
+                bool withWrap = request.WithWrap ?? false;
+
                 if (simulationCanary != null
                     && mfr.Transfers.Count > 0
                     && !string.IsNullOrEmpty(request.Source)
                     && !string.IsNullOrEmpty(request.Sink)
                     && !hasSimulated
-                    && !sourceUnsimulatable)
+                    && !sourceUnsimulatable
+                    && !withWrap)
                 {
                     Dictionary<string, string>? wrapperMap = null;
                     try
@@ -316,6 +325,16 @@ internal sealed class FindPathHandler(
                             Transfers: new List<TransferPathStep>(mfr.Transfers),
                             WrapperToAvatar: wrapperMap));
                     }
+                }
+                else if (simulationCanary != null
+                         && mfr.Transfers.Count > 0
+                         && !string.IsNullOrEmpty(request.Source)
+                         && !string.IsNullOrEmpty(request.Sink)
+                         && !hasSimulated
+                         && !sourceUnsimulatable
+                         && withWrap)
+                {
+                    SimulationCanaryService.RecordSkipped("with_wrap");
                 }
 
                 log.LogInformation(


### PR DESCRIPTION
## Summary

- Add `!withWrap` guard to the simulation-canary enqueue chain in `FindPathHandler`.
- Add Prometheus counter `circles_canary_simulation_skipped_total{reason}` (first label value: `with_wrap`) to keep the volume of dropped signal observable.

## Why

The simulation canary replays `Hub.operateFlowMatrix` via `eth_call`, but the SDK prepends `Wrapper.unwrap(amount)` calls client-side before `operateFlowMatrix`. When a path consumes wrapped ERC20 supply (`withWrap=true`), the canary's `eth_call` sees zero ERC1155 balance and reports a false-positive `ERC1155InsufficientBalance` revert (selector `0x03dee4c5`).

`HubContractValidator` already audits `withWrap` paths statically, so skipping the eth_call canary for these requests is not a coverage regression — only less defense-in-depth until the proper unwrap-prefix simulation lands as a follow-up.

## Test plan

- [x] `dotnet build -c Release` — clean, no new warnings.
- [x] `./scripts/test.sh pathfinder` — full pathfinder suite green.
- [ ] After staging deploy: `circles_canary_simulation_skipped_total{reason="with_wrap"}` increments on real `withWrap=true` traffic.
- [ ] After staging deploy: canary alert fire rate for `label=insufficient_balance` drops to ~zero within the alert eval window.
- [ ] After staging deploy: non-`withWrap` paths still produce canary signal (success + revert counters still tick).