### PR TITLE
feat(pathfinder): simulate withWrap paths via eth_simulateV1 bundle

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -1,4 +1,6 @@
+using System.Globalization;
 using System.Net.Http.Json;
+using System.Numerics;
 using System.Text.Json;
 using System.Threading.Channels;
 using Circles.Common.Dto;
@@ -16,7 +18,8 @@ internal sealed record CanaryWorkItem(
     string Sink,
     long GraphBlock,
     List<TransferPathStep> Transfers,
-    IReadOnlyDictionary<string, string>? WrapperToAvatar = null);
+    IReadOnlyDictionary<string, string>? WrapperToAvatar = null,
+    bool WithWrap = false);
 
 /// <summary>
 /// Background service that simulates pathfinder results via eth_call against the local
@@ -35,13 +38,13 @@ internal sealed class SimulationCanaryService : BackgroundService
     // Metrics
     private static readonly Counter SimulationTotal = Metrics.CreateCounter(
         "circles_canary_simulation_total",
-        "Total eth_call simulations attempted",
-        new CounterConfiguration { LabelNames = new[] { "result" } });
+        "Total eth_call/eth_simulateV1 simulations attempted",
+        new CounterConfiguration { LabelNames = new[] { "result", "prefix" } });
 
     private static readonly Counter SimulationRevertTotal = Metrics.CreateCounter(
         "circles_canary_simulation_revert_total",
-        "Simulated reverts by category and label",
-        new CounterConfiguration { LabelNames = new[] { "category", "label" } });
+        "Simulated reverts by category, label, and which call in the bundle reverted",
+        new CounterConfiguration { LabelNames = new[] { "category", "label", "stage" } });
 
     private static readonly Histogram SimulationDuration = Metrics.CreateHistogram(
         "circles_canary_simulation_duration_seconds",
@@ -114,18 +117,23 @@ internal sealed class SimulationCanaryService : BackgroundService
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _log.LogError(ex, "[{ReqId}] SimulationCanary: unexpected error during simulation", item.ReqId);
-                SimulationTotal.WithLabels("error").Inc();
+                SimulationTotal.WithLabels("error", "none").Inc();
             }
         }
     }
 
     private async Task SimulateAsync(CanaryWorkItem item, CancellationToken ct)
     {
+        // Compute unwrap prefix once — the same list is needed to decide which RPC method to use
+        // AND to populate the bundle when withWrap=true. Resolve TokenOwners using the same map
+        // so the operateFlowMatrix calldata references avatar addresses, not wrappers.
+        IReadOnlyList<UnwrapCall> unwrapCalls;
         string calldata;
         try
         {
-            // Hub.sol expects avatar addresses as token owners, not wrapper contract addresses.
-            // The SDK does this conversion client-side; the canary must do it before simulation.
+            unwrapCalls = item.WithWrap
+                ? BuildUnwrapPrefix(item.Transfers, item.WrapperToAvatar)
+                : Array.Empty<UnwrapCall>();
             var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
             calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, transfers);
         }
@@ -134,9 +142,15 @@ internal sealed class SimulationCanaryService : BackgroundService
             _log.LogError(ex,
                 "[{ReqId}] SimulationCanary: calldata encoding failed from={Source} to={Sink} block={Block} steps={Steps}",
                 item.ReqId, item.Source, item.Sink, item.GraphBlock, item.Transfers.Count);
-            SimulationTotal.WithLabels("encode_error").Inc();
+            SimulationTotal.WithLabels("encode_error", "none").Inc();
             return;
         }
+
+        // Empty unwrap list ⇒ no wrapper-form supply in this path. Fall back to plain eth_call
+        // even when withWrap=true was requested — the unwrap-prefix code path adds nothing here
+        // and eth_call has wider node-version support.
+        bool useUnwrapBundle = unwrapCalls.Count > 0;
+        string prefixLabel = useUnwrapBundle ? "unwrap" : "none";
 
         using var timer = SimulationDuration.NewTimer();
 
@@ -149,6 +163,13 @@ internal sealed class SimulationCanaryService : BackgroundService
             if (item.GraphBlock <= 0)
                 _log.LogWarning("[{ReqId}] SimulationCanary: GraphBlock={Block} — simulating at 'latest', results may not match served graph",
                     item.ReqId, item.GraphBlock);
+
+            if (useUnwrapBundle)
+            {
+                await SimulateBundleAsync(item, unwrapCalls, calldata, blockTag, prefixLabel, client, ct);
+                QueueDepth.Set(_channel.Reader.Count);
+                return;
+            }
 
             var rpcRequest = new
             {
@@ -169,7 +190,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 _log.LogWarning(
                     "[{ReqId}] SimulationCanary: eth_call HTTP {StatusCode} from={Source} to={Sink}",
                     item.ReqId, (int)response.StatusCode, item.Source, item.Sink);
-                SimulationTotal.WithLabels("rpc_http_error").Inc();
+                SimulationTotal.WithLabels("rpc_http_error", prefixLabel).Inc();
                 return;
             }
 
@@ -183,7 +204,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 _log.LogWarning(jex,
                     "[{ReqId}] SimulationCanary: non-JSON response from={Source} to={Sink}",
                     item.ReqId, item.Source, item.Sink);
-                SimulationTotal.WithLabels("rpc_parse_error").Inc();
+                SimulationTotal.WithLabels("rpc_parse_error", prefixLabel).Inc();
                 return;
             }
 
@@ -192,7 +213,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 _log.LogWarning(
                     "[{ReqId}] SimulationCanary: empty/null response from eth_call — node may be misconfigured",
                     item.ReqId);
-                SimulationTotal.WithLabels("rpc_empty_response").Inc();
+                SimulationTotal.WithLabels("rpc_empty_response", prefixLabel).Inc();
                 return;
             }
 
@@ -203,8 +224,8 @@ internal sealed class SimulationCanaryService : BackgroundService
 
                 var (category, label) = RevertClassifier.Classify(revertData ?? revertMsg);
 
-                SimulationTotal.WithLabels("revert").Inc();
-                SimulationRevertTotal.WithLabels(category, label).Inc();
+                SimulationTotal.WithLabels("revert", prefixLabel).Inc();
+                SimulationRevertTotal.WithLabels(category, label, "flow_matrix").Inc();
 
                 // Full replay context: everything needed to reproduce
                 _log.LogError(
@@ -223,7 +244,7 @@ internal sealed class SimulationCanaryService : BackgroundService
             }
             else
             {
-                SimulationTotal.WithLabels("success").Inc();
+                SimulationTotal.WithLabels("success", prefixLabel).Inc();
             }
         }
         catch (TaskCanceledException) when (ct.IsCancellationRequested)
@@ -235,10 +256,319 @@ internal sealed class SimulationCanaryService : BackgroundService
             _log.LogWarning(ex,
                 "[{ReqId}] SimulationCanary: eth_call failed (network/timeout) from={Source} to={Sink}",
                 item.ReqId, item.Source, item.Sink);
-            SimulationTotal.WithLabels("rpc_error").Inc();
+            SimulationTotal.WithLabels("rpc_error", prefixLabel).Inc();
         }
 
         QueueDepth.Set(_channel.Reader.Count);
+    }
+
+    /// <summary>
+    /// `function unwrap(uint256)` ABI selector — keccak256("unwrap(uint256)")[:4].
+    /// </summary>
+    private const string UnwrapSelector = "0xde0e9a3e";
+
+    /// <summary>
+    /// One unwrap call in the eth_simulateV1 bundle: caller (from) unwraps `amount` of the
+    /// wrapped ERC20 at `wrapper`, which mints the underlying 1155 to caller on Hub.sol.
+    /// </summary>
+    internal readonly record struct UnwrapCall(string From, string Wrapper, BigInteger Amount);
+
+    /// <summary>
+    /// For each transfer whose TokenOwner is a known wrapper, attribute one unwrap call
+    /// to the transfer's From address for the full transfer value. Groups identical
+    /// (from, wrapper) pairs and sums amounts so a single SDK-equivalent unwrap precedes
+    /// the operateFlowMatrix call in the bundle.
+    /// </summary>
+    internal static IReadOnlyList<UnwrapCall> BuildUnwrapPrefix(
+        List<TransferPathStep> transfers,
+        IReadOnlyDictionary<string, string>? wrapperToAvatar)
+    {
+        if (wrapperToAvatar == null || wrapperToAvatar.Count == 0)
+            return Array.Empty<UnwrapCall>();
+
+        // Deterministic ordering: pathfinder emits transfers in pipeline order, and we
+        // want unwraps grouped by (from, wrapper). A list-of-keys preserves first-seen
+        // order across the bundle's call array.
+        var sums = new Dictionary<(string From, string Wrapper), BigInteger>();
+        var order = new List<(string From, string Wrapper)>();
+        foreach (var t in transfers)
+        {
+            var tokenOwner = t.TokenOwner.ToLowerInvariant();
+            if (!wrapperToAvatar.ContainsKey(tokenOwner))
+                continue;
+
+            var key = (From: t.From.ToLowerInvariant(), Wrapper: tokenOwner);
+            if (!BigInteger.TryParse(t.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                || value <= 0)
+                continue;
+
+            if (sums.TryGetValue(key, out var existing))
+            {
+                sums[key] = existing + value;
+            }
+            else
+            {
+                sums[key] = value;
+                order.Add(key);
+            }
+        }
+
+        if (order.Count == 0)
+            return Array.Empty<UnwrapCall>();
+
+        var calls = new List<UnwrapCall>(order.Count);
+        foreach (var key in order)
+            calls.Add(new UnwrapCall(key.From, key.Wrapper, sums[key]));
+
+        return calls;
+    }
+
+    /// <summary>
+    /// Encodes a single `unwrap(uint256)` calldata hex string.
+    /// </summary>
+    internal static string EncodeUnwrapCalldata(BigInteger amount)
+    {
+        // uint256 cannot represent negatives; BuildUnwrapPrefix already filters value <= 0,
+        // so a negative here means a programming error, not a path with weird supply.
+        if (amount < 0)
+            throw new ArgumentOutOfRangeException(nameof(amount), "uint256 amount must be non-negative");
+
+        // BigInteger.ToString("x") prepends a leading 0 on positive numbers whose top
+        // nibble is ≥0x8 to avoid sign ambiguity. Trim it so the left-pad math is correct.
+        var hex = amount.ToString("x", CultureInfo.InvariantCulture);
+        if (hex.Length > 0 && hex[0] == '0' && hex.Length > 1) hex = hex.TrimStart('0');
+        if (hex.Length == 0) hex = "0";
+        return UnwrapSelector + hex.PadLeft(64, '0');
+    }
+
+    /// <summary>
+    /// Executes the unwrap-prefix bundle via Nethermind's eth_simulateV1. Sequences
+    /// the unwrap calls then the operateFlowMatrix call; state is shared across calls
+    /// within a single blockStateCalls entry, mirroring the SDK's actual broadcast order.
+    /// </summary>
+    private async Task SimulateBundleAsync(
+        CanaryWorkItem item,
+        IReadOnlyList<UnwrapCall> unwrapCalls,
+        string flowMatrixCalldata,
+        string blockTag,
+        string prefixLabel,
+        HttpClient client,
+        CancellationToken ct)
+    {
+        var calls = new List<object>(unwrapCalls.Count + 1);
+        foreach (var u in unwrapCalls)
+        {
+            calls.Add(new
+            {
+                from = u.From,
+                to = u.Wrapper,
+                data = EncodeUnwrapCalldata(u.Amount)
+            });
+        }
+
+        calls.Add(new
+        {
+            from = item.Source,
+            to = FlowMatrixEncoder.CirclesHubAddress,
+            data = flowMatrixCalldata
+        });
+
+        var rpcRequest = new
+        {
+            jsonrpc = "2.0",
+            method = "eth_simulateV1",
+            @params = new object[]
+            {
+                new
+                {
+                    blockStateCalls = new[] { new { calls } },
+                    validation = false,
+                    traceTransfers = false
+                },
+                blockTag
+            },
+            id = 1
+        };
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PostAsJsonAsync(_rpcUrl, rpcRequest, ct);
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "[{ReqId}] SimulationCanary: eth_simulateV1 failed (network/timeout) from={Source} to={Sink}",
+                item.ReqId, item.Source, item.Sink);
+            SimulationTotal.WithLabels("rpc_error", prefixLabel).Inc();
+            return;
+        }
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.LogWarning(
+                "[{ReqId}] SimulationCanary: eth_simulateV1 HTTP {StatusCode} from={Source} to={Sink}",
+                item.ReqId, (int)response.StatusCode, item.Source, item.Sink);
+            SimulationTotal.WithLabels("rpc_http_error", prefixLabel).Inc();
+            return;
+        }
+
+        JsonElement json;
+        try
+        {
+            json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+        }
+        catch (JsonException jex)
+        {
+            _log.LogWarning(jex,
+                "[{ReqId}] SimulationCanary: non-JSON response from={Source} to={Sink}",
+                item.ReqId, item.Source, item.Sink);
+            SimulationTotal.WithLabels("rpc_parse_error", prefixLabel).Inc();
+            return;
+        }
+
+        int expected = unwrapCalls.Count + 1;
+        var parsed = ParseSimulateV1Response(json, expected);
+
+        switch (parsed.Outcome)
+        {
+            case BundleOutcome.TopLevelError:
+            case BundleOutcome.MethodNotSupported:
+                var resultLabel = parsed.Outcome == BundleOutcome.MethodNotSupported
+                    ? "rpc_method_not_supported" : "rpc_error";
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: eth_simulateV1 returned error code={Code} message={Msg} from={Source} to={Sink}",
+                    item.ReqId, parsed.ErrorCode, parsed.RevertMessage ?? "unknown", item.Source, item.Sink);
+                SimulationTotal.WithLabels(resultLabel, prefixLabel).Inc();
+                return;
+
+            case BundleOutcome.EmptyResponse:
+            case BundleOutcome.MissingCallsArray:
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: eth_simulateV1 returned no usable result from={Source} to={Sink}",
+                    item.ReqId, item.Source, item.Sink);
+                SimulationTotal.WithLabels("rpc_empty_response", prefixLabel).Inc();
+                return;
+
+            case BundleOutcome.Truncated:
+                // Fewer results than calls sent. Fail closed — never silently classify
+                // missing entries as success.
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: eth_simulateV1 returned truncated results, expected {Expected} — treating as truncated",
+                    item.ReqId, expected);
+                SimulationTotal.WithLabels("rpc_truncated_response", prefixLabel).Inc();
+                return;
+
+            case BundleOutcome.Revert:
+                SimulationTotal.WithLabels("revert", prefixLabel).Inc();
+                SimulationRevertTotal.WithLabels(parsed.Category!, parsed.Label!, parsed.Stage!).Inc();
+                _log.LogError(
+                    "[{ReqId}] SimulationCanary: REVERT stage={Stage} category={Category} label={Label} " +
+                    "from={Source} to={Sink} graphBlock={Block} simBlock={SimBlock} steps={Steps} unwraps={Unwraps} revert={Revert}",
+                    item.ReqId, parsed.Stage, parsed.Category, parsed.Label,
+                    item.Source, item.Sink, item.GraphBlock, blockTag,
+                    item.Transfers.Count, unwrapCalls.Count, parsed.RevertMessage ?? parsed.RevertData);
+                return;
+
+            case BundleOutcome.Success:
+                SimulationTotal.WithLabels("success", prefixLabel).Inc();
+                return;
+        }
+    }
+
+    /// <summary>
+    /// Discriminated outcome of an eth_simulateV1 bundle. Each value maps to exactly one
+    /// metric label so the canary cannot silently fold a partial response into success.
+    /// </summary>
+    internal enum BundleOutcome
+    {
+        Success,
+        TopLevelError,
+        MethodNotSupported,
+        EmptyResponse,
+        MissingCallsArray,
+        Truncated,
+        Revert
+    }
+
+    internal readonly record struct BundleParseResult(
+        BundleOutcome Outcome,
+        int ErrorCode = 0,
+        string? Stage = null,
+        string? Category = null,
+        string? Label = null,
+        string? RevertData = null,
+        string? RevertMessage = null);
+
+    /// <summary>
+    /// Pure parser for eth_simulateV1 responses, isolated so the truncation and
+    /// status-classification paths can be unit-tested without HTTP plumbing.
+    /// </summary>
+    internal static BundleParseResult ParseSimulateV1Response(JsonElement json, int expectedCalls)
+    {
+        // Top-level JSON-RPC error (method not supported, validation failed, etc.).
+        if (json.TryGetProperty("error", out var topError))
+        {
+            int code = 0;
+            if (topError.TryGetProperty("code", out var c) && c.ValueKind == JsonValueKind.Number)
+                c.TryGetInt32(out code);
+            var msg = topError.TryGetProperty("message", out var m) ? m.GetString() : "unknown";
+            var outcome = code == -32601 ? BundleOutcome.MethodNotSupported : BundleOutcome.TopLevelError;
+            return new BundleParseResult(outcome, ErrorCode: code, RevertMessage: msg);
+        }
+
+        if (!json.TryGetProperty("result", out var result)
+            || result.ValueKind != JsonValueKind.Array
+            || result.GetArrayLength() == 0)
+            return new BundleParseResult(BundleOutcome.EmptyResponse);
+
+        // eth_simulateV1 returns one entry per blockStateCalls element; we sent exactly one.
+        var block0 = result[0];
+        if (!block0.TryGetProperty("calls", out var innerCalls) || innerCalls.ValueKind != JsonValueKind.Array)
+            return new BundleParseResult(BundleOutcome.MissingCallsArray);
+
+        int actual = innerCalls.GetArrayLength();
+        if (actual < expectedCalls)
+            return new BundleParseResult(BundleOutcome.Truncated);
+
+        // Scan unwrap results in order; surface the FIRST failing one.
+        // Extra entries beyond expectedCalls are ignored.
+        for (int i = 0; i < expectedCalls; i++)
+        {
+            var call = innerCalls[i];
+            bool isFlowMatrix = i == expectedCalls - 1;
+            string stage = isFlowMatrix ? "flow_matrix" : $"unwrap_{i}";
+
+            var status = call.TryGetProperty("status", out var s) ? s.GetString() : null;
+            if (status == "0x1")
+                continue;
+
+            string? revertData = null;
+            string? revertMsg = null;
+            if (call.TryGetProperty("error", out var callErr))
+            {
+                if (callErr.TryGetProperty("data", out var d)) revertData = d.GetString();
+                if (callErr.TryGetProperty("message", out var m)) revertMsg = m.GetString();
+            }
+            // Fallback: some nodes put returnData on the failing call instead of error.
+            if (revertData == null && call.TryGetProperty("returnData", out var rd))
+                revertData = rd.GetString();
+
+            var (category, label) = RevertClassifier.Classify(revertData ?? revertMsg ?? "unknown");
+            return new BundleParseResult(
+                BundleOutcome.Revert,
+                Stage: stage,
+                Category: category,
+                Label: label,
+                RevertData: revertData,
+                RevertMessage: revertMsg);
+        }
+
+        return new BundleParseResult(BundleOutcome.Success);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -259,16 +259,15 @@ internal sealed class FindPathHandler(
                 if (mfr.ValidatorException)
                     FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
 
-                // Simulation canary: enqueue for async eth_call validation.
+                // Simulation canary: enqueue for async on-chain validation.
                 // Skip when:
                 //   - simulated balances/trusts (not real state),
                 //   - source is a Group/Organization (Hub.sol operateFlowMatrix requires
                 //     isApprovedForAll(source, msg.sender); Groups/Orgs don't self-approve →
-                //     false-positive OperatorNotApprovedForSource),
-                //   - withWrap=true (SDK prepends Wrapper.unwrap() before operateFlowMatrix;
-                //     canary's eth_call only replays operateFlowMatrix and sees zero ERC1155
-                //     balance → false-positive ERC1155InsufficientBalance. Full fix tracked
-                //     as the unwrap-prefix simulation follow-up).
+                //     false-positive OperatorNotApprovedForSource).
+                // withWrap=true is handled via eth_simulateV1 bundle inside the canary:
+                // source's Wrapper.unwrap() calls run before operateFlowMatrix in a single
+                // shared-state simulation, mirroring how the SDK builds the on-chain tx.
                 bool hasSimulated = (request.SimulatedBalances?.Count > 0)
                                     || (request.SimulatedTrusts?.Count > 0)
                                     || (request.SimulatedConsentedAvatars?.Count > 0);
@@ -288,8 +287,7 @@ internal sealed class FindPathHandler(
                     && !string.IsNullOrEmpty(request.Source)
                     && !string.IsNullOrEmpty(request.Sink)
                     && !hasSimulated
-                    && !sourceUnsimulatable
-                    && !withWrap)
+                    && !sourceUnsimulatable)
                 {
                     Dictionary<string, string>? wrapperMap = null;
                     try
@@ -313,7 +311,10 @@ internal sealed class FindPathHandler(
                     if (wrapperMap == null && h.Graph.WrapperToAvatar.Count > 0)
                     {
                         // Wrapper resolution failed — simulation without it would produce
-                        // false-positive AvatarMustBeRegistered reverts. Skip entirely.
+                        // false-positive AvatarMustBeRegistered reverts (and would skip the
+                        // unwrap prefix for withWrap=true). Skip entirely and record the
+                        // reason so operators can spot map-build failures in metrics.
+                        SimulationCanaryService.RecordSkipped("wrapper_map_unavailable");
                     }
                     else
                     {
@@ -323,18 +324,9 @@ internal sealed class FindPathHandler(
                             Sink: request.Sink,
                             GraphBlock: mfr.GraphBlock,
                             Transfers: new List<TransferPathStep>(mfr.Transfers),
-                            WrapperToAvatar: wrapperMap));
+                            WrapperToAvatar: wrapperMap,
+                            WithWrap: withWrap));
                     }
-                }
-                else if (simulationCanary != null
-                         && mfr.Transfers.Count > 0
-                         && !string.IsNullOrEmpty(request.Source)
-                         && !string.IsNullOrEmpty(request.Sink)
-                         && !hasSimulated
-                         && !sourceUnsimulatable
-                         && withWrap)
-                {
-                    SimulationCanaryService.RecordSkipped("with_wrap");
                 }
 
                 log.LogInformation(

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryParserTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryParserTests.cs
@@ -1,0 +1,276 @@
+using System.Text.Json;
+using Circles.Pathfinder.Host.Canary;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Unit tests for SimulationCanaryService.ParseSimulateV1Response — the pure parser
+/// that classifies eth_simulateV1 bundle responses into a discriminated outcome.
+/// Critical: a truncated response (node returns fewer call results than sent) must
+/// never silently land in the success bucket.
+/// </summary>
+[TestFixture, Parallelizable]
+public class SimulationCanaryParserTests
+{
+    private static JsonElement Parse(string json) => JsonDocument.Parse(json).RootElement;
+
+    #region Top-level error
+
+    [Test]
+    public void TopLevelError_MethodNotFound_ReturnsMethodNotSupported()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""error"":{""code"":-32601,""message"":""Method not found""}}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 2);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.MethodNotSupported));
+        Assert.That(result.ErrorCode, Is.EqualTo(-32601));
+        Assert.That(result.RevertMessage, Is.EqualTo("Method not found"));
+    }
+
+    [Test]
+    public void TopLevelError_OtherCode_ReturnsTopLevelError()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""error"":{""code"":-32000,""message"":""bad input""}}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 2);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.TopLevelError));
+        Assert.That(result.ErrorCode, Is.EqualTo(-32000));
+    }
+
+    [Test]
+    public void TopLevelError_NonNumberCode_DoesNotThrow()
+    {
+        // Defensive: some nodes have sent string codes. TryGetInt32 must not propagate.
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""error"":{""code"":""32601"",""message"":""bad node""}}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 2);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.TopLevelError));
+        Assert.That(result.ErrorCode, Is.EqualTo(0), "Non-numeric code falls back to 0 (no -32xxx semantics)");
+    }
+
+    [Test]
+    public void TopLevelError_MissingCode_DoesNotThrow()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""error"":{""message"":""mystery""}}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.TopLevelError));
+        Assert.That(result.ErrorCode, Is.EqualTo(0));
+    }
+
+    #endregion
+
+    #region Empty / malformed
+
+    [Test]
+    public void NoResultField_ReturnsEmptyResponse()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.EmptyResponse));
+    }
+
+    [Test]
+    public void EmptyResultArray_ReturnsEmptyResponse()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""result"":[]}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.EmptyResponse));
+    }
+
+    [Test]
+    public void MissingCallsArray_ReturnsMissingCallsArray()
+    {
+        var json = Parse(@"{""jsonrpc"":""2.0"",""id"":1,""result"":[{""number"":""0x1""}]}");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.MissingCallsArray));
+    }
+
+    #endregion
+
+    #region Truncated — the deploy-blocker the review caught
+
+    [Test]
+    public void TruncatedResponse_ReturnsTruncated_NeverSuccess()
+    {
+        // Sent 3 calls (2 unwraps + 1 flow matrix), node returned 1 successful entry.
+        // Must NOT fold into success.
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[{""status"":""0x1""}]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Truncated),
+            "Truncated bundle responses must not be classified as success");
+    }
+
+    [Test]
+    public void TruncatedResponse_OneShort_StillTruncated()
+    {
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[{""status"":""0x1""},{""status"":""0x1""}]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Truncated));
+    }
+
+    [Test]
+    public void ExactlyExpectedCount_AllSuccess_ReturnsSuccess()
+    {
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[{""status"":""0x1""},{""status"":""0x1""},{""status"":""0x1""}]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Success));
+    }
+
+    [Test]
+    public void ExtraCallsBeyondExpected_AreIgnored_NotTruncated()
+    {
+        // Node returned MORE entries than we sent (unusual, but should be tolerated —
+        // we only inspect indices [0, expectedCalls)).
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x1""},{""status"":""0x1""},{""status"":""0x1""},{""status"":""0x1""}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Success));
+    }
+
+    #endregion
+
+    #region Revert classification
+
+    [Test]
+    public void FirstUnwrapReverts_StageIsUnwrap0()
+    {
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x0"",""error"":{""data"":""0x03dee4c5"",""message"":""insufficient""}},
+                {""status"":""0x1""},
+                {""status"":""0x1""}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.Stage, Is.EqualTo("unwrap_0"));
+        Assert.That(result.RevertData, Is.EqualTo("0x03dee4c5"));
+        Assert.That(result.RevertMessage, Is.EqualTo("insufficient"));
+    }
+
+    [Test]
+    public void SecondUnwrapReverts_StageIsUnwrap1()
+    {
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x1""},
+                {""status"":""0x0"",""error"":{""data"":""0xc14c0700""}},
+                {""status"":""0x1""}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.Stage, Is.EqualTo("unwrap_1"));
+    }
+
+    [Test]
+    public void FlowMatrixReverts_StageIsFlowMatrix()
+    {
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x1""},
+                {""status"":""0x0"",""error"":{""data"":""0x5e418dba""}}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 2);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.Stage, Is.EqualTo("flow_matrix"));
+    }
+
+    [Test]
+    public void StatusMissing_TreatedAsRevert_NotSuccess()
+    {
+        // Defensive: if the node omits `status` entirely, fail closed.
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""returnData"":""0x""}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.Stage, Is.EqualTo("flow_matrix"));
+    }
+
+    [Test]
+    public void ReturnDataFallback_WhenErrorMissing()
+    {
+        // Some nodes report revert payload in returnData on the call itself, not in an error field.
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x0"",""returnData"":""0x03dee4c5deadbeef""}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 1);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.RevertData, Is.EqualTo("0x03dee4c5deadbeef"));
+    }
+
+    [Test]
+    public void OnlyFirstRevertSurfaces()
+    {
+        // If multiple calls report revert, we want the FIRST one (closest to the cause).
+        var json = Parse(@"{
+            ""jsonrpc"":""2.0"",""id"":1,
+            ""result"":[{""calls"":[
+                {""status"":""0x1""},
+                {""status"":""0x0"",""error"":{""data"":""0xAAAA""}},
+                {""status"":""0x0"",""error"":{""data"":""0xBBBB""}}
+            ]}]
+        }");
+
+        var result = SimulationCanaryService.ParseSimulateV1Response(json, expectedCalls: 3);
+
+        Assert.That(result.Outcome, Is.EqualTo(SimulationCanaryService.BundleOutcome.Revert));
+        Assert.That(result.Stage, Is.EqualTo("unwrap_1"));
+        Assert.That(result.RevertData, Is.EqualTo("0xAAAA"));
+    }
+
+    #endregion
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryUnwrapPrefixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryUnwrapPrefixTests.cs
@@ -1,0 +1,249 @@
+using System.Numerics;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Host.Canary;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Unit tests for the eth_simulateV1 unwrap-prefix path in SimulationCanaryService.
+/// Exercises BuildUnwrapPrefix and EncodeUnwrapCalldata only — the HTTP-driven
+/// SimulateBundleAsync is covered by integration via the staging eth_simulateV1 probe.
+/// </summary>
+[TestFixture, Parallelizable]
+public class SimulationCanaryUnwrapPrefixTests
+{
+    private const string Source = "0x742b7dbb0f1d330a83497df79075ebc778e6e698";
+    private const string Sink = "0xd4cf9afd3ae777c24454b70dd28e32d1bd516f05";
+    private const string V4Avatar = "0x837bf44405f7551f572f0256e55adb4a4e28157a";
+    private const string V4Wrapper = "0x82f929cf40b063f08751fe9a1839eb002cf9320e";
+    private const string V6Avatar = "0xc5377c93487953327902c349ed5bc75c306effcb";
+    private const string V6Wrapper = "0xac2dc25d07e1194802eb45d8535f9e8c28d57907";
+
+    private static IReadOnlyDictionary<string, string> WrapperMap() => new Dictionary<string, string>
+    {
+        [V4Wrapper] = V4Avatar,
+        [V6Wrapper] = V6Avatar
+    };
+
+    private static TransferPathStep Step(string from, string to, string tokenOwner, string value) =>
+        new() { From = from, To = to, TokenOwner = tokenOwner, Value = value };
+
+    #region BuildUnwrapPrefix
+
+    [Test]
+    public void BuildUnwrapPrefix_NullMap_ReturnsEmpty()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, Sink, V4Wrapper, "1000000000000000000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, null);
+
+        Assert.That(calls, Is.Empty);
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_EmptyMap_ReturnsEmpty()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, Sink, V4Wrapper, "1000000000000000000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, new Dictionary<string, string>());
+
+        Assert.That(calls, Is.Empty);
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_NoWrapperTransfers_ReturnsEmpty()
+    {
+        // Both transfers carry native 1155 (TokenOwner = avatar, not wrapper).
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, Sink, V4Avatar, "1000000000000000000"),
+            Step(Source, Sink, V6Avatar, "500000000000000000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Is.Empty);
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_SingleWrapperTransfer_EmitsOneCall()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Wrapper, "1000000000000000000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(1));
+        Assert.That(calls[0].From, Is.EqualTo(Source));
+        Assert.That(calls[0].Wrapper, Is.EqualTo(V4Wrapper));
+        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("1000000000000000000")));
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_SamePairAcrossTransfers_SumsAmounts()
+    {
+        // Two transfers from Source using the same wrapper but going to different recipients
+        // → one unwrap call covering both legs.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Wrapper, "1000000000000000000"),
+            Step(Source, "0xbbb", V4Wrapper, "2500000000000000000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(1));
+        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("3500000000000000000")));
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_DifferentWrappers_EmitsCallPerWrapperInFirstSeenOrder()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V6Wrapper, "100"),
+            Step(Source, "0xbbb", V4Wrapper, "200"),
+            Step(Source, "0xccc", V6Wrapper, "50")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(2));
+        Assert.That(calls[0].Wrapper, Is.EqualTo(V6Wrapper), "V6 first-seen → first in bundle");
+        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(150)));
+        Assert.That(calls[1].Wrapper, Is.EqualTo(V4Wrapper));
+        Assert.That(calls[1].Amount, Is.EqualTo(new BigInteger(200)));
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_MixedWrapperAndNative_OnlyWrapperEmitsCalls()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Avatar, "999"),   // native — ignored
+            Step(Source, "0xbbb", V4Wrapper, "1000"), // wrapper — emit
+            Step(Source, "0xccc", V6Avatar, "777")    // native — ignored
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(1));
+        Assert.That(calls[0].Wrapper, Is.EqualTo(V4Wrapper));
+        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(1000)));
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_ZeroOrNegativeValue_Skipped()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Wrapper, "0"),
+            Step(Source, "0xbbb", V4Wrapper, "-50"),       // pathological — defensive skip
+            Step(Source, "0xccc", V4Wrapper, "not-a-num"), // defensive parse skip
+            Step(Source, "0xddd", V4Wrapper, "10")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(1));
+        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(10)));
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_TokenOwnerCaseInsensitive()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Wrapper.ToUpperInvariant(), "1000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(1));
+        Assert.That(calls[0].Wrapper, Is.EqualTo(V4Wrapper),
+            "Wrapper key normalised to lowercase before map lookup and emission");
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_DifferentFromsForSameWrapper_KeptSeparate()
+    {
+        // If an intermediary (not source) ever held wrapped supply that the pathfinder
+        // routed — currently filtered out by GraphFactory:884, but the prefix builder
+        // must not silently merge holders if that ever changes.
+        var otherHolder = "0xdeadbeef00000000000000000000000000000001";
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Source, "0xaaa", V4Wrapper, "1000"),
+            Step(otherHolder, "0xbbb", V4Wrapper, "2000")
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
+
+        Assert.That(calls, Has.Count.EqualTo(2),
+            "Per-(from, wrapper) grouping must not collapse across distinct holders");
+    }
+
+    #endregion
+
+    #region EncodeUnwrapCalldata
+
+    [Test]
+    public void EncodeUnwrapCalldata_Zero()
+    {
+        var data = SimulationCanaryService.EncodeUnwrapCalldata(BigInteger.Zero);
+
+        Assert.That(data, Is.EqualTo("0xde0e9a3e" + new string('0', 64)));
+    }
+
+    [Test]
+    public void EncodeUnwrapCalldata_One()
+    {
+        var data = SimulationCanaryService.EncodeUnwrapCalldata(BigInteger.One);
+
+        Assert.That(data, Is.EqualTo("0xde0e9a3e" + new string('0', 63) + "1"));
+    }
+
+    [Test]
+    public void EncodeUnwrapCalldata_OneEther()
+    {
+        var data = SimulationCanaryService.EncodeUnwrapCalldata(BigInteger.Parse("1000000000000000000"));
+
+        // 1e18 == 0x0de0b6b3a7640000 → padded to 64 nibbles
+        Assert.That(data, Is.EqualTo("0xde0e9a3e0000000000000000000000000000000000000000000000000de0b6b3a7640000"));
+    }
+
+    [Test]
+    public void EncodeUnwrapCalldata_LargeAmountWithTopBitSet_NoLeadingSignByte()
+    {
+        // 0x8000000000000000_0000000000000000_0000000000000000_0000000000000000
+        // BigInteger.ToString("x") would normally emit "8000...0" with leading 0 to
+        // disambiguate sign. Verify we strip that so the encoded calldata is exactly
+        // 32 bytes (64 hex chars) after the selector.
+        var amount = BigInteger.Pow(2, 255);
+        var data = SimulationCanaryService.EncodeUnwrapCalldata(amount);
+
+        Assert.That(data.Length, Is.EqualTo(2 + 8 + 64), "0x + selector + 32-byte word");
+        Assert.That(data, Does.StartWith("0xde0e9a3e8"),
+            "Encoded amount must start with 8 (top nibble), no leading zero or sign byte");
+    }
+
+    [Test]
+    public void EncodeUnwrapCalldata_MaxUint256_ExactlyOneWord()
+    {
+        // 2^256 - 1 — confirms padding logic handles the largest legal amount.
+        var maxU256 = (BigInteger.One << 256) - 1;
+        var data = SimulationCanaryService.EncodeUnwrapCalldata(maxU256);
+
+        Assert.That(data, Is.EqualTo("0xde0e9a3e" + new string('f', 64)));
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Closes the simulation canary's previous skip for `withWrap=true` requests by replaying the SDK's actual broadcast shape: an `eth_simulateV1` bundle that runs each `Wrapper.unwrap(amount)` in shared state ahead of `Hub.operateFlowMatrix(...)`. Previously these paths were observed only via a `circles_canary_simulation_skipped_total{reason="with_wrap"}` increment.
- Hardens the bundle response parser: truncated responses (fewer call results than calls sent) now emit `rpc_truncated_response` and bail, preventing silent classification as success. Top-level `error.code` parsing tolerates missing or non-Number values. `EncodeUnwrapCalldata` rejects negative amounts.
- Extracts `ParseSimulateV1Response` as a pure function so the truncation guard, top-level error paths, and per-call revert attribution have direct unit coverage without HTTP plumbing.

## Metric / label changes

- `circles_canary_simulation_total` gains a `prefix` label: `unwrap` for bundle simulations, `none` for plain `eth_call`.
- `circles_canary_simulation_revert_total` gains a `stage` label: `unwrap_{i}` for a reverting unwrap call in the bundle, `flow_matrix` for the trailing `operateFlowMatrix`.
- New `circles_canary_simulation_total{result="rpc_truncated_response"}` outcome.
- Skip-reason `with_wrap` is removed; `wrapper_map_unavailable` is added for the case where the wrapper→avatar map cannot be built.

## Test plan

- [ ] Pathfinder test suite: `dotnet test src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj -c Release` (expect 1052 passed, 0 failed, 270 skipped — same as base)
- [ ] After deploy, confirm `circles_canary_simulation_total{prefix="unwrap"}` increments under load on a node serving `withWrap=true` requests
- [ ] Confirm `circles_canary_simulation_skipped_total{reason="with_wrap"}` no longer increments
- [ ] Confirm `circles_canary_simulation_total{result="rpc_method_not_supported"}` stays at zero (`eth_simulateV1` available on the node version in use)