### PR TITLE
feat(canary): log calldata on simulated revert

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -227,13 +227,14 @@ internal sealed class SimulationCanaryService : BackgroundService
                 SimulationTotal.WithLabels("revert", prefixLabel).Inc();
                 SimulationRevertTotal.WithLabels(category, label, "flow_matrix").Inc();
 
-                // Full replay context: everything needed to reproduce
+                // Full replay context: everything needed to reproduce (incl. calldata
+                // so the canary log alone is sufficient to feed scripts/_resources/run-sim.sh).
                 _log.LogError(
                     "[{ReqId}] SimulationCanary: REVERT category={Category} label={Label} " +
-                    "from={Source} to={Sink} graphBlock={Block} simBlock={SimBlock} steps={Steps} revert={Revert}",
+                    "from={Source} to={Sink} graphBlock={Block} simBlock={SimBlock} steps={Steps} revert={Revert} calldata={Calldata}",
                     item.ReqId, category, label,
                     item.Source, item.Sink, item.GraphBlock, blockTag,
-                    item.Transfers.Count, revertMsg);
+                    item.Transfers.Count, revertMsg, calldata);
 
                 if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)
                 {
@@ -466,12 +467,18 @@ internal sealed class SimulationCanaryService : BackgroundService
             case BundleOutcome.Revert:
                 SimulationTotal.WithLabels("revert", prefixLabel).Inc();
                 SimulationRevertTotal.WithLabels(parsed.Category!, parsed.Label!, parsed.Stage!).Inc();
+                // Full replay context: everything needed to reproduce, incl. calldata
+                // and the wrapper list so the canary log alone is sufficient to feed
+                // scripts/_resources/run-sim.sh.
+                var wrappers = string.Join(",", unwrapCalls.Select(u => u.Wrapper));
                 _log.LogError(
                     "[{ReqId}] SimulationCanary: REVERT stage={Stage} category={Category} label={Label} " +
-                    "from={Source} to={Sink} graphBlock={Block} simBlock={SimBlock} steps={Steps} unwraps={Unwraps} revert={Revert}",
+                    "from={Source} to={Sink} graphBlock={Block} simBlock={SimBlock} steps={Steps} unwraps={Unwraps} " +
+                    "revert={Revert} wrappers={Wrappers} calldata={Calldata}",
                     item.ReqId, parsed.Stage, parsed.Category, parsed.Label,
                     item.Source, item.Sink, item.GraphBlock, blockTag,
-                    item.Transfers.Count, unwrapCalls.Count, parsed.RevertMessage ?? parsed.RevertData);
+                    item.Transfers.Count, unwrapCalls.Count,
+                    parsed.RevertMessage ?? parsed.RevertData, wrappers, flowMatrixCalldata);
                 return;
 
             case BundleOutcome.Success:


### PR DESCRIPTION
## Summary

- Adds `calldata=` to the `SimulationCanary` revert log line in both code paths (plain `eth_call` and `eth_simulateV1` bundle). For the bundle path, also adds `wrappers=` (comma-separated list of wrapper contracts in the unwrap prefix).
- No behavioral or metric changes; pure observability additive. The canary log line for a successful or non-reverting simulation is unchanged.
- Combined with `scripts/_resources/run-sim.sh` and the local forge-debug workspace, a canary revert log entry is now sufficient on its own to replay the failing path on a Tenderly fork — no need to re-issue the original `findPath` request (which would build against fresh chain state and lose the failing snapshot).

## Test plan

- [ ] After deploy, look up a recent `SimulationCanary: REVERT` log line in Loki for the pathfinder pod
- [ ] Confirm new `calldata=` field is populated with a non-empty `0x...` hex string
- [ ] For a `stage=unwrap_*` or bundle-flow-matrix revert: confirm `wrappers=` lists the wrapper contracts