### PR TITLE
feat(canary): observability + resolver-failure tests + RPC error short-circuit + DemurrageMode rename

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -241,7 +241,7 @@ public class PathfinderGraphControllerTests
 
         response!.Balances.Should().HaveCount(1);
         response.Balances![0].IsWrapped.Should().BeTrue();
-        response.Balances[0].CirclesType.Should().Be("demurraged");
+        response.Balances[0].DemurrageMode.Should().Be("demurraged");
     }
 
     [Fact]
@@ -262,7 +262,7 @@ public class PathfinderGraphControllerTests
 
         response!.Balances.Should().HaveCount(1);
         response.Balances![0].IsWrapped.Should().BeTrue();
-        response.Balances[0].CirclesType.Should().Be("static");
+        response.Balances[0].DemurrageMode.Should().Be("static");
     }
 
     [Fact]
@@ -303,7 +303,7 @@ public class PathfinderGraphControllerTests
         response!.Balances.Should().HaveCount(1);
         response.Balances![0].TokenAddress.Should().Be(wrapperAddress);
         response.Balances[0].IsWrapped.Should().BeTrue();
-        response.Balances[0].CirclesType.Should().Be("static");
+        response.Balances[0].DemurrageMode.Should().Be("static");
     }
 
     // ── BuildTrust ─────────────────────────────────────────────────────

--- a/src/Cache/Circles.Cache.Service/ApiResponses.cs
+++ b/src/Cache/Circles.Cache.Service/ApiResponses.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Circles.Common;
 
 namespace Circles.Cache.Service.Models;
@@ -194,13 +195,30 @@ public record PathfinderGraphResponse(
     IReadOnlyList<PathfinderOperatorApprovalRow>? OperatorApprovals
 );
 
+/// <summary>
+/// Balance row for the /api/pathfinder/graph snapshot.
+/// </summary>
+/// <remarks>
+/// <para><b>Wire-format note for the <c>DemurrageMode</c> field:</b> the JSON property
+/// is intentionally <c>circlesType</c> (not <c>demurrageMode</c>) via
+/// <c>[JsonPropertyName]</c>. The C# property was renamed away from <c>CirclesType</c>
+/// to avoid a same-file name collision with <see cref="PathfinderWrapperMappingRow.CirclesType"/>
+/// (which is the typed enum). The wire field MUST remain <c>circlesType</c> for
+/// backward compat — independent cache/pathfinder rollouts depend on this. Renaming
+/// the wire field (dropping <c>[JsonPropertyName]</c>) would require a coordinated
+/// cache+pathfinder deploy and a schema-version bump.</para>
+/// <para>Default <c>"demurraged"</c> is the safe-degrade direction: a snapshot from
+/// an older cache that omits the field deserializes to demurraged, which the
+/// pathfinder consumer (<c>CacheLoadGraph.LoadV2Balances</c>) routes via the
+/// non-static branch — matches pre-field-introduction behavior.</para>
+/// </remarks>
 public record PathfinderBalanceRow(
     string Balance,
     string Account,
     string TokenAddress,
     long LastActivity,
     bool IsWrapped,
-    string CirclesType
+    [property: JsonPropertyName("circlesType")] string DemurrageMode = "demurraged"
 );
 
 public record PathfinderTrustRow(
@@ -232,6 +250,17 @@ public record PathfinderConsentedFlowRow(
     bool HasConsentedFlow
 );
 
+/// <summary>
+/// Wrapper-mapping row for the /api/pathfinder/graph snapshot.
+/// </summary>
+/// <remarks>
+/// The <see cref="CirclesType"/> property is the typed enum representation of the
+/// same protocol concept that <see cref="PathfinderBalanceRow.DemurrageMode"/>
+/// encodes as a string (<c>"static"</c> ↔ <see cref="Circles.Common.CirclesType.InflationaryCircles"/>,
+/// <c>"demurraged"</c> ↔ <see cref="Circles.Common.CirclesType.DemurrageCircles"/>).
+/// The dual encoding is a tracked oddity — see the comment on
+/// <see cref="PathfinderBalanceRow.DemurrageMode"/> for the wire-compat rationale.
+/// </remarks>
 public record PathfinderWrapperMappingRow(
     string WrapperAddress,
     string UnderlyingAvatar,

--- a/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
+++ b/src/Cache/Circles.Cache.Service/Controllers/PathfinderGraphController.cs
@@ -276,7 +276,7 @@ public class PathfinderGraphController : ControllerBase
                 TokenAddress: tokenAddress,
                 LastActivity: lastActivity,
                 IsWrapped: isWrapped,
-                CirclesType: isStatic ? "static" : "demurraged"
+                DemurrageMode: isStatic ? "static" : "demurraged"
             ));
         }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -42,8 +42,10 @@ internal sealed class SimulationCanaryService : BackgroundService
     private readonly ILogger<SimulationCanaryService> _log;
     private readonly string _rpcUrl;
 
-    // Metrics
-    private static readonly Counter SimulationTotal = Metrics.CreateCounter(
+    // Metrics. Counters that tests read are `internal` (see InternalsVisibleTo on
+    // Circles.Pathfinder.Tests); promoting them is the existing pattern in this repo
+    // (cf. GraphUpdateMetrics.DriftEntries usage in CacheSourceDriftResetTests).
+    internal static readonly Counter SimulationTotal = Metrics.CreateCounter(
         "circles_canary_simulation_total",
         "Total eth_call/eth_simulateV1 simulations attempted",
         new CounterConfiguration { LabelNames = new[] { "result", "prefix" } });
@@ -70,6 +72,25 @@ internal sealed class SimulationCanaryService : BackgroundService
         "circles_canary_simulation_skipped_total",
         "Work items skipped before enqueue, by reason",
         new CounterConfiguration { LabelNames = new[] { "reason" } });
+
+    // Observability for the 1ppt over-ask added in PR #426 (covers the on-chain
+    // Math64x64 floor-floor roundtrip loss for InflationaryCircles wrappers).
+    // Counter ticks once per inflationary unwrap whose raw resolver amount is
+    // large enough to trigger a non-zero bump (I ≥ 1e12 wei). If Hub.sol's
+    // conversion math ever changes and the gap exceeds 1 ppt, this counter
+    // diverges from `circles_canary_simulation_total{result="success",prefix="unwrap"}`
+    // and ERC1155InsufficientBalance reverts return — the divergence is the
+    // operator signal that points at the bump as suspect.
+    //
+    // Deliberately a SEPARATE counter (not a SimulationTotal label): bump-applied
+    // events are per-arithmetic-step (multiple per work item possible), while
+    // SimulationTotal is per-simulation-outcome (one per work item). Folding them
+    // would double-count. Also deliberately UNLABELLED — adding a {wrapper} label
+    // would explode cardinality (one series per wrapper address ever seen). Per-
+    // wrapper detail is in the DEBUG log on the bump path, not in the metric.
+    internal static readonly Counter InflationaryBumpApplied = Metrics.CreateCounter(
+        "circles_canary_inflationary_bump_applied_total",
+        "Inflationary unwrap amounts where the floor-floor roundtrip over-ask was non-zero");
 
     public static void RecordSkipped(string reason) => SimulationSkipped.WithLabels(reason).Inc();
 
@@ -835,7 +856,9 @@ internal sealed class SimulationCanaryService : BackgroundService
     /// </summary>
     internal static IReadOnlyList<ResolvedUnwrapCall> ApplyInflationaryAmounts(
         IReadOnlyList<DemurragedUnwrapCall> calls,
-        IReadOnlyList<BigInteger?> inflationaryAmountsForInflationaryCalls)
+        IReadOnlyList<BigInteger?> inflationaryAmountsForInflationaryCalls,
+        ILogger? log = null,
+        string? reqIdForLog = null)
     {
         var resolved = new List<ResolvedUnwrapCall>(calls.Count);
         int infIdx = 0;
@@ -851,9 +874,24 @@ internal sealed class SimulationCanaryService : BackgroundService
                 ? inflationaryAmountsForInflationaryCalls[infIdx]
                 : null;
             infIdx++;
-            resolved.Add(resolvedAmount.HasValue
-                ? ResolvedUnwrapCall.FromInflated(src, ApplyInflationaryRoundtripBump(resolvedAmount.Value))
-                : ResolvedUnwrapCall.FromDemurraged(src));
+            if (!resolvedAmount.HasValue)
+            {
+                resolved.Add(ResolvedUnwrapCall.FromDemurraged(src));
+                continue;
+            }
+            var bumped = ApplyInflationaryRoundtripBump(resolvedAmount.Value);
+            var delta = bumped - resolvedAmount.Value;
+            if (delta > 0)
+            {
+                InflationaryBumpApplied.Inc();
+                if (log != null && log.IsEnabled(LogLevel.Debug))
+                {
+                    log.LogDebug(
+                        "[{ReqId}] SimulationCanary: inflationary roundtrip bump applied wrapper={Wrapper} from={From} rawInflated={RawInflated} bumped={Bumped} delta={Delta}",
+                        reqIdForLog ?? "-", src.Wrapper, src.From, resolvedAmount.Value, bumped, delta);
+                }
+            }
+            resolved.Add(ResolvedUnwrapCall.FromInflated(src, bumped));
         }
         return resolved;
     }
@@ -1071,6 +1109,30 @@ internal sealed class SimulationCanaryService : BackgroundService
             return PromoteAllDemurraged(calls);
         }
 
+        // Step 3.5: top-level RPC error short-circuit. When the JSON-RPC layer
+        // itself rejects the batch (parse error, method not found, internal error
+        // upstream), the response carries `{"error": {"code": …, "message": …}}`
+        // at the root with no `result` field. Without this check ExtractInflationaryAmounts
+        // would log one per-call partial-failure warning per inflationary entry and
+        // emit N `inflation_resolve_partial` counter ticks — noisy and misleading,
+        // since the root cause is a single batch rejection, not N independent failures.
+        // `"error": null` is a valid JSON-RPC success-shape emitted by some servers
+        // alongside a populated `result` — guard explicitly so we don't false-positive
+        // on it and trigger the per-batch fallback when the batch actually succeeded.
+        if (json.ValueKind == JsonValueKind.Object
+            && json.TryGetProperty("error", out var rpcErr)
+            && rpcErr.ValueKind != JsonValueKind.Null)
+        {
+            var errMsg = rpcErr.ValueKind == JsonValueKind.Object && rpcErr.TryGetProperty("message", out var m)
+                ? m.GetString()
+                : rpcErr.ToString();
+            _log.LogWarning(
+                "[{ReqId}] SimulationCanary: ResolveInflationaryAmounts: eth_simulateV1 batch rejected at RPC layer: {Error}",
+                item.ReqId, errMsg);
+            SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Inc();
+            return PromoteAllDemurraged(calls);
+        }
+
         // Step 4: extract per-position results; ApplyInflationaryAmounts substitutes only
         // inflationary positions (demurraged calls pass through unchanged).
         var inflationaryAmounts = ExtractInflationaryAmounts(json, inflationaryIndices.Count);
@@ -1092,7 +1154,7 @@ internal sealed class SimulationCanaryService : BackgroundService
             SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Inc();
         }
 
-        return ApplyInflationaryAmounts(calls, inflationaryAmounts);
+        return ApplyInflationaryAmounts(calls, inflationaryAmounts, _log, item.ReqId);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SnapshotBuilder.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SnapshotBuilder.cs
@@ -26,7 +26,7 @@ public static class SnapshotBuilder
             TokenAddress: AddressIdPool.StringOf(b.TokenAddress),
             LastActivity: 0,
             IsWrapped: b.IsWrapped,
-            CirclesType: b.IsStatic ? "static" : "demurraged"
+            DemurrageMode: b.IsStatic ? "static" : "demurraged"
         )).ToList();
 
         var trust = mock.LoadV2Trust().Select(t => new PathfinderGraphTrustRow(
@@ -81,7 +81,7 @@ public static class SnapshotBuilder
             TokenAddress: b.Token.ToLowerInvariant(),
             LastActivity: 0,
             IsWrapped: b.IsWrapped,
-            CirclesType: b.IsStatic ? "static" : "demurraged"
+            DemurrageMode: b.IsStatic ? "static" : "demurraged"
         )).ToList();
 
         var trust = (subgraph.Trust ?? [])

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs
@@ -195,6 +195,181 @@ public class SimulationCanaryResolverFastPathTests
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // Resolver-failure branches — every fallback path falls back to PromoteAllDemurraged
+    // and increments its labeled counter exactly once. These tests close the
+    // observability gap that PR #426's bump-applied counter alone did not cover.
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_BlockLookupFails_FallsBackAndIncrementsCounter()
+    {
+        // eth_getBlockByNumber returns a JSON-RPC error envelope. The resolver MUST
+        // log + tick `block_lookup_failed` and return PromoteAllDemurraged (inflationary
+        // entries get their demurraged amount unchanged) — the canary then re-uses the
+        // pre-PR-#408 false-positive class for that wrapper, which is acceptable
+        // observability degradation but NOT silent.
+        var handler = new BlockLookupErrorHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI", "0xwrapI", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+        };
+
+        var before = SimulationCanaryService.SimulationTotal.WithLabels("block_lookup_failed", "unwrap").Value;
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+        var after = SimulationCanaryService.SimulationTotal.WithLabels("block_lookup_failed", "unwrap").Value;
+
+        Assert.That(after - before, Is.EqualTo(1.0),
+            "block_lookup_failed counter must tick exactly once");
+        Assert.That(handler.Count, Is.EqualTo(1),
+            "only eth_getBlockByNumber should be attempted before bailing");
+        Assert.That(resolved.Count, Is.EqualTo(1));
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("200")),
+            "fallback: inflationary entry takes the original demurraged amount");
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_SimulateV1HttpError_FallsBackAndIncrementsCounter()
+    {
+        // eth_getBlockByNumber succeeds; eth_simulateV1 returns HTTP 500.
+        var handler = new SimulateV1HttpErrorHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI", "0xwrapI", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+        };
+
+        var before = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Value;
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+        var after = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_failed", "unwrap").Value;
+
+        Assert.That(after - before, Is.EqualTo(1.0),
+            "inflation_resolve_failed counter must tick exactly once on HTTP 500");
+        Assert.That(handler.Count, Is.EqualTo(2),
+            "both eth_getBlockByNumber and eth_simulateV1 are attempted (only the second fails)");
+        Assert.That(resolved.Count, Is.EqualTo(1));
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("200")),
+            "fallback: inflationary entry takes the original demurraged amount");
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_PerCallNullReturn_TicksPartialAndFallsBackPerWrapper()
+    {
+        // eth_getBlockByNumber + eth_simulateV1 both succeed at the transport layer, but the
+        // batch response includes one slot with status=0x0 (call reverted, no returnData)
+        // alongside one normal slot. The resolver MUST tick `inflation_resolve_partial` for
+        // the failed slot and fall back to demurraged ONLY for that slot — the healthy slot
+        // still gets its inflated value applied.
+        var handler = new PartialFailureScriptedHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromOK",   "0xwrapOK",   BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromFAIL", "0xwrapFAIL", BigInteger.Parse("500"), CirclesType.InflationaryCircles),
+        };
+
+        var before = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Value;
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+        var after = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Value;
+
+        Assert.That(after - before, Is.EqualTo(1.0),
+            "inflation_resolve_partial ticks exactly once (one failed slot, not two)");
+        Assert.That(resolved.Count, Is.EqualTo(2));
+        // Slot 0 succeeded — inflated value applied (300 from scripted return; bump=0 below 1e12)
+        Assert.That(resolved[0].Wrapper, Is.EqualTo("0xwrapOK"));
+        Assert.That(resolved[0].Amount,  Is.EqualTo(BigInteger.Parse("300")));
+        // Slot 1 failed — falls back to its original demurraged amount unchanged
+        Assert.That(resolved[1].Wrapper, Is.EqualTo("0xwrapFAIL"));
+        Assert.That(resolved[1].Amount,  Is.EqualTo(BigInteger.Parse("500")));
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_TopLevelRpcError_TicksFailedAndShortCircuits()
+    {
+        // eth_simulateV1 returns a valid HTTP 200 envelope but the JSON-RPC layer itself
+        // rejected the batch: `{"error": {"code": -32603, "message": "..."}}`. Without the
+        // top-level error short-circuit, ExtractInflationaryAmounts would log N noisy
+        // per-call partial-failure warnings (one per inflationary entry) — the check
+        // collapses the signal to one batch-level log + one `inflation_resolve_failed` tick.
+        var handler = new TopLevelRpcErrorHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromA", "0xwrapA", BigInteger.Parse("200"), CirclesType.InflationaryCircles),
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromB", "0xwrapB", BigInteger.Parse("500"), CirclesType.InflationaryCircles),
+        };
+
+        var beforeFailed  = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_failed",  "unwrap").Value;
+        var beforePartial = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Value;
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+        var afterFailed  = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_failed",  "unwrap").Value;
+        var afterPartial = SimulationCanaryService.SimulationTotal.WithLabels("inflation_resolve_partial", "unwrap").Value;
+
+        Assert.That(afterFailed - beforeFailed, Is.EqualTo(1.0),
+            "inflation_resolve_failed ticks once for the whole batch (NOT per-call)");
+        Assert.That(afterPartial - beforePartial, Is.EqualTo(0.0),
+            "inflation_resolve_partial must NOT tick — the batch rejection is one event, not N");
+        Assert.That(resolved.Count, Is.EqualTo(2));
+        // Both fall back to original demurraged amount unchanged.
+        Assert.That(resolved[0].Amount, Is.EqualTo(BigInteger.Parse("200")));
+        Assert.That(resolved[1].Amount, Is.EqualTo(BigInteger.Parse("500")));
+    }
+
+    [Test]
+    public async Task ResolveInflationaryAmounts_LargeInflated_IncrementsBumpAppliedCounter()
+    {
+        // Item 1: the bump-applied counter must tick exactly once per inflationary entry
+        // whose resolver-returned value triggers a non-zero bump (raw ≥ 1e12 wei).
+        // Below-threshold values are tested elsewhere (SubTrillionWei pass-through).
+        var handler = new LargeInflatedScriptedHandler();
+        var factory = new SingleHandlerHttpClientFactory(handler);
+        var service = NewService(factory);
+        var item = NewWorkItem();
+        var calls = new[]
+        {
+            new SimulationCanaryService.DemurragedUnwrapCall(
+                "0xfromI", "0xwrapI", BigInteger.Parse("10000000000000000000000"), CirclesType.InflationaryCircles),
+        };
+
+        var before = SimulationCanaryService.InflationaryBumpApplied.Value;
+        using var client = factory.CreateClient("canary-simulation");
+        var resolved = await service.ResolveInflationaryAmountsAsync(
+            item, calls, "0x3e8", client, CancellationToken.None);
+        var after = SimulationCanaryService.InflationaryBumpApplied.Value;
+
+        Assert.That(after - before, Is.EqualTo(1.0),
+            "bump-applied counter must tick once for a single inflationary entry with raw ≥ 1e12");
+        // The scripted resolver returns 15030682683872941930529 (canonical 10000 CRC at
+        // day 2051 per PR #426). Bump adds raw/1e12 = 15_030_682_683 wei.
+        var rawInflated = BigInteger.Parse("15030682683872941930529");
+        var expectedBumped = rawInflated + (rawInflated / 1_000_000_000_000);
+        Assert.That(resolved[0].Amount, Is.EqualTo(expectedBumped),
+            "resolved amount is the post-bump value, not the raw resolver output");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Helpers
     // ──────────────────────────────────────────────────────────────────────
 
@@ -293,5 +468,135 @@ public class SimulationCanaryResolverFastPathTests
         public SingleHandlerHttpClientFactory(HttpMessageHandler handler) => _handler = handler;
         public HttpClient CreateClient(string name) =>
             new(_handler, disposeHandler: false) { BaseAddress = new Uri("http://localhost/canary-test") };
+    }
+
+    /// <summary>eth_getBlockByNumber → JSON-RPC error envelope. Exercises the
+    /// <c>block_lookup_failed</c> branch + fallback to PromoteAllDemurraged.</summary>
+    private sealed class BlockLookupErrorHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            Interlocked.Increment(ref _count);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32603,\"message\":\"block not found\"}}")
+            });
+        }
+    }
+
+    /// <summary>eth_getBlockByNumber → ok; eth_simulateV1 → HTTP 500. Exercises the
+    /// <c>inflation_resolve_failed</c> branch on the non-success-status code path.</summary>
+    private sealed class SimulateV1HttpErrorHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            if (n == 1)
+            {
+                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}")
+                });
+            }
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("internal error")
+            });
+        }
+    }
+
+    /// <summary>eth_getBlockByNumber → ok; eth_simulateV1 → 2-call batch where the
+    /// first call status=0x1 returnData=300, the second status=0x0 (no returnData,
+    /// modelling a revert). Exercises the per-slot <c>inflation_resolve_partial</c>
+    /// branch + per-wrapper fallback (the good slot still gets its inflated value).</summary>
+    private sealed class PartialFailureScriptedHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        // First slot: status=0x1, returnData=300 (0x12c, left-padded to 64 hex chars).
+        // Second slot: status=0x0, empty returnData → ParseConvertCallReturnData yields null.
+        private static readonly string SimulateV1Body =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"calls\":[" +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + new string('0', 61) + "12c\"}," +
+            "{\"status\":\"0x0\",\"returnData\":\"0x\"}" +
+            "]}]}";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            string body = n == 1
+                ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}"
+                : SimulateV1Body;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
+    }
+
+    /// <summary>eth_getBlockByNumber → ok; eth_simulateV1 → JSON-RPC top-level error
+    /// envelope (HTTP 200 with `{"error": {...}}` at root). Exercises the
+    /// Step 3.5 short-circuit added with Item 3 — collapses N per-call partial
+    /// warnings into one batch-level <c>inflation_resolve_failed</c> tick.</summary>
+    private sealed class TopLevelRpcErrorHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            string body = n == 1
+                ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}"
+                : "{\"jsonrpc\":\"2.0\",\"id\":1,\"error\":{\"code\":-32603,\"message\":\"simulation pool exhausted\"}}";
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
+    }
+
+    /// <summary>eth_simulateV1 returns the canonical 10000-CRC inflated value
+    /// (15030682683872941930529 = 0x32e16cdd5b1deceefe1) — large enough to trigger
+    /// a non-zero bump in ApplyInflationaryRoundtripBump. Used to exercise the
+    /// InflationaryBumpApplied counter end-to-end through ResolveInflationaryAmountsAsync.</summary>
+    private sealed class LargeInflatedScriptedHandler : HttpMessageHandler
+    {
+        private int _count;
+        public int Count => Volatile.Read(ref _count);
+
+        // 15030682683872941930529 in hex = 32ed09ff90335af7821 (19 hex digits, pad to 64).
+        // Matches the canonical "10000 CRC at day 2051" capture from PR #426 investigation.
+        private const string InflatedHex = "32ed09ff90335af7821";
+        private static readonly string SimulateV1Body =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[{\"calls\":[" +
+            "{\"status\":\"0x1\",\"returnData\":\"0x" + new string('0', 64 - InflatedHex.Length) + InflatedHex + "\"}" +
+            "]}]}";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken ct)
+        {
+            int n = Interlocked.Increment(ref _count);
+            string body = n == 1
+                ? "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"timestamp\":\"0x6\"}}"
+                : SimulateV1Body;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body)
+            });
+        }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs
@@ -29,13 +29,29 @@ public record PathfinderGraphOperatorApprovalRow(
     string Operator
 );
 
+/// <summary>
+/// Deserialized balance row from the cache service's /api/pathfinder/graph snapshot.
+/// </summary>
+/// <remarks>
+/// <para><b>Wire-format note for the <c>DemurrageMode</c> field:</b> the JSON property
+/// is intentionally <c>circlesType</c> (not <c>demurrageMode</c>) via
+/// <c>[JsonPropertyName]</c>. The C# property was renamed away from <c>CirclesType</c>
+/// to avoid a same-file name collision with <see cref="PathfinderGraphWrapperMappingRow.CirclesType"/>
+/// (which is the typed enum). The wire field MUST remain <c>circlesType</c> for
+/// backward compat — independent cache/pathfinder rollouts depend on this. Renaming
+/// the wire field (dropping <c>[JsonPropertyName]</c>) would require a coordinated
+/// cache+pathfinder deploy and a schema-version bump.</para>
+/// <para>Default <c>"demurraged"</c> is the safe-degrade direction: a snapshot from
+/// an older cache that omits the field deserializes to demurraged, which
+/// <c>CacheLoadGraph.LoadV2Balances</c> routes via the non-static branch.</para>
+/// </remarks>
 public record PathfinderGraphBalanceRow(
     string Balance,
     string Account,
     string TokenAddress,
     long LastActivity,
     bool IsWrapped,
-    string CirclesType
+    [property: JsonPropertyName("circlesType")] string DemurrageMode = "demurraged"
 );
 
 public record PathfinderGraphTrustRow(
@@ -67,6 +83,17 @@ public record PathfinderGraphConsentedFlowRow(
     bool HasConsentedFlow
 );
 
+/// <summary>
+/// Wrapper-mapping row from the cache service's /api/pathfinder/graph snapshot.
+/// </summary>
+/// <remarks>
+/// The <see cref="CirclesType"/> property is the typed enum representation of the
+/// same protocol concept that <see cref="PathfinderGraphBalanceRow.DemurrageMode"/>
+/// encodes as a string (<c>"static"</c> ↔ <see cref="Circles.Common.CirclesType.InflationaryCircles"/>,
+/// <c>"demurraged"</c> ↔ <see cref="Circles.Common.CirclesType.DemurrageCircles"/>).
+/// The dual encoding is a tracked oddity — see the comment on
+/// <see cref="PathfinderGraphBalanceRow.DemurrageMode"/> for the wire-compat rationale.
+/// </remarks>
 public record PathfinderGraphWrapperMappingRow(
     string WrapperAddress,
     string UnderlyingAvatar,

--- a/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Data/CacheLoadGraph.cs
@@ -58,7 +58,7 @@ public sealed class CacheLoadGraph : ILoadGraph
                 AddressIdPool.IdOf(row.Account.ToLowerInvariant()),
                 AddressIdPool.IdOf(row.TokenAddress.ToLowerInvariant()),
                 row.IsWrapped,
-                string.Equals(row.CirclesType, "static", StringComparison.OrdinalIgnoreCase));
+                string.Equals(row.DemurrageMode, "static", StringComparison.OrdinalIgnoreCase));
         }
     }
 


### PR DESCRIPTION
## Summary

Four bundled follow-ups to PR #426 (canary inflationary unwrap roundtrip fix):

1. **Bump-applied observability**: `circles_canary_inflationary_bump_applied_total` counter (no labels — wrapper-cardinality risk) + DEBUG log of `(rawInflated, bumped, delta)`. Ticks once per inflationary unwrap whose raw resolver value triggers a non-zero bump (`I >= 1e12` wei). Operators can diff against `circles_canary_simulation_total{result="success",prefix="unwrap"}` so a future Hub.sol math change that pushes the floor-floor gap past 1 ppt is immediately visible.
2. **Resolver-failure metric branch tests** (+5 in `SimulationCanaryResolverFastPathTests`): `block_lookup_failed`, `inflation_resolve_failed` (HTTP 500), `inflation_resolve_partial` (per-slot revert), top-level JSON-RPC error short-circuit, bump-counter end-to-end increment. Each asserts the correct counter ticks exactly once plus correct fallback assignment per slot.
3. **Top-level RPC error short-circuit** in `ResolveInflationaryAmountsAsync`: when the RPC envelope is `{"error": {...}}` at root, log + tick `inflation_resolve_failed` once and short-circuit before per-call extraction. Collapses N noisy partial-failure warnings into one batch-level signal. Guards explicit `"error": null` success shape via `JsonValueKind.Null` check.
4. **`PathfinderBalanceRow.CirclesType` → `DemurrageMode` rename**: eliminates the same-file name collision with the typed `CirclesType` enum on `PathfinderWrapperMappingRow`. JSON wire field preserved as `circlesType` via `[property: JsonPropertyName]` — cache and pathfinder deploy independently, no coordinated rollout needed. Default value `"demurraged"` so missing-field deserialization matches the consumer's safe-degrade routing. XML doc on both renamed records and cross-reference docs on sibling wrapper-mapping records.

## Files changed

- `src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs` (Items 1+3 + metric taxonomy doc)
- `src/Cache/Circles.Cache.Service/ApiResponses.cs` + `Controllers/PathfinderGraphController.cs` (Item 4 producer)
- `src/Pathfinder/Circles.Pathfinder/Data/CacheGraphModels.cs` + `Data/CacheLoadGraph.cs` (Item 4 consumer)
- `src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs` + `src/Pathfinder/Circles.Pathfinder.Tests/Helpers/SnapshotBuilder.cs` (Item 4 test updates)
- `src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryResolverFastPathTests.cs` (Item 2 — 5 new tests + 4 handler classes)

## Test plan

- [x] `dotnet build -c Release` clean
- [x] `dotnet test` pathfinder suite: 1091 / 0 fail / 270 skipped (+5 new tests)
- [x] `dotnet test` cache-service suite: 226 / 0 fail / 26 skipped
- [ ] Post-deploy: watch `circles_canary_inflationary_bump_applied_total` track with `circles_canary_simulation_total{result="success",prefix="unwrap"}` on inflationary-wrapper attempts
- [ ] Confirm `circles_canary_simulation_total{result="revert", prefix="unwrap", label="insufficient_balance"}` continues to stay at 0 (PR #426 fix held)
- [ ] Smoke-test cache-service `/api/pathfinder/graph` response: JSON field name is still `circlesType` (wire compat)