### PR TITLE
fix(rpc): close groupType leak in SQL fallback + wire-handler parser test

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Circles.Rpc.Host.Wire;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SearchProfilesRequestParser"/>.
+///
+/// These tests pin down the positional contract of the JSON-RPC params array
+/// used by <c>circles_searchProfiles</c>. They run without a Nethermind runtime
+/// and guard against positional-shift bugs in the wire handler: if anyone
+/// inserts a new parameter at position 4 (instead of appending) the GroupType
+/// assertions here will fail.
+/// </summary>
+[TestFixture]
+public class SearchProfilesRequestParserTests
+{
+    private static JsonElement[] ParseParams(string json) =>
+        JsonSerializer.Deserialize<JsonElement[]>(json)!;
+
+    [Test]
+    public void Parse_throws_when_parameters_array_is_empty()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(ParseParams("[]")));
+    }
+
+    [Test]
+    public void Parse_throws_when_parameters_is_null()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(null));
+    }
+
+    [Test]
+    public void Parse_with_only_text_applies_defaults()
+    {
+        var result = SearchProfilesRequestParser.Parse(ParseParams("[\"alice\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(SearchProfilesRequestParser.DefaultLimit));
+            Assert.That(result.Offset, Is.EqualTo(SearchProfilesRequestParser.DefaultOffset));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Parse_reads_groupType_from_position_4()
+    {
+        // [text, limit, offset, types, groupType] — groupType must be index 4.
+        // Regression guard: if anyone shifts the positional order, this fails.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 5, null, \"closed\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(10));
+            Assert.That(result.Offset, Is.EqualTo(5));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.EqualTo("closed"));
+        });
+    }
+
+    [Test]
+    public void Parse_reads_types_from_position_3()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, [\"group\", \"organization\"], \"open\"]"));
+
+        Assert.That(result.Types, Is.EqualTo(new[] { "group", "organization" }));
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_treats_explicit_null_at_position_4_as_unset_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+    }
+
+    [Test]
+    public void Parse_omits_groupType_when_only_4_params_are_supplied()
+    {
+        // Legacy callers (pre-groupType) send 4 params and must continue to work.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+        Assert.That(result.Limit, Is.EqualTo(10));
+        Assert.That(result.Offset, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Parse_handles_open_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"open\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_passes_through_unknown_groupType_values_for_module_level_validation()
+    {
+        // The parser does not validate the groupType value — that's the module's
+        // job (CirclesRpcModule.SearchProfiles throws on unknown values). This
+        // separation keeps the parser thin and the validation centralized.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"restricted\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("restricted"));
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -999,38 +999,10 @@ static async Task<object> HandleGetProfileByAddressBatch(JsonRpcRequest request,
 static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRpcModule rpcModule)
 {
     var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
-    if (parameters == null || parameters.Length == 0)
-    {
-        throw new ArgumentException("Search text parameter is required");
-    }
+    var parsed = Circles.Rpc.Host.Wire.SearchProfilesRequestParser.Parse(parameters);
 
-    string text = parameters[0].GetString() ?? "";
-    int limit = 20;
-    int offset = 0;
-    string[]? types = null;
-    string? groupType = null;
-
-    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
-    {
-        limit = parameters[1].GetInt32();
-    }
-
-    if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
-    {
-        offset = parameters[2].GetInt32();
-    }
-
-    if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
-    {
-        types = parameters[3].Deserialize<string[]>();
-    }
-
-    if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
-    {
-        groupType = parameters[4].GetString();
-    }
-
-    var searchResults = await rpcModule.SearchProfiles(text, limit, offset, types, groupType);
+    var searchResults = await rpcModule.SearchProfiles(
+        parsed.Text, parsed.Limit, parsed.Offset, parsed.Types, parsed.GroupType);
     var transformedResults = searchResults.Results.Select(item =>
     {
         // Extract properties from AvatarInfo

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -627,17 +627,25 @@ public partial class CirclesRpcModule
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Profile pinning service proxy failed, falling back to SQL");
+                _logger?.LogWarning(ex, "Profile pinning service proxy failed for SearchProfiles (groupType={GroupType})", groupTypeFilter);
             }
         }
 
-        // Fallback: direct SQL search. SQL fallback cannot filter by groupType — the chain
-        // index has no such column. Log a warning so callers can see the degradation, then
-        // proceed unfiltered (preferred over throwing; matches the existing "fall back silently" pattern).
+        // SQL fallback cannot honor a groupType filter — the chain index table has no
+        // group_type column, so a SQL search would silently return rows from the wrong
+        // group type. The only data source that knows group_type is the pinning service;
+        // if it's unreachable, the truthful answer to a groupType-filtered query is empty,
+        // not "everything that matches the text". Return an authoritative empty result
+        // so closed-group filters can't leak open-group rows during a proxy outage.
         if (groupTypeFilter != null)
         {
-            _logger?.LogWarning("SearchProfiles groupType={GroupType} filter ignored in SQL fallback (chain index has no group_type column)", groupTypeFilter);
+            _logger?.LogWarning(
+                "SearchProfiles groupType={GroupType} requested but pinning-service proxy did not return a result; returning empty (SQL fallback has no group_type column)",
+                groupTypeFilter);
+            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
         }
+
+        // Fallback: direct SQL search when no groupType filter is in play.
         return await SearchProfilesViaSql(qText, limit, offset, typeFilter);
     }
 

--- a/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
+++ b/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+
+namespace Circles.Rpc.Host.Wire;
+
+/// <summary>
+/// Parsed positional parameters for <c>circles_searchProfiles</c>.
+///
+/// The wire format is a JSON-RPC params array, positional:
+///   [0] text:      string                  (required)
+///   [1] limit:     int   (default 20)      (optional)
+///   [2] offset:    int   (default 0)       (optional)
+///   [3] types:     string[] | null         (optional)
+///   [4] groupType: string | null           (optional)
+///
+/// Each position is independent — a caller can pass <c>null</c> for any
+/// optional slot, or omit trailing slots entirely. New params MUST be appended,
+/// never inserted, to avoid silently shifting the meaning of existing callers.
+/// </summary>
+public sealed record SearchProfilesRequest(
+    string Text,
+    int Limit,
+    int Offset,
+    string[]? Types,
+    string? GroupType);
+
+public static class SearchProfilesRequestParser
+{
+    public const int DefaultLimit = 20;
+    public const int DefaultOffset = 0;
+
+    /// <summary>
+    /// Parse the positional JSON-RPC params for <c>circles_searchProfiles</c>.
+    /// Throws <see cref="ArgumentException"/> if the required text parameter is missing.
+    /// </summary>
+    public static SearchProfilesRequest Parse(JsonElement[]? parameters)
+    {
+        if (parameters == null || parameters.Length == 0)
+        {
+            throw new ArgumentException("Search text parameter is required");
+        }
+
+        string text = parameters[0].GetString() ?? "";
+        int limit = DefaultLimit;
+        int offset = DefaultOffset;
+        string[]? types = null;
+        string? groupType = null;
+
+        if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        {
+            limit = parameters[1].GetInt32();
+        }
+
+        if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
+        {
+            offset = parameters[2].GetInt32();
+        }
+
+        if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
+        {
+            types = parameters[3].Deserialize<string[]>();
+        }
+
+        if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
+        {
+            groupType = parameters[4].GetString();
+        }
+
+        return new SearchProfilesRequest(text, limit, offset, types, groupType);
+    }
+}


### PR DESCRIPTION
## Summary

Audit follow-ups for the group profile extension on the RPC plugin. Targets `feature/profile-group-fields` so the fixes land inside the feature branch before it merges to `dev`.

## What changed

**Close the `groupType` leak on the proxy exception path**
When `circles_searchProfiles` is called with a `groupType` filter AND the pinning-service proxy fails (HTTP error, timeout, or null return), the previous behaviour was to fall through to `SearchProfilesViaSql`. The SQL fallback has no `group_type` column, so it would silently return rows from the wrong group type — exactly the leak the existing empty-array short-circuit was designed to prevent.

The fix extends the authoritative-empty rule to the exception path: when `groupType` is set and the proxy did not produce a result for any reason, return `ProfileSearchResult(0, [])` and log a warning. The SQL fallback is only used when no `groupType` filter is in play.

**Wire-handler parameter parser + regression test**
Extracted the JSON-RPC params parsing for `circles_searchProfiles` (previously inline in `Program.cs:HandleSearchProfiles`) into a small testable static class, `SearchProfilesRequestParser`. Added a non-`[Ignore]` test class that pins down the positional contract: text, limit, offset, types, groupType — in that order, with `groupType` at index 4.

A future positional shift (e.g. inserting a new param at index 4 instead of appending) would now fail in CI rather than at deploy time. The existing `[Ignore]`-gated `CirclesRpcModuleTests` fixture requires a Nethermind runtime; this new test class deliberately runs without it.

## Test plan

- [x] `dotnet test` — 9 new parser tests pass; existing 137 non-`[Ignore]` tests still pass.
- [x] `dotnet build` — no errors.
- [ ] Simulate proxy outage on staging (block pinning service via firewall or set bad URL); call `circles_searchProfiles` with `groupType: "closed"`; assert response is `{Total: 0, Results: []}` and a warning is logged.
- [ ] Same call without `groupType` falls through to SQL fallback as before.
- [ ] Legacy callers passing only 4 params (no `groupType`) continue to work byte-identically.
