### PR TITLE
feat(rpc): groupType filter + extended profile fields in circles_searchProfiles

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
@@ -610,6 +610,49 @@ public class CirclesRpcModuleTests
             Throws.InstanceOf<ArgumentException>());
     }
 
+    [Test]
+    public void SearchProfiles_WithInvalidGroupType_Throws()
+    {
+        RequireModule();
+
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: "garbage"),
+            Throws.InstanceOf<ArgumentException>());
+    }
+
+    [Test]
+    public void SearchProfiles_WithEmptyGroupType_DoesNotThrow()
+    {
+        RequireModule();
+
+        // Whitespace/empty groupType should be treated as "no filter", not an error.
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: ""),
+            Throws.Nothing);
+        Assert.That(async () => await _module!.SearchProfiles("test", limit: 10, groupType: "   "),
+            Throws.Nothing);
+    }
+
+    [Test]
+    public async Task SearchProfiles_WithValidGroupTypeOpen_ReturnsResult()
+    {
+        RequireModule();
+
+        var result = await _module!.SearchProfiles("test", limit: 10, groupType: "open");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.InstanceOf<ProfileSearchResult>());
+    }
+
+    [Test]
+    public async Task SearchProfiles_WithValidGroupTypeClosed_ReturnsResult()
+    {
+        RequireModule();
+
+        var result = await _module!.SearchProfiles("test", limit: 10, groupType: "closed");
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result, Is.InstanceOf<ProfileSearchResult>());
+    }
+
     #endregion
 
     #region GetTokenInfo Tests

--- a/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/SearchProfilesRequestParserTests.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+using Circles.Rpc.Host.Wire;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="SearchProfilesRequestParser"/>.
+///
+/// These tests pin down the positional contract of the JSON-RPC params array
+/// used by <c>circles_searchProfiles</c>. They run without a Nethermind runtime
+/// and guard against positional-shift bugs in the wire handler: if anyone
+/// inserts a new parameter at position 4 (instead of appending) the GroupType
+/// assertions here will fail.
+/// </summary>
+[TestFixture]
+public class SearchProfilesRequestParserTests
+{
+    private static JsonElement[] ParseParams(string json) =>
+        JsonSerializer.Deserialize<JsonElement[]>(json)!;
+
+    [Test]
+    public void Parse_throws_when_parameters_array_is_empty()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(ParseParams("[]")));
+    }
+
+    [Test]
+    public void Parse_throws_when_parameters_is_null()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            SearchProfilesRequestParser.Parse(null));
+    }
+
+    [Test]
+    public void Parse_with_only_text_applies_defaults()
+    {
+        var result = SearchProfilesRequestParser.Parse(ParseParams("[\"alice\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(SearchProfilesRequestParser.DefaultLimit));
+            Assert.That(result.Offset, Is.EqualTo(SearchProfilesRequestParser.DefaultOffset));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.Null);
+        });
+    }
+
+    [Test]
+    public void Parse_reads_groupType_from_position_4()
+    {
+        // [text, limit, offset, types, groupType] — groupType must be index 4.
+        // Regression guard: if anyone shifts the positional order, this fails.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 5, null, \"closed\"]"));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.Text, Is.EqualTo("alice"));
+            Assert.That(result.Limit, Is.EqualTo(10));
+            Assert.That(result.Offset, Is.EqualTo(5));
+            Assert.That(result.Types, Is.Null);
+            Assert.That(result.GroupType, Is.EqualTo("closed"));
+        });
+    }
+
+    [Test]
+    public void Parse_reads_types_from_position_3()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, [\"group\", \"organization\"], \"open\"]"));
+
+        Assert.That(result.Types, Is.EqualTo(new[] { "group", "organization" }));
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_treats_explicit_null_at_position_4_as_unset_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+    }
+
+    [Test]
+    public void Parse_omits_groupType_when_only_4_params_are_supplied()
+    {
+        // Legacy callers (pre-groupType) send 4 params and must continue to work.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 10, 0, null]"));
+
+        Assert.That(result.GroupType, Is.Null);
+        Assert.That(result.Limit, Is.EqualTo(10));
+        Assert.That(result.Offset, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Parse_handles_open_groupType()
+    {
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"open\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("open"));
+    }
+
+    [Test]
+    public void Parse_passes_through_unknown_groupType_values_for_module_level_validation()
+    {
+        // The parser does not validate the groupType value — that's the module's
+        // job (CirclesRpcModule.SearchProfiles throws on unknown values). This
+        // separation keeps the parser thin and the validation centralized.
+        var result = SearchProfilesRequestParser.Parse(
+            ParseParams("[\"alice\", 20, 0, null, \"restricted\"]"));
+
+        Assert.That(result.GroupType, Is.EqualTo("restricted"));
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -105,7 +105,8 @@ public interface ICirclesRpcModule
     /// <param name="limit">Maximum results to return (default: 20, max: 100)</param>
     /// <param name="offset">Number of results to skip</param>
     /// <param name="types">Filter by avatar types (e.g., "CrcV2_RegisterHuman", "CrcV2_RegisterGroup")</param>
-    Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null);
+    /// <param name="groupType">Filter by group type: "open" or "closed". Only matches profiles whose stored group_type equals this value.</param>
+    Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null, string? groupType = null);
 
     // ========================================================================
     // SDK Enablement Methods

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -85,7 +85,7 @@ public static class OpenRpcGenerator
 
         ("circles_searchProfiles", "SearchProfiles", "Profiles",
             "Full-text search across profiles",
-            "Searches avatar profiles by name and description text. Supports up to 3 search tokens (each must be > 1 character). Can filter by avatar type.\n\n**Common use case**: User search bar — type a name, get matching profiles.\n\n**Tip**: For searching by address prefix OR name, use `circles_searchProfileByAddressOrName` which auto-detects the query type."),
+            "Searches avatar profiles by name and description text. Supports up to 3 search tokens (each must be > 1 character). Can filter by avatar type and (for group profiles) by `groupType` (`open`/`closed`).\n\n**Common use case**: User search bar — type a name, get matching profiles.\n\n**Tip**: For searching by address prefix OR name, use `circles_searchProfileByAddressOrName` which auto-detects the query type.\n\n**Extended return fields** (each result item's `Profile` sub-object, omitted when unset): `externalWebsite`, `minRepScore`, `membershipFee`, `additionalCriteria`, `groupType`, `contactEmail`, `contactWebsite`."),
 
         // ── Trust & Network Methods ──────────────────────────────────────────
         ("circles_getTrustRelations", "GetTrustRelations", "Trust",
@@ -308,7 +308,9 @@ public static class OpenRpcGenerator
             Param("offset", false, "integer",
                 "Number of results to skip. Use with limit for offset-based pagination (e.g., offset=20, limit=20 for page 2)."),
             ParamArray("types", false, "string",
-                "Filter results by avatar type. Valid values: 'CrcV2_RegisterHuman', 'CrcV2_RegisterGroup', 'CrcV2_RegisterOrganization'. Omit to search all types.")
+                "Filter results by avatar type. Valid values: 'CrcV2_RegisterHuman', 'CrcV2_RegisterGroup', 'CrcV2_RegisterOrganization'. Omit to search all types."),
+            Param("groupType", false, "string",
+                "Filter group profiles by their stored group type. Valid values: 'open', 'closed'. Forwarded to the profile-pinning service (fast path); silently ignored by the SQL fallback (chain index has no group_type column). Omit to apply no group-type filter.")
         ],
         ["circles_getTrustRelations"] =
         [
@@ -688,6 +690,19 @@ public static class OpenRpcGenerator
                     new() { Name = "limit", Value = 20 },
                     new() { Name = "offset", Value = 0 },
                     new() { Name = "types", Value = new[] { "CrcV2_RegisterGroup" } },
+                ],
+            },
+            new()
+            {
+                Name = "Search closed groups",
+                Description = "Find closed-membership group profiles matching 'community' (filter on the extended groupType field)",
+                Params =
+                [
+                    new() { Name = "text", Value = "community" },
+                    new() { Name = "limit", Value = 20 },
+                    new() { Name = "offset", Value = 0 },
+                    new() { Name = "types", Value = new[] { "CrcV2_RegisterGroup" } },
+                    new() { Name = "groupType", Value = "closed" },
                 ],
             }
         ],

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -999,32 +999,10 @@ static async Task<object> HandleGetProfileByAddressBatch(JsonRpcRequest request,
 static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRpcModule rpcModule)
 {
     var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());
-    if (parameters == null || parameters.Length == 0)
-    {
-        throw new ArgumentException("Search text parameter is required");
-    }
+    var parsed = Circles.Rpc.Host.Wire.SearchProfilesRequestParser.Parse(parameters);
 
-    string text = parameters[0].GetString() ?? "";
-    int limit = 20;
-    int offset = 0;
-    string[]? types = null;
-
-    if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
-    {
-        limit = parameters[1].GetInt32();
-    }
-
-    if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
-    {
-        offset = parameters[2].GetInt32();
-    }
-
-    if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
-    {
-        types = parameters[3].Deserialize<string[]>();
-    }
-
-    var searchResults = await rpcModule.SearchProfiles(text, limit, offset, types);
+    var searchResults = await rpcModule.SearchProfiles(
+        parsed.Text, parsed.Limit, parsed.Offset, parsed.Types, parsed.GroupType);
     var transformedResults = searchResults.Results.Select(item =>
     {
         // Extract properties from AvatarInfo
@@ -1033,20 +1011,41 @@ static async Task<object> HandleSearchProfiles(JsonRpcRequest request, CirclesRp
         var cid = avatarInfo.CidV0; // Remote expects "cid"
         var avatarType = avatarInfo.Type; // Remote expects "avatarType"
 
-        // Extract properties from Profile (JsonElement)
-        var profileName = item.Profile?.TryGetProperty("name", out var nameElement) == true ? nameElement.GetString() : null;
-        var profileDescription = item.Profile?.TryGetProperty("description", out var descElement) == true ? descElement.GetString() : null;
-        var profilePreviewImageUrl = item.Profile?.TryGetProperty("previewImageUrl", out var imageUrlElement) == true ? imageUrlElement.GetString() : null;
+        // Extract properties from Profile (JsonElement). Extended group-profile fields
+        // are surfaced when the underlying proxy result populated them; null values are
+        // dropped from the JSON output by the global DefaultIgnoreCondition=WhenWritingNull
+        // serializer setting, so legacy profiles stay byte-identical to the pre-change baseline.
+        var profile = item.Profile;
+        string? GetStr(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind != JsonValueKind.Null
+                ? el.GetString() : null;
+        double? GetNum(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind == JsonValueKind.Number
+                ? el.GetDouble() : null;
+        string[]? GetStrArr(string key) =>
+            profile?.TryGetProperty(key, out var el) == true && el.ValueKind == JsonValueKind.Array
+                ? el.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString()!)
+                    .ToArray()
+                : null;
 
         // Construct the flattened anonymous object
         return new
         {
             address = address,
             cid = cid,
-            name = profileName,
-            description = profileDescription,
-            previewImageUrl = profilePreviewImageUrl,
-            avatarType = avatarType
+            name = GetStr("name"),
+            description = GetStr("description"),
+            previewImageUrl = GetStr("previewImageUrl"),
+            avatarType = avatarType,
+            externalWebsite = GetStr("externalWebsite"),
+            minRepScore = GetNum("minRepScore"),
+            membershipFee = GetNum("membershipFee"),
+            additionalCriteria = GetStrArr("additionalCriteria"),
+            groupType = GetStr("groupType"),
+            contactEmail = GetStr("contactEmail"),
+            contactWebsite = GetStr("contactWebsite")
         };
     }).ToArray();
 

--- a/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMetrics.cs
@@ -129,4 +129,55 @@ public static class RpcMetrics
         {
             Buckets = new[] { 1.0, 2.0, 5.0, 10.0, 20.0, 30.0, 50.0 }
         });
+
+    // ---- circles_searchProfiles instrumentation (Phase 4 measurement) ----
+    // Path label values (kept here so dashboards/alerts can reference one source):
+    //   proxy_hit              proxy returned >=1 result, no SQL ran
+    //   proxy_zero_then_sql    proxy returned [], SQL ran as fallback
+    //   proxy_error_then_sql   proxy non-2xx, SQL ran as fallback
+    //   proxy_timeout_then_sql proxy threw timeout/transport, SQL ran as fallback
+    //   sql_only               ProfilePinningServiceUrl unset, SQL ran directly
+    //   short_circuit_empty    all tokens <=1 char, returned empty without searching
+
+    /// <summary>
+    /// Total circles_searchProfiles requests, labelled by which code path served them.
+    /// </summary>
+    public static readonly Counter SearchProfilesPathTotal = Metrics.CreateCounter(
+        "circles_search_profiles_path_total",
+        "Total circles_searchProfiles requests by served path",
+        new CounterConfiguration { LabelNames = new[] { "path" } });
+
+    /// <summary>
+    /// End-to-end circles_searchProfiles duration (RPC entry → return), by path.
+    /// Includes the proxy attempt latency for *_then_sql paths.
+    /// </summary>
+    public static readonly Histogram SearchProfilesDuration = Metrics.CreateHistogram(
+        "circles_search_profiles_duration_seconds",
+        "circles_searchProfiles end-to-end duration in seconds",
+        new HistogramConfiguration
+        {
+            LabelNames = new[] { "path" },
+            Buckets = new[] { 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 20.0 }
+        });
+
+    /// <summary>
+    /// Distribution of search query lengths after trim, observed for every request
+    /// (including short-circuit-empty rejections).
+    /// </summary>
+    public static readonly Histogram SearchProfilesQueryLength = Metrics.CreateHistogram(
+        "circles_search_profiles_query_length_chars",
+        "Distribution of circles_searchProfiles query lengths in characters",
+        new HistogramConfiguration
+        {
+            Buckets = new[] { 1.0, 2.0, 3.0, 5.0, 10.0, 20.0, 50.0 }
+        });
+
+    /// <summary>
+    /// Total circles_searchProfiles requests that returned zero results, by path.
+    /// Useful for spotting paths where the proxy is "successful" but useless.
+    /// </summary>
+    public static readonly Counter SearchProfilesZeroResultsTotal = Metrics.CreateCounter(
+        "circles_search_profiles_zero_results_total",
+        "Total circles_searchProfiles requests that returned an empty result set",
+        new CounterConfiguration { LabelNames = new[] { "path" } });
 }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Circles.Common;
@@ -574,6 +575,8 @@ public partial class CirclesRpcModule
         return await GetProfileByCidBatchInternal(cids);
     }
 
+    private enum SearchProxyOutcome { Hit, Zero, Error }
+
     public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null)
     {
         const int hardLimit = 100;
@@ -582,12 +585,17 @@ public partial class CirclesRpcModule
             throw new ArgumentException($"limit must not exceed {hardLimit} (got {limit}).");
         }
 
+        var sw = Stopwatch.StartNew();
         string qText = text.Trim();
+        RpcMetrics.SearchProfilesQueryLength.Observe(qText.Length);
+
         string[] tokens = qText.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
         if (!tokens.Any(o => o.Length > 1))
         {
-            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            var emptyResult = new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            RecordSearchProfilesPath("short_circuit_empty", sw.Elapsed, emptyResult);
+            return emptyResult;
         }
 
         if (tokens.Length > 3)
@@ -603,32 +611,61 @@ public partial class CirclesRpcModule
             .Distinct(StringComparer.Ordinal)
             .ToArray();
 
+        string path = "sql_only";
+
         // Try profile pinning service first (fast path)
         if (!string.IsNullOrEmpty(_settings.ProfilePinningServiceUrl))
         {
             try
             {
-                var proxyResult = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
-                if (proxyResult != null)
+                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
+                switch (outcome)
                 {
-                    return proxyResult;
+                    case SearchProxyOutcome.Hit:
+                        RecordSearchProfilesPath("proxy_hit", sw.Elapsed, proxyResult!);
+                        return proxyResult!;
+                    case SearchProxyOutcome.Zero:
+                        path = "proxy_zero_then_sql";
+                        break;
+                    case SearchProxyOutcome.Error:
+                        path = "proxy_error_then_sql";
+                        break;
                 }
             }
             catch (Exception ex)
             {
-                _logger?.LogWarning(ex, "Profile pinning service proxy failed, falling back to SQL");
+                path = ClassifyProxyException(ex);
+                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}), falling back to SQL", path);
             }
         }
 
         // Fallback: direct SQL search
-        return await SearchProfilesViaSql(qText, limit, offset, typeFilter);
+        var sqlResult = await SearchProfilesViaSql(qText, limit, offset, typeFilter);
+        RecordSearchProfilesPath(path, sw.Elapsed, sqlResult);
+        return sqlResult;
     }
+
+    private static void RecordSearchProfilesPath(string path, TimeSpan elapsed, ProfileSearchResult result)
+    {
+        RpcMetrics.SearchProfilesPathTotal.WithLabels(path).Inc();
+        RpcMetrics.SearchProfilesDuration.WithLabels(path).Observe(elapsed.TotalSeconds);
+        if (result.Total == 0)
+        {
+            RpcMetrics.SearchProfilesZeroResultsTotal.WithLabels(path).Inc();
+        }
+    }
+
+    private static string ClassifyProxyException(Exception ex) => ex switch
+    {
+        OperationCanceledException => "proxy_timeout_then_sql",
+        _ => "proxy_error_then_sql",
+    };
 
     /// <summary>
     /// Fast path: proxy search to the profile-pinning service REST API.
-    /// Returns null if the service is unavailable or returns an error.
+    /// Returns an outcome indicating Hit/Zero/Error so the caller can label metrics.
     /// </summary>
-    private async Task<ProfileSearchResult?> SearchProfilesViaProxy(
+    private async Task<(SearchProxyOutcome outcome, ProfileSearchResult? result)> SearchProfilesViaProxy(
         string qText, int limit, int offset, string[]? typeFilter)
     {
         var baseUrl = _settings.ProfilePinningServiceUrl!.TrimEnd('/');
@@ -653,7 +690,7 @@ public partial class CirclesRpcModule
         if (!response.IsSuccessStatusCode)
         {
             _logger?.LogWarning("Profile pinning service returned {StatusCode}", response.StatusCode);
-            return null;
+            return (SearchProxyOutcome.Error, null);
         }
 
         var json = await response.Content.ReadAsStringAsync(cts.Token);
@@ -661,8 +698,7 @@ public partial class CirclesRpcModule
 
         if (proxyResults == null || proxyResults.Length == 0)
         {
-            // Return null to fall through to SQL fallback
-            return null;
+            return (SearchProxyOutcome.Zero, null);
         }
 
         // Safety net: server handles offset, but cap to requested limit
@@ -676,7 +712,7 @@ public partial class CirclesRpcModule
 
         if (addresses.Length == 0)
         {
-            return new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            return (SearchProxyOutcome.Hit, new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>()));
         }
 
         // Batch avatar info lookup (single DB call instead of N+1)
@@ -712,7 +748,7 @@ public partial class CirclesRpcModule
             ));
         }
 
-        return new ProfileSearchResult(Total: results.Count, Results: results.ToArray());
+        return (SearchProxyOutcome.Hit, new ProfileSearchResult(Total: results.Count, Results: results.ToArray()));
     }
 
     /// <summary>

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -577,12 +577,23 @@ public partial class CirclesRpcModule
 
     private enum SearchProxyOutcome { Hit, Zero, Error }
 
-    public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null)
+    public async Task<ProfileSearchResult> SearchProfiles(string text, int limit = 20, int offset = 0, string[]? types = null, string? groupType = null)
     {
         const int hardLimit = 100;
         if (limit > hardLimit)
         {
             throw new ArgumentException($"limit must not exceed {hardLimit} (got {limit}).");
+        }
+
+        string? groupTypeFilter = null;
+        if (!string.IsNullOrWhiteSpace(groupType))
+        {
+            var gt = groupType.Trim();
+            if (gt != "open" && gt != "closed")
+            {
+                throw new ArgumentException($"groupType must be 'open' or 'closed' (got '{groupType}').", nameof(groupType));
+            }
+            groupTypeFilter = gt;
         }
 
         var sw = Stopwatch.StartNew();
@@ -618,7 +629,7 @@ public partial class CirclesRpcModule
         {
             try
             {
-                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter);
+                var (outcome, proxyResult) = await SearchProfilesViaProxy(qText, limit, offset, typeFilter, groupTypeFilter);
                 switch (outcome)
                 {
                     case SearchProxyOutcome.Hit:
@@ -635,8 +646,21 @@ public partial class CirclesRpcModule
             catch (Exception ex)
             {
                 path = ClassifyProxyException(ex);
-                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}), falling back to SQL", path);
+                _logger?.LogWarning(ex, "Profile pinning service proxy failed ({Path}, groupType={GroupType}), falling back to SQL", path, groupTypeFilter);
             }
+        }
+
+        // SQL fallback cannot honor a groupType filter — the chain index has no
+        // group_type column. Falling through would silently return rows from the
+        // wrong group type. Return authoritative empty instead.
+        if (groupTypeFilter != null)
+        {
+            var emptyResult = new ProfileSearchResult(Total: 0, Results: Array.Empty<ProfileSearchResultItem>());
+            _logger?.LogWarning(
+                "SearchProfiles groupType={GroupType} requested but pinning-service proxy did not return a result; returning empty (SQL fallback has no group_type column)",
+                groupTypeFilter);
+            RecordSearchProfilesPath(path, sw.Elapsed, emptyResult);
+            return emptyResult;
         }
 
         // Fallback: direct SQL search
@@ -666,7 +690,7 @@ public partial class CirclesRpcModule
     /// Returns an outcome indicating Hit/Zero/Error so the caller can label metrics.
     /// </summary>
     private async Task<(SearchProxyOutcome outcome, ProfileSearchResult? result)> SearchProfilesViaProxy(
-        string qText, int limit, int offset, string[]? typeFilter)
+        string qText, int limit, int offset, string[]? typeFilter, string? groupType = null)
     {
         var baseUrl = _settings.ProfilePinningServiceUrl!.TrimEnd('/');
 
@@ -682,6 +706,11 @@ public partial class CirclesRpcModule
         if (typeFilter is { Length: > 0 })
         {
             url += $"&type={Uri.EscapeDataString(typeFilter[0])}";
+        }
+
+        if (!string.IsNullOrEmpty(groupType))
+        {
+            url += $"&groupType={Uri.EscapeDataString(groupType)}";
         }
 
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
@@ -735,6 +764,28 @@ public partial class CirclesRpcModule
                 profileDict["description"] = descEl.GetString();
             if (proxyEntry.TryGetProperty("location", out var locEl) && locEl.ValueKind != JsonValueKind.Null)
                 profileDict["location"] = locEl.GetString();
+
+            // Extended group-profile fields (proxy returns flat shape — see pinning service
+            // ProfileResponse). Keys are omitted by the proxy when unset, so the same is true here.
+            // Numeric fields come back as JS numbers thanks to the `::float8` cast applied
+            // in the pinning service's repositories/profiles.ts (migration 017 follow-up).
+            if (proxyEntry.TryGetProperty("externalWebsite", out var extWebEl) && extWebEl.ValueKind != JsonValueKind.Null)
+                profileDict["externalWebsite"] = extWebEl.GetString();
+            if (proxyEntry.TryGetProperty("minRepScore", out var minRepEl) && minRepEl.ValueKind == JsonValueKind.Number)
+                profileDict["minRepScore"] = minRepEl.GetDouble();
+            if (proxyEntry.TryGetProperty("membershipFee", out var feeEl) && feeEl.ValueKind == JsonValueKind.Number)
+                profileDict["membershipFee"] = feeEl.GetDouble();
+            if (proxyEntry.TryGetProperty("additionalCriteria", out var critEl) && critEl.ValueKind == JsonValueKind.Array)
+                profileDict["additionalCriteria"] = critEl.EnumerateArray()
+                    .Where(e => e.ValueKind == JsonValueKind.String)
+                    .Select(e => e.GetString())
+                    .ToArray();
+            if (proxyEntry.TryGetProperty("groupType", out var gtEl) && gtEl.ValueKind != JsonValueKind.Null)
+                profileDict["groupType"] = gtEl.GetString();
+            if (proxyEntry.TryGetProperty("contactEmail", out var emailEl) && emailEl.ValueKind != JsonValueKind.Null)
+                profileDict["contactEmail"] = emailEl.GetString();
+            if (proxyEntry.TryGetProperty("contactWebsite", out var contWebEl) && contWebEl.ValueKind != JsonValueKind.Null)
+                profileDict["contactWebsite"] = contWebEl.GetString();
 
             if (profileDict.Count > 0)
             {

--- a/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
+++ b/src/Rpc/Circles.Rpc.Host/Wire/SearchProfilesRequest.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+
+namespace Circles.Rpc.Host.Wire;
+
+/// <summary>
+/// Parsed positional parameters for <c>circles_searchProfiles</c>.
+///
+/// The wire format is a JSON-RPC params array, positional:
+///   [0] text:      string                  (required)
+///   [1] limit:     int   (default 20)      (optional)
+///   [2] offset:    int   (default 0)       (optional)
+///   [3] types:     string[] | null         (optional)
+///   [4] groupType: string | null           (optional)
+///
+/// Each position is independent — a caller can pass <c>null</c> for any
+/// optional slot, or omit trailing slots entirely. New params MUST be appended,
+/// never inserted, to avoid silently shifting the meaning of existing callers.
+/// </summary>
+public sealed record SearchProfilesRequest(
+    string Text,
+    int Limit,
+    int Offset,
+    string[]? Types,
+    string? GroupType);
+
+public static class SearchProfilesRequestParser
+{
+    public const int DefaultLimit = 20;
+    public const int DefaultOffset = 0;
+
+    /// <summary>
+    /// Parse the positional JSON-RPC params for <c>circles_searchProfiles</c>.
+    /// Throws <see cref="ArgumentException"/> if the required text parameter is missing.
+    /// </summary>
+    public static SearchProfilesRequest Parse(JsonElement[]? parameters)
+    {
+        if (parameters == null || parameters.Length == 0)
+        {
+            throw new ArgumentException("Search text parameter is required");
+        }
+
+        string text = parameters[0].GetString() ?? "";
+        int limit = DefaultLimit;
+        int offset = DefaultOffset;
+        string[]? types = null;
+        string? groupType = null;
+
+        if (parameters.Length > 1 && parameters[1].ValueKind != JsonValueKind.Null)
+        {
+            limit = parameters[1].GetInt32();
+        }
+
+        if (parameters.Length > 2 && parameters[2].ValueKind != JsonValueKind.Null)
+        {
+            offset = parameters[2].GetInt32();
+        }
+
+        if (parameters.Length > 3 && parameters[3].ValueKind != JsonValueKind.Null)
+        {
+            types = parameters[3].Deserialize<string[]>();
+        }
+
+        if (parameters.Length > 4 && parameters[4].ValueKind != JsonValueKind.Null)
+        {
+            groupType = parameters[4].GetString();
+        }
+
+        return new SearchProfilesRequest(text, limit, offset, types, groupType);
+    }
+}


### PR DESCRIPTION
## Summary

Brings the `circles_searchProfiles` groupType filter + 7 extended group-profile fields onto `dev` so prod can be aligned with the pinning-service group-profile feature.

Two-commit cherry-pick of work already validated on `staging` for ~16 hours with zero regressions.

## Commits

1. **`feat(rpc): add path metrics to circles_searchProfiles`** — observability prereq the feature commit builds on:
   - `SearchProxyOutcome` enum (Hit / Zero / Error) replacing nullable-return signaling
   - `RpcMetrics.cs` Prometheus instruments: `circles_search_profiles_path_total{path}`, `circles_search_profiles_duration_seconds{path}`, `circles_search_profiles_query_length_chars`, `circles_search_profiles_zero_results_total{path}`
   - Path label values: `proxy_hit`, `proxy_zero_then_sql`, `proxy_error_then_sql`, `proxy_timeout_then_sql`, `sql_only`, `short_circuit_empty`
   - No behavior change — fallback rules, return shapes, log messages preserved

2. **`feat(rpc): groupType filter + extended profile fields in circles_searchProfiles`** — the actual feature:
   - `SearchProfiles` signature adds optional positional 5th param `string? groupType` (`"open" | "closed"`, anything else throws `ArgumentException` → JSON-RPC -32602)
   - Proxy forwards `groupType` to pinning service `/search` and `/search/text`
   - Reads 7 new flat fields from result items into Profile dict: `externalWebsite`, `minRepScore`, `membershipFee`, `additionalCriteria`, `groupType`, `contactEmail`, `contactWebsite`
   - Wire handler `HandleSearchProfiles` updated; positional parsing extracted into testable `SearchProfilesRequestParser` (with unit tests)
   - **Authoritative-empty guard**: when `groupType` is set and proxy returns Zero / Error / throws, returns empty result instead of falling through to SQL (which has no `group_type` column and would leak unfiltered rows)
   - Extended fields use `DefaultIgnoreCondition = WhenWritingNull` → byte-identical responses for legacy profiles
   - OpenRPC schema updated for `groupType` param + extended return fields

## Compatibility

- 5th positional param is optional — old 4-param callers (`text, limit, offset, types`) untouched
- Extended JSON keys are omitted when underlying value is null → legacy profiles return byte-identical responses
- Pinning service half of this feature is already on `master` and has been live on staging since 2026-05-27 with no regressions

## Test plan

- [x] `dotnet build src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj` — 0 errors
- [x] `SearchProfilesRequestParserTests` — 9/9 passing locally
- [x] Already exercised on `staging` for ~16h: `groupType=closed` filters correctly, invalid `groupType=closeed` returns JSON-RPC -32602, 4-param legacy callers work, extended fields appear in result Profile sub-objects when present
- [ ] After merge: deploy plugin to prod alongside pinning service (which already has the matching `/search?groupType=` and flat-field response shape on `master`)

## Staging deploy reference

- Plugin staging PR: aboutcircles/circles-nethermind-plugin#411 (merged to `staging` 2026-05-27)
- Pinning service prod-ready: aboutcircles/profile_pinning_service master (extended fields already deployed to staging)
- CirclesTools docs: aboutcircles/CirclesTools (matching docs PR merged)