### PR TITLE
test(openrpc): guard against dispatch/MethodMappings drift + catalog scoreGroupMintLimits

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/OpenRpcGeneratorTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/OpenRpcGeneratorTests.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 using Circles.Rpc.Host.OpenRpc;
 
 namespace Circles.Rpc.Host.Tests;
@@ -136,5 +138,46 @@ public class OpenRpcGeneratorTests
             Assert.That(method.Examples, Is.Not.Null.And.Not.Empty,
                 $"Method {method.Name} is missing examples");
         }
+    }
+
+    // SSOT for the live RPC surface is the dispatch switch in Program.cs. The OpenRPC
+    // spec is hand-derived from MethodMappings in OpenRpcGenerator. This test parses
+    // Program.cs at test time and asserts every dispatched circles_*/circlesV2_* arm
+    // has a MethodMappings entry — adding a handler without updating MethodMappings
+    // fails CI here instead of silently shipping a stale /openrpc.json.
+    [Test]
+    public void Generate_AllDispatchedMethods_ArePresentInOpenRpcSpec()
+    {
+        var programCsPath = ResolveProgramCsPath();
+        var source = File.ReadAllText(programCsPath);
+
+        var dispatchArm = new Regex(@"""(circles_[A-Za-z_]+|circlesV2_[A-Za-z_]+)""\s*=>");
+        var dispatched = dispatchArm.Matches(source)
+            .Select(m => m.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        Assert.That(dispatched, Is.Not.Empty,
+            $"No dispatch arms matched in {programCsPath} — regex stale or file moved");
+
+        var documented = OpenRpcGenerator.Generate().Methods
+            .Select(m => m.Name)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = dispatched.Except(documented).OrderBy(x => x, StringComparer.Ordinal).ToList();
+        Assert.That(missing, Is.Empty,
+            "Methods dispatched in Program.cs but missing from OpenRpcGenerator.MethodMappings:\n  - " +
+            string.Join("\n  - ", missing) +
+            "\n\nAdd a MethodMappings entry for each dispatched method to keep /openrpc.json fresh.");
+    }
+
+    private static string ResolveProgramCsPath([CallerFilePath] string? thisFile = null)
+    {
+        var dir = Path.GetDirectoryName(thisFile!)!;
+        var candidate = Path.GetFullPath(Path.Combine(dir, "..", "Circles.Rpc.Host", "Program.cs"));
+        if (!File.Exists(candidate))
+            Assert.Ignore(
+                $"OpenRPC drift guard requires source-tree access. Program.cs not at '{candidate}' " +
+                "— skipping (test was likely built on a different host than it is run on).");
+        return candidate;
     }
 }

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -117,6 +117,10 @@ public static class OpenRpcGenerator
             "Get groups an avatar is a member of",
             "Inverse of `circles_getGroupMembers` — returns all groups that trust a given avatar address.\n\n**Common use case**: Show which groups a user belongs to in their profile view."),
 
+        ("circles_getScoreGroupMintLimits", "GetScoreGroupMintLimits", "Groups",
+            "Get per-collateral mint limits for a score-weighted group",
+            "Returns the available mint limit for each (group, collateral) pair governed by an on-chain score-weighted group mint policy. Server applies the on-chain demurrage policy at query time; clients may subtract their own safety margin before minting.\n\n**Common use case**: Pre-flight check before invoking a score-group mint — discover how much of the group token can be minted from each collateral the caller holds.\n\n**Params**:\n- `groupAddress` (required): The group token address.\n- `collateralToken` (optional): Restrict to a single collateral token; omit to return all collaterals."),
+
         // ── Transaction Methods ──────────────────────────────────────────────
         ("circles_getTransactionHistory", "GetTransactionHistory", "Transactions",
             "Get transaction history for an avatar",
@@ -419,6 +423,15 @@ public static class OpenRpcGenerator
                 "Maximum number of memberships to return. Default: 50, max: 200."),
             Param("cursor", false, "string",
                 "Cursor from a previous response's nextCursor field for pagination.")
+        ],
+        ["circles_getScoreGroupMintLimits"] =
+        [
+            Param("groupAddress", true, "string",
+                "Score-weighted group token address to query mint limits for.",
+                pattern: AddrPattern),
+            Param("collateralToken", false, "string",
+                "Optional collateral-token filter. When provided, restricts the response to the single (group, collateral) row matching this token. When omitted, returns all collaterals governed by the group's on-chain mint policy.",
+                pattern: AddrPattern)
         ],
         ["circles_getTransactionHistory"] =
         [
@@ -1098,6 +1111,28 @@ public static class OpenRpcGenerator
                 [
                     new() { Name = "memberAddress", Value = ExampleAddr1 },
                     new() { Name = "limit", Value = 50 },
+                ],
+            }
+        ],
+        ["circles_getScoreGroupMintLimits"] =
+        [
+            new()
+            {
+                Name = "All mint limits for a group",
+                Description = "Get available mint limits for every collateral governed by the group's score-weighted policy",
+                Params =
+                [
+                    new() { Name = "groupAddress", Value = ExampleGroup },
+                ],
+            },
+            new()
+            {
+                Name = "Mint limit for a single collateral",
+                Description = "Restrict the response to one (group, collateral) row",
+                Params =
+                [
+                    new() { Name = "groupAddress", Value = ExampleGroup },
+                    new() { Name = "collateralToken", Value = ExampleToken },
                 ],
             }
         ],


### PR DESCRIPTION
## Summary
- The OpenRPC catalog (`OpenRpcGenerator.MethodMappings`) is hand-maintained; the live RPC surface lives in the Program.cs dispatch switch. Until now these could drift silently, producing a stale `/openrpc.json`.
- Catches the existing drift in this PR — `circles_getScoreGroupMintLimits` was dispatched but missing from the catalog. Adds the missing `MethodMappings` / `ParameterOverrides` / `MethodExamples` entries.
- New test `Generate_AllDispatchedMethods_ArePresentInOpenRpcSpec` parses Program.cs at test time, extracts every `"circles_*"/"circlesV2_*" =>` arm, and asserts each one has a `MethodMappings` entry. Test source-locates Program.cs via `[CallerFilePath]`; falls back to `Assert.Ignore` if the source tree isn't available at runtime.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~OpenRpcGeneratorTests"` → 9/9 pass.
- [x] Removing the new `MethodMappings` entry locally makes the guard fail with a deterministic message listing `circles_getScoreGroupMintLimits`.
- [x] No changes outside `Circles.Rpc.Host` + its test project.