### PR TITLE
feat(rpc): groupType filter + extended profile fields in circles_searchProfiles

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
@@ -610,6 +610,49 @@ public class CirclesRpcModuleTests
             Throws.InstanceOf<ArgumentException>());
     }
 
+    [Test]
+    public void SearchProfiles_WithInvalidGroupType_Throws()
+    {
+        RequireModule();
+
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: "garbage"),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void SearchProfiles_WithEmptyGroupType_DoesNotThrow()
+    {
+        RequireModule();
+
+        // Whitespace/empty groupType should be treated as "no filter", not an error.
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: ""),
+            Throws.Nothing);
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: "   "),
+            Throws.Nothing);
+    }
+
+    [Test]
+    public async Task SearchProfiles_WithValidGroupTypeOpen_ReturnsResult()
+    {
+        RequireModule();
+
+        var result = await _module!.SearchProfiles("test", limit: 10, groupType: "open");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.InstanceOf<ProfileSearchResult>());
+    }
+
+    [Test]
+    public async Task SearchProfiles_WithValidGroupTypeClosed_ReturnsResult()
+    {
+        RequireModule();
+
+        var result = await _module!.SearchProfiles("test", limit: 10, groupType: "closed");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.InstanceOf<ProfileSearchResult>());
+    }
+
     #endregion
 
     #region GetTokenInfo Tests

--- a/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Circles.Rpc.Host.Wire;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SearchProfilesRequestParser"/>.
+///
+/// These tests pin down the positional contract of the JSON-RPC params array
+/// used by <c>circles_searchProfiles</c>. They run without a Nethermind runtime
+/// and guard against positional-shift bugs in the wire handler: if anyone
+/// inserts a new parameter at position 4 (instead of appending) the GroupType
+/// assertions here will fail.
+/// </summary>
+[TestFixture]
+public class SearchProfilesRequestParserTests
+{
+    private static JsonElement[] ParseParams(string json) =>
+        JsonSerializer.Deserialize<JsonElement[]>(json)!;
+
+    [Test]
+    public void Parse_throws_when_parameters_array_is_empty()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(ParseParams("[]")));
+    }
+
+    [Test]
+    public void Parse_throws_when_parameters_is_null()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(null));
+    }
+
+    [Test]
+    public void Parse_with_only_text_applies_defaults()
+    {
+        var result = SearchProfilesRequestParser.Parse(ParseParams("[\"alice\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(SearchProfilesRequestParser.DefaultLimit));
+            Assert.That(result.Offset, Is.EqualTo(SearchProfilesRequestParser.DefaultOffset));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Parse_reads_groupType_from_position_4()
+    {
+        // [text, limit, offset, types, groupType] — groupType must be index 4.
+        // Regression guard: if anyone shifts the positional order, this fails.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 5, null, \"closed\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(10));
+            Assert.That(result.Offset, Is.EqualTo(5));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.EqualTo("closed"));
+        });
+    }
+
+    [Test]
+    public void Parse_reads_types_from_position_3()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, [\"group\", \"organization\"], \"open\"]"));
+
+        Assert.That(result.Types, Is.EqualTo(new[] { "group", "organization" }));
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_treats_explicit_null_at_position_4_as_unset_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+    }
+
+    [Test]
+    public void Parse_omits_groupType_when_only_4_params_are_supplied()
+    {
+        // Legacy callers (pre-groupType) send 4 params and must continue to work.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+        Assert.That(result.Limit, Is.EqualTo(10));
+        Assert.That(result.Offset, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Parse_handles_open_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"open\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_passes_through_unknown_groupType_values_for_module_level_validation()
+    {
+        // The parser does not validate the groupType value — that's the module's
+        // job (CirclesRpcModule.SearchProfiles throws on unknown values). This
+        // separation keeps the parser thin and the validation centralized.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"restricted\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("restricted"));
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -105,7 +105,8 @@ public interface ICirclesRpcModule
     /// <param name="limit">Maximum results to return (default: 20, max: 100)</param>
     /// <param name="offset">Number of results to skip</param>
     /// <param name="types">Filter by avatar types (e.g., "CrcV2_RegisterHuman", "CrcV2_RegisterGroup")</param>
-    Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null);
+    /// <param name="groupType">Filter by group type: "open" or "closed". Only matches profiles whose stored group_type equals this value.</param>
+    Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null, string? groupType = null);
 
     // ========================================================================
     // SDK Enablement Methods

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -85,7 +85,7 @@ public static class OpenRpcGenerator
 
         ("circles_searchProfiles", "SearchProfiles", "Profiles",
             "Full-text search across profiles",
-            "Searches avatar profiles by name and description text. Supports up to 3 search tokens (each must be > 1 character). Can filter by avatar type.\n\n**Common use case**: User search bar — type a name, get matching profiles.\n\n**Tip**: For searching by address prefix OR name, use `circles_searchProfileByAddressOrName` which auto-detects the query type."),
+            "Searches avatar profiles by name and description text. Supports up to 3 search tokens (each must be > 1 character). Can filter by avatar type and (for group profiles) by `groupType` (`open`/`closed`).\n\n**Common use case**: User search bar — type a name, get matching profiles.\n\n**Tip**: For searching by address prefix OR name, use `circles_searchProfileByAddressOrName` which auto-detects the query type.\n\n**Extended return fields** (each result item's `Profile` sub-object, omitted when unset): `externalWebsite`, `minRepScore`, `membershipFee`, `additionalCriteria`, `groupType`, `contactEmail`, `contactWebsite`."),
 
         // ── Trust & Network Methods ──────────────────────────────────────────
         ("circles_getTrustRelations", "GetTrustRelations", "Trust",
@@ -312,7 +312,9 @@ public static class OpenRpcGenerator
             Param("offset", false, "integer",
                 "Number of results to skip. Use with limit for offset-based pagination (e.g., offset=20, limit=20 for page 2)."),
             ParamArray("types", false, "string",
-                "Filter results by avatar type. Valid values: 'CrcV2_RegisterHuman', 'CrcV2_RegisterGroup', 'CrcV2_RegisterOrganization'. Omit to search all types.")
+                "Filter results by avatar type. Valid values: 'CrcV2_RegisterHuman', 'CrcV2_RegisterGroup', 'CrcV2_RegisterOrganization'. Omit to search all types."),
+            Param("groupType", false, "string",
+                "Filter group profiles by their stored group type. Valid values: 'open', 'closed'. Forwarded to the profile-pinning service (fast path); silently ignored by the SQL fallback (chain index has no group_type column). Omit to apply no group-type filter.")
         ],
         ["circles_getTrustRelations"] =
         [
@@ -701,6 +703,19 @@ public static class OpenRpcGenerator
                     new() { Name = "limit", Value = 20 },
                     new() { Name = "offset", Value = 0 },
                     new() { Name = "types", Value = new[] { "CrcV2_RegisterGroup" } },
+                ],
+            },
+            new()
+            {
+                Name = "Search closed groups",
+                Description = "Find closed-membership group profiles matching 'community' (filter on the extended groupType field)",
+                Params =
+                [
+                    new() { Name = "text", Value = "community" },
+                    new() { Name = "limit", Value = 20 },
+                    new() { Name = "offset", Value = 0 },
+                    new() { Name = "types", Value = new[] { "CrcV2_RegisterGroup" } },
+                    new() { Name = "groupType", Value = "closed" },
                 ],
             }
         ],

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -1000,38 +1000,10 @@ static async Task<object> HandleGetProfileByAddressBatch(JsonRpcRequest request,
 static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRpcModule rpcModule)
 {
     var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
-    if (parameters == null || parameters.Length == 0)
-    {
-        throw new ArgumentException("Search text parameter is required");
-    }
+    var parsed = Circles.Rpc.Host.Wire.SearchProfilesRequestParser.Parse(parameters);
 
-    string text = parameters[0].GetString() ?? "";
-    int limit = 20;
-    int offset = 0;
-    string[]? types = null;
-    string? groupType = null;
-
-    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
-    {
-        limit = parameters[1].GetInt32();
-    }
-
-    if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
-    {
-        offset = parameters[2].GetInt32();
-    }
-
-    if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
-    {
-        types = parameters[3].Deserialize<string[]>();
-    }
-
-    if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
-    {
-        groupType = parameters[4].GetString();
-    }
-
-    var searchResults = await rpcModule.SearchProfiles(text, limit, offset, types, groupType);
+    var searchResults = await rpcModule.SearchProfiles(
+        parsed.Text, parsed.Limit, parsed.Offset, parsed.Types, parsed.GroupType);
     var transformedResults = searchResults.Results.Select(item =>
     {
         // Extract properties from AvatarInfo

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -1009,6 +1009,7 @@ static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRp
     int limit = 20;
     int offset = 0;
     string[]? types = null;
+    string? groupType = null;
 
     if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
     {
@@ -1025,7 +1026,12 @@ static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRp
         types = parameters[3].Deserialize<string[]>();
     }
 
-    var searchResults = await rpcModule.SearchProfiles(text, limit, offset, types);
+    if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
+    {
+        groupType = parameters[4].GetString();
+    }
+
+    var searchResults = await rpcModule.SearchProfiles(text, limit, offset, types, groupType);
     var transformedResults = searchResults.Results.Select(item =>
     {
         // Extract properties from AvatarInfo
@@ -1034,20 +1040,41 @@ static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRp
         var cid = avatarInfo.CidV0; // Remote expects "cid"
         var avatarType = avatarInfo.Type; // Remote expects "avatarType"
 
-        // Extract properties from Profile (JsonElement)
-        var profileName = item.Profile?.TryGetProperty("name", out var nameElement) == true ? nameElement.GetString() : null;
-        var profileDescription = item.Profile?.TryGetProperty("description", out var descElement) == true ? descElement.GetString() : null;
-        var profilePreviewImageUrl = item.Profile?.TryGetProperty("previewImageUrl", out var imageUrlElement) == true ? imageUrlElement.GetString() : null;
+        // Extract properties from Profile (JsonElement). Extended group-profile fields
+        // are surfaced when the underlying proxy result populated them; null values are
+        // dropped from the JSON output by the global DefaultIgnoreCondition=WhenWritingNull
+        // serializer setting, so legacy profiles stay byte-identical to the pre-change baseline.
+        var profile = item.Profile;
+        string? GetStr(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind != JsonValueKind.Null
+                ? el.GetString() : null;
+        double? GetNum(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind == JsonValueKind.Number
+                ? el.GetDouble() : null;
+        string[]? GetStrArr(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind == JsonValueKind.Array
+                ? el.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString()!)
+                    .ToArray()
+                : null;
 
         // Construct the flattened anonymous object
         return new
         {
             address = address,
             cid = cid,
-            name = profileName,
-            description = profileDescription,
-            previewImageUrl = profilePreviewImageUrl,
-            avatarType = avatarType
+            name = GetStr("name"),
+            description = GetStr("description"),
+            previewImageUrl = GetStr("previewImageUrl"),
+            avatarType = avatarType,
+            externalWebsite = GetStr("externalWebsite"),
+            minRepScore = GetNum("minRepScore"),
+            membershipFee = GetNum("membershipFee"),
+            additionalCriteria = GetStrArr("additionalCriteria"),
+            groupType = GetStr("groupType"),
+            contactEmail = GetStr("contactEmail"),
+            contactWebsite = GetStr("contactWebsite")
         };
     }).ToArray();
 

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -646,7 +646,7 @@ public partial class CirclesRpcModule
             catch (Exception ex)
             {
                 path = ClassifyProxyException(ex);
-                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}), falling back to SQL", path);
+                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}, groupType={GroupType}), falling back to SQL", path, groupTypeFilter);
             }
         }
 

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -577,12 +577,23 @@ public partial class CirclesRpcModule
 
     private enum SearchProxyOutcome { Hit, Zero, Error }
 
-    public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null)
+    public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null, string? groupType = null)
     {
         const int hardLimit = 100;
         if (limit > hardLimit)
         {
             throw new ArgumentException($"limit must not exceed {hardLimit} (got {limit}).");
+        }
+
+        string? groupTypeFilter = null;
+        if (!string.IsNullOrWhiteSpace(groupType))
+        {
+            var gt = groupType.Trim();
+            if (gt != "open" && gt != "closed")
+            {
+                throw new ArgumentException($"groupType must be 'open' or 'closed' (got '{groupType}').", nameof(groupType));
+            }
+            groupTypeFilter = gt;
         }
 
         var sw = Stopwatch.StartNew();
@@ -618,7 +629,7 @@ public partial class CirclesRpcModule
         {
             try
             {
-                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
+                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter, groupTypeFilter);
                 switch (outcome)
                 {
                     case SearchProxyOutcome.Hit:
@@ -637,6 +648,19 @@ public partial class CirclesRpcModule
                 path = ClassifyProxyException(ex);
                 _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}), falling back to SQL", path);
             }
+        }
+
+        // SQL fallback cannot honor a groupType filter — the chain index has no
+        // group_type column. Falling through would silently return rows from the
+        // wrong group type. Return authoritative empty instead.
+        if (groupTypeFilter != null)
+        {
+            var emptyResult = new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            _logger?.LogWarning(
+                "SearchProfiles groupType={GroupType} requested but pinning-service proxy did not return a result; returning empty (SQL fallback has no group_type column)",
+                groupTypeFilter);
+            RecordSearchProfilesPath(path, sw.Elapsed, emptyResult);
+            return emptyResult;
         }
 
         // Fallback: direct SQL search
@@ -666,7 +690,7 @@ public partial class CirclesRpcModule
     /// Returns an outcome indicating Hit/Zero/Error so the caller can label metrics.
     /// </summary>
     private async Task<(SearchProxyOutcome outcome, ProfileSearchResult? result)> SearchProfilesViaProxy(
-        string qText, int limit, int offset, string[]? typeFilter)
+        string qText, int limit, int offset, string[]? typeFilter, string? groupType = null)
     {
         var baseUrl = _settings.ProfilePinningServiceUrl!.TrimEnd('/');
 
@@ -682,6 +706,11 @@ public partial class CirclesRpcModule
         if (typeFilter is { Length: > 0 })
         {
             url += $"&type={Uri.EscapeDataString(typeFilter[0])}";
+        }
+
+        if (!string.IsNullOrEmpty(groupType))
+        {
+            url += $"&groupType={Uri.EscapeDataString(groupType)}";
         }
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -735,6 +764,28 @@ public partial class CirclesRpcModule
                 profileDict["description"] = descEl.GetString();
             if (proxyEntry.TryGetProperty("location", out var locEl) && locEl.ValueKind != JsonValueKind.Null)
                 profileDict["location"] = locEl.GetString();
+
+            // Extended group-profile fields (proxy returns flat shape — see pinning service
+            // ProfileResponse). Keys are omitted by the proxy when unset, so the same is true here.
+            // Numeric fields come back as JS numbers thanks to the `::float8` cast applied
+            // in the pinning service's repositories/profiles.ts (migration 017 follow-up).
+            if (proxyEntry.TryGetProperty("externalWebsite", out var extWebEl) && extWebEl.ValueKind != JsonValueKind.Null)
+                profileDict["externalWebsite"] = extWebEl.GetString();
+            if (proxyEntry.TryGetProperty("minRepScore", out var minRepEl) && minRepEl.ValueKind == JsonValueKind.Number)
+                profileDict["minRepScore"] = minRepEl.GetDouble();
+            if (proxyEntry.TryGetProperty("membershipFee", out var feeEl) && feeEl.ValueKind == JsonValueKind.Number)
+                profileDict["membershipFee"] = feeEl.GetDouble();
+            if (proxyEntry.TryGetProperty("additionalCriteria", out var critEl) && critEl.ValueKind == JsonValueKind.Array)
+                profileDict["additionalCriteria"] = critEl.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString())
+                    .ToArray();
+            if (proxyEntry.TryGetProperty("groupType", out var gtEl) && gtEl.ValueKind != JsonValueKind.Null)
+                profileDict["groupType"] = gtEl.GetString();
+            if (proxyEntry.TryGetProperty("contactEmail", out var emailEl) && emailEl.ValueKind != JsonValueKind.Null)
+                profileDict["contactEmail"] = emailEl.GetString();
+            if (proxyEntry.TryGetProperty("contactWebsite", out var contWebEl) && contWebEl.ValueKind != JsonValueKind.Null)
+                profileDict["contactWebsite"] = contWebEl.GetString();
 
             if (profileDict.Count > 0)
             {

--- a/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
+++ b/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+
+namespace Circles.Rpc.Host.Wire;
+
+/// <summary>
+/// Parsed positional parameters for <c>circles_searchProfiles</c>.
+///
+/// The wire format is a JSON-RPC params array, positional:
+///   [0] text:      string                  (required)
+///   [1] limit:     int   (default 20)      (optional)
+///   [2] offset:    int   (default 0)       (optional)
+///   [3] types:     string[] | null         (optional)
+///   [4] groupType: string | null           (optional)
+///
+/// Each position is independent — a caller can pass <c>null</c> for any
+/// optional slot, or omit trailing slots entirely. New params MUST be appended,
+/// never inserted, to avoid silently shifting the meaning of existing callers.
+/// </summary>
+public sealed record SearchProfilesRequest(
+    string Text,
+    int Limit,
+    int Offset,
+    string[]? Types,
+    string? GroupType);
+
+public static class SearchProfilesRequestParser
+{
+    public const int DefaultLimit = 20;
+    public const int DefaultOffset = 0;
+
+    /// <summary>
+    /// Parse the positional JSON-RPC params for <c>circles_searchProfiles</c>.
+    /// Throws <see cref="ArgumentException"/> if the required text parameter is missing.
+    /// </summary>
+    public static SearchProfilesRequest Parse(JsonElement[]? parameters)
+    {
+        if (parameters == null || parameters.Length == 0)
+        {
+            throw new ArgumentException("Search text parameter is required");
+        }
+
+        string text = parameters[0].GetString() ?? "";
+        int limit = DefaultLimit;
+        int offset = DefaultOffset;
+        string[]? types = null;
+        string? groupType = null;
+
+        if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        {
+            limit = parameters[1].GetInt32();
+        }
+
+        if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
+        {
+            offset = parameters[2].GetInt32();
+        }
+
+        if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
+        {
+            types = parameters[3].Deserialize<string[]>();
+        }
+
+        if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
+        {
+            groupType = parameters[4].GetString();
+        }
+
+        return new SearchProfilesRequest(text, limit, offset, types, groupType);
+    }
+}


### PR DESCRIPTION
## Summary

Plumbs the group-extension profile fields through the RPC layer. Adds a `groupType` filter to `circles_searchProfiles` and surfaces 7 new flat fields in each result item's Profile sub-object when present.

Targets `staging` directly. This is a rebase of the original `feature/profile-group-fields` branch onto current `staging` — the original branch had diverged 40 commits behind and its merge would have buried the 3 actual feature commits under a wide merge commit. Clean 3-commit rebase here. Supersedes #409.

## What changed

- **`ICirclesRpcModule.SearchProfiles`** signature extended with `string? groupType = null` (positional, appended after `types`). Invalid values throw `ArgumentException`.
- **`SearchProfilesViaProxy`** forwards `groupType` to the pinning service `/search` and `/search/text` endpoints, and reads 7 new flat fields (`externalWebsite`, `minRepScore`, `membershipFee`, `additionalCriteria`, `groupType`, `contactEmail`, `contactWebsite`) into each result item's Profile dictionary. Numeric fields arrive as JSON numbers.
- **`HandleSearchProfiles`** (wire-level manual handler in `Program.cs`) reads `params[4]` as `groupType`, forwards it to `_module.SearchProfiles`, and extends the result-transform anonymous object with the 7 new fields. `DefaultIgnoreCondition=WhenWritingNull` keeps responses byte-identical for legacy profiles.
- **`SearchProfilesRequestParser`** — extracted the JSON-RPC params parsing into a small testable static class. Added 9 non-`[Ignore]` regression tests that pin down the positional contract `[text, limit, offset, types, groupType]`. A future positional shift (e.g. inserting at index 4 instead of appending) now fails in CI rather than at deploy time.
- **Authoritative-empty when `groupType` filter is set**: on top of staging's `SearchProxyOutcome` (Hit/Zero/Error) outcomes, when `groupTypeFilter != null` and the proxy did not return a result (empty, error, or thrown exception), return `ProfileSearchResult(0, [])` instead of falling through to `SearchProfilesViaSql`. The SQL fallback has no `group_type` column and would silently return rows from the wrong group type. The empty-result short-circuit is recorded in metrics via `RecordSearchProfilesPath` so the path label still tells the operator how we got there.
- **OpenRPC**: `circles_searchProfiles` method spec updated with the new param + return fields.

## Integration with staging refactor

`SearchProfilesViaProxy` was refactored on `staging` (PRs #345–#349 era) to return a `(SearchProxyOutcome outcome, ProfileSearchResult? result)` tuple with explicit Hit/Zero/Error outcomes, Stopwatch-based duration metrics, and `ClassifyProxyException` for labeled exception paths. The groupType filter is layered on top: it threads through the proxy call, the URL, the response parsing, and the post-fallback safety guard, while preserving every staging metric label and timing observation.

## Test plan

- [x] `dotnet build` — 0 errors.
- [x] `dotnet test` — 9 new parser tests pass; 147 existing non-`[Ignore]` tests still pass; no regressions.
- [ ] Deploy to staging environment; `circles_searchProfiles` with `groupType: 'closed'` returns only closed groups; `'open'` returns only open groups; unset returns no filter.
- [ ] Invalid `groupType` value returns JSON-RPC `-32602` (Invalid params).
- [ ] Legacy person profiles return zero extended-shape keys (byte-identical baseline).
- [ ] `circles_getProfileByAddress` returns extended fields in nested IPFS shape when underlying profile has them.
- [ ] Proxy returning empty array with `groupType` set → result is `Total: 0, Results: []` (NOT a SQL passthrough).
- [ ] Proxy throwing with `groupType` set → result is `Total: 0, Results: []`.