### PR TITLE
score-group: rename MerkleRootUpdated.group to merkleTreeManager

### DIFF
--- a/src/Common/Circles.Common/Settings.cs
+++ b/src/Common/Circles.Common/Settings.cs
@@ -235,6 +235,22 @@ public class Settings
         Environment.GetEnvironmentVariable("V2_BASE_GROUP_ROUTER")?.ToLowerInvariant()
         ?? "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
 
+    /// <summary>
+    /// Comma-separated allowlist of contract addresses that emit score-group events.
+    ///
+    /// Post-score-refactor this list MUST include BOTH the mint policy AND the
+    /// merkle-tree registry/manager(s):
+    ///   - The mint policy emits <c>GroupInitialized</c>, <c>HistoricalSupply</c>,
+    ///     <c>PersonalMinted</c>, <c>RouterMinted</c>.
+    ///   - The merkle-tree registry emits <c>MerkleRootUpdated</c>.
+    /// Replacing the policy with the manager would silently drop the four policy-emitted
+    /// events; replacing the manager with the policy would silently drop merkle-root
+    /// updates. Pathfinder queries also compare entries here against
+    /// <c>CrcV2_RegisterGroup.mint</c>, which only matches policy addresses — so policy
+    /// entries must be present for the pathfinder side to function.
+    ///
+    /// Format: <c>"0xPOLICY,0xMERKLE_REGISTRY[,0xMERKLE_REGISTRY_2…]"</c> (whitespace tolerant).
+    /// </summary>
     public readonly string[] ScoreGroupMintPolicies =
         Environment.GetEnvironmentVariable("V2_SCORE_GROUP_MINT_POLICIES")?.Split(',')
             .Select(x => x.Trim().ToLowerInvariant())

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/DatabaseSchema.cs
@@ -15,6 +15,7 @@ public record GroupInitialized(
     string MerkleTreeManager,
     string PathMintRouter) : IIndexEvent;
 
+// score-refactor: MerkleRootUpdated event moved from policy → merkle-tree contract; Topic[1] is now manager, not group.
 public record MerkleRootUpdated(
     long BlockNumber,
     long Timestamp,
@@ -22,7 +23,7 @@ public record MerkleRootUpdated(
     int LogIndex,
     string TransactionHash,
     string Emitter,
-    string Group,
+    string MerkleTreeManager,
     byte[] NewMerkleRoot,
     byte[] PreviousRoot,
     UInt256 UpdateBlockNumber) : IIndexEvent;
@@ -99,9 +100,12 @@ public class DatabaseSchema : BaseDatabaseSchema
         "CrcV2_ScoreGroup",
         "event GroupInitialized(address indexed group,address indexed merkleTreeManager,address pathMintRouter)"));
 
+    // score-refactor: MerkleRootUpdated event moved from policy → merkle-tree contract; Topic[1] is now manager, not group.
+    // TODO(score-refactor): point V2_SCORE_GROUP_MINT_POLICIES at the new merkle-tree contract address(es) at cutover.
+    // This signature change re-hashes the event topic; pre-cutover logs will no longer match.
     public static readonly EventSchema MerkleRootUpdated = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
-        "event MerkleRootUpdated(address indexed group,bytes32 newMerkleRoot,bytes32 previousRoot,uint256 updateBlockNumber)"));
+        "event MerkleRootUpdated(address indexed merkleTreeManager,bytes32 newMerkleRoot,bytes32 previousRoot,uint256 updateBlockNumber)"));
 
     public static readonly EventSchema HistoricalSupply = WithEmitterColumn(EventSchema.FromSolidity(
         "CrcV2_ScoreGroup",
@@ -143,6 +147,7 @@ public class DatabaseSchema : BaseDatabaseSchema
                 ("pathMintRouter", e => e.PathMintRouter)
             ]);
 
+        // score-refactor: MerkleRootUpdated event moved from policy → merkle-tree contract; Topic[1] is now manager, not group.
         AddMappings<MerkleRootUpdated>(
             ns: "CrcV2_ScoreGroup",
             table: "MerkleRootUpdated",
@@ -150,7 +155,7 @@ public class DatabaseSchema : BaseDatabaseSchema
             databaseFieldMap:
             [
                 ("emitter", e => e.Emitter),
-                ("group", e => e.Group),
+                ("merkleTreeManager", e => e.MerkleTreeManager),
                 ("newMerkleRoot", e => e.NewMerkleRoot),
                 ("previousRoot", e => e.PreviousRoot),
                 ("updateBlockNumber", e => (BigInteger)e.UpdateBlockNumber)

--- a/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2.ScoreGroup/LogParser.cs
@@ -139,10 +139,11 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
 
     private static MerkleRootUpdated ParseMerkleRootUpdated(Block block, TxReceipt receipt, LogEntry log, int logIndex)
     {
-        // event MerkleRootUpdated(address indexed group, bytes32 newMerkleRoot,
+        // score-refactor: MerkleRootUpdated event moved from policy → merkle-tree contract; Topic[1] is now manager, not group.
+        // event MerkleRootUpdated(address indexed merkleTreeManager, bytes32 newMerkleRoot,
         //                         bytes32 previousRoot, uint256 updateBlockNumber)
         // 96 unindexed bytes: newMerkleRoot | previousRoot | updateBlockNumber.
-        var group = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
+        var merkleTreeManager = LogDataParsingHelper.ParseAddressFromTopic(log.Topics[1].Bytes);
         var data = log.Data.AsSpan();
 
         return new MerkleRootUpdated(
@@ -152,7 +153,7 @@ public class LogParser(ImmutableHashSet<Address> policyAddresses) : ILogParser
             logIndex,
             receipt.TxHash!.ToString(),
             log.Address.ToLowerHex(),
-            group,
+            merkleTreeManager,
             data.Slice(0, 32).ToArray(),
             data.Slice(32, 32).ToArray(),
             Uint(data.Slice(64, 32)));


### PR DESCRIPTION
## Summary

The on-chain refactor moves `MerkleRootUpdated` off the mint policy and onto a shared `MerkleTreeRegistry`. The event's first indexed param renames from `group` to `merkleTreeManager` (the calling Safe).

- `DatabaseSchema.cs`: record field `Group` → `MerkleTreeManager`; `EventSchema.FromSolidity` signature updated; column rename in `AddMappings`.
- `LogParser.cs`: local var rename in `ParseMerkleRootUpdated`; semantics now reflect the Safe-as-key model (registry stores roots keyed by `msg.sender`).
- `Settings.cs`: docstring on `ScoreGroupMintPolicies` rewritten — env value must hold BOTH policy AND registry/manager addresses (policy still emits 4 events; registry emits MerkleRootUpdated). Replacing one with the other silently drops events.

## Cutover SQL (run on each plugin DB before deploy)

The column rename has no auto-migration. Existing score-group tables must be dropped so the indexer recreates them with the new schema and reindexes from the new policy/registry deploy block (staging-only data, fresh start preferred):

```sql
DROP TABLE IF EXISTS "CrcV2_ScoreGroup_GroupInitialized" CASCADE;
DROP TABLE IF EXISTS "CrcV2_ScoreGroup_HistoricalSupply" CASCADE;
DROP TABLE IF EXISTS "CrcV2_ScoreGroup_PersonalMinted" CASCADE;
DROP TABLE IF EXISTS "CrcV2_ScoreGroup_RouterMinted" CASCADE;
DROP TABLE IF EXISTS "CrcV2_ScoreGroup_MerkleRootUpdated" CASCADE;
```

After the indexer restarts, the `CrcV2_ScoreGroup` dependency group (see `StateMachine.cs:571`) rescans events from the new contract deploy block forward.

## Test plan

- [ ] `dotnet build -c Release` 0 errors
- [ ] Cutover SQL executed on staging plugin DBs
- [ ] Post-deploy + reindex, verify `CrcV2_ScoreGroup_MerkleRootUpdated` rows populate `merkleTreeManager` with the publisher Safe address