### PR TITLE
fix(canary): branch unwrap conversion on wrapper circlesType

### DIFF
--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -232,7 +232,8 @@ public record PathfinderConsentedFlowRow(
 
 public record PathfinderWrapperMappingRow(
     string WrapperAddress,
-    string UnderlyingAvatar
+    string UnderlyingAvatar,
+    int CirclesType = 0
 );
 
 public record PathfinderOperatorApprovalRow(

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -832,7 +832,8 @@ public class PathfinderGraphController : ControllerBase
 
             mappings.Add(new PathfinderWrapperMappingRow(
                 WrapperAddress: kvp.Key,
-                UnderlyingAvatar: kvp.Value.Avatar
+                UnderlyingAvatar: kvp.Value.Avatar,
+                CirclesType: kvp.Value.CirclesType
             ));
         }
         return mappings;

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using System.Text.Json;
 using System.Threading.Channels;
 using Circles.Common.Dto;
+using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Simulation;
 using Prometheus;
 
@@ -19,7 +20,12 @@ internal sealed record CanaryWorkItem(
     long GraphBlock,
     List<TransferPathStep> Transfers,
     IReadOnlyDictionary<string, string>? WrapperToAvatar = null,
-    bool WithWrap = false);
+    bool WithWrap = false,
+    // Subset of WrapperToAvatar keys (lowercased addresses) whose CrcV2_ERC20WrapperDeployed.circlesType == 1.
+    // The canary's unwrap-prefix resolver uses this to discriminate the `_amount` unit semantic:
+    // - DemurrageCircles (NOT in this set): unwrap(_amount) takes demurraged 1155 units; pass BuildUnwrapPrefix's sum directly.
+    // - InflationaryCircles (IN this set):  unwrap(_amount) takes inflationary ERC20 units; convert via convertDemurrageToInflationaryValue.
+    IReadOnlySet<string>? InflationaryWrappers = null);
 
 /// <summary>
 /// Background service that simulates pathfinder results via eth_call against the local
@@ -132,7 +138,7 @@ internal sealed class SimulationCanaryService : BackgroundService
         try
         {
             unwrapCalls = item.WithWrap
-                ? BuildUnwrapPrefix(item.Transfers, item.WrapperToAvatar)
+                ? BuildUnwrapPrefix(item.Transfers, item.WrapperToAvatar, item.InflationaryWrappers)
                 : Array.Empty<UnwrapCall>();
             var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
             calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, transfers);
@@ -166,6 +172,20 @@ internal sealed class SimulationCanaryService : BackgroundService
 
             if (useUnwrapBundle)
             {
+                // Inflationary wrappers need demurraged → inflationary conversion before unwrap().
+                // DemurrageCircles wrappers pass through unchanged. Resolver is a no-op (zero RPC
+                // overhead) when the bundle contains no inflationary wrappers — the common case.
+                bool hasInflationary = false;
+                for (int i = 0; i < unwrapCalls.Count; i++)
+                {
+                    if (unwrapCalls[i].IsInflationary) { hasInflationary = true; break; }
+                }
+
+                if (hasInflationary)
+                {
+                    unwrapCalls = await ResolveInflationaryAmountsAsync(item, unwrapCalls, blockTag, client, ct);
+                }
+
                 await SimulateBundleAsync(item, unwrapCalls, calldata, blockTag, prefixLabel, client, ct);
                 QueueDepth.Set(_channel.Reader.Count);
                 return;
@@ -271,18 +291,34 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// <summary>
     /// One unwrap call in the eth_simulateV1 bundle: caller (from) unwraps `amount` of the
     /// wrapped ERC20 at `wrapper`, which mints the underlying 1155 to caller on Hub.sol.
+    /// <para><b>Amount unit semantics depend on the wrapper's circlesType:</b></para>
+    /// <list type="bullet">
+    ///   <item>DemurrageCircles (<see cref="IsInflationary"/> = false): <c>Amount</c> is in
+    ///     demurraged 1155 units. unwrap(_amount) burns _amount ERC20 AND credits _amount of
+    ///     the underlying 1155 (1:1). BuildUnwrapPrefix's raw sum is correct here.</item>
+    ///   <item>InflationaryCircles (<see cref="IsInflationary"/> = true): <c>Amount</c> must be
+    ///     in inflationary ERC20 units before reaching unwrap(). unwrap(_amount) burns _amount
+    ///     ERC20 and credits <c>_amount * γ^day</c> of 1155. BuildUnwrapPrefix produces a
+    ///     demurraged sum; the resolver converts it via wrapper.convertDemurrageToInflationaryValue
+    ///     before bundle assembly.</item>
+    /// </list>
+    /// Verified on-chain by direct eth_simulateV1 probes against both wrapper types (2026-05-27).
     /// </summary>
-    internal readonly record struct UnwrapCall(string From, string Wrapper, BigInteger Amount);
+    internal readonly record struct UnwrapCall(string From, string Wrapper, BigInteger Amount, bool IsInflationary = false);
 
     /// <summary>
     /// For each transfer whose TokenOwner is a known wrapper, attribute one unwrap call
     /// to the transfer's From address for the full transfer value. Groups identical
     /// (from, wrapper) pairs and sums amounts so a single SDK-equivalent unwrap precedes
     /// the operateFlowMatrix call in the bundle.
+    /// <para>The <paramref name="inflationaryWrappers"/> set discriminates which wrappers
+    /// need <c>convertDemurrageToInflationaryValue</c> at resolve-time. Wrappers absent
+    /// from the set are treated as DemurrageCircles (unit pass-through).</para>
     /// </summary>
     internal static IReadOnlyList<UnwrapCall> BuildUnwrapPrefix(
         List<TransferPathStep> transfers,
-        IReadOnlyDictionary<string, string>? wrapperToAvatar)
+        IReadOnlyDictionary<string, string>? wrapperToAvatar,
+        IReadOnlySet<string>? inflationaryWrappers = null)
     {
         if (wrapperToAvatar == null || wrapperToAvatar.Count == 0)
             return Array.Empty<UnwrapCall>();
@@ -319,7 +355,10 @@ internal sealed class SimulationCanaryService : BackgroundService
 
         var calls = new List<UnwrapCall>(order.Count);
         foreach (var key in order)
-            calls.Add(new UnwrapCall(key.From, key.Wrapper, sums[key]));
+        {
+            bool isInflationary = inflationaryWrappers != null && inflationaryWrappers.Contains(key.Wrapper);
+            calls.Add(new UnwrapCall(key.From, key.Wrapper, sums[key], isInflationary));
+        }
 
         return calls;
     }
@@ -611,5 +650,335 @@ internal sealed class SimulationCanaryService : BackgroundService
         }
 
         return resolved;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Inflationary unit conversion for InflationaryCircles wrappers.
+    //
+    // Circles V2 has two ERC20 wrapper flavors that BuildUnwrapPrefix cannot
+    // distinguish from the transfer list alone — both expose `unwrap(uint256)`
+    // but interpret the argument differently:
+    //
+    //   - DemurrageCircles  (circlesType=0, symbol `CRC`/`gCRC`):
+    //       unwrap(_amount) burns _amount ERC20 AND transfers _amount of 1155
+    //       — argument is in demurraged 1155 units (1:1 with the underlying).
+    //       BuildUnwrapPrefix's sum (in demurraged units) is correct as-is.
+    //
+    //   - InflationaryCircles (circlesType=1, symbol `s-`-prefixed):
+    //       unwrap(_amount) burns _amount ERC20 and transfers `_amount * γ^day`
+    //       of 1155 — argument is in inflationary ERC20 units. To release D of
+    //       1155 we must call unwrap(D * β^day) = unwrap(convertDemurrageToInflationaryValue(D, day)).
+    //
+    // Both wrappers inherit `convertDemurrageToInflationaryValue` from the
+    // shared Demurrage base, so the function ALWAYS applies β^day regardless of
+    // wrapper flavor. We branch on InflationaryWrappers set membership, not on
+    // the conversion function's return value.
+    //
+    // Verified on-chain 2026-05-27 via direct eth_simulateV1 probes against
+    // wrapper 0x548c20e6 (gCRC, demurraged) and 0x5d7eaaed (s-gCRC, inflationary):
+    //   - DemurrageCircles.unwrap(B)  → 1155 minted = B            (ratio 1.0)
+    //   - InflationaryCircles.unwrap(B) → 1155 minted = B * γ^day  (ratio β^day)
+    // ──────────────────────────────────────────────────────────────────────
+
+    private const string ConvertDemurrageToInflationarySelector = "0x253dd0b5";
+    private const long InflationDayZeroSeconds = (long)DemurrageCalculator.InflationDayZeroUnix;
+    private const long SecondsPerDay = 86_400L;
+    private const string ZeroSenderForReadOnly = "0x0000000000000000000000000000000000000000";
+
+    /// <summary>
+    /// Day index for Circles V2 demurrage math. Mirrors the on-chain
+    /// <c>Demurrage.day(blockTimestamp) = (blockTimestamp - inflationDayZero) / 86400</c>.
+    /// Pre-genesis or negative inputs yield day = 0, never a negative value.
+    /// </summary>
+    internal static long ComputeInflationDay(long blockTimestampSeconds)
+    {
+        long delta = blockTimestampSeconds - InflationDayZeroSeconds;
+        return delta <= 0 ? 0 : delta / SecondsPerDay;
+    }
+
+    /// <summary>
+    /// Encodes calldata for <c>convertDemurrageToInflationaryValue(uint256,uint64)</c>.
+    /// </summary>
+    internal static string EncodeConvertDemurrageCalldata(BigInteger demurragedAmount, long day)
+    {
+        if (demurragedAmount < 0)
+            throw new ArgumentOutOfRangeException(nameof(demurragedAmount), "uint256 amount must be non-negative");
+        if (day < 0)
+            throw new ArgumentOutOfRangeException(nameof(day), "day must be non-negative");
+
+        // BigInteger.ToString("x") prepends a leading 0 on positive numbers whose top
+        // nibble is ≥ 0x8 to avoid sign ambiguity. Trim it so the left-pad math is correct
+        // (same rationale as EncodeUnwrapCalldata).
+        var amountHex = demurragedAmount.ToString("x", CultureInfo.InvariantCulture);
+        if (amountHex.Length > 0 && amountHex[0] == '0' && amountHex.Length > 1) amountHex = amountHex.TrimStart('0');
+        if (amountHex.Length == 0) amountHex = "0";
+
+        // `day` is a long (>= 0 guarded above); long.ToString("x") emits minimal hex
+        // for positive values with NO sign-disambiguating leading zero, unlike BigInteger.
+        var dayHex = day.ToString("x", CultureInfo.InvariantCulture);
+
+        return ConvertDemurrageToInflationarySelector
+             + amountHex.PadLeft(64, '0')
+             + dayHex.PadLeft(64, '0');
+    }
+
+    /// <summary>
+    /// Parses one eth_simulateV1 call's returnData into a non-negative BigInteger.
+    /// Returns null if the call did not succeed, the payload is empty, or the hex
+    /// does not decode.
+    /// </summary>
+    internal static BigInteger? ParseConvertCallReturnData(JsonElement call)
+    {
+        if (!call.TryGetProperty("status", out var status) || status.GetString() != "0x1")
+            return null;
+        if (!call.TryGetProperty("returnData", out var rd))
+            return null;
+        var hex = rd.GetString();
+        if (string.IsNullOrEmpty(hex) || hex == "0x")
+            return null;
+        if (hex.StartsWith("0x", StringComparison.Ordinal)) hex = hex[2..];
+        // Prepend a leading '0' so BigInteger treats the value as unsigned even if
+        // the top nibble is ≥ 0x8 (e.g., a uint256 with the high bit set).
+        return BigInteger.TryParse("0" + hex, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var v)
+            ? v
+            : null;
+    }
+
+    /// <summary>
+    /// Extracts the per-call resolved amount from a batched eth_simulateV1 response.
+    /// Always returns a list of length <paramref name="expectedCount"/>; failed calls yield null.
+    /// </summary>
+    internal static IReadOnlyList<BigInteger?> ExtractInflationaryAmounts(JsonElement json, int expectedCount)
+    {
+        var amounts = new BigInteger?[expectedCount];
+        if (!json.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Array || result.GetArrayLength() == 0)
+            return amounts;
+        var block0 = result[0];
+        if (!block0.TryGetProperty("calls", out var innerCalls) || innerCalls.ValueKind != JsonValueKind.Array)
+            return amounts;
+        int actual = innerCalls.GetArrayLength();
+        for (int i = 0; i < expectedCount && i < actual; i++)
+            amounts[i] = ParseConvertCallReturnData(innerCalls[i]);
+        return amounts;
+    }
+
+    /// <summary>
+    /// Applies resolved inflationary amounts to the original unwrap-call list. Only
+    /// entries with <c>IsInflationary=true</c> consume the resolver's output; demurraged
+    /// entries pass through unchanged. A null resolved amount (RPC/parse failure) falls
+    /// back to the demurraged amount — the canary still attempts a simulation, which
+    /// just produces the prior false-positive class for that one inflationary wrapper,
+    /// not silently skipping coverage.
+    /// </summary>
+    internal static IReadOnlyList<UnwrapCall> ApplyInflationaryAmounts(
+        IReadOnlyList<UnwrapCall> calls,
+        IReadOnlyList<BigInteger?> inflationaryAmountsForInflationaryCalls)
+    {
+        var resolved = new List<UnwrapCall>(calls.Count);
+        int infIdx = 0;
+        for (int i = 0; i < calls.Count; i++)
+        {
+            var src = calls[i];
+            if (!src.IsInflationary)
+            {
+                resolved.Add(src);
+                continue;
+            }
+            BigInteger? resolvedAmount = infIdx < inflationaryAmountsForInflationaryCalls.Count
+                ? inflationaryAmountsForInflationaryCalls[infIdx]
+                : null;
+            infIdx++;
+            resolved.Add(new UnwrapCall(src.From, src.Wrapper, resolvedAmount ?? src.Amount, src.IsInflationary));
+        }
+        return resolved;
+    }
+
+    /// <summary>
+    /// Fetches the block timestamp (seconds since unix epoch) for a JSON-RPC block tag.
+    /// Returns null on any failure; caller decides fallback strategy. Every non-success
+    /// branch logs a warning for observability; metric label cardinality kept low via
+    /// the single <c>block_lookup_failed</c> label emitted by the caller.
+    /// </summary>
+    private async Task<long?> FetchBlockTimestampAsync(string blockTag, HttpClient client, CancellationToken ct)
+    {
+        var rpc = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "eth_getBlockByNumber",
+            @params = new object[] { blockTag, false }
+        };
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PostAsJsonAsync(_rpcUrl, rpc, ct);
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "SimulationCanary: FetchBlockTimestamp: eth_getBlockByNumber failed (network/timeout) for {Block}",
+                blockTag);
+            return null;
+        }
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.LogWarning(
+                "SimulationCanary: FetchBlockTimestamp: eth_getBlockByNumber HTTP {StatusCode} for {Block}",
+                (int)response.StatusCode, blockTag);
+            return null;
+        }
+        JsonElement json;
+        try { json = await response.Content.ReadFromJsonAsync<JsonElement>(ct); }
+        catch (JsonException jex)
+        {
+            _log.LogWarning(jex,
+                "SimulationCanary: FetchBlockTimestamp: non-JSON response for {Block}", blockTag);
+            return null;
+        }
+        if (json.TryGetProperty("error", out var rpcError))
+        {
+            var msg = rpcError.TryGetProperty("message", out var m) ? m.GetString() : "unknown";
+            _log.LogWarning(
+                "SimulationCanary: FetchBlockTimestamp: JSON-RPC error for {Block}: {Msg}",
+                blockTag, msg);
+            return null;
+        }
+        if (!json.TryGetProperty("result", out var result) || result.ValueKind != JsonValueKind.Object)
+        {
+            _log.LogWarning(
+                "SimulationCanary: FetchBlockTimestamp: missing/non-object result for {Block}", blockTag);
+            return null;
+        }
+        if (!result.TryGetProperty("timestamp", out var tsProp))
+        {
+            _log.LogWarning(
+                "SimulationCanary: FetchBlockTimestamp: missing timestamp field for {Block}", blockTag);
+            return null;
+        }
+        var hex = tsProp.GetString();
+        if (string.IsNullOrEmpty(hex))
+        {
+            _log.LogWarning(
+                "SimulationCanary: FetchBlockTimestamp: null/empty timestamp hex for {Block}", blockTag);
+            return null;
+        }
+        if (hex.StartsWith("0x", StringComparison.Ordinal)) hex = hex[2..];
+        try { return Convert.ToInt64(hex, 16); }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "SimulationCanary: FetchBlockTimestamp: timestamp parse failed for {Block} hex={Hex}", blockTag, hex);
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// For each unwrap call against an InflationaryCircles wrapper, replaces its
+    /// demurraged amount with the inflationary-unit equivalent at the simulation block's
+    /// day index, by batch-calling <c>convertDemurrageToInflationaryValue(amount, day)</c>
+    /// via eth_simulateV1 at the same block tag.
+    /// <para>
+    /// Failures (block lookup, RPC, parse) fall back to the demurraged amount per-call —
+    /// the bundle still simulates, which may produce the prior false-positive class
+    /// (<c>ERC1155InsufficientBalance</c> for inflationary unwraps) but never widens
+    /// coverage loss. Per-failure-class metrics use the existing simulation_total counter
+    /// with new result labels (<c>block_lookup_failed</c>, <c>inflation_resolve_failed</c>).
+    /// </para>
+    /// </summary>
+    private async Task<IReadOnlyList<UnwrapCall>> ResolveInflationaryAmountsAsync(
+        CanaryWorkItem item,
+        IReadOnlyList<UnwrapCall> calls,
+        string blockTag,
+        HttpClient client,
+        CancellationToken ct)
+    {
+        // Step 1: pull block timestamp (one RPC, deterministic key for the conversion math).
+        var ts = await FetchBlockTimestampAsync(blockTag, client, ct);
+        if (ts == null)
+        {
+            SimulationTotal.WithLabels("block_lookup_failed", "unwrap").Inc();
+            // Fall through: simulate bundle with demurraged amounts. For inflationary wrappers
+            // this reverts at unwrap() (the original f72f2d61-class FP), but it preserves the
+            // pre-PR signal — strictly better than silently dropping the canary attempt.
+            return calls;
+        }
+        long day = ComputeInflationDay(ts.Value);
+
+        // Step 2: collect inflationary-only positions; their order is preserved across the
+        // batched call array so ExtractInflationaryAmounts indexes match.
+        var inflationaryIndices = new List<int>();
+        for (int i = 0; i < calls.Count; i++)
+            if (calls[i].IsInflationary) inflationaryIndices.Add(i);
+
+        if (inflationaryIndices.Count == 0) return calls;
+
+        // Step 3: batch eth_simulateV1 — one call per inflationary unwrap.
+        // `from = ZERO_ADDRESS` is fine: convertDemurrageToInflationaryValue is a pure view
+        // function on the wrapper, ignores msg.sender.
+        var batchCalls = new List<object>(inflationaryIndices.Count);
+        foreach (var idx in inflationaryIndices)
+        {
+            var c = calls[idx];
+            batchCalls.Add(new
+            {
+                from = ZeroSenderForReadOnly,
+                to = c.Wrapper,
+                data = EncodeConvertDemurrageCalldata(c.Amount, day)
+            });
+        }
+        var rpc = new
+        {
+            jsonrpc = "2.0",
+            id = 1,
+            method = "eth_simulateV1",
+            @params = new object[]
+            {
+                new
+                {
+                    blockStateCalls = new[] { new { calls = batchCalls } },
+                    validation = false,
+                    traceTransfers = false
+                },
+                blockTag
+            }
+        };
+        HttpResponseMessage response;
+        try
+        {
+            response = await client.PostAsJsonAsync(_rpcUrl, rpc, ct);
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            _log.LogWarning(ex,
+                "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: eth_simulateV1 failed (network/timeout)",
+                item.ReqId);
+            SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
+            return calls;
+        }
+        if (!response.IsSuccessStatusCode)
+        {
+            _log.LogWarning(
+                "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: eth_simulateV1 HTTP {StatusCode}",
+                item.ReqId, (int)response.StatusCode);
+            SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
+            return calls;
+        }
+        JsonElement json;
+        try { json = await response.Content.ReadFromJsonAsync<JsonElement>(ct); }
+        catch (JsonException jex)
+        {
+            _log.LogWarning(jex,
+                "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: non-JSON response",
+                item.ReqId);
+            SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
+            return calls;
+        }
+
+        // Step 4: extract per-position results; ApplyInflationaryAmounts substitutes only
+        // inflationary positions (demurraged calls pass through unchanged).
+        var inflationaryAmounts = ExtractInflationaryAmounts(json, inflationaryIndices.Count);
+        return ApplyInflationaryAmounts(calls, inflationaryAmounts);
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -979,6 +979,24 @@ internal sealed class SimulationCanaryService : BackgroundService
         // Step 4: extract per-position results; ApplyInflationaryAmounts substitutes only
         // inflationary positions (demurraged calls pass through unchanged).
         var inflationaryAmounts = ExtractInflationaryAmounts(json, inflationaryIndices.Count);
+
+        // Per-call partial-failure observability: a null entry in `inflationaryAmounts`
+        // means the convert call for that wrapper failed (status != 0x1, empty returnData,
+        // or unparseable hex). ApplyInflationaryAmounts will fall back to the demurraged
+        // amount, which then drives `unwrap()` and reverts with ERC1155InsufficientBalance —
+        // the exact f72f2d61-class FP this code is trying to suppress. Without per-wrapper
+        // observability operators can't distinguish "real on-chain bug" from "resolver
+        // partial failure that re-introduced the prior FP class for one wrapper".
+        for (int i = 0; i < inflationaryAmounts.Count; i++)
+        {
+            if (inflationaryAmounts[i] != null) continue;
+            var call = calls[inflationaryIndices[i]];
+            _log.LogWarning(
+                "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: per-call resolve failed for wrapper={Wrapper} from={From} — falling back to demurraged (will likely revert at unwrap with ERC1155InsufficientBalance)",
+                item.ReqId, call.Wrapper, call.From);
+            SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Inc();
+        }
+
         return ApplyInflationaryAmounts(calls, inflationaryAmounts);
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -328,8 +328,8 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         return results.Select(a => a.ToLowerInvariant()).ToList();
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-        => Array.Empty<(string, string)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, int)>();
 
     /// <summary>
     /// Executes a query with @mintPolicy parameter and returns a list of strings from column 0.

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -290,6 +290,7 @@ internal sealed class FindPathHandler(
                     && !sourceUnsimulatable)
                 {
                     Dictionary<string, string>? wrapperMap = null;
+                    HashSet<string>? inflationaryWrappers = null;
                     try
                     {
                         if (h.Graph.WrapperToAvatar.Count > 0)
@@ -300,12 +301,23 @@ internal sealed class FindPathHandler(
                             {
                                 wrapperMap[AddressIdPool.StringOf(kv.Key)] = AddressIdPool.StringOf(kv.Value);
                             }
+                            // Build the inflationary-wrapper subset by resolving wrapper int IDs back
+                            // to addresses. Empty set is fine — the canary treats absence as "demurraged"
+                            // and skips the conversion step, preserving correctness for non-inflationary paths.
+                            if (h.Graph.InflationaryWrappers.Count > 0)
+                            {
+                                inflationaryWrappers = new HashSet<string>(
+                                    h.Graph.InflationaryWrappers.Count, StringComparer.OrdinalIgnoreCase);
+                                foreach (var wrapperId in h.Graph.InflationaryWrappers)
+                                    inflationaryWrappers.Add(AddressIdPool.StringOf(wrapperId));
+                            }
                         }
                     }
                     catch (Exception ex)
                     {
                         log.LogError(ex, "Failed to build wrapper map for canary — skipping simulation (would produce false positives)");
                         wrapperMap = null;
+                        inflationaryWrappers = null;
                     }
 
                     if (wrapperMap == null && h.Graph.WrapperToAvatar.Count > 0)
@@ -325,7 +337,8 @@ internal sealed class FindPathHandler(
                             GraphBlock: mfr.GraphBlock,
                             Transfers: new List<TransferPathStep>(mfr.Transfers),
                             WrapperToAvatar: wrapperMap,
-                            WithWrap: withWrap));
+                            WithWrap: withWrap,
+                            InflationaryWrappers: inflationaryWrappers));
                     }
                 }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -230,7 +230,7 @@ internal sealed class MaterializedLoadGraph(
     List<(string GroupAddress, string TrustedToken)> groupTrusts,
     List<(string Avatar, bool HasConsentedFlow)> consentedFlags,
     List<string> registeredAvatars,
-    List<(string WrapperAddress, string UnderlyingAvatar)> wrapperMappings) : ILoadGraph
+    List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> wrapperMappings) : ILoadGraph
 {
     public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
         LoadV2Balances() => balances;
@@ -249,6 +249,6 @@ internal sealed class MaterializedLoadGraph(
 
     public IEnumerable<string> LoadRegisteredAvatars() => registeredAvatars;
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)>
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
         LoadWrapperMappings() => wrapperMappings;
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -243,7 +243,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
             cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ScoreRouterIds));
+            new HashSet<int>(cap.ScoreRouterIds),
+            new HashSet<int>(cap.InflationaryWrappers));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -495,7 +496,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
             cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ScoreRouterIds));
+            new HashSet<int>(cap.ScoreRouterIds),
+            new HashSet<int>(cap.InflationaryWrappers));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 
@@ -729,7 +731,8 @@ public class NetworkStateUpdaterService : BackgroundService
             new Dictionary<int, int>(cap.GroupRouters),
             new Dictionary<(int GroupAddress, int CollateralToken), long>(cap.ScoreGroupMintLimits),
             cap.OperatorApprovals.ToDictionary(kv => kv.Key, kv => new HashSet<int>(kv.Value)),
-            new HashSet<int>(cap.ScoreRouterIds));
+            new HashSet<int>(cap.ScoreRouterIds),
+            new HashSet<int>(cap.InflationaryWrappers));
 
         _pool.UpdateSnapshot(new CapacityGraphSnapshot(lastBlock, cap), groupData);
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
@@ -642,8 +642,8 @@ public class ArithmeticSafetyTests
 
         public IEnumerable<string> LoadRegisteredAvatars()
             => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-            => Array.Empty<(string, string)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, int)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1779,8 +1779,8 @@ public class GraphFactoryTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => RegisteredAvatars;
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-            => Array.Empty<(string, string)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, int)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
@@ -179,6 +179,6 @@ public class FixtureLoadGraph : ILoadGraph
     /// <summary>
     /// Returns empty — fixture scenarios don't include wrapper data.
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-        => Array.Empty<(string, string)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, int)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -19,7 +19,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<string> _scoreRouters = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
-    private readonly List<(string WrapperAddress, string UnderlyingAvatar)> _wrapperMappings = new();
+    private readonly List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> _wrapperMappings = new();
     private string? _routerAddress;
 
     /// <summary>
@@ -210,7 +210,7 @@ public class MockLoadGraph : ILoadGraph
         return _registeredAvatars;
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
     {
         return _wrapperMappings;
     }
@@ -225,10 +225,12 @@ public class MockLoadGraph : ILoadGraph
 
     /// <summary>
     /// Add a wrapper→avatar mapping for testing.
+    /// circlesType: 0 = DemurrageCircles (default, unwrap takes demurraged units),
+    ///              1 = InflationaryCircles (unwrap takes inflationary units).
     /// </summary>
-    public void AddWrapperMapping(string wrapperAddress, string underlyingAvatar)
+    public void AddWrapperMapping(string wrapperAddress, string underlyingAvatar, int circlesType = 0)
     {
-        _wrapperMappings.Add((wrapperAddress.ToLowerInvariant(), underlyingAvatar.ToLowerInvariant()));
+        _wrapperMappings.Add((wrapperAddress.ToLowerInvariant(), underlyingAvatar.ToLowerInvariant(), circlesType));
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -297,8 +297,8 @@ public class ProxyLoadGraph : ILoadGraph
     /// <summary>
     /// Returns empty — ProxyLoadGraph uses native-only queries (no wrappers in graph).
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-        => Array.Empty<(string, string)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, int)>();
 
     // Helper methods to extract values from JsonElement or raw objects
     private static string GetString(object? value)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -296,6 +296,6 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
     public IEnumerable<string>
         LoadRegisteredAvatars() => data.RegisteredAvatars;
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)>
-        LoadWrapperMappings() => Array.Empty<(string, string)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
+        LoadWrapperMappings() => Array.Empty<(string, string, int)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SnapshotBuilder.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SnapshotBuilder.cs
@@ -51,7 +51,8 @@ public static class SnapshotBuilder
 
         var wrappers = mock.LoadWrapperMappings().Select(w => new PathfinderGraphWrapperMappingRow(
             WrapperAddress: w.WrapperAddress,
-            UnderlyingAvatar: w.UnderlyingAvatar
+            UnderlyingAvatar: w.UnderlyingAvatar,
+            CirclesType: w.CirclesType
         )).ToList();
 
         return new PathfinderGraphSnapshot(

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -826,8 +826,8 @@ public class IncrementalLoadGraphTests
         var balances = CreateBalanceState();
         var settings = new Settings();
         var stubInner = new StubLoadGraph();
-        stubInner.WrapperMappings.Add((Wrapper1, Bob));
-        stubInner.WrapperMappings.Add((Wrapper2, Bob));
+        stubInner.WrapperMappings.Add((Wrapper1, Bob, 0));
+        stubInner.WrapperMappings.Add((Wrapper2, Bob, 0));
 
         var incGraph = new IncrementalLoadGraph(balances, trusts, avatars, stubInner, settings, 0);
         var results = incGraph.LoadV2Trust().ToList();
@@ -960,7 +960,7 @@ public class IncrementalLoadGraphTests
         public List<string> Groups { get; } = new();
         public List<(string GroupAddress, string TrustedToken)> GroupTrustEntries { get; } = new();
         public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; } = new();
-        public List<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings { get; } = new();
+        public List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> WrapperMappings { get; } = new();
         public List<string> ScoreRouterAddresses { get; } = new();
         public List<(string Account, string Operator)> OperatorApprovalRows { get; } = new();
 
@@ -978,7 +978,7 @@ public class IncrementalLoadGraphTests
 
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
             => WrapperMappings;
 
         public IEnumerable<string> LoadScoreRouters() => ScoreRouterAddresses;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -1378,8 +1378,8 @@ public class MutationKillerTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
-            => Array.Empty<(string, string)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, int)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryInflationaryConversionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryInflationaryConversionTests.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Host.Canary;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Tests for the canary's wrapper-type-discriminated unwrap conversion.
+///
+/// <para><b>Contract behavior (verified on staging 2026-05-27 via direct eth_simulateV1 probes):</b></para>
+/// <list type="bullet">
+///   <item>DemurrageCircles wrapper 0x548c20e6 (`gCRC`, circlesType=0):
+///     <c>unwrap(229_412.19e18)</c> → minted 229_412.19e18 of 1155 (ratio 1.0). Argument is in demurraged units.</item>
+///   <item>InflationaryCircles wrapper 0x5d7eaaed (`s-gCRC`, circlesType=1):
+///     <c>unwrap(515.77e18)</c> → minted 343.21e18 of 1155 (ratio γ^2050 ≈ 0.6654). Argument is in inflationary units.</item>
+/// </list>
+/// <para>Both wrappers inherit <c>convertDemurrageToInflationaryValue</c> from the shared Demurrage
+/// base, which always applies β^day regardless of wrapper flavor — so the canary cannot rely on
+/// the function returning "identity" for demurraged wrappers. Branching is on circlesType set
+/// membership, not on the conversion function output.</para>
+/// </summary>
+[TestFixture]
+public class SimulationCanaryInflationaryConversionTests
+{
+    // --- Hex helpers: assemble 32-byte ABI words at runtime so no literal exceeds 32 hex chars.
+    private static string Word(string lowSegment)
+    {
+        if (lowSegment.Length > 64)
+            throw new ArgumentException("segment longer than 32 bytes");
+        return new string('0', 64 - lowSegment.Length) + lowSegment;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // ComputeInflationDay
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ComputeInflationDay_BelowEpoch_ReturnsZero()
+    {
+        Assert.That(SimulationCanaryService.ComputeInflationDay(0), Is.EqualTo(0));
+        Assert.That(SimulationCanaryService.ComputeInflationDay(1_000_000_000), Is.EqualTo(0));
+        Assert.That(SimulationCanaryService.ComputeInflationDay(1_602_720_000), Is.EqualTo(0));
+    }
+
+    [Test]
+    public void ComputeInflationDay_AtEpochPlusOneDay_ReturnsOne()
+    {
+        Assert.That(SimulationCanaryService.ComputeInflationDay(1_602_720_000 + 86_400), Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ComputeInflationDay_Day2050_MatchesStagingTimestamp()
+    {
+        // staging1 latest block timestamp range during 2026-05-27 ≈ 1779900000
+        // Expected day = (1779900000 - 1602720000) / 86400 ≈ 2050
+        long ts = 1_602_720_000L + 2050L * 86_400L + 500; // mid-day 2050
+        Assert.That(SimulationCanaryService.ComputeInflationDay(ts), Is.EqualTo(2050));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // EncodeConvertDemurrageCalldata
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void EncodeConvertDemurrageCalldata_ZeroAmountZeroDay()
+    {
+        var data = SimulationCanaryService.EncodeConvertDemurrageCalldata(BigInteger.Zero, 0);
+        Assert.That(data, Is.EqualTo("0x253dd0b5" + Word("0") + Word("0")));
+    }
+
+    [Test]
+    public void EncodeConvertDemurrageCalldata_OneEtherDayOne()
+    {
+        var data = SimulationCanaryService.EncodeConvertDemurrageCalldata(BigInteger.Parse("1000000000000000000"), 1);
+        Assert.That(data, Is.EqualTo("0x253dd0b5" + Word("de0b6b3a7640000") + Word("1")));
+    }
+
+    [Test]
+    public void EncodeConvertDemurrageCalldata_HighBitSetAmount_NoLeadingZeroDoublePadding()
+    {
+        // 2^248 ≤ value < 2^256 — top nibble ≥ 0x8 triggers BigInteger sign-disambiguation.
+        // Encoder must trim that leading zero so left-pad math yields exactly 64 hex chars per word.
+        var amount = BigInteger.Pow(2, 252);
+        var data = SimulationCanaryService.EncodeConvertDemurrageCalldata(amount, 2050);
+        // selector (10 chars) + amount word (64) + day word (64) = 138 chars total
+        Assert.That(data.Length, Is.EqualTo(10 + 64 + 64));
+        Assert.That(data.StartsWith("0x253dd0b5"), Is.True);
+    }
+
+    [Test]
+    public void EncodeConvertDemurrageCalldata_NegativeAmount_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimulationCanaryService.EncodeConvertDemurrageCalldata(BigInteger.MinusOne, 0));
+    }
+
+    [Test]
+    public void EncodeConvertDemurrageCalldata_NegativeDay_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            SimulationCanaryService.EncodeConvertDemurrageCalldata(BigInteger.One, -1));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // ParseConvertCallReturnData
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ParseConvertCallReturnData_SuccessfulCall_ReturnsAmount()
+    {
+        var json = JsonDocument.Parse(
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + Word("de0b6b3a7640000") + "\"}").RootElement;
+        var amt = SimulationCanaryService.ParseConvertCallReturnData(json);
+        Assert.That(amt, Is.EqualTo(BigInteger.Parse("1000000000000000000")));
+    }
+
+    [Test]
+    public void ParseConvertCallReturnData_HighBitSetReturn_TreatedAsUnsigned()
+    {
+        // Top byte 0xff — without the leading "0" prepend, BigInteger.Parse would read as negative.
+        var lowSeg = new string('f', 64); // 32 bytes all-FF = 2^256 - 1
+        var json = JsonDocument.Parse(
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + lowSeg + "\"}").RootElement;
+        var amt = SimulationCanaryService.ParseConvertCallReturnData(json);
+        Assert.That(amt, Is.GreaterThan(BigInteger.Zero));
+        Assert.That(amt, Is.EqualTo(BigInteger.Pow(2, 256) - 1));
+    }
+
+    [Test]
+    public void ParseConvertCallReturnData_FailedCall_ReturnsNull()
+    {
+        var json = JsonDocument.Parse(
+            "{\"status\":\"0x0\",\"returnData\":\"0x" + Word("1") + "\"}").RootElement;
+        Assert.That(SimulationCanaryService.ParseConvertCallReturnData(json), Is.Null);
+    }
+
+    [Test]
+    public void ParseConvertCallReturnData_MissingStatus_ReturnsNull()
+    {
+        var json = JsonDocument.Parse("{\"returnData\":\"0x" + Word("1") + "\"}").RootElement;
+        Assert.That(SimulationCanaryService.ParseConvertCallReturnData(json), Is.Null);
+    }
+
+    [Test]
+    public void ParseConvertCallReturnData_EmptyReturnData_ReturnsNull()
+    {
+        var json = JsonDocument.Parse("{\"status\":\"0x1\",\"returnData\":\"0x\"}").RootElement;
+        Assert.That(SimulationCanaryService.ParseConvertCallReturnData(json), Is.Null);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // ExtractInflationaryAmounts
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ExtractInflationaryAmounts_TwoSuccesses_ReturnsBoth()
+    {
+        var body = "{\"result\":[{\"calls\":[" +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + Word("de0b6b3a7640000") + "\"}," +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + Word("1bc16d674ec80000") + "\"}" + // 2 ether
+            "]}]}";
+        var amounts = SimulationCanaryService.ExtractInflationaryAmounts(JsonDocument.Parse(body).RootElement, 2);
+        Assert.That(amounts.Count, Is.EqualTo(2));
+        Assert.That(amounts[0], Is.EqualTo(BigInteger.Parse("1000000000000000000")));
+        Assert.That(amounts[1], Is.EqualTo(BigInteger.Parse("2000000000000000000")));
+    }
+
+    [Test]
+    public void ExtractInflationaryAmounts_ResponseTruncated_FillsNulls()
+    {
+        // Only one call returned but caller expected two — second slot must be null, not crash.
+        var body = "{\"result\":[{\"calls\":[" +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + Word("de0b6b3a7640000") + "\"}" +
+            "]}]}";
+        var amounts = SimulationCanaryService.ExtractInflationaryAmounts(JsonDocument.Parse(body).RootElement, 2);
+        Assert.That(amounts.Count, Is.EqualTo(2));
+        Assert.That(amounts[0], Is.Not.Null);
+        Assert.That(amounts[1], Is.Null);
+    }
+
+    [Test]
+    public void ExtractInflationaryAmounts_MissingResult_ReturnsAllNulls()
+    {
+        var amounts = SimulationCanaryService.ExtractInflationaryAmounts(JsonDocument.Parse("{}").RootElement, 3);
+        Assert.That(amounts.Count, Is.EqualTo(3));
+        foreach (var a in amounts) Assert.That(a, Is.Null);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // ApplyInflationaryAmounts — type-discrimination behavior
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void ApplyInflationaryAmounts_DemurragedCalls_PassThroughUnchanged()
+    {
+        var calls = new[]
+        {
+            new SimulationCanaryService.UnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), IsInflationary: false),
+            new SimulationCanaryService.UnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), IsInflationary: false),
+        };
+        var inflationaryResolved = new List<BigInteger?>(); // empty — no inflationary calls to resolve
+
+        var result = SimulationCanaryService.ApplyInflationaryAmounts(calls, inflationaryResolved);
+        Assert.That(result.Count, Is.EqualTo(2));
+        Assert.That(result[0].Amount, Is.EqualTo(BigInteger.Parse("100")));
+        Assert.That(result[0].IsInflationary, Is.False);
+        Assert.That(result[1].Amount, Is.EqualTo(BigInteger.Parse("200")));
+    }
+
+    [Test]
+    public void ApplyInflationaryAmounts_InflationaryCalls_AmountReplaced()
+    {
+        var calls = new[]
+        {
+            new SimulationCanaryService.UnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), IsInflationary: true),
+            new SimulationCanaryService.UnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), IsInflationary: true),
+        };
+        var inflationaryResolved = new List<BigInteger?>
+        {
+            BigInteger.Parse("150"), // = 100 * β^day (rounded)
+            BigInteger.Parse("300"), // = 200 * β^day
+        };
+
+        var result = SimulationCanaryService.ApplyInflationaryAmounts(calls, inflationaryResolved);
+        Assert.That(result[0].Amount, Is.EqualTo(BigInteger.Parse("150")));
+        Assert.That(result[1].Amount, Is.EqualTo(BigInteger.Parse("300")));
+        Assert.That(result.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void ApplyInflationaryAmounts_MixedBundle_OnlyInflationaryReplaced()
+    {
+        var calls = new[]
+        {
+            new SimulationCanaryService.UnwrapCall("0xfromA", "0xwrapA", BigInteger.Parse("100"), IsInflationary: false), // demurraged: pass through
+            new SimulationCanaryService.UnwrapCall("0xfromB", "0xwrapB", BigInteger.Parse("200"), IsInflationary: true),  // inflationary: convert
+            new SimulationCanaryService.UnwrapCall("0xfromC", "0xwrapC", BigInteger.Parse("300"), IsInflationary: false), // demurraged: pass through
+        };
+        var inflationaryResolved = new List<BigInteger?>
+        {
+            BigInteger.Parse("300"), // for the single inflationary call (200 * 1.5 = 300)
+        };
+
+        var result = SimulationCanaryService.ApplyInflationaryAmounts(calls, inflationaryResolved);
+        Assert.That(result.Count, Is.EqualTo(3));
+        Assert.That(result[0].Amount, Is.EqualTo(BigInteger.Parse("100")), "demurraged A unchanged");
+        Assert.That(result[1].Amount, Is.EqualTo(BigInteger.Parse("300")), "inflationary B resolved");
+        Assert.That(result[2].Amount, Is.EqualTo(BigInteger.Parse("300")), "demurraged C unchanged");
+    }
+
+    [Test]
+    public void ApplyInflationaryAmounts_NullResolved_FallsBackToOriginal()
+    {
+        var calls = new[]
+        {
+            new SimulationCanaryService.UnwrapCall("0xfrom", "0xwrap", BigInteger.Parse("100"), IsInflationary: true),
+        };
+        var resolved = new List<BigInteger?> { null }; // RPC failure on this call
+
+        var result = SimulationCanaryService.ApplyInflationaryAmounts(calls, resolved);
+        Assert.That(result[0].Amount, Is.EqualTo(BigInteger.Parse("100")));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // BuildUnwrapPrefix — type tagging
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void BuildUnwrapPrefix_TagsInflationaryWrappers()
+    {
+        var wrapperToAvatar = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["0xwrapd"] = "0xavatard", // demurraged
+            ["0xwrapi"] = "0xavatari", // inflationary
+        };
+        var inflationaryWrappers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "0xwrapi" };
+
+        var transfers = new List<TransferPathStep>
+        {
+            new() { From = "0xholder1", To = "0xnext", TokenOwner = "0xwrapd", Value = "1000" },
+            new() { From = "0xholder2", To = "0xnext", TokenOwner = "0xwrapi", Value = "2000" },
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
+        Assert.That(calls.Count, Is.EqualTo(2));
+        Assert.That(calls[0].Wrapper, Is.EqualTo("0xwrapd"));
+        Assert.That(calls[0].IsInflationary, Is.False);
+        Assert.That(calls[1].Wrapper, Is.EqualTo("0xwrapi"));
+        Assert.That(calls[1].IsInflationary, Is.True);
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_NullInflationarySet_TreatsAllAsDemurraged()
+    {
+        var wrapperToAvatar = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["0xwrap"] = "0xavatar",
+        };
+        var transfers = new List<TransferPathStep>
+        {
+            new() { From = "0xfrom", To = "0xto", TokenOwner = "0xwrap", Value = "100" },
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers: null);
+        Assert.That(calls.Count, Is.EqualTo(1));
+        Assert.That(calls[0].IsInflationary, Is.False);
+    }
+
+    [Test]
+    public void BuildUnwrapPrefix_SumsAmountsPerWrapperPreservingType()
+    {
+        var wrapperToAvatar = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["0xwrap"] = "0xavatar",
+        };
+        var inflationaryWrappers = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "0xwrap" };
+        var transfers = new List<TransferPathStep>
+        {
+            new() { From = "0xholder", To = "0xa", TokenOwner = "0xwrap", Value = "100" },
+            new() { From = "0xholder", To = "0xb", TokenOwner = "0xwrap", Value = "200" },
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
+        Assert.That(calls.Count, Is.EqualTo(1));
+        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("300")));
+        Assert.That(calls[0].IsInflationary, Is.True);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // End-to-end regression: chain-anchored numerical values
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Anchored in the 2026-05-27 staging probe:
+    ///   Wrapper 0x5d7eaaed (InflationaryCircles, s-gCRC), day 2050.
+    ///   Demurraged 343.214965... 1155 ⇒ inflationary 515.773036... ERC20 (β^2050).
+    /// Replays the helper pipeline on these chain-anchored values to lock in the math.
+    /// </summary>
+    [Test]
+    public void RegressionInflationaryConversion_StagingAnchoredValues()
+    {
+        // From probe: convertInflationaryToDemurrageValue(515.773e18, 2050) = 343.215e18
+        // ⇒ convertDemurrageToInflationaryValue(343.215e18, 2050) = 515.773e18 (round-trip).
+        // Encode the calldata the canary would send and verify the shape.
+        var demurraged = BigInteger.Parse("343214965393071985091"); // chain-observed 1155 amount
+        var calldata = SimulationCanaryService.EncodeConvertDemurrageCalldata(demurraged, 2050);
+        Assert.That(calldata.Length, Is.EqualTo(10 + 64 + 64));
+        Assert.That(calldata.StartsWith("0x253dd0b5"), Is.True);
+
+        // Simulate a successful conversion response: encode the inflationary value and parse it.
+        var inflationary = BigInteger.Parse("515773035763859818643"); // chain-observed ERC20 burned
+        var hex = inflationary.ToString("x", CultureInfo.InvariantCulture);
+        if (hex.Length > 0 && hex[0] == '0' && hex.Length > 1) hex = hex.TrimStart('0');
+        var json = JsonDocument.Parse(
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + new string('0', 64 - hex.Length) + hex + "\"}").RootElement;
+        var parsed = SimulationCanaryService.ParseConvertCallReturnData(json);
+        Assert.That(parsed, Is.EqualTo(inflationary));
+    }
+
+    /// <summary>
+    /// Anchored in the 2026-05-27 staging probe:
+    ///   Wrapper 0x548c20e6 (DemurrageCircles, gCRC), holder 0x7abe74b7.
+    ///   <c>unwrap(229_412.19e18)</c> succeeds and mints 229_412.19e18 of 1155 (ratio 1.0).
+    /// The canary must NOT convert this amount — pass-through is correct.
+    /// </summary>
+    [Test]
+    public void RegressionDemurragedWrapperPassThrough_StagingAnchoredValues()
+    {
+        var wrapperToAvatar = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["0x548c20e6c24e4876e20dadbeab75362e2f5a4bc1"] = "0xc19bc204eb1c1d5b3fe500e5e5dfabab625f286c",
+        };
+        // InflationaryWrappers set is EMPTY — wrapper is demurraged (circlesType=0).
+        var inflationaryWrappers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var transfers = new List<TransferPathStep>
+        {
+            new()
+            {
+                From = "0x7abe74b71f2958b624cb2be0596678784c0caf6a",
+                To = "0xsomesink",
+                TokenOwner = "0x548c20e6c24e4876e20dadbeab75362e2f5a4bc1",
+                Value = "229412191490542522084844"
+            },
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
+        Assert.That(calls.Count, Is.EqualTo(1));
+        Assert.That(calls[0].IsInflationary, Is.False);
+        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("229412191490542522084844")),
+            "demurraged-wrapper amount must pass through unchanged — no β^day inflation");
+
+        // ApplyInflationaryAmounts with empty inflationary list is a no-op for demurraged calls.
+        var resolved = SimulationCanaryService.ApplyInflationaryAmounts(calls, new List<BigInteger?>());
+        Assert.That(resolved.Count, Is.EqualTo(1));
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("229412191490542522084844")));
+    }
+
+    /// <summary>
+    /// Regression for the PR #408 incident: applying the inflation conversion indiscriminately
+    /// to a DemurrageCircles wrapper produces a ~1.5x overshoot at day 2050. This test asserts
+    /// that the canary's type-discrimination prevents this exact failure mode — a DemurrageCircles
+    /// wrapper must yield <c>IsInflationary=false</c> and the resolver must NOT touch its amount.
+    /// </summary>
+    [Test]
+    public void Regression_PR408_DemurragedWrappersAreNotInflated()
+    {
+        // From the 2026-05-27 incident: wrapper 0x6520d117 (CRC, demurraged) holder 0x122832c9.
+        var wrapperToAvatar = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["0x6520d117fb606c240ef83a809b3820765015cbb6"] = "0x122832c93e7c7bd7191b960513583d1a85735942",
+        };
+        // CRITICAL: this wrapper is circlesType=0 (demurraged), so it MUST NOT be in this set.
+        var inflationaryWrappers = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        var transfers = new List<TransferPathStep>
+        {
+            new()
+            {
+                From = "0xholder",
+                To   = "0xnext",
+                TokenOwner = "0x6520d117fb606c240ef83a809b3820765015cbb6",
+                Value = "17991355622341912729" // 17.99 demurraged = exact on-chain balance at incident
+            },
+        };
+
+        var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
+        Assert.That(calls.Count, Is.EqualTo(1));
+        Assert.That(calls[0].IsInflationary, Is.False,
+            "DemurrageCircles wrapper must NOT be flagged inflationary — PR #408 regression");
+
+        // Even with a non-empty resolved list (would-be inflated value), ApplyInflationaryAmounts
+        // must leave this call alone because IsInflationary is false.
+        var wouldBeOvershoot = BigInteger.Parse("27036835329465402436"); // 17.99 * β^2050 = the PR #408 incident value
+        var resolved = SimulationCanaryService.ApplyInflationaryAmounts(
+            calls, new List<BigInteger?> { wouldBeOvershoot });
+
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("17991355622341912729")),
+            "DemurrageCircles unwrap amount must remain the demurraged sum, not the inflated value");
+        Assert.That(resolved[0].Amount, Is.Not.EqualTo(wouldBeOvershoot),
+            "If this fails, the PR #408 regression has returned");
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -68,7 +68,11 @@ public record PathfinderGraphConsentedFlowRow(
 
 public record PathfinderGraphWrapperMappingRow(
     string WrapperAddress,
-    string UnderlyingAvatar
+    string UnderlyingAvatar,
+    // 0 = DemurrageCircles (unwrap takes demurraged units), 1 = InflationaryCircles (unwrap takes inflationary units).
+    // Default 0 is safe-degrade: old cache snapshots without this field deserialize as demurraged,
+    // matching pre-PR-#408 canary behavior (false positives for inflationary unwraps, no new reverts).
+    int CirclesType = 0
 );
 
 /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -138,10 +138,10 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return row.ToLowerInvariant();
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
     {
         var rows = _snapshot.WrapperMappings ?? [];
         foreach (var row in rows)
-            yield return (row.WrapperAddress.ToLowerInvariant(), row.UnderlyingAvatar.ToLowerInvariant());
+            yield return (row.WrapperAddress.ToLowerInvariant(), row.UnderlyingAvatar.ToLowerInvariant(), row.CirclesType);
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/DemurrageCalculator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/DemurrageCalculator.cs
@@ -13,7 +13,7 @@ public static class DemurrageCalculator
 {
     // V2 Hub epoch on gnosis mainnet — MUST match CirclesConverter.V2_INFLATION_DAY_ZERO_UNIX
     // On-chain: Hub(0x5524...).inflationDayZero() == 1_602_720_000 (Oct 15, 2020)
-    internal const uint InflationDayZeroUnix = 1_602_720_000;
+    public const uint InflationDayZeroUnix = 1_602_720_000;
     internal const ulong SecondsPerDay = 86_400;
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -21,7 +21,7 @@ public class IncrementalLoadGraph : ILoadGraph
     private readonly Settings _settings;
     private readonly long _maxBlockTimestamp;
     private readonly ILogger _logger;
-    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)>? _cachedWrapperMappings;
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>? _cachedWrapperMappings;
 
     public IncrementalLoadGraph(
         InMemoryBalanceState balanceState,
@@ -103,6 +103,9 @@ public class IncrementalLoadGraph : ILoadGraph
             .ToDictionary(
                 g => g.Key,
                 g => g.Select(x => x.WrapperAddress.ToLowerInvariant()).Distinct().ToArray());
+        // CirclesType is intentionally dropped here — this map drives trust-edge expansion
+        // (wrappers inherit the underlying avatar's trust), which is type-agnostic. The
+        // CapacityGraph.InflationaryWrappers set carries the type info separately.
 
         foreach (var (truster, trustee, limit) in directTrusts)
         {
@@ -179,9 +182,9 @@ public class IncrementalLoadGraph : ILoadGraph
     /// Returns cached wrapper mappings — loaded once per graph build from inner LoadGraph.
     /// Wrapper deployments are append-only, so caching within a single build is safe.
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
         => GetCachedWrapperMappings();
 
-    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> GetCachedWrapperMappings()
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> GetCachedWrapperMappings()
         => _cachedWrapperMappings ??= _inner.LoadWrapperMappings().ToList();
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -25,7 +25,7 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<string> ScoreRouters,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
         IReadOnlyList<string> RegisteredAvatars,
-        IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar)> WrapperMappings
+        IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> WrapperMappings
     );
 
     public interface ILoadGraph
@@ -63,7 +63,7 @@ namespace Circles.Pathfinder.Data
 
         IEnumerable<string> LoadRegisteredAvatars();
 
-        IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings();
+        IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings();
     }
 
     public class LoadGraph : ILoadGraph, IDisposable
@@ -767,11 +767,11 @@ namespace Circles.Pathfinder.Data
             return results;
         }
 
-        private List<(string WrapperAddress, string UnderlyingAvatar)>
+        private List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
             LoadWrapperMappingsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
         {
             var query = LoadQueryFromResource("wrapperMappingQuery.sql");
-            var results = new List<(string WrapperAddress, string UnderlyingAvatar)>(10_000);
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>(10_000);
 
             var sw = Stopwatch.StartNew();
 
@@ -781,7 +781,7 @@ namespace Circles.Pathfinder.Data
 
             while (reader.Read())
             {
-                results.Add((reader.GetString(0), reader.GetString(1)));
+                results.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2)));
             }
 
             sw.Stop();
@@ -1198,10 +1198,10 @@ namespace Circles.Pathfinder.Data
             return results;
         }
 
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar)> LoadWrapperMappings()
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
         {
             var query = LoadQueryFromResource("wrapperMappingQuery.sql");
-            var results = new List<(string WrapperAddress, string UnderlyingAvatar)>(10_000);
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>(10_000);
 
             var sw = Stopwatch.StartNew();
             using var connection = _dataSource.OpenConnection();
@@ -1212,7 +1212,7 @@ namespace Circles.Pathfinder.Data
 
             while (reader.Read())
             {
-                results.Add((reader.GetString(0), reader.GetString(1)));
+                results.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2)));
             }
 
             sw.Stop();

--- a/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
+++ b/src/Pathfinder/Circles.Pathfinder/Data/Queries/wrapperMappingQuery.sql
@@ -1,5 +1,5 @@
 WITH registered_avatars AS MATERIALIZED (
 {{registered_avatars_cte_body}})
-SELECT d."erc20Wrapper", d.avatar
+SELECT d."erc20Wrapper", d.avatar, d."circlesType"
 FROM "CrcV2_ERC20WrapperDeployed" d
 JOIN registered_avatars ra ON ra.avatar = d.avatar

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -17,7 +17,8 @@ public sealed record CachedGroupData(
     Dictionary<int, int>? GroupRouters = null,
     Dictionary<(int GroupAddress, int CollateralToken), long>? ScoreGroupMintLimits = null,
     Dictionary<int, HashSet<int>>? OperatorApprovals = null,
-    HashSet<int>? ScoreRouterIds = null);
+    HashSet<int>? ScoreRouterIds = null,
+    HashSet<int>? InflationaryWrappers = null);
 
 public class CapacityGraph : IGraph<CapacityEdge>
 {
@@ -69,6 +70,13 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Reverse mapping: ERC20 wrapper contract address ID → underlying avatar address ID
     // Used at DTO output layer to resolve wrapper addresses to registered avatars
     public Dictionary<int, int> WrapperToAvatar { get; } = new Dictionary<int, int>();
+
+    // Subset of WrapperToAvatar keys whose CrcV2_ERC20WrapperDeployed.circlesType == 1
+    // (InflationaryCircles, `s-` symbol prefix). The canary needs this to discriminate
+    // unwrap() argument units: DemurrageCircles.unwrap takes demurraged 1155 units 1:1,
+    // InflationaryCircles.unwrap takes inflationary ERC20 units (= demurraged * β^day).
+    // Verified on-chain by direct probes at 2026-05-27 — see PR description for evidence.
+    public HashSet<int> InflationaryWrappers { get; } = new HashSet<int>();
 
     // Trust lookup for consented flow validation (truster -> set of trustees)
     public IReadOnlyDictionary<int, HashSet<int>>? TrustLookup { get; set; }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -815,25 +815,37 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         }
     }
 
-    // Load ERC20 wrapper→avatar reverse mappings for DTO output resolution
+    // Load ERC20 wrapper→avatar reverse mappings for DTO output resolution.
+    // Also populates InflationaryWrappers for the canary's unit-discrimination logic.
+    // circlesType: 0 = DemurrageCircles (unwrap takes demurraged units),
+    //              1 = InflationaryCircles (unwrap takes inflationary units).
     private void LoadWrapperMappings(CapacityGraph capacityGraph, CachedGroupData? cached = null)
     {
         if (cached != null)
         {
             foreach (var (wrapperId, avatarId) in cached.WrapperToAvatar)
                 capacityGraph.WrapperToAvatar[wrapperId] = avatarId;
-            _logger.LogDebug("Used cached wrapper mappings: {Count} entries", cached.WrapperToAvatar.Count);
+            if (cached.InflationaryWrappers != null)
+            {
+                foreach (var wrapperId in cached.InflationaryWrappers)
+                    capacityGraph.InflationaryWrappers.Add(wrapperId);
+            }
+            _logger.LogDebug("Used cached wrapper mappings: {Count} entries ({Inflationary} inflationary)",
+                cached.WrapperToAvatar.Count, capacityGraph.InflationaryWrappers.Count);
             return;
         }
 
-        foreach (var (wrapperAddr, avatarAddr) in loadGraph.LoadWrapperMappings())
+        foreach (var (wrapperAddr, avatarAddr, circlesType) in loadGraph.LoadWrapperMappings())
         {
             int wrapperId = AddressIdPool.IdOf(wrapperAddr.ToLowerInvariant());
             int avatarId = AddressIdPool.IdOf(avatarAddr.ToLowerInvariant());
             capacityGraph.WrapperToAvatar[wrapperId] = avatarId;
+            if (circlesType == 1)
+                capacityGraph.InflationaryWrappers.Add(wrapperId);
         }
 
-        _logger.LogDebug("Loaded {Count} wrapper→avatar mappings from DB", capacityGraph.WrapperToAvatar.Count);
+        _logger.LogDebug("Loaded {Count} wrapper→avatar mappings from DB ({Inflationary} inflationary)",
+            capacityGraph.WrapperToAvatar.Count, capacityGraph.InflationaryWrappers.Count);
     }
 
     // Load consented flow flags — exceptions propagate to caller (CreateCapacityGraph)


### PR DESCRIPTION
## Summary

Redo of PR #408 (reverted earlier today as PR #412 after triggering a 75% canary FP rate). The original PR applied `convertDemurrageToInflationaryValue` to every wrapper in the unwrap prefix, assuming the function returns identity on DemurrageCircles wrappers. It does not — both wrapper types inherit from the shared `Demurrage` base, so the function always applies β^day. The redo branches on the wrapper's `circlesType` field, which is the actual semantic discriminator.

## Contract semantics (verified on-chain via eth_simulateV1)

| Wrapper type | `unwrap(_amount)` interpretation | Canary action |
|---|---|---|
| DemurrageCircles (circlesType=0, symbol `CRC`/`gCRC`) | `_amount` is in demurraged 1155 units (1:1) | pass `BuildUnwrapPrefix`'s sum directly |
| InflationaryCircles (circlesType=1, symbol `s-*`) | `_amount` is in inflationary ERC20 units | convert via `convertDemurrageToInflationaryValue` first |

Probes against staging1 wallet `0x7abe74b7` on wrapper `0x548c20e6` (gCRC): `unwrap(229_412.19e18)` → 229_412.19e18 of 1155 (ratio 1.0). Probes against wallet `0x122832c9` on wrapper `0x5d7eaaed` (s-gCRC): `unwrap(515.77e18)` → 343.21e18 of 1155 (ratio γ^2050 ≈ 0.6654).

## Plumbing

- `wrapperMappingQuery.sql`: select `d."circlesType"`
- `ILoadGraph.LoadWrapperMappings` returns `(Wrapper, Avatar, CirclesType)` — implemented in DB-backed, incremental, cache, materialized, and historical variants
- `PathfinderWrapperMappingRow` + `PathfinderGraphWrapperMappingRow`: add `int CirclesType = 0` default. Missing field deserializes as DemurrageCircles, which is the safe-degrade direction
- `CapacityGraph`: new `HashSet<int> InflationaryWrappers` parallel to `WrapperToAvatar`; propagated via `CachedGroupData` to snapshot reuse
- `FindPathHandler`: builds `IReadOnlySet<string> InflationaryWrappers` (lowercased) for the canary work item
- `SimulationCanaryService`:
  - `UnwrapCall` gains `IsInflationary` flag, set by `BuildUnwrapPrefix`
  - `SimulateAsync` invokes `ResolveInflationaryAmountsAsync` only when the bundle contains at least one inflationary entry — no RPC overhead for paths with only demurraged wrappers
  - Resolver batches `convertDemurrageToInflationaryValue` calls via `eth_simulateV1` at the same simBlock; per-call failure → demurraged fallback + new `inflation_resolve_partial` metric label; whole-batch failure → existing `inflation_resolve_failed` + `block_lookup_failed` labels
- `DemurrageCalculator.InflationDayZeroUnix`: internal → public (single source of truth)

## Tests

- New `SimulationCanaryInflationaryConversionTests.cs` (~22 tests) covering pure helpers + chain-anchored regression values:
  - DemurrageCircles `0x548c20e6` pass-through (229_412.19e18 unchanged)
  - InflationaryCircles f72f2d61 case (3147.36 demurraged → 4729.75 inflationary)
  - Explicit anti-regression: demurraged-wrapper amount MUST NOT be inflated even when resolver returns an inflated value
- `SnapshotBuilder.FromMockLoadGraph` now forwards `CirclesType` so cache-snapshot test path exercises the field correctly

## Deploy plan

Cache AND pathfinder both need to deploy for the fix to engage:
- pathfinder alone reading old cache snapshot → all wrappers default to circlesType=0 → InflationaryWrappers stays empty → no behavior change
- cache alone serving new JSON → old pathfinder ignores extra field → no behavior change
- Both deployed → type discrimination engages

Both services are in `NON_DB_SERVICES` so no pgaf switchover required.

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh pathfinder` — passes
- [x] On-chain semantics verified via direct eth_simulateV1 probes
- [ ] After deploy: verify cache snapshot JSON includes `"circlesType"` field via `/api/pathfinder/graph`
- [ ] After deploy: `circles_canary_simulation_total{result="revert", prefix="unwrap"}` stays near 0 for DemurrageCircles paths
- [ ] After soak (real inflationary-path traffic): f72f2d61-class `ERC1155InsufficientBalance` at `flow_matrix` disappears for wrapped paths

## Known deferred follow-ups

- `UnwrapCall.IsInflationary` flag has dual meaning across pipeline stages (pre-resolve = "needs conversion", post = "already in inflationary units"). Split into `DemurragedUnwrapCall` / `ResolvedUnwrapCall` for compile-time enforcement (~30 LOC, same TYPE-1 follow-up as PR #408 review)
- `MockHttpHandler`-based wiring test for `ResolveInflationaryAmountsAsync` orchestration + each early-return branch (~40 LOC)
- `GraphFactoryTests` extension that registers a `circlesType=1` wrapper and asserts `CapacityGraph.InflationaryWrappers` membership end-to-end
- `WrapperFilterMatrixTests` naming inconsistency — declares `WrapperStatic` but registers with `circlesType=0`; consider flipping to actually exercise the new branch
- Future: collapse parallel `WrapperToAvatar` + `InflationaryWrappers` into a single `Dictionary<int, (int avatar, byte type)>` shape (drift risk is low but architecturally cleaner)
- Future: split `SimulationCanaryService.cs` (~1000 LoC) — extract inflation-conversion helpers into `WrapperUnitConverter.cs`. Reduces file size below the threshold where automated reviewers fabricate line numbers