### PR TITLE
refactor(canary): typed unwrap records + CirclesType enum

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/AdversarialBugTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/AdversarialBugTests.cs
@@ -66,7 +66,7 @@ public class AdversarialBugTests
         cache.V1TokenOwnerByToken.Seed(new Dictionary<string, string>());
         cache.V1AvatarToCidMap.Seed(new Dictionary<string, string>());
         cache.V2Avatars.Seed(new Dictionary<string, (string, long)>());
-        cache.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, int)>());
+        cache.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, CirclesType)>());
         cache.Groups.Seed(new Dictionary<string, (string, string, string)>());
         cache.GroupMemberships.Seed(new Dictionary<string, (string, long)>());
         cache.V2AvatarToCidMap.Seed(new Dictionary<string, string>());
@@ -198,7 +198,7 @@ public class AdversarialBugTests
         // Or equivalently, only apply demurrage to ERC1155 tokens.
 
         // We verify the classification is distinguishable:
-        var isInflationary = info.Value.CirclesType == 1;
+        var isInflationary = info.Value.CirclesType == CirclesType.InflationaryCircles;
         var isErc20Wrapper = true; // GetWrapperInfo returned non-null
         var isDemurragedWrapper = isErc20Wrapper && !isInflationary;
 

--- a/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Cache.Service;
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Services;
@@ -694,7 +695,7 @@ public class NotificationListenerServiceTests
         caches.V1TokenOwnerByToken.Seed(new Dictionary<string, string>(), blockNo);
         caches.V1AvatarToCidMap.Seed(new Dictionary<string, string>(), blockNo);
         caches.V2Avatars.Seed(new Dictionary<string, (string, long)>(), blockNo);
-        caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, int)>(), blockNo);
+        caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, CirclesType)>(), blockNo);
         caches.Groups.Seed(new Dictionary<string, (string, string, string)>(), blockNo);
         caches.GroupMemberships.Seed(new Dictionary<string, (string Member, long ExpiryTime)>(), blockNo);
         caches.V2AvatarToCidMap.Seed(new Dictionary<string, string>(), blockNo);

--- a/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CachePathfinderConformanceTests.cs
@@ -66,8 +66,8 @@ public class CachePathfinderConformanceTests
         caches.Groups.Add(Block, NonRouterGroup, ("NonRouterGroup", "0xothermint", "NRG"));
 
         // --- Wrappers ---
-        caches.UpsertWrapper(Block, Wrapper1, Human1, 0); // valid: underlying is registered
-        caches.UpsertWrapper(Block, WrapperUnregistered, Unregistered, 0); // INVALID: underlying is unregistered
+        caches.UpsertWrapper(Block, Wrapper1, Human1, CirclesType.DemurrageCircles); // valid: underlying is registered
+        caches.UpsertWrapper(Block, WrapperUnregistered, Unregistered, CirclesType.DemurrageCircles); // INVALID: underlying is unregistered
 
         // --- V2 Balances ---
         // Valid: registered account, registered token owner (native)

--- a/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CirclesInvariantsTests.cs
@@ -290,7 +290,7 @@ public class CirclesInvariantsTests
     public void CacheWrapperLookup_ResolvesWrapperToAvatar()
     {
         var caches = new CacheContainer(rollbackCapacity: 4);
-        caches.UpsertWrapper(1, Wrapper1, Human1, 0);
+        caches.UpsertWrapper(1, Wrapper1, Human1, CirclesType.DemurrageCircles);
 
         var lookup = new CacheWrapperLookup(caches);
 

--- a/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/ControllerTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Controllers;
 using Circles.Cache.Service.Models;
@@ -579,7 +580,7 @@ public class ControllerTests
     {
         var wrapper = "0xwrapper0000000000000000000000000000000000";
         var avatar = "0xavatar00000000000000000000000000000000000";
-        _cache.UpsertWrapper(2000, wrapper, avatar, 1); // inflationary
+        _cache.UpsertWrapper(2000, wrapper, avatar, CirclesType.InflationaryCircles); // inflationary
 
         var controller = CreateTokensController();
         var result = controller.GetTokenInfo(wrapper);
@@ -674,7 +675,7 @@ public class ControllerTests
         // Register account, wrapper underlying, and ERC1155 token owner
         _cache.V2Avatars.Add(2000, address, ("CrcV2_RegisterHuman", 12345L));
         _cache.V2Avatars.Add(2000, "0xunderlying", ("CrcV2_RegisterHuman", 12345L));
-        _cache.UpsertWrapper(2000, wrapperAddr, "0xunderlying", 0); // demurraged wrapper
+        _cache.UpsertWrapper(2000, wrapperAddr, "0xunderlying", CirclesType.DemurrageCircles); // demurraged wrapper
         _cache.V2Avatars.Add(2000, erc1155Id, ("CrcV2_RegisterHuman", 12345L));
 
         // Add balances for both — both are hex addresses starting with "0x"

--- a/src/Cache/Circles.Cache.Service.Tests/CrossDomainTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CrossDomainTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Cache.Service.Caches;
 using Xunit;
 using FluentAssertions;
@@ -99,7 +100,7 @@ public class CrossDomainTests
         var avatar = "0xavatar00000000000000000000000000000000000";
 
         // Register wrapper
-        _cache.UpsertWrapper(100, wrapperAddr, avatar, 1); // inflationary
+        _cache.UpsertWrapper(100, wrapperAddr, avatar, CirclesType.InflationaryCircles); // inflationary
 
         // Add wrapper balance to V2 cache (same cache as ERC1155)
         _cache.V2BalancesByAccountAndToken.Add(100, $"{address}:{wrapperAddr}", 500m);
@@ -112,7 +113,7 @@ public class CrossDomainTests
         // Wrapper info should identify it as ERC20
         var info = _cache.GetWrapperInfo(wrapperAddr);
         info.Should().NotBeNull();
-        info!.Value.CirclesType.Should().Be(1);
+        info!.Value.CirclesType.Should().Be(CirclesType.InflationaryCircles);
     }
 
     [Fact]
@@ -125,7 +126,7 @@ public class CrossDomainTests
         // Upsert with mixed case
         _cache.UpsertV2Trust(100, mixedCase, "0xTRUSTEE000000000000000000000000000000000", 999999L);
         _cache.UpsertGroupMembership(100, mixedCase, "0xMEMBER0000000000000000000000000000000000", 999999L);
-        _cache.UpsertWrapper(100, mixedCase, "0xAVATAR0000000000000000000000000000000000", 0);
+        _cache.UpsertWrapper(100, mixedCase, "0xAVATAR0000000000000000000000000000000000", CirclesType.DemurrageCircles);
 
         // Query with lowercase — should find everything
         _cache.GetTrustsFor(lowerCase, isV1: false).Should().HaveCount(1);

--- a/src/Cache/Circles.Cache.Service.Tests/DomainLifecycleTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/DomainLifecycleTests.cs
@@ -265,9 +265,9 @@ public class DomainLifecycleTests
         var wrapper = "0xwrapper0000000000000000000000000000000000";
         var avatar = "0xavatar00000000000000000000000000000000000";
 
-        _cache.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, int)>
+        _cache.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, CirclesType)>
         {
-            [wrapper] = (avatar, 0)
+            [wrapper] = (avatar, CirclesType.DemurrageCircles)
         }, atBlockNo: 99);
         _cache.RebuildSecondaryIndexes();
 
@@ -275,7 +275,7 @@ public class DomainLifecycleTests
 
         // Add at block 100
         var wrapper2 = "0xwrapper2000000000000000000000000000000000";
-        _cache.UpsertWrapper(100, wrapper2, "0xavatar2", 1);
+        _cache.UpsertWrapper(100, wrapper2, "0xavatar2", CirclesType.InflationaryCircles);
 
         _cache.GetWrapperInfo(wrapper2).Should().NotBeNull();
 
@@ -400,7 +400,7 @@ public class DomainLifecycleTests
         _cache.V1TrustRelations.Add(100, $"{addr}:{truster}", 50L);
         _cache.V2TrustRelations.Add(100, $"{addr}:{truster}", 999999L);
         _cache.GroupMemberships.Add(100, $"{group}:{member}", (member, 999999L));
-        _cache.Erc20WrapperAddresses.Add(100, wrapper, ("0xavatar", 0));
+        _cache.Erc20WrapperAddresses.Add(100, wrapper, ("0xavatar", CirclesType.DemurrageCircles));
 
         // Rebuild and verify
         _cache.RebuildSecondaryIndexes();

--- a/src/Cache/Circles.Cache.Service.Tests/PR242RegressionTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PR242RegressionTests.cs
@@ -179,7 +179,7 @@ public class PR242RegressionTests
         var wrapper = "0xwrapper0000000000000000000000000000000000";
         var avatar = "0xavatar00000000000000000000000000000000000";
 
-        _cache.UpsertWrapper(100, wrapper, avatar, 0);
+        _cache.UpsertWrapper(100, wrapper, avatar, CirclesType.DemurrageCircles);
 
         // Without RebuildSecondaryIndexes, wrapper info should be available
         var info = _cache.GetWrapperInfo(wrapper);

--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -230,7 +230,7 @@ public class PathfinderGraphControllerTests
 
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2Avatars.Add(1000, underlyingAvatar, ("CrcV2_RegisterHuman", 1704067200L));
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 0)); // 0 = demurraged
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, CirclesType.DemurrageCircles)); // 0 = demurraged
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
         _cache.V2LastActivity.Add(1000, $"{account}:{wrapperAddress}",
             (long)DateTimeOffset.UtcNow.ToUnixTimeSeconds());
@@ -253,7 +253,7 @@ public class PathfinderGraphControllerTests
 
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2Avatars.Add(1000, underlyingAvatar, ("CrcV2_RegisterHuman", 1704067200L));
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, 1)); // 1 = static
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (underlyingAvatar, CirclesType.InflationaryCircles)); // 1 = static
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
 
         var controller = CreateController();
@@ -274,7 +274,7 @@ public class PathfinderGraphControllerTests
 
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         // underlyingAvatar NOT registered in V2Avatars
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (unregisteredAvatar, 0));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (unregisteredAvatar, CirclesType.DemurrageCircles));
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
 
         var controller = CreateController();
@@ -293,7 +293,7 @@ public class PathfinderGraphControllerTests
 
         _cache.V2Avatars.Add(1000, account, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.Groups.Add(1000, groupAvatar, ("Group", StandardTreasuryMint, "G"));
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, 1)); // static wrapper
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, CirclesType.InflationaryCircles)); // static wrapper
         _cache.V2BalancesByAccountAndToken.Add(1000, $"{account}:{wrapperAddress}", 50m);
 
         var controller = CreateController();
@@ -354,7 +354,7 @@ public class PathfinderGraphControllerTests
         _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
         // trustee has a wrapper deployed
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (trustee, 0));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (trustee, CirclesType.DemurrageCircles));
 
         var controller = CreateController();
         var result = controller.GetGraph(include: "trust");
@@ -377,8 +377,8 @@ public class PathfinderGraphControllerTests
         _cache.V2Avatars.Add(1000, truster, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2Avatars.Add(1000, trustee, ("CrcV2_RegisterHuman", 1704067200L));
         _cache.V2TrustRelations.Add(1000, $"{truster}:{trustee}", 9999999999L);
-        _cache.Erc20WrapperAddresses.Add(1000, wrapper1, (trustee, 0));
-        _cache.Erc20WrapperAddresses.Add(1000, wrapper2, (trustee, 1));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapper1, (trustee, CirclesType.DemurrageCircles));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapper2, (trustee, CirclesType.InflationaryCircles));
 
         var controller = CreateController();
         var result = controller.GetGraph(include: "trust");
@@ -731,7 +731,7 @@ public class PathfinderGraphControllerTests
         var groupAvatar = "0xaa00aa00aa00aa00aa00aa00aa00aa00aa00aa00";
 
         _cache.Groups.Add(1000, groupAvatar, ("Group", StandardTreasuryMint, "G"));
-        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, 0));
+        _cache.Erc20WrapperAddresses.Add(1000, wrapperAddress, (groupAvatar, CirclesType.DemurrageCircles));
 
         var controller = CreateController();
         var result = controller.GetGraph(include: "wrapperMappings");

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -1,3 +1,5 @@
+using Circles.Common;
+
 namespace Circles.Cache.Service.Models;
 
 /// <summary>
@@ -233,7 +235,7 @@ public record PathfinderConsentedFlowRow(
 public record PathfinderWrapperMappingRow(
     string WrapperAddress,
     string UnderlyingAvatar,
-    int CirclesType = 0
+    CirclesType CirclesType = CirclesType.DemurrageCircles
 );
 
 public record PathfinderOperatorApprovalRow(

--- a/src/Cache/Circles.Cache.Service/CacheContainer.cs
+++ b/src/Cache/Circles.Cache.Service/CacheContainer.cs
@@ -25,7 +25,7 @@ public class CacheContainer : IDisposable
     public RollbackCache<string, string> V1AvatarToCidMap { get; private set; } = null!;
 
     public RollbackCache<string, (string Type, long RegisteredAt)> V2Avatars { get; private set; } = null!;
-    public RollbackCache<string, (string Avatar, int CirclesType)> Erc20WrapperAddresses { get; private set; } = null!;
+    public RollbackCache<string, (string Avatar, CirclesType CirclesType)> Erc20WrapperAddresses { get; private set; } = null!;
     public RollbackCache<string, (string Name, string Mint, string Symbol)> Groups { get; private set; } = null!;
     public RollbackCache<string, (string Member, long ExpiryTime)> GroupMemberships { get; private set; } = null!;
     public RollbackCache<string, string> V2AvatarToCidMap { get; private set; } = null!;
@@ -65,9 +65,8 @@ public class CacheContainer : IDisposable
     // Maps member -> set of "group:member" keys
     private readonly Dictionary<string, HashSet<string>> _membershipsByMember = new();
 
-    // Reverse index for ERC20 wrappers: wrapper address -> (avatar address, circlesType)
-    // circlesType: 0 = demurraged, 1 = inflationary
-    private readonly Dictionary<string, (string Avatar, int CirclesType)> _erc20WrapperToAvatar = new();
+    // Reverse index for ERC20 wrappers: wrapper address -> (avatar address, wrapper flavor)
+    private readonly Dictionary<string, (string Avatar, CirclesType CirclesType)> _erc20WrapperToAvatar = new();
 
     // Per-domain reader-writer locks: concurrent reads, exclusive writes
     private readonly ReaderWriterLockSlim _balanceLock = new();
@@ -104,7 +103,7 @@ public class CacheContainer : IDisposable
         V1AvatarToCidMap = new RollbackCache<string, string>("V1AvatarToCidMap", _rollbackCapacity);
         // V2 Caches
         V2Avatars = new RollbackCache<string, (string Type, long RegisteredAt)>("V2Avatars", _rollbackCapacity);
-        Erc20WrapperAddresses = new RollbackCache<string, (string Avatar, int CirclesType)>("Erc20WrapperAddresses", _rollbackCapacity);
+        Erc20WrapperAddresses = new RollbackCache<string, (string Avatar, CirclesType CirclesType)>("Erc20WrapperAddresses", _rollbackCapacity);
         Groups = new RollbackCache<string, (string Name, string Mint, string Symbol)>("Groups", _rollbackCapacity);
         GroupMemberships = new RollbackCache<string, (string Member, long ExpiryTime)>("GroupMemberships", _rollbackCapacity);
         V2AvatarToCidMap = new RollbackCache<string, string>("V2AvatarToCidMap", _rollbackCapacity);
@@ -248,7 +247,7 @@ public class CacheContainer : IDisposable
         }
     }
 
-    public void UpsertWrapper(long blockNo, string wrapperAddress, string avatar, int circlesType)
+    public void UpsertWrapper(long blockNo, string wrapperAddress, string avatar, CirclesType circlesType)
     {
         var wrapperLower = wrapperAddress.ToLowerInvariant();
         var avatarLower = avatar.ToLowerInvariant();
@@ -649,11 +648,10 @@ public class CacheContainer : IDisposable
     }
 
     /// <summary>
-    /// Gets full wrapper info (avatar address and circlesType) for an ERC20 wrapper contract.
-    /// circlesType: 0 = demurraged, 1 = inflationary
+    /// Gets full wrapper info (avatar address and wrapper flavor) for an ERC20 wrapper contract.
     /// O(1) lookup using reverse index.
     /// </summary>
-    public (string Avatar, int CirclesType)? GetWrapperInfo(string wrapperAddress)
+    public (string Avatar, CirclesType CirclesType)? GetWrapperInfo(string wrapperAddress)
     {
         var wrapperLower = wrapperAddress.ToLowerInvariant();
         _wrapperLock.EnterReadLock();

--- a/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/BalancesController.cs
@@ -178,7 +178,7 @@ public class BalancesController : ControllerBase
                         isErc20 = true;
                         isWrapped = true;
                         tokenOwner = wrapperInfo.Value.Avatar;
-                        isInflationary = wrapperInfo.Value.CirclesType == 1;
+                        isInflationary = wrapperInfo.Value.CirclesType == CirclesType.InflationaryCircles;
                         tokenType = isInflationary
                             ? "CrcV2_ERC20WrapperDeployed_Inflationary"
                             : "CrcV2_ERC20WrapperDeployed_Demurraged";
@@ -333,7 +333,7 @@ public class BalancesController : ControllerBase
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
-                    var isInflationary = wrapperInfo?.CirclesType == 1;
+                    var isInflationary = wrapperInfo?.CirclesType == CirclesType.InflationaryCircles;
 
                     total += isInflationary ? balance : ApplyV2Demurrage(key, balance);
                 }
@@ -401,7 +401,7 @@ public class BalancesController : ControllerBase
                         continue;
 
                     var wrapperInfo = _caches.GetWrapperInfo(tokenId);
-                    var isInflationary = wrapperInfo?.CirclesType == 1;
+                    var isInflationary = wrapperInfo?.CirclesType == CirclesType.InflationaryCircles;
 
                     v2Total += isInflationary ? balance : ApplyV2Demurrage(key, balance);
                 }

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -232,7 +232,7 @@ public class PathfinderGraphController : ControllerBase
             if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddress, out var wrapperInfo))
             {
                 isWrapped = true;
-                isStatic = wrapperInfo.CirclesType == 1;
+                isStatic = wrapperInfo.CirclesType == CirclesType.InflationaryCircles;
             }
 
             // Convert decimal Circles → attoCircles BigInteger

--- a/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/TokensController.cs
@@ -1,5 +1,6 @@
 using Circles.Cache.Service.Caches;
 using Circles.Cache.Service.Models;
+using Circles.Common;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Circles.Cache.Service.Controllers;
@@ -141,8 +142,7 @@ public class TokensController : ControllerBase
         // 3. Check V2 ERC20 Wrapper
         if (_caches.Erc20WrapperAddresses.TryGetValue(tokenAddressLower, out var wrapperInfo))
         {
-            // circlesType: 0 = demurraged, 1 = inflationary
-            var isInflationary = wrapperInfo.CirclesType == 1;
+            var isInflationary = wrapperInfo.CirclesType == CirclesType.InflationaryCircles;
             var tokenType = isInflationary
                 ? "CrcV2_ERC20WrapperDeployed_Inflationary"
                 : "CrcV2_ERC20WrapperDeployed_Demurraged";

--- a/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/CacheWarmupService.cs
@@ -592,9 +592,9 @@ public class CacheWarmupService : BackgroundService
             INNER JOIN registered_avatars ra ON ra.avatar = e.""avatar""
             WHERE e.""blockNumber"" <= @toBlock";
 
-        // Key by wrapper address (not avatar) to support avatars with multiple wrappers
-        // An avatar can have both demurraged (circlesType=0) and inflationary (circlesType=1) wrappers
-        var wrappers = new Dictionary<string, (string Avatar, int CirclesType)>();
+        // Key by wrapper address (not avatar) to support avatars with multiple wrappers —
+        // an avatar can have both DemurrageCircles and InflationaryCircles wrappers deployed.
+        var wrappers = new Dictionary<string, (string Avatar, CirclesType CirclesType)>();
 
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("toBlock", toBlock);
@@ -605,7 +605,7 @@ public class CacheWarmupService : BackgroundService
         {
             var avatar = reader.GetString(0);
             var erc20Wrapper = reader.GetString(1);
-            var circlesType = reader.GetInt32(2);
+            var circlesType = (CirclesType)reader.GetInt32(2);
 
             // Key by wrapper address for direct lookup
             var wrapperKey = erc20Wrapper.ToLowerInvariant();
@@ -1902,7 +1902,7 @@ public class CacheWarmupService : BackgroundService
                 var blockNumber = wrapperReader.GetInt64(0);
                 var avatar = wrapperReader.GetString(1);
                 var erc20Wrapper = wrapperReader.GetString(2);
-                var circlesType = wrapperReader.GetInt32(3);
+                var circlesType = (CirclesType)wrapperReader.GetInt32(3);
 
                 // Key by wrapper address (not avatar) to support avatars with multiple wrappers
                 var wrapperKey = erc20Wrapper.ToLowerInvariant();
@@ -1924,7 +1924,7 @@ public class CacheWarmupService : BackgroundService
         _caches.V1TokenOwnerByToken.Seed(new Dictionary<string, string>());
         _caches.V1AvatarToCidMap.Seed(new Dictionary<string, string>());
         _caches.V2Avatars.Seed(new Dictionary<string, (string, long)>());
-        _caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, int)>());
+        _caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, CirclesType)>());
         _caches.Groups.Seed(new Dictionary<string, (string, string, string)>());
         _caches.GroupMemberships.Seed(new Dictionary<string, (string, long)>());
         _caches.V2AvatarToCidMap.Seed(new Dictionary<string, string>());

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -330,7 +330,7 @@ public class NotificationListenerService : BackgroundService
         _caches.V1TokenOwnerByToken.Seed(new Dictionary<string, string>());
         _caches.V1AvatarToCidMap.Seed(new Dictionary<string, string>());
         _caches.V2Avatars.Seed(new Dictionary<string, (string, long)>());
-        _caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, int)>());
+        _caches.Erc20WrapperAddresses.Seed(new Dictionary<string, (string, CirclesType)>());
         _caches.Groups.Seed(new Dictionary<string, (string, string, string)>());
         _caches.GroupMemberships.Seed(new Dictionary<string, (string, long)>());
         _caches.V2AvatarToCidMap.Seed(new Dictionary<string, string>());
@@ -740,7 +740,7 @@ public class NotificationListenerService : BackgroundService
                     var blockNumber = wrapperReader.GetInt64(0);
                     var avatar = wrapperReader.GetString(1);
                     var erc20Wrapper = wrapperReader.GetString(2);
-                    var circlesType = wrapperReader.GetInt32(3);
+                    var circlesType = (CirclesType)wrapperReader.GetInt32(3);
 
                     // Key by wrapper address (not avatar) to support avatars with multiple wrappers
                     var wrapperKey = erc20Wrapper.ToLowerInvariant();

--- a/src/Common/Circles.Common/CirclesType.cs
+++ b/src/Common/Circles.Common/CirclesType.cs
@@ -1,0 +1,21 @@
+namespace Circles.Common;
+
+/// <summary>
+/// Wrapper flavor of a <c>CrcV2_ERC20WrapperDeployed</c> token.
+/// Underlying value matches the on-chain <c>uint8 circlesType</c> emitted by
+/// Hub.sol so the wire format (Postgres column, JSON payload) stays unchanged.
+/// </summary>
+public enum CirclesType : byte
+{
+    /// <summary>
+    /// Symbol <c>CRC</c> / <c>gCRC</c>. <c>unwrap(uint256)</c> argument is in
+    /// demurraged 1155 units; the underlying 1155 transfer is the same amount.
+    /// </summary>
+    DemurrageCircles = 0,
+
+    /// <summary>
+    /// Symbol prefix <c>s-</c>. <c>unwrap(uint256)</c> argument is in inflation-corrected
+    /// ERC20 units; the underlying 1155 transfer is <c>amount * γ^day</c>.
+    /// </summary>
+    InflationaryCircles = 1,
+}

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Numerics;
 using System.Text.Json;
 using System.Threading.Channels;
+using Circles.Common;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Simulation;
@@ -21,7 +22,7 @@ internal sealed record CanaryWorkItem(
     List<TransferPathStep> Transfers,
     IReadOnlyDictionary<string, string>? WrapperToAvatar = null,
     bool WithWrap = false,
-    // Subset of WrapperToAvatar keys (lowercased addresses) whose CrcV2_ERC20WrapperDeployed.circlesType == 1.
+    // Subset of WrapperToAvatar keys (lowercased addresses) flagged as CirclesType.InflationaryCircles.
     // The canary's unwrap-prefix resolver uses this to discriminate the `_amount` unit semantic:
     // - DemurrageCircles (NOT in this set): unwrap(_amount) takes demurraged 1155 units; pass BuildUnwrapPrefix's sum directly.
     // - InflationaryCircles (IN this set):  unwrap(_amount) takes inflationary ERC20 units; convert via convertDemurrageToInflationaryValue.
@@ -133,13 +134,13 @@ internal sealed class SimulationCanaryService : BackgroundService
         // Compute unwrap prefix once — the same list is needed to decide which RPC method to use
         // AND to populate the bundle when withWrap=true. Resolve TokenOwners using the same map
         // so the operateFlowMatrix calldata references avatar addresses, not wrappers.
-        IReadOnlyList<UnwrapCall> unwrapCalls;
+        IReadOnlyList<DemurragedUnwrapCall> unwrapCalls;
         string calldata;
         try
         {
             unwrapCalls = item.WithWrap
                 ? BuildUnwrapPrefix(item.Transfers, item.WrapperToAvatar, item.InflationaryWrappers)
-                : Array.Empty<UnwrapCall>();
+                : Array.Empty<DemurragedUnwrapCall>();
             var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
             calldata = FlowMatrixEncoder.BuildCalldata(item.Source, item.Sink, transfers);
         }
@@ -172,21 +173,13 @@ internal sealed class SimulationCanaryService : BackgroundService
 
             if (useUnwrapBundle)
             {
-                // Inflationary wrappers need demurraged → inflationary conversion before unwrap().
-                // DemurrageCircles wrappers pass through unchanged. Resolver is a no-op (zero RPC
-                // overhead) when the bundle contains no inflationary wrappers — the common case.
-                bool hasInflationary = false;
-                for (int i = 0; i < unwrapCalls.Count; i++)
-                {
-                    if (unwrapCalls[i].IsInflationary) { hasInflationary = true; break; }
-                }
+                // Resolver ALWAYS runs in the withWrap path — the type system (DemurragedUnwrapCall
+                // → ResolvedUnwrapCall) forces this. For bundles with no InflationaryCircles
+                // entries the resolver short-circuits as a pure pass-through (no RPC overhead).
+                IReadOnlyList<ResolvedUnwrapCall> resolved =
+                    await ResolveInflationaryAmountsAsync(item, unwrapCalls, blockTag, client, ct);
 
-                if (hasInflationary)
-                {
-                    unwrapCalls = await ResolveInflationaryAmountsAsync(item, unwrapCalls, blockTag, client, ct);
-                }
-
-                await SimulateBundleAsync(item, unwrapCalls, calldata, blockTag, prefixLabel, client, ct);
+                await SimulateBundleAsync(item, resolved, calldata, blockTag, prefixLabel, client, ct);
                 QueueDepth.Set(_channel.Reader.Count);
                 return;
             }
@@ -289,22 +282,32 @@ internal sealed class SimulationCanaryService : BackgroundService
     private const string UnwrapSelector = "0xde0e9a3e";
 
     /// <summary>
-    /// One unwrap call in the eth_simulateV1 bundle: caller (from) unwraps `amount` of the
-    /// wrapped ERC20 at `wrapper`, which mints the underlying 1155 to caller on Hub.sol.
-    /// <para><b>Amount unit semantics depend on the wrapper's circlesType:</b></para>
+    /// Output of <see cref="BuildUnwrapPrefix"/>: an unwrap call whose <see cref="DemurragedAmount"/>
+    /// is in 1155 ledger units, NOT the wrapper's native unwrap-argument unit. Must pass through
+    /// <see cref="ResolveInflationaryAmountsAsync"/> before it can be encoded as calldata.
+    /// <para>This is the "raw" form. <see cref="WrapperType"/> carries the discriminant the
+    /// resolver needs:</para>
     /// <list type="bullet">
-    ///   <item>DemurrageCircles (<see cref="IsInflationary"/> = false): <c>Amount</c> is in
-    ///     demurraged 1155 units. unwrap(_amount) burns _amount ERC20 AND credits _amount of
-    ///     the underlying 1155 (1:1). BuildUnwrapPrefix's raw sum is correct here.</item>
-    ///   <item>InflationaryCircles (<see cref="IsInflationary"/> = true): <c>Amount</c> must be
-    ///     in inflationary ERC20 units before reaching unwrap(). unwrap(_amount) burns _amount
-    ///     ERC20 and credits <c>_amount * γ^day</c> of 1155. BuildUnwrapPrefix produces a
-    ///     demurraged sum; the resolver converts it via wrapper.convertDemurrageToInflationaryValue
-    ///     before bundle assembly.</item>
+    ///   <item><see cref="CirclesType.DemurrageCircles"/>: unwrap(_amount) takes demurraged
+    ///     units 1:1 — resolver passes <c>DemurragedAmount</c> through unchanged.</item>
+    ///   <item><see cref="CirclesType.InflationaryCircles"/>: unwrap(_amount) takes inflation-
+    ///     corrected ERC20 units — resolver calls <c>convertDemurrageToInflationaryValue</c>
+    ///     to convert before bundle assembly.</item>
     /// </list>
     /// Verified on-chain by direct eth_simulateV1 probes against both wrapper types (2026-05-27).
     /// </summary>
-    internal readonly record struct UnwrapCall(string From, string Wrapper, BigInteger Amount, bool IsInflationary = false);
+    internal readonly record struct DemurragedUnwrapCall(
+        string From, string Wrapper, BigInteger DemurragedAmount, CirclesType WrapperType);
+
+    /// <summary>
+    /// Output of <see cref="ResolveInflationaryAmountsAsync"/>: an unwrap call whose
+    /// <see cref="Amount"/> is in the wrapper's NATIVE unit (whatever <c>unwrap(uint256)</c>
+    /// expects on-chain). Direct input to <see cref="SimulateBundleAsync"/>.
+    /// <para>Splitting this from <see cref="DemurragedUnwrapCall"/> makes the unit conversion
+    /// step compile-time mandatory: passing a <see cref="DemurragedUnwrapCall"/> to
+    /// <see cref="SimulateBundleAsync"/> is a type error — the exact regression class of PR #408.</para>
+    /// </summary>
+    internal readonly record struct ResolvedUnwrapCall(string From, string Wrapper, BigInteger Amount);
 
     /// <summary>
     /// For each transfer whose TokenOwner is a known wrapper, attribute one unwrap call
@@ -313,15 +316,15 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// the operateFlowMatrix call in the bundle.
     /// <para>The <paramref name="inflationaryWrappers"/> set discriminates which wrappers
     /// need <c>convertDemurrageToInflationaryValue</c> at resolve-time. Wrappers absent
-    /// from the set are treated as DemurrageCircles (unit pass-through).</para>
+    /// from the set are treated as <see cref="CirclesType.DemurrageCircles"/> (unit pass-through).</para>
     /// </summary>
-    internal static IReadOnlyList<UnwrapCall> BuildUnwrapPrefix(
+    internal static IReadOnlyList<DemurragedUnwrapCall> BuildUnwrapPrefix(
         List<TransferPathStep> transfers,
         IReadOnlyDictionary<string, string>? wrapperToAvatar,
         IReadOnlySet<string>? inflationaryWrappers = null)
     {
         if (wrapperToAvatar == null || wrapperToAvatar.Count == 0)
-            return Array.Empty<UnwrapCall>();
+            return Array.Empty<DemurragedUnwrapCall>();
 
         // Deterministic ordering: pathfinder emits transfers in pipeline order, and we
         // want unwraps grouped by (from, wrapper). A list-of-keys preserves first-seen
@@ -351,13 +354,15 @@ internal sealed class SimulationCanaryService : BackgroundService
         }
 
         if (order.Count == 0)
-            return Array.Empty<UnwrapCall>();
+            return Array.Empty<DemurragedUnwrapCall>();
 
-        var calls = new List<UnwrapCall>(order.Count);
+        var calls = new List<DemurragedUnwrapCall>(order.Count);
         foreach (var key in order)
         {
-            bool isInflationary = inflationaryWrappers != null && inflationaryWrappers.Contains(key.Wrapper);
-            calls.Add(new UnwrapCall(key.From, key.Wrapper, sums[key], isInflationary));
+            var wrapperType = inflationaryWrappers != null && inflationaryWrappers.Contains(key.Wrapper)
+                ? CirclesType.InflationaryCircles
+                : CirclesType.DemurrageCircles;
+            calls.Add(new DemurragedUnwrapCall(key.From, key.Wrapper, sums[key], wrapperType));
         }
 
         return calls;
@@ -388,7 +393,7 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// </summary>
     private async Task SimulateBundleAsync(
         CanaryWorkItem item,
-        IReadOnlyList<UnwrapCall> unwrapCalls,
+        IReadOnlyList<ResolvedUnwrapCall> unwrapCalls,
         string flowMatrixCalldata,
         string blockTag,
         string prefixLabel,
@@ -398,6 +403,8 @@ internal sealed class SimulationCanaryService : BackgroundService
         var calls = new List<object>(unwrapCalls.Count + 1);
         foreach (var u in unwrapCalls)
         {
+            // Amount is in the wrapper's native unwrap-argument unit by construction —
+            // the ResolvedUnwrapCall type makes that invariant compile-enforced.
             calls.Add(new
             {
                 from = u.From,
@@ -763,32 +770,32 @@ internal sealed class SimulationCanaryService : BackgroundService
     }
 
     /// <summary>
-    /// Applies resolved inflationary amounts to the original unwrap-call list. Only
-    /// entries with <c>IsInflationary=true</c> consume the resolver's output; demurraged
-    /// entries pass through unchanged. A null resolved amount (RPC/parse failure) falls
-    /// back to the demurraged amount — the canary still attempts a simulation, which
-    /// just produces the prior false-positive class for that one inflationary wrapper,
-    /// not silently skipping coverage.
+    /// Promotes a list of <see cref="DemurragedUnwrapCall"/> to <see cref="ResolvedUnwrapCall"/>,
+    /// substituting the resolver's inflationary amounts only into <see cref="CirclesType.InflationaryCircles"/>
+    /// positions. Demurraged entries pass through (their <c>DemurragedAmount</c> already IS the
+    /// native unwrap-argument unit). A null resolved amount (RPC/parse failure) falls back to
+    /// the demurraged amount — the canary still attempts a simulation, which just produces the
+    /// prior false-positive class for that one inflationary wrapper, not silently skipping coverage.
     /// </summary>
-    internal static IReadOnlyList<UnwrapCall> ApplyInflationaryAmounts(
-        IReadOnlyList<UnwrapCall> calls,
+    internal static IReadOnlyList<ResolvedUnwrapCall> ApplyInflationaryAmounts(
+        IReadOnlyList<DemurragedUnwrapCall> calls,
         IReadOnlyList<BigInteger?> inflationaryAmountsForInflationaryCalls)
     {
-        var resolved = new List<UnwrapCall>(calls.Count);
+        var resolved = new List<ResolvedUnwrapCall>(calls.Count);
         int infIdx = 0;
         for (int i = 0; i < calls.Count; i++)
         {
             var src = calls[i];
-            if (!src.IsInflationary)
+            if (src.WrapperType != CirclesType.InflationaryCircles)
             {
-                resolved.Add(src);
+                resolved.Add(new ResolvedUnwrapCall(src.From, src.Wrapper, src.DemurragedAmount));
                 continue;
             }
             BigInteger? resolvedAmount = infIdx < inflationaryAmountsForInflationaryCalls.Count
                 ? inflationaryAmountsForInflationaryCalls[infIdx]
                 : null;
             infIdx++;
-            resolved.Add(new UnwrapCall(src.From, src.Wrapper, resolvedAmount ?? src.Amount, src.IsInflationary));
+            resolved.Add(new ResolvedUnwrapCall(src.From, src.Wrapper, resolvedAmount ?? src.DemurragedAmount));
         }
         return resolved;
     }
@@ -886,13 +893,21 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// with new result labels (<c>block_lookup_failed</c>, <c>inflation_resolve_failed</c>).
     /// </para>
     /// </summary>
-    private async Task<IReadOnlyList<UnwrapCall>> ResolveInflationaryAmountsAsync(
+    private async Task<IReadOnlyList<ResolvedUnwrapCall>> ResolveInflationaryAmountsAsync(
         CanaryWorkItem item,
-        IReadOnlyList<UnwrapCall> calls,
+        IReadOnlyList<DemurragedUnwrapCall> calls,
         string blockTag,
         HttpClient client,
         CancellationToken ct)
     {
+        // Step 0: fast path — if no entries need conversion, promote 1:1 with zero RPC overhead.
+        // The common case (DemurrageCircles only, ≈89% of wrapper population) hits this branch.
+        var inflationaryIndices = new List<int>();
+        for (int i = 0; i < calls.Count; i++)
+            if (calls[i].WrapperType == CirclesType.InflationaryCircles) inflationaryIndices.Add(i);
+
+        if (inflationaryIndices.Count == 0) return PromoteAllDemurraged(calls);
+
         // Step 1: pull block timestamp (one RPC, deterministic key for the conversion math).
         var ts = await FetchBlockTimestampAsync(blockTag, client, ct);
         if (ts == null)
@@ -901,19 +916,11 @@ internal sealed class SimulationCanaryService : BackgroundService
             // Fall through: simulate bundle with demurraged amounts. For inflationary wrappers
             // this reverts at unwrap() (the original f72f2d61-class FP), but it preserves the
             // pre-PR signal — strictly better than silently dropping the canary attempt.
-            return calls;
+            return PromoteAllDemurraged(calls);
         }
         long day = ComputeInflationDay(ts.Value);
 
-        // Step 2: collect inflationary-only positions; their order is preserved across the
-        // batched call array so ExtractInflationaryAmounts indexes match.
-        var inflationaryIndices = new List<int>();
-        for (int i = 0; i < calls.Count; i++)
-            if (calls[i].IsInflationary) inflationaryIndices.Add(i);
-
-        if (inflationaryIndices.Count == 0) return calls;
-
-        // Step 3: batch eth_simulateV1 — one call per inflationary unwrap.
+        // Step 2: batch eth_simulateV1 — one call per inflationary unwrap.
         // `from = ZERO_ADDRESS` is fine: convertDemurrageToInflationaryValue is a pure view
         // function on the wrapper, ignores msg.sender.
         var batchCalls = new List<object>(inflationaryIndices.Count);
@@ -924,7 +931,7 @@ internal sealed class SimulationCanaryService : BackgroundService
             {
                 from = ZeroSenderForReadOnly,
                 to = c.Wrapper,
-                data = EncodeConvertDemurrageCalldata(c.Amount, day)
+                data = EncodeConvertDemurrageCalldata(c.DemurragedAmount, day)
             });
         }
         var rpc = new
@@ -955,7 +962,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: eth_simulateV1 failed (network/timeout)",
                 item.ReqId);
             SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
-            return calls;
+            return PromoteAllDemurraged(calls);
         }
         if (!response.IsSuccessStatusCode)
         {
@@ -963,7 +970,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: eth_simulateV1 HTTP {StatusCode}",
                 item.ReqId, (int)response.StatusCode);
             SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
-            return calls;
+            return PromoteAllDemurraged(calls);
         }
         JsonElement json;
         try { json = await response.Content.ReadFromJsonAsync<JsonElement>(ct); }
@@ -973,7 +980,7 @@ internal sealed class SimulationCanaryService : BackgroundService
                 "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: non-JSON response",
                 item.ReqId);
             SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
-            return calls;
+            return PromoteAllDemurraged(calls);
         }
 
         // Step 4: extract per-position results; ApplyInflationaryAmounts substitutes only
@@ -998,5 +1005,22 @@ internal sealed class SimulationCanaryService : BackgroundService
         }
 
         return ApplyInflationaryAmounts(calls, inflationaryAmounts);
+    }
+
+    /// <summary>
+    /// Promotes every <see cref="DemurragedUnwrapCall"/> to a <see cref="ResolvedUnwrapCall"/>
+    /// 1:1 using its <c>DemurragedAmount</c>. Used in the all-DemurrageCircles fast path
+    /// (no conversion needed) and as the fallback for resolver failures (preserves pre-PR-#408
+    /// false-positive class for inflationary wrappers — never silently drops the canary).
+    /// </summary>
+    private static IReadOnlyList<ResolvedUnwrapCall> PromoteAllDemurraged(IReadOnlyList<DemurragedUnwrapCall> calls)
+    {
+        var resolved = new List<ResolvedUnwrapCall>(calls.Count);
+        for (int i = 0; i < calls.Count; i++)
+        {
+            var c = calls[i];
+            resolved.Add(new ResolvedUnwrapCall(c.From, c.Wrapper, c.DemurragedAmount));
+        }
+        return resolved;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -306,8 +306,47 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// <para>Splitting this from <see cref="DemurragedUnwrapCall"/> makes the unit conversion
     /// step compile-time mandatory: passing a <see cref="DemurragedUnwrapCall"/> to
     /// <see cref="SimulateBundleAsync"/> is a type error — the exact regression class of PR #408.</para>
+    /// <para>The constructor is private: instances can only be produced via
+    /// <see cref="FromDemurraged"/> (1:1 lift for <see cref="CirclesType.DemurrageCircles"/> or as
+    /// resolver-failure fallback) or <see cref="FromInflated"/> (substitute the γ^day-converted
+    /// amount for an <see cref="CirclesType.InflationaryCircles"/> wrapper). Both factories take
+    /// a <see cref="DemurragedUnwrapCall"/> as input — the resolver pipeline is the only path
+    /// that can yield a Resolved call, so a future contributor cannot accidentally bypass unit
+    /// discrimination by synthesizing one in the bundle assembler.</para>
     /// </summary>
-    internal readonly record struct ResolvedUnwrapCall(string From, string Wrapper, BigInteger Amount);
+    internal readonly record struct ResolvedUnwrapCall
+    {
+        public string From { get; }
+        public string Wrapper { get; }
+        public BigInteger Amount { get; }
+
+        private ResolvedUnwrapCall(string from, string wrapper, BigInteger amount)
+        {
+            From = from;
+            Wrapper = wrapper;
+            Amount = amount;
+        }
+
+        /// <summary>
+        /// Lift a <see cref="DemurragedUnwrapCall"/> 1:1. Used for
+        /// <see cref="CirclesType.DemurrageCircles"/> wrappers (unwrap argument == demurraged
+        /// amount) and as the fallback when the inflationary resolver RPC fails for one wrapper
+        /// — the canary still attempts the bundle, which produces the prior false-positive class
+        /// for that one inflationary entry rather than silently skipping coverage.
+        /// </summary>
+        internal static ResolvedUnwrapCall FromDemurraged(DemurragedUnwrapCall call)
+            => new(call.From, call.Wrapper, call.DemurragedAmount);
+
+        /// <summary>
+        /// Lift a <see cref="DemurragedUnwrapCall"/> through the inflationary conversion (γ^day)
+        /// for a <see cref="CirclesType.InflationaryCircles"/> wrapper. The caller is responsible
+        /// for sourcing <paramref name="inflatedAmount"/> from
+        /// <c>convertDemurrageToInflationaryValue</c> at the simulation block — the type system
+        /// does not enforce that the amount actually matches the wrapper's day-index conversion.
+        /// </summary>
+        internal static ResolvedUnwrapCall FromInflated(DemurragedUnwrapCall call, BigInteger inflatedAmount)
+            => new(call.From, call.Wrapper, inflatedAmount);
+    }
 
     /// <summary>
     /// For each transfer whose TokenOwner is a known wrapper, attribute one unwrap call
@@ -788,14 +827,16 @@ internal sealed class SimulationCanaryService : BackgroundService
             var src = calls[i];
             if (src.WrapperType != CirclesType.InflationaryCircles)
             {
-                resolved.Add(new ResolvedUnwrapCall(src.From, src.Wrapper, src.DemurragedAmount));
+                resolved.Add(ResolvedUnwrapCall.FromDemurraged(src));
                 continue;
             }
             BigInteger? resolvedAmount = infIdx < inflationaryAmountsForInflationaryCalls.Count
                 ? inflationaryAmountsForInflationaryCalls[infIdx]
                 : null;
             infIdx++;
-            resolved.Add(new ResolvedUnwrapCall(src.From, src.Wrapper, resolvedAmount ?? src.DemurragedAmount));
+            resolved.Add(resolvedAmount.HasValue
+                ? ResolvedUnwrapCall.FromInflated(src, resolvedAmount.Value)
+                : ResolvedUnwrapCall.FromDemurraged(src));
         }
         return resolved;
     }
@@ -893,7 +934,7 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// with new result labels (<c>block_lookup_failed</c>, <c>inflation_resolve_failed</c>).
     /// </para>
     /// </summary>
-    private async Task<IReadOnlyList<ResolvedUnwrapCall>> ResolveInflationaryAmountsAsync(
+    internal async Task<IReadOnlyList<ResolvedUnwrapCall>> ResolveInflationaryAmountsAsync(
         CanaryWorkItem item,
         IReadOnlyList<DemurragedUnwrapCall> calls,
         string blockTag,
@@ -1017,10 +1058,7 @@ internal sealed class SimulationCanaryService : BackgroundService
     {
         var resolved = new List<ResolvedUnwrapCall>(calls.Count);
         for (int i = 0; i < calls.Count; i++)
-        {
-            var c = calls[i];
-            resolved.Add(new ResolvedUnwrapCall(c.From, c.Wrapper, c.DemurragedAmount));
-        }
+            resolved.Add(ResolvedUnwrapCall.FromDemurraged(calls[i]));
         return resolved;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -328,8 +328,11 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         return results.Select(a => a.ToLowerInvariant()).ToList();
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-        => Array.Empty<(string, string, int)>();
+    // Historical canary path: wrapper mappings are not yet block-filtered, so the canary
+    // is effectively skipped for historical requests. Acceptable today because the canary's
+    // job is detecting LIVE graph drift; historical traffic doesn't broadcast on-chain.
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, CirclesType)>();
 
     /// <summary>
     /// Executes a query with @mintPolicy parameter and returns a list of strings from column 0.

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Circles.Common;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host.Data;
@@ -230,7 +231,7 @@ internal sealed class MaterializedLoadGraph(
     List<(string GroupAddress, string TrustedToken)> groupTrusts,
     List<(string Avatar, bool HasConsentedFlow)> consentedFlags,
     List<string> registeredAvatars,
-    List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> wrapperMappings) : ILoadGraph
+    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings) : ILoadGraph
 {
     public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
         LoadV2Balances() => balances;
@@ -249,6 +250,6 @@ internal sealed class MaterializedLoadGraph(
 
     public IEnumerable<string> LoadRegisteredAvatars() => registeredAvatars;
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>
         LoadWrapperMappings() => wrapperMappings;
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ArithmeticSafetyTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Edges;
 using Circles.Pathfinder.Graphs;
@@ -642,8 +643,8 @@ public class ArithmeticSafetyTests
 
         public IEnumerable<string> LoadRegisteredAvatars()
             => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-            => Array.Empty<(string, string, int)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, CirclesType)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Graphs;
@@ -1779,8 +1780,8 @@ public class GraphFactoryTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => RegisteredAvatars;
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-            => Array.Empty<(string, string, int)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, CirclesType)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/FixtureLoadGraph.cs
@@ -179,6 +179,6 @@ public class FixtureLoadGraph : ILoadGraph
     /// <summary>
     /// Returns empty — fixture scenarios don't include wrapper data.
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-        => Array.Empty<(string, string, int)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, CirclesType)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/MockLoadGraph.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Pathfinder.Data;
 using Nethermind.Int256;
 
@@ -19,7 +20,7 @@ public class MockLoadGraph : ILoadGraph
     private readonly List<string> _scoreRouters = new();
     private readonly List<(string Avatar, bool HasConsentedFlow)> _consentedFlags = new();
     private readonly List<string> _registeredAvatars = new();
-    private readonly List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> _wrapperMappings = new();
+    private readonly List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> _wrapperMappings = new();
     private string? _routerAddress;
 
     /// <summary>
@@ -210,7 +211,7 @@ public class MockLoadGraph : ILoadGraph
         return _registeredAvatars;
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
     {
         return _wrapperMappings;
     }
@@ -224,11 +225,11 @@ public class MockLoadGraph : ILoadGraph
     }
 
     /// <summary>
-    /// Add a wrapper→avatar mapping for testing.
-    /// circlesType: 0 = DemurrageCircles (default, unwrap takes demurraged units),
-    ///              1 = InflationaryCircles (unwrap takes inflationary units).
+    /// Add a wrapper→avatar mapping for testing. Default flavor is
+    /// <see cref="CirclesType.DemurrageCircles"/> — pass
+    /// <see cref="CirclesType.InflationaryCircles"/> for s-prefix wrappers.
     /// </summary>
-    public void AddWrapperMapping(string wrapperAddress, string underlyingAvatar, int circlesType = 0)
+    public void AddWrapperMapping(string wrapperAddress, string underlyingAvatar, CirclesType circlesType = CirclesType.DemurrageCircles)
     {
         _wrapperMappings.Add((wrapperAddress.ToLowerInvariant(), underlyingAvatar.ToLowerInvariant(), circlesType));
     }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -297,8 +297,8 @@ public class ProxyLoadGraph : ILoadGraph
     /// <summary>
     /// Returns empty — ProxyLoadGraph uses native-only queries (no wrappers in graph).
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-        => Array.Empty<(string, string, int)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+        => Array.Empty<(string, string, CirclesType)>();
 
     // Helper methods to extract values from JsonElement or raw objects
     private static string GetString(object? value)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SharedGraphCache.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using System.Collections.Concurrent;
 using Circles.Common.TestUtils;
 using Circles.Pathfinder.Data;
@@ -296,6 +297,6 @@ internal class CachedLoadGraph(CachedGraphData data) : ILoadGraph
     public IEnumerable<string>
         LoadRegisteredAvatars() => data.RegisteredAvatars;
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
-        LoadWrapperMappings() => Array.Empty<(string, string, int)>();
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>
+        LoadWrapperMappings() => Array.Empty<(string, string, CirclesType)>();
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalStateTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using System.Numerics;
 using Circles.Pathfinder.Data;
 
@@ -960,7 +961,7 @@ public class IncrementalLoadGraphTests
         public List<string> Groups { get; } = new();
         public List<(string GroupAddress, string TrustedToken)> GroupTrustEntries { get; } = new();
         public List<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; } = new();
-        public List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> WrapperMappings { get; } = new();
+        public List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> WrapperMappings { get; } = new();
         public List<string> ScoreRouterAddresses { get; } = new();
         public List<(string Account, string Operator)> OperatorApprovalRows { get; } = new();
 
@@ -978,7 +979,7 @@ public class IncrementalLoadGraphTests
 
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
             => WrapperMappings;
 
         public IEnumerable<string> LoadScoreRouters() => ScoreRouterAddresses;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MutationKillerTests.cs
@@ -1,3 +1,4 @@
+using Circles.Common;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Data;
 using Circles.Pathfinder.Edges;
@@ -1378,8 +1379,8 @@ public class MutationKillerTests
         public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts() => GroupTrusts;
         public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags() => ConsentedFlags;
         public IEnumerable<string> LoadRegisteredAvatars() => Enumerable.Empty<string>();
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
-            => Array.Empty<(string, string, int)>();
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
+            => Array.Empty<(string, string, CirclesType)>();
     }
 
     #endregion

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryInflationaryConversionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryInflationaryConversionTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Numerics;
 using System.Text.Json;
+using Circles.Common;
 using Circles.Common.Dto;
 using Circles.Pathfinder.Host.Canary;
 using NUnit.Framework;
@@ -200,15 +201,14 @@ public class SimulationCanaryInflationaryConversionTests
     {
         var calls = new[]
         {
-            new SimulationCanaryService.UnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), IsInflationary: false),
-            new SimulationCanaryService.UnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), IsInflationary: false),
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), CirclesType.DemurrageCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), CirclesType.DemurrageCircles),
         };
         var inflationaryResolved = new List<BigInteger?>(); // empty — no inflationary calls to resolve
 
         var result = SimulationCanaryService.ApplyInflationaryAmounts(calls, inflationaryResolved);
         Assert.That(result.Count, Is.EqualTo(2));
         Assert.That(result[0].Amount, Is.EqualTo(BigInteger.Parse("100")));
-        Assert.That(result[0].IsInflationary, Is.False);
         Assert.That(result[1].Amount, Is.EqualTo(BigInteger.Parse("200")));
     }
 
@@ -217,8 +217,8 @@ public class SimulationCanaryInflationaryConversionTests
     {
         var calls = new[]
         {
-            new SimulationCanaryService.UnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), IsInflationary: true),
-            new SimulationCanaryService.UnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), IsInflationary: true),
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfrom1", "0xwrap1", BigInteger.Parse("100"), CirclesType.InflationaryCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfrom2", "0xwrap2", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
         };
         var inflationaryResolved = new List<BigInteger?>
         {
@@ -237,9 +237,9 @@ public class SimulationCanaryInflationaryConversionTests
     {
         var calls = new[]
         {
-            new SimulationCanaryService.UnwrapCall("0xfromA", "0xwrapA", BigInteger.Parse("100"), IsInflationary: false), // demurraged: pass through
-            new SimulationCanaryService.UnwrapCall("0xfromB", "0xwrapB", BigInteger.Parse("200"), IsInflationary: true),  // inflationary: convert
-            new SimulationCanaryService.UnwrapCall("0xfromC", "0xwrapC", BigInteger.Parse("300"), IsInflationary: false), // demurraged: pass through
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfromA", "0xwrapA", BigInteger.Parse("100"), CirclesType.DemurrageCircles),    // pass through
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfromB", "0xwrapB", BigInteger.Parse("200"), CirclesType.InflationaryCircles), // convert
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfromC", "0xwrapC", BigInteger.Parse("300"), CirclesType.DemurrageCircles),    // pass through
         };
         var inflationaryResolved = new List<BigInteger?>
         {
@@ -258,7 +258,7 @@ public class SimulationCanaryInflationaryConversionTests
     {
         var calls = new[]
         {
-            new SimulationCanaryService.UnwrapCall("0xfrom", "0xwrap", BigInteger.Parse("100"), IsInflationary: true),
+            new SimulationCanaryService.DemurragedUnwrapCall("0xfrom", "0xwrap", BigInteger.Parse("100"), CirclesType.InflationaryCircles),
         };
         var resolved = new List<BigInteger?> { null }; // RPC failure on this call
 
@@ -289,9 +289,9 @@ public class SimulationCanaryInflationaryConversionTests
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
         Assert.That(calls.Count, Is.EqualTo(2));
         Assert.That(calls[0].Wrapper, Is.EqualTo("0xwrapd"));
-        Assert.That(calls[0].IsInflationary, Is.False);
+        Assert.That(calls[0].WrapperType, Is.EqualTo(CirclesType.DemurrageCircles));
         Assert.That(calls[1].Wrapper, Is.EqualTo("0xwrapi"));
-        Assert.That(calls[1].IsInflationary, Is.True);
+        Assert.That(calls[1].WrapperType, Is.EqualTo(CirclesType.InflationaryCircles));
     }
 
     [Test]
@@ -308,7 +308,7 @@ public class SimulationCanaryInflationaryConversionTests
 
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers: null);
         Assert.That(calls.Count, Is.EqualTo(1));
-        Assert.That(calls[0].IsInflationary, Is.False);
+        Assert.That(calls[0].WrapperType, Is.EqualTo(CirclesType.DemurrageCircles));
     }
 
     [Test]
@@ -327,8 +327,8 @@ public class SimulationCanaryInflationaryConversionTests
 
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
         Assert.That(calls.Count, Is.EqualTo(1));
-        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("300")));
-        Assert.That(calls[0].IsInflationary, Is.True);
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(BigInteger.Parse("300")));
+        Assert.That(calls[0].WrapperType, Is.EqualTo(CirclesType.InflationaryCircles));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -391,8 +391,8 @@ public class SimulationCanaryInflationaryConversionTests
 
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
         Assert.That(calls.Count, Is.EqualTo(1));
-        Assert.That(calls[0].IsInflationary, Is.False);
-        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("229412191490542522084844")),
+        Assert.That(calls[0].WrapperType, Is.EqualTo(CirclesType.DemurrageCircles));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(BigInteger.Parse("229412191490542522084844")),
             "demurraged-wrapper amount must pass through unchanged — no β^day inflation");
 
         // ApplyInflationaryAmounts with empty inflationary list is a no-op for demurraged calls.
@@ -431,7 +431,7 @@ public class SimulationCanaryInflationaryConversionTests
 
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, wrapperToAvatar, inflationaryWrappers);
         Assert.That(calls.Count, Is.EqualTo(1));
-        Assert.That(calls[0].IsInflationary, Is.False,
+        Assert.That(calls[0].WrapperType, Is.EqualTo(CirclesType.DemurrageCircles),
             "DemurrageCircles wrapper must NOT be flagged inflationary — PR #408 regression");
 
         // Even with a non-empty resolved list (would-be inflated value), ApplyInflationaryAmounts

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Numerics;
+using System.Threading;
+using System.Threading.Tasks;
+using Circles.Common;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Host;
+using Circles.Pathfinder.Host.Canary;
+using Microsoft.Extensions.Logging.Abstractions;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Wiring tests for the canary's inflation resolver: prove that the all-DemurrageCircles
+/// short-circuit is consulted, not just declared.
+/// <para>A predicate-only test would still pass if a future change deleted the early-return —
+/// the resolver would harmlessly dial both RPCs and produce the same output. These tests
+/// inject a counting HttpMessageHandler so the contract under test is "no HTTP at all"
+/// rather than "the output happens to be equal".</para>
+/// </summary>
+[TestFixture]
+public class SimulationCanaryResolverFastPathTests
+{
+    private string? _prevRpcUrl;
+    private string? _prevPgConn;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _prevRpcUrl = Environment.GetEnvironmentVariable("NETHERMIND_RPC_URL");
+        _prevPgConn = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
+        // SimulationCanaryService caches NethermindRpcUrl in its ctor; the actual network
+        // gate is the injected IHttpClientFactory, so the URL value here is irrelevant
+        // as long as it satisfies the non-null contract. The base Common.Settings ctor
+        // separately requires POSTGRES_CONNECTION_STRING (not used by the fast path).
+        Environment.SetEnvironmentVariable(
+            "NETHERMIND_RPC_URL", "http://localhost:0/canary-test-never-hit");
+        Environment.SetEnvironmentVariable(
+            "POSTGRES_CONNECTION_STRING", "Host=localhost;Port=0;Database=canary-test;Username=u;Password=p");
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("NETHERMIND_RPC_URL", _prevRpcUrl);
+        Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING", _prevPgConn);
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_AllDemurraged_MakesZeroRpcCalls()
+    {
+        var handler = new CountingHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromA", "0xwrapA", BigInteger.Parse("100"), CirclesType.DemurrageCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromB", "0xwrapB", BigInteger.Parse("200"), CirclesType.DemurrageCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromC", "0xwrapC", BigInteger.Parse("300"), CirclesType.DemurrageCircles),
+        };
+
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+
+        Assert.That(handler.Count, Is.EqualTo(0),
+            "all-DemurrageCircles batch must short-circuit before any HTTP — both " +
+            "eth_getBlockByNumber AND eth_simulateV1 are wasted RPCs in this path");
+        Assert.That(resolved.Count, Is.EqualTo(3));
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("100")));
+        Assert.That(resolved[1].Amount, Is.EqualTo(BigInteger.Parse("200")));
+        Assert.That(resolved[2].Amount, Is.EqualTo(BigInteger.Parse("300")));
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_EmptyBatch_MakesZeroRpcCalls()
+    {
+        // Defensive case: zero-length unwrap list (e.g. wrapperToAvatar populated but no
+        // transfer actually referenced a wrapper) must short-circuit cleanly. The predicate
+        // must not throw and must not dial out.
+        var handler = new CountingHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = Array.Empty<SimulationCanaryService.DemurragedUnwrapCall>();
+
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+
+        Assert.That(handler.Count, Is.EqualTo(0));
+        Assert.That(resolved.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_OneInflationaryEntry_TriggersTwoRpcs()
+    {
+        // Positive control: when a single InflationaryCircles entry needs γ^day conversion
+        // the predicate must NOT short-circuit. Expect exactly two RPCs:
+        //   1. eth_getBlockByNumber (resolve simulation block timestamp → day)
+        //   2. eth_simulateV1 (one convertDemurrageToInflationaryValue per inflationary entry)
+        // The demurraged neighbor must pass through unchanged.
+        var handler = new ScriptedHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromD", "0xwrapD", BigInteger.Parse("100"), CirclesType.DemurrageCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI", "0xwrapI", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+        };
+
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+
+        Assert.That(handler.Count, Is.EqualTo(2),
+            "positive control: 1× eth_getBlockByNumber + 1× eth_simulateV1 batch");
+        Assert.That(resolved.Count, Is.EqualTo(2));
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("100")),
+            "DemurrageCircles entry passes through unchanged");
+        Assert.That(resolved[1].Amount, Is.EqualTo(BigInteger.Parse("300")),
+            "InflationaryCircles entry substituted with scripted convertDemurrageToInflationaryValue result");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────
+
+    private static SimulationCanaryService NewService(IHttpClientFactory factory) =>
+        // Fully qualified: Circles.Pathfinder.Settings (base) is also in scope via the
+        // Pathfinder reference, and the derived Host.Settings is the one SimulationCanaryService accepts.
+        new(new Circles.Pathfinder.Host.Settings(), NullLogger<SimulationCanaryService>.Instance, factory);
+
+    private static CanaryWorkItem NewWorkItem() =>
+        new("test-req", "0xsource", "0xsink", 1000, new List<TransferPathStep>());
+
+    private sealed class CountingHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _count);
+            // Return a syntactically valid JSON-RPC envelope so the resolver's downstream
+            // parsing doesn't blow up on an unexpected execution path (test still asserts
+            // Count == 0 first, but we want the failure mode to be a clean assertion miss,
+            // not a parser exception masking the actual regression).
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}")
+            });
+        }
+    }
+
+    /// <summary>
+    /// Scripts the two RPCs the resolver issues when an InflationaryCircles entry is present:
+    /// (1) eth_getBlockByNumber → timestamp 0x6 (pre-epoch → day=0, exercises the
+    /// <c>ComputeInflationDay</c> floor branch); (2) eth_simulateV1 → one call returning
+    /// 0x12c (300) for the lone convertDemurrageToInflationaryValue.
+    /// </summary>
+    private sealed class ScriptedHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        // 300 (decimal) = 0x12c, left-padded to 64 hex chars for the returnData word
+        private static readonly string SimulateV1Body =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"calls\":[{\"status\":\"0x1\",\"returnData\":\"0x" +
+            new string('0', 61) + "12c\"}]}]}";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            string body = n == 1
+                ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}"
+                : SimulateV1Body;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
+    }
+
+    private sealed class SingleHandlerHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public SingleHandlerHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) =>
+            new(_handler, disposeHandler: false) { BaseAddress = new Uri("http://localhost/canary-test") };
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
@@ -31,6 +31,12 @@ public class SimulationCanaryResolverFastPathTests
     [SetUp]
     public void SetUp()
     {
+        // DO NOT add [Parallelizable] to this fixture: SetUp/TearDown mutate process-wide
+        // environment variables (NETHERMIND_RPC_URL, POSTGRES_CONNECTION_STRING). Peer
+        // fixtures such as HostSettingsRegressionTests, HttpEndpointTests, and
+        // NetworkStateUpdaterServiceTests also read these. NUnit assembly default is
+        // sequential per-fixture, which keeps this safe today — opting in to fixture
+        // parallelism here would silently corrupt those neighbors.
         _prevRpcUrl = Environment.GetEnvironmentVariable("NETHERMIND_RPC_URL");
         _prevPgConn = Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING");
         // SimulationCanaryService caches NethermindRpcUrl in its ctor; the actual network
@@ -75,9 +81,17 @@ public class SimulationCanaryResolverFastPathTests
             "all-DemurrageCircles batch must short-circuit before any HTTP — both " +
             "eth_getBlockByNumber AND eth_simulateV1 are wasted RPCs in this path");
         Assert.That(resolved.Count, Is.EqualTo(3));
-        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("100")));
-        Assert.That(resolved[1].Amount, Is.EqualTo(BigInteger.Parse("200")));
-        Assert.That(resolved[2].Amount, Is.EqualTo(BigInteger.Parse("300")));
+        // Per-row From/Wrapper assertions in addition to Amount: catches a future
+        // factory mutation that swaps fields (e.g. `new(call.Wrapper, call.From, ...)`).
+        Assert.That(resolved[0].From,    Is.EqualTo("0xfromA"));
+        Assert.That(resolved[0].Wrapper, Is.EqualTo("0xwrapA"));
+        Assert.That(resolved[0].Amount,  Is.EqualTo(BigInteger.Parse("100")));
+        Assert.That(resolved[1].From,    Is.EqualTo("0xfromB"));
+        Assert.That(resolved[1].Wrapper, Is.EqualTo("0xwrapB"));
+        Assert.That(resolved[1].Amount,  Is.EqualTo(BigInteger.Parse("200")));
+        Assert.That(resolved[2].From,    Is.EqualTo("0xfromC"));
+        Assert.That(resolved[2].Wrapper, Is.EqualTo("0xwrapC"));
+        Assert.That(resolved[2].Amount,  Is.EqualTo(BigInteger.Parse("300")));
     }
 
     [Test]
@@ -127,10 +141,57 @@ public class SimulationCanaryResolverFastPathTests
         Assert.That(handler.Count, Is.EqualTo(2),
             "positive control: 1× eth_getBlockByNumber + 1× eth_simulateV1 batch");
         Assert.That(resolved.Count, Is.EqualTo(2));
-        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("100")),
+        Assert.That(resolved[0].From,    Is.EqualTo("0xfromD"));
+        Assert.That(resolved[0].Wrapper, Is.EqualTo("0xwrapD"));
+        Assert.That(resolved[0].Amount,  Is.EqualTo(BigInteger.Parse("100")),
             "DemurrageCircles entry passes through unchanged");
-        Assert.That(resolved[1].Amount, Is.EqualTo(BigInteger.Parse("300")),
+        Assert.That(resolved[1].From,    Is.EqualTo("0xfromI"));
+        Assert.That(resolved[1].Wrapper, Is.EqualTo("0xwrapI"));
+        Assert.That(resolved[1].Amount,  Is.EqualTo(BigInteger.Parse("300")),
             "InflationaryCircles entry substituted with scripted convertDemurrageToInflationaryValue result");
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_MixedBatch_WalksInfIdxAcrossDemurragedGaps()
+    {
+        // ApplyInflationaryAmounts walks an `infIdx` cursor that ONLY advances for
+        // InflationaryCircles positions. An off-by-one (e.g. advancing on every position)
+        // still passes OneInflationaryEntry because there's only one inflationary slot.
+        // This test forces the resolver to walk past a demurraged entry between two
+        // inflationary ones, with two distinct scripted return amounts so a misaligned
+        // cursor produces a visibly wrong assignment.
+        var handler = new MixedBatchScriptedHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI1", "0xwrapI1", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromD",  "0xwrapD",  BigInteger.Parse("500"), CirclesType.DemurrageCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI2", "0xwrapI2", BigInteger.Parse("400"), CirclesType.InflationaryCircles),
+        };
+
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+
+        Assert.That(handler.Count, Is.EqualTo(2),
+            "two RPCs: eth_getBlockByNumber + eth_simulateV1 with batch of 2 convert calls");
+        Assert.That(resolved.Count, Is.EqualTo(3));
+        // Slot 0 (inflationary) gets the first scripted return = 300
+        Assert.That(resolved[0].Wrapper, Is.EqualTo("0xwrapI1"));
+        Assert.That(resolved[0].Amount,  Is.EqualTo(BigInteger.Parse("300")));
+        // Slot 1 (demurraged) passes through with original 500 — proves the resolver
+        // does NOT consume an inflationary-batch result for this position.
+        Assert.That(resolved[1].Wrapper, Is.EqualTo("0xwrapD"));
+        Assert.That(resolved[1].Amount,  Is.EqualTo(BigInteger.Parse("500")));
+        // Slot 2 (inflationary) gets the second scripted return = 700; an off-by-one
+        // infIdx would either reuse 300 here or assign 700 to slot 0 / 500 to slot 2.
+        Assert.That(resolved[2].Wrapper, Is.EqualTo("0xwrapI2"));
+        Assert.That(resolved[2].Amount,  Is.EqualTo(BigInteger.Parse("700")));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -180,6 +241,37 @@ public class SimulationCanaryResolverFastPathTests
         private static readonly string SimulateV1Body =
             "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"calls\":[{\"status\":\"0x1\",\"returnData\":\"0x" +
             new string('0', 61) + "12c\"}]}]}";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            string body = n == 1
+                ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}"
+                : SimulateV1Body;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
+    }
+
+    /// <summary>
+    /// Variant of <see cref="ScriptedHandler"/> that returns TWO distinct values in the
+    /// eth_simulateV1 batch (300, 700) — so an off-by-one <c>infIdx</c> in
+    /// <c>ApplyInflationaryAmounts</c> produces a visibly wrong assignment to slot 0 vs slot 2.
+    /// </summary>
+    private sealed class MixedBatchScriptedHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        // 300 (decimal) = 0x12c, 700 = 0x2bc — both padded to 64 hex chars
+        private static readonly string SimulateV1Body =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"calls\":[" +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + new string('0', 61) + "12c\"}," +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + new string('0', 61) + "2bc\"}" +
+            "]}]}";
 
         protected override Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request, CancellationToken ct)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryUnwrapPrefixTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryUnwrapPrefixTests.cs
@@ -84,7 +84,7 @@ public class SimulationCanaryUnwrapPrefixTests
         Assert.That(calls, Has.Count.EqualTo(1));
         Assert.That(calls[0].From, Is.EqualTo(Source));
         Assert.That(calls[0].Wrapper, Is.EqualTo(V4Wrapper));
-        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("1000000000000000000")));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(BigInteger.Parse("1000000000000000000")));
     }
 
     [Test]
@@ -101,7 +101,7 @@ public class SimulationCanaryUnwrapPrefixTests
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
 
         Assert.That(calls, Has.Count.EqualTo(1));
-        Assert.That(calls[0].Amount, Is.EqualTo(BigInteger.Parse("3500000000000000000")));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(BigInteger.Parse("3500000000000000000")));
     }
 
     [Test]
@@ -118,9 +118,9 @@ public class SimulationCanaryUnwrapPrefixTests
 
         Assert.That(calls, Has.Count.EqualTo(2));
         Assert.That(calls[0].Wrapper, Is.EqualTo(V6Wrapper), "V6 first-seen → first in bundle");
-        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(150)));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(new BigInteger(150)));
         Assert.That(calls[1].Wrapper, Is.EqualTo(V4Wrapper));
-        Assert.That(calls[1].Amount, Is.EqualTo(new BigInteger(200)));
+        Assert.That(calls[1].DemurragedAmount, Is.EqualTo(new BigInteger(200)));
     }
 
     [Test]
@@ -137,7 +137,7 @@ public class SimulationCanaryUnwrapPrefixTests
 
         Assert.That(calls, Has.Count.EqualTo(1));
         Assert.That(calls[0].Wrapper, Is.EqualTo(V4Wrapper));
-        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(1000)));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(new BigInteger(1000)));
     }
 
     [Test]
@@ -154,7 +154,7 @@ public class SimulationCanaryUnwrapPrefixTests
         var calls = SimulationCanaryService.BuildUnwrapPrefix(transfers, WrapperMap());
 
         Assert.That(calls, Has.Count.EqualTo(1));
-        Assert.That(calls[0].Amount, Is.EqualTo(new BigInteger(10)));
+        Assert.That(calls[0].DemurragedAmount, Is.EqualTo(new BigInteger(10)));
     }
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Circles.Common;
 
 namespace Circles.Pathfinder.Data;
 
@@ -69,10 +70,10 @@ public record PathfinderGraphConsentedFlowRow(
 public record PathfinderGraphWrapperMappingRow(
     string WrapperAddress,
     string UnderlyingAvatar,
-    // 0 = DemurrageCircles (unwrap takes demurraged units), 1 = InflationaryCircles (unwrap takes inflationary units).
-    // Default 0 is safe-degrade: old cache snapshots without this field deserialize as demurraged,
-    // matching pre-PR-#408 canary behavior (false positives for inflationary unwraps, no new reverts).
-    int CirclesType = 0
+    // Default DemurrageCircles is safe-degrade: old cache snapshots without this field deserialize
+    // as demurraged, matching pre-PR-#408 canary behavior (false positives for inflationary
+    // unwraps, no new reverts).
+    CirclesType CirclesType = CirclesType.DemurrageCircles
 );
 
 /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Numerics;
+using Circles.Common;
 
 namespace Circles.Pathfinder.Data;
 
@@ -138,7 +139,7 @@ public sealed class CacheLoadGraph : ILoadGraph
             yield return row.ToLowerInvariant();
     }
 
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
     {
         var rows = _snapshot.WrapperMappings ?? [];
         foreach (var row in rows)

--- a/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/IncrementalLoadGraph.cs
@@ -21,7 +21,7 @@ public class IncrementalLoadGraph : ILoadGraph
     private readonly Settings _settings;
     private readonly long _maxBlockTimestamp;
     private readonly ILogger _logger;
-    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>? _cachedWrapperMappings;
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>? _cachedWrapperMappings;
 
     public IncrementalLoadGraph(
         InMemoryBalanceState balanceState,
@@ -182,9 +182,9 @@ public class IncrementalLoadGraph : ILoadGraph
     /// Returns cached wrapper mappings — loaded once per graph build from inner LoadGraph.
     /// Wrapper deployments are append-only, so caching within a single build is safe.
     /// </summary>
-    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+    public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
         => GetCachedWrapperMappings();
 
-    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> GetCachedWrapperMappings()
+    private IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> GetCachedWrapperMappings()
         => _cachedWrapperMappings ??= _inner.LoadWrapperMappings().ToList();
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/LoadGraph.cs
@@ -25,7 +25,7 @@ namespace Circles.Pathfinder.Data
         IReadOnlyList<string> ScoreRouters,
         IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags,
         IReadOnlyList<string> RegisteredAvatars,
-        IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> WrapperMappings
+        IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> WrapperMappings
     );
 
     public interface ILoadGraph
@@ -63,7 +63,7 @@ namespace Circles.Pathfinder.Data
 
         IEnumerable<string> LoadRegisteredAvatars();
 
-        IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings();
+        IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings();
     }
 
     public class LoadGraph : ILoadGraph, IDisposable
@@ -767,11 +767,11 @@ namespace Circles.Pathfinder.Data
             return results;
         }
 
-        private List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>
+        private List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>
             LoadWrapperMappingsInternal(NpgsqlConnection connection, NpgsqlTransaction tx)
         {
             var query = LoadQueryFromResource("wrapperMappingQuery.sql");
-            var results = new List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>(10_000);
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>(10_000);
 
             var sw = Stopwatch.StartNew();
 
@@ -781,7 +781,7 @@ namespace Circles.Pathfinder.Data
 
             while (reader.Read())
             {
-                results.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2)));
+                results.Add((reader.GetString(0), reader.GetString(1), (CirclesType)reader.GetInt32(2)));
             }
 
             sw.Stop();
@@ -1198,10 +1198,10 @@ namespace Circles.Pathfinder.Data
             return results;
         }
 
-        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)> LoadWrapperMappings()
+        public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
         {
             var query = LoadQueryFromResource("wrapperMappingQuery.sql");
-            var results = new List<(string WrapperAddress, string UnderlyingAvatar, int CirclesType)>(10_000);
+            var results = new List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>(10_000);
 
             var sw = Stopwatch.StartNew();
             using var connection = _dataSource.OpenConnection();
@@ -1212,7 +1212,7 @@ namespace Circles.Pathfinder.Data
 
             while (reader.Read())
             {
-                results.Add((reader.GetString(0), reader.GetString(1), reader.GetInt32(2)));
+                results.Add((reader.GetString(0), reader.GetString(1), (CirclesType)reader.GetInt32(2)));
             }
 
             sw.Stop();

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraph.cs
@@ -71,11 +71,11 @@ public class CapacityGraph : IGraph<CapacityEdge>
     // Used at DTO output layer to resolve wrapper addresses to registered avatars
     public Dictionary<int, int> WrapperToAvatar { get; } = new Dictionary<int, int>();
 
-    // Subset of WrapperToAvatar keys whose CrcV2_ERC20WrapperDeployed.circlesType == 1
-    // (InflationaryCircles, `s-` symbol prefix). The canary needs this to discriminate
-    // unwrap() argument units: DemurrageCircles.unwrap takes demurraged 1155 units 1:1,
-    // InflationaryCircles.unwrap takes inflationary ERC20 units (= demurraged * β^day).
-    // Verified on-chain by direct probes at 2026-05-27 — see PR description for evidence.
+    // Subset of WrapperToAvatar keys flagged as CirclesType.InflationaryCircles
+    // (`s-` symbol prefix). The canary needs this to discriminate unwrap() argument units:
+    // DemurrageCircles.unwrap takes demurraged 1155 units 1:1, InflationaryCircles.unwrap
+    // takes inflationary ERC20 units (= demurraged * β^day). Verified on-chain by direct
+    // probes 2026-05-27 — see PR description for evidence.
     public HashSet<int> InflationaryWrappers { get; } = new HashSet<int>();
 
     // Trust lookup for consented flow validation (truster -> set of trustees)

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -817,8 +817,6 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
 
     // Load ERC20 wrapper→avatar reverse mappings for DTO output resolution.
     // Also populates InflationaryWrappers for the canary's unit-discrimination logic.
-    // circlesType: 0 = DemurrageCircles (unwrap takes demurraged units),
-    //              1 = InflationaryCircles (unwrap takes inflationary units).
     private void LoadWrapperMappings(CapacityGraph capacityGraph, CachedGroupData? cached = null)
     {
         if (cached != null)
@@ -840,7 +838,7 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             int wrapperId = AddressIdPool.IdOf(wrapperAddr.ToLowerInvariant());
             int avatarId = AddressIdPool.IdOf(avatarAddr.ToLowerInvariant());
             capacityGraph.WrapperToAvatar[wrapperId] = avatarId;
-            if (circlesType == 1)
+            if (circlesType == CirclesType.InflationaryCircles)
                 capacityGraph.InflationaryWrappers.Add(wrapperId);
         }
 

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Circles.Common;
 using Microsoft.Extensions.Caching.Memory;
 using Npgsql;
 
@@ -359,12 +360,10 @@ public partial class CirclesRpcModule
                 if (await reader.ReadAsync())
                 {
                     var tokenOwner = reader.GetString(1);
-                    var circlesType = reader.GetInt32(2);
+                    var circlesType = (CirclesType)reader.GetInt32(2);
                     var isGroupToken = reader.GetBoolean(3);
 
-                    // Determine token type based on circlesType
-                    // circlesType = 0 for demurraged, 1 for inflationary
-                    var isInflationary = circlesType == 1;
+                    var isInflationary = circlesType == CirclesType.InflationaryCircles;
                     var tokenType = isInflationary
                         ? "CrcV2_ERC20WrapperDeployed_Inflationary"
                         : "CrcV2_ERC20WrapperDeployed_Demurraged";


### PR DESCRIPTION
## Summary

Splits the canary's single `UnwrapCall` record into `DemurragedUnwrapCall` (input, 1155 ledger units) and `ResolvedUnwrapCall` (output, native `unwrap(uint256)` argument units). `SimulateBundleAsync` now accepts only the resolved type — passing a demurraged amount to the bundle is a compile error.

Replaces magic `int 0/1` wrapper-flavor literals with `enum CirclesType : byte { DemurrageCircles = 0, InflationaryCircles = 1 }` across cache, pathfinder, and RPC call sites.

## What this prevents

The PR #408 regression class: skipping the unit-conversion step and passing demurraged sums to a wrapper that expects inflationary units. Previously the compiler accepted it (both states shared the `UnwrapCall` type with a `bool IsInflationary` discriminant). Now the producer/consumer types are different — a refactor dropping the `await ResolveInflationaryAmountsAsync(...)` call fails to compile.

## Wire-format compatibility

`int CirclesType = 0` → `CirclesType CirclesType = CirclesType.DemurrageCircles`. Verified:
- No `JsonStringEnumConverter` registered on the cache→pathfinder JSON HTTP boundary
- Default System.Text.Json serializes enums as their underlying integer (`byte`)
- Default `DemurrageCircles` on both `PathfinderWrapperMappingRow` and `PathfinderGraphWrapperMappingRow` — old snapshots safe to deserialize

## Behavior changes

- `SimulateAsync` no longer has an explicit `hasInflationary` pre-flight loop. The resolver always runs on the withWrap path; for all-DemurrageCircles bundles it short-circuits via `PromoteAllDemurraged` (zero RPC overhead, identical observable behavior).
- All three failure-class metric labels (`block_lookup_failed`, `inflation_resolve_failed`, `inflation_resolve_partial`) emitted at exactly the same trigger points.

## Test plan

- [x] Full solution build: 0 errors
- [x] Pathfinder tests: 1078 passed, 270 skipped
- [x] Cache tests: 226 passed, 26 skipped
- [x] RPC tests: 147 passed, 113 skipped
- [x] Index tests: 79 + 98 passed, 0 skipped
- [x] Common tests: 97 passed
- [x] Query tests: 18 passed, 11 skipped
- [x] Wire-format verified unchanged (no `JsonStringEnumConverter` on this path)
- [ ] Rolling deploy on staging (cache-service, then pathfinder)
- [ ] Verify canary still emits expected metrics post-deploy