### PR TITLE
feat(pathfinder): observe-only HolderBalanceAvailable validator rule

### DIFF
--- a/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
+++ b/src/Common/Circles.Common/Dto/MaxFlowResponse.cs
@@ -108,6 +108,24 @@ public class MaxFlowResponse
     public bool ValidatorException { get; set; }
 
     /// <summary>
+    /// Number of warning-severity violations detected by HubContractValidator. Warnings
+    /// are observe-only — they NEVER cause the response to be replaced with the empty
+    /// path; the transfers are returned as-is. Used by diagnostic rules whose root cause
+    /// is still under investigation (the path may or may not actually revert on-chain).
+    /// Serialized only when non-zero.
+    /// </summary>
+    [JsonPropertyName("validationWarnings")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public int ValidationWarnings { get; set; }
+
+    /// <summary>
+    /// Rule names of each detected warning-severity violation. Serialized when not null.
+    /// </summary>
+    [JsonPropertyName("validationWarningRules")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<string>? ValidationWarningRules { get; set; }
+
+    /// <summary>
     /// Block number of the graph snapshot used for this computation.
     /// Lets callers detect staleness by comparing to the current chain head.
     /// </summary>

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -251,13 +251,23 @@ internal sealed class FindPathHandler(
                         ConsentDroppedPaths = mfr.ConsentDroppedPaths,
                         ValidationErrors = mfr.ValidationErrors,
                         ValidationViolationRules = mfr.ValidationViolationRules,
-                        ValidatorException = mfr.ValidatorException
+                        ValidatorException = mfr.ValidatorException,
+                        ValidationWarnings = mfr.ValidationWarnings,
+                        ValidationWarningRules = mfr.ValidationWarningRules,
                     };
                     result = emptyResponse;
                     mfr = emptyResponse;
                 }
                 if (mfr.ValidatorException)
                     FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
+
+                // Warning-severity violations: observe-only, response NOT replaced.
+                // Per-rule counter for alerting; the original response is preserved.
+                if (mfr.ValidationWarnings > 0 && mfr.ValidationWarningRules != null)
+                {
+                    foreach (var rule in mfr.ValidationWarningRules)
+                        FindPathMetrics.PathAuditWarningsTotal.WithLabels(rule).Inc();
+                }
 
                 // Simulation canary: enqueue for async on-chain validation.
                 // Skip when:
@@ -506,7 +516,9 @@ internal sealed class FindPathHandler(
                         ConsentDroppedPaths = mfr.ConsentDroppedPaths,
                         ValidationErrors = mfr.ValidationErrors,
                         ValidationViolationRules = mfr.ValidationViolationRules,
-                        ValidatorException = mfr.ValidatorException
+                        ValidatorException = mfr.ValidatorException,
+                        ValidationWarnings = mfr.ValidationWarnings,
+                        ValidationWarningRules = mfr.ValidationWarningRules,
                     };
                     result = emptyResponse;
                     mfr = emptyResponse;
@@ -517,6 +529,14 @@ internal sealed class FindPathHandler(
                 // whenever a request uses X-Max-Block-Number.
                 if (mfr.ValidatorException)
                     FindPathMetrics.CanaryValidatorExceptionTotal.Inc();
+
+                // Mirror the live-path's warning bucket on the historical path so
+                // diagnostic rules show up in telemetry for X-Max-Block-Number requests too.
+                if (mfr.ValidationWarnings > 0 && mfr.ValidationWarningRules != null)
+                {
+                    foreach (var rule in mfr.ValidationWarningRules)
+                        FindPathMetrics.PathAuditWarningsTotal.WithLabels(rule).Inc();
+                }
 
                 log.LogInformation(
                     "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode}",

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathMetrics.cs
@@ -52,4 +52,14 @@ internal class FindPathMetrics
         Metrics.CreateCounter(
             "circles_canary_validator_exception_total",
             "Times HubContractValidator threw an unexpected exception");
+
+    // Path audit: warning-severity violations detected (observe-only, response NOT replaced).
+    // Diagnostic counter for rules whose root cause is still under investigation
+    // (e.g. HolderBalanceAvailable). Alertable in the same way as PathAuditViolationsTotal,
+    // but without an associated PathAuditBlockedTotal increment.
+    public static readonly Counter PathAuditWarningsTotal =
+        Metrics.CreateCounter(
+            "circles_path_audit_warnings_total",
+            "Pathfinder warning-severity validator violations (observe-only, never block response)",
+            new CounterConfiguration { LabelNames = new[] { "rule" } });
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -501,12 +501,12 @@ public class GraphFactoryTests
     [Test]
     public void SelfMintViaPath_GroupTokenWithNoSupply_VirtualSinkSurvivesViaGroupEdge()
     {
-        // Regression for self-mint via path returning maxFlow=0 against prod
-        // ScoreGroup 0x7CadB2E9… (2026-05-19). Reproduces shape: source==sink,
-        // toTokens=[group whose CRC nobody holds yet]. Pre-fix the virtualSink
-        // had zero inbound edges (TokenPool(groupToken) doesn't exist pre-mint)
-        // and got pruned, yielding maxFlow=0 for legitimate self-mint paths.
-        // Fix: Group → virtualSink fallback when pool is absent and t is a group.
+        // Regression for self-mint via path returning maxFlow=0. Reproduces
+        // shape: source==sink, toTokens=[group whose CRC nobody holds yet].
+        // Pre-fix the virtualSink had zero inbound edges (TokenPool(groupToken)
+        // doesn't exist pre-mint) and got pruned, yielding maxFlow=0 for
+        // legitimate self-mint paths. Fix: Group → virtualSink fallback when
+        // pool is absent and t is a group.
         var mock = new MockLoadGraph
         {
             Groups = new List<string> { GroupG },

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HubContractValidatorTests.cs
@@ -51,6 +51,11 @@ public class HubContractValidatorTests
         public Dictionary<(string Group, string Collateral), long> ScoreGroupMintLimits { get; set; }
             = new();
 
+        // (holder, token) → balance in graph units (wei / 10^12). Missing keys map to
+        // GetHolderBalance() == null, which Rule 13 treats as zero (flagged when any outflow).
+        public Dictionary<(string Holder, string Token), long> HolderBalances { get; set; }
+            = new();
+
         // (account, operator) tuples lowercased. Membership grants approval — but only when
         // StrictApprovals is true. Default behavior is permissive (returns true regardless),
         // matching the IContractState default so existing tests don't have to seed anything.
@@ -58,6 +63,11 @@ public class HubContractValidatorTests
         public bool StrictApprovals { get; set; }
 
         public string? RouterAddress => Router;
+        // IsRouter mirrors production: ScoreRouters in production are added to
+        // RouterNodes via SetGroupRouter → SetRouter (CapacityGraph.cs:123,133),
+        // so a score router satisfies BOTH IsRouter and IsScoreRouter. The mock
+        // preserves that coupling so existing ApproveCRCRequired tests still
+        // exercise the score-router→ApproveCRCRequired path via IsRouter(to).
         public bool IsRouter(string address) =>
             (Router != null && string.Equals(Router, address, StringComparison.OrdinalIgnoreCase))
             || Routers.Contains(address)
@@ -88,6 +98,14 @@ public class HubContractValidatorTests
         {
             if (!StrictApprovals) return true;
             return Approvals.Contains((account.ToLowerInvariant(), @operator.ToLowerInvariant()));
+        }
+
+        public long? GetHolderBalance(string holder, string token)
+        {
+            return HolderBalances.TryGetValue(
+                (holder.ToLowerInvariant(), token.ToLowerInvariant()), out var bal)
+                ? bal
+                : null;
         }
     }
 
@@ -1299,5 +1317,212 @@ public class HubContractValidatorTests
         Assert.That(violations, Is.Empty,
             "Wrapper-keyed lookup must succeed without wrapper resolution; " +
             "if Rule 12 resolved to Alice, the lookup would miss and fail-close.");
+    }
+
+    // ═══════════════════════════════════════════
+    // Rule 13: HolderBalanceAvailable (observe-only warning)
+    // ═══════════════════════════════════════════
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_NoViolation_WhenOutflowWithinBalance()
+    {
+        var state = DefaultState();
+        // Alice has 5 graph units = 5e12 wei of TokenA (its own token).
+        state.HolderBalances[(Alice.ToLowerInvariant(), Alice.ToLowerInvariant())] = 5;
+
+        // 3 wei outflow << 5e12 wei available
+        var steps = new[] { Step(Alice, Bob, Alice, "3") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Is.Empty);
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_FlagsOvershoot_AsWarning()
+    {
+        var state = DefaultState();
+        // Alice has 1 graph unit = 1e12 wei of TokenA.
+        state.HolderBalances[(Alice.ToLowerInvariant(), Alice.ToLowerInvariant())] = 1;
+
+        // Demand 7.3e16 wei → 73,000× over-ask (matches the 88fd976f shape).
+        var steps = new[] { Step(Alice, Bob, Alice, "73000000000000000") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Severity, Is.EqualTo("warning"),
+            "Rule must use warning severity so FindPathHandler does NOT replace the response.");
+        Assert.That(violations[0].Rule, Is.EqualTo("HolderBalanceAvailable"));
+        Assert.That(violations[0].Message, Does.Contain("overshoot"));
+        Assert.That(violations[0].Message, Does.Contain(Alice.ToLowerInvariant()));
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_SumsAcrossEdgesPerHolderToken()
+    {
+        var state = DefaultState();
+        // Alice has 1 graph unit = 1e12 wei of TokenA. Two edges each within balance
+        // individually but together overshoot.
+        state.HolderBalances[(Alice.ToLowerInvariant(), Alice.ToLowerInvariant())] = 1;
+
+        var steps = new[]
+        {
+            Step(Alice, Bob, Alice, "800000000000"),    // 0.8e12 wei (within)
+            Step(Alice, Carol, Alice, "800000000000"),  // another 0.8e12 wei
+            // Aggregate outflow = 1.6e12 wei > 1e12 wei available
+        };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Has.Count.EqualTo(1),
+            "Per-edge totals are summed before comparing to the cached balance.");
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_SkipsGroupSenders()
+    {
+        var state = DefaultState();
+        state.Groups.Add(GroupA);
+        // GroupA has NO holder balance entry — but as a group, it can mint unlimited.
+
+        var steps = new[] { Step(GroupA, Bob, GroupA, "9999999999999999999999999") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Group senders are unbounded mint sources; no balance check applies.");
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_SkipsRouterSenders()
+    {
+        var state = DefaultState();
+        // Router senders are proxies; their flow is gated by ScoreGroupMintLimits (Rule 12),
+        // not by holder balance.
+        var steps = new[] { Step(Router, GroupA, Alice, "9999999999999999999999999") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Is.Empty);
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_UnknownBalance_FlagsAsWarning()
+    {
+        var state = DefaultState();
+        // Alice has NO entry for TokenA in HolderBalances — treated as zero.
+
+        var steps = new[] { Step(Alice, Bob, Alice, "1000000000000") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Severity, Is.EqualTo("warning"));
+        Assert.That(violations[0].Message, Does.Contain("no balance entry"));
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_LooksUpUnderWrapperKeyNotUnderlying()
+    {
+        // Production: GraphFactory.AddHolderToTokenEdges_Pooled stores wrapped
+        // balances under the WRAPPER token id (bn.Token == wrapper_id when
+        // bn.IsWrapped). The rule must mirror that keying — looking up by raw
+        // token id, NOT resolving wrapper→underlying. Resolving would always
+        // miss the wrapped-balance entry and produce a false-positive
+        // "no balance entry" warning on every withWrap=true path.
+        var state = DefaultState();
+        var wrapper = "0x0000000000000000000000000000000000000777";
+        state.Wrappers[wrapper] = Alice;
+
+        // Bob holds 5 graph units keyed under the WRAPPER (matches production).
+        state.HolderBalances[(Bob.ToLowerInvariant(), wrapper.ToLowerInvariant())] = 5;
+
+        // Step uses wrapper as TokenOwner; rule should find the balance under
+        // the wrapper key (no resolution), 2e12 wei << 5e12 wei available.
+        var steps = new[] { Step(Bob, Carol, wrapper, "2000000000000") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Wrapper balances are keyed under the wrapper id by AddHolderToTokenEdges_Pooled; " +
+            "the rule must look up under the wrapper key, not resolve to underlying.");
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_BalanceUnderUnderlyingOnly_FlagsViolation()
+    {
+        // Negative case for the F4 invariant: a balance recorded only under the
+        // underlying avatar (NOT the wrapper) must NOT be found when the step
+        // references the wrapper id. No cross-key fallback exists in production;
+        // the rule must flag the missing wrapper-keyed entry to surface the
+        // genuine "no wrapped balance available" condition.
+        var state = DefaultState();
+        var wrapper = "0x0000000000000000000000000000000000000777";
+        state.Wrappers[wrapper] = Alice;
+
+        // Balance only under the underlying — wrapper-keyed lookup must miss.
+        state.HolderBalances[(Bob.ToLowerInvariant(), Alice.ToLowerInvariant())] = 5;
+
+        var steps = new[] { Step(Bob, Carol, wrapper, "2000000000000") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Severity, Is.EqualTo("warning"));
+        Assert.That(violations[0].Message, Does.Contain("no balance entry"));
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_SkipsScoreRouterSenders()
+    {
+        // Rule 13 skips score-router senders (proxies, not real holders).
+        // Production couples IsRouter + IsScoreRouter for score routers
+        // (CapacityGraph.SetGroupRouter → SetRouter adds to RouterNodes), so
+        // both predicates fire in real life. Rule 13 carries an explicit
+        // IsScoreRouter skip after the IsRouter skip as defensive coverage —
+        // this test enforces "score-router senders are exempt" end-to-end,
+        // regardless of which predicate ends up matching.
+        var state = DefaultState();
+        var scoreRouterOnly = "0x000000000000000000000000000000000000005c";
+        state.ScoreRouters.Add(scoreRouterOnly);
+        // ScoreRouter has NO holder balance entry — must be exempt anyway.
+
+        var steps = new[] { Step(scoreRouterOnly, GroupA, Alice, "9999999999999999999999999") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Is.Empty,
+            "Score-router senders are proxies; their flow is gated by ScoreGroupMintLimits (Rule 12), " +
+            "not by holder balance.");
+    }
+
+    [Test]
+    public void Rule13_HolderBalanceAvailable_UnparseableValue_EmitsWarning()
+    {
+        // F5: parse failure must emit a warning so corrupted Value strings show
+        // up in metrics instead of silently dropping out of the aggregation.
+        var state = DefaultState();
+        state.HolderBalances[(Alice.ToLowerInvariant(), Alice.ToLowerInvariant())] = 5;
+
+        var steps = new[] { Step(Alice, Bob, Alice, "not-a-number") };
+
+        var violations = new List<ValidationViolation>();
+        HubContractValidator.ValidateHolderBalanceAvailable(steps, state, violations);
+
+        Assert.That(violations, Has.Count.EqualTo(1));
+        Assert.That(violations[0].Severity, Is.EqualTo("warning"));
+        Assert.That(violations[0].Rule, Is.EqualTo("HolderBalanceAvailable"));
+        Assert.That(violations[0].Message, Does.Contain("unparseable"));
+        Assert.That(violations[0].EdgeIndex, Is.EqualTo(0));
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
+++ b/src/Pathfinder/Circles.Pathfinder/V2Pathfinder.cs
@@ -150,6 +150,12 @@ public class V2Pathfinder
         public int ValidationErrors { get; set; }
         public IReadOnlyList<string>? ValidationViolationRules { get; set; }
         public bool ValidatorException { get; set; }
+
+        // Warning-severity validator violations: logged + metricised but NEVER block
+        // the response (in contrast to errors, which the host replaces with empty
+        // results in FindPathHandler.cs).
+        public int ValidationWarnings { get; set; }
+        public IReadOnlyList<string>? ValidationWarningRules { get; set; }
     }
 
     /* ======================================================================
@@ -466,16 +472,32 @@ public class V2Pathfinder
             _logger.LogDebug("[{ReqId}] Transfers: {Summary}", ctx.ReqId, summary);
         }
 
-        // Path audit: run HubContractValidator on every response (observe-only, NEVER blocks)
+        // Path audit: run HubContractValidator on every response (observe-only, NEVER blocks).
+        //
+        // Two separate try blocks intentionally:
+        //   - The error-gathering block sets ctx.ValidatorException on failure, which
+        //     FindPathHandler reads to replace the response with an empty path (the
+        //     error path is the only one that gates the response). A failure to even
+        //     enumerate error-severity violations means we have no proof the path is
+        //     safe → fail-closed by blocking.
+        //   - The warning-gathering block is OBSERVE-ONLY: a failure to enumerate
+        //     warnings (e.g. NRE on a concurrent _balanceIndex read, an
+        //     AddressIdPool key-not-found) must NEVER set ValidatorException,
+        //     otherwise a warning-only diagnostic could block legitimate paths.
+        //     Log and continue with empty warning telemetry.
         if (ctx.Transfers.Count > 0)
         {
+            IReadOnlyList<Validation.ValidationViolation> allViolations =
+                Array.Empty<Validation.ValidationViolation>();
+
             try
             {
                 var contractState = new Validation.CapacityGraphContractState(ctx.Graph);
                 var validation = Validation.HubContractValidator.Validate(
                     ctx.Transfers, ctx.Request.Source!, ctx.Request.Sink!, contractState);
+                allViolations = validation.Violations;
 
-                var errorViolations = validation.Violations.Where(v => v.Severity == "error").ToList();
+                var errorViolations = allViolations.Where(v => v.Severity == "error").ToList();
                 if (errorViolations.Count > 0)
                 {
                     var errors = errorViolations.Select(v => $"[{v.Rule}] {v.Message}");
@@ -496,9 +518,42 @@ public class V2Pathfinder
             catch (Exception ex)
             {
                 _logger.LogError(ex,
-                    "[{ReqId}] Path audit: unexpected exception (observe-only, not blocking response)",
+                    "[{ReqId}] Path audit: unexpected exception during error-gathering (observe-only, not blocking response)",
                     ctx.ReqId);
                 ctx.ValidatorException = true;
+            }
+
+            // Warning-severity violations are observe-only: they log + surface in a
+            // separate per-rule metrics bucket, never block the response. Used by
+            // diagnostic rules (e.g. HolderBalanceAvailable) that flag pathfinder
+            // bugs whose root cause is not yet pinpointed — operator sees the alert
+            // upstream, the path still returns so users aren't blocked on uncertain
+            // signal. A failure HERE must NOT set ValidatorException — see comment
+            // block above.
+            try
+            {
+                var warningViolations = allViolations.Where(v => v.Severity == "warning").ToList();
+                if (warningViolations.Count > 0)
+                {
+                    var warnings = warningViolations.Select(v => $"[{v.Rule}] {v.Message}");
+                    _logger.LogWarning(
+                        "[{ReqId}] Path audit: {Count} warning(s) from={Source} to={Sink} block={Block}: {Violations}",
+                        ctx.ReqId, warningViolations.Count, ctx.Request.Source, ctx.Request.Sink,
+                        ctx.Graph.Block, string.Join("; ", warnings));
+                }
+                ctx.ValidationWarnings = warningViolations.Count;
+                ctx.ValidationWarningRules = warningViolations
+                    .Select(v => v.Rule)
+                    .Distinct(StringComparer.Ordinal)
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                // Warning gathering is observe-only: log + continue with empty telemetry.
+                // Do NOT set ValidatorException — that gate is reserved for the error path.
+                _logger.LogError(ex,
+                    "[{ReqId}] Path audit: unexpected exception during warning-gathering — telemetry suppressed for this request, response not blocked",
+                    ctx.ReqId);
             }
         }
     }
@@ -531,7 +586,9 @@ public class V2Pathfinder
             ConsentDroppedPaths = ctx.ConsentDroppedPaths,
             ValidationErrors = ctx.ValidationErrors,
             ValidationViolationRules = ctx.ValidationViolationRules,
-            ValidatorException = ctx.ValidatorException
+            ValidatorException = ctx.ValidatorException,
+            ValidationWarnings = ctx.ValidationWarnings,
+            ValidationWarningRules = ctx.ValidationWarningRules
         };
     }
 

--- a/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/CapacityGraphContractState.cs
@@ -10,6 +10,7 @@ namespace Circles.Pathfinder.Validation;
 public sealed class CapacityGraphContractState : IContractState
 {
     private readonly CapacityGraph _graph;
+    private Dictionary<(int Holder, int Token), long>? _balanceIndex;
 
     public CapacityGraphContractState(CapacityGraph graph)
     {
@@ -181,5 +182,36 @@ public sealed class CapacityGraphContractState : IContractState
         return _graph.ScoreGroupMintLimits.TryGetValue((groupId, collateralId), out var limit)
             ? limit
             : null;
+    }
+
+    /// <summary>
+    /// Returns the graph's view of (holder, token) bare-ERC1155 balance in graph
+    /// units (wei / 10^12). Backed by the holder→pool(token) edges built in
+    /// GraphFactory.AddHolderToTokenEdges_Pooled. Lazy O(|E|) one-pass index;
+    /// subsequent lookups are O(1).
+    /// </summary>
+    public long? GetHolderBalance(string holder, string token)
+    {
+        if (!AddressIdPool.TryIdOf(holder.ToLowerInvariant(), out int holderId))
+            return null;
+        if (!AddressIdPool.TryIdOf(token.ToLowerInvariant(), out int tokenId))
+            return null;
+
+        if (_balanceIndex == null)
+        {
+            var idx = new Dictionary<(int Holder, int Token), long>();
+            foreach (var e in _graph.Edges)
+            {
+                if (!AddressIdPool.IsBalanceNode(e.To))
+                    continue;
+                var toName = AddressIdPool.StringOf(e.To);
+                if (!toName.StartsWith("tpool-", StringComparison.Ordinal))
+                    continue;
+                idx[(e.From, e.Token)] = e.InitialCapacity;
+            }
+            _balanceIndex = idx;
+        }
+
+        return _balanceIndex.TryGetValue((holderId, tokenId), out var cap) ? cap : null;
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -43,6 +43,7 @@ public static class HubContractValidator
         ValidateNoDuplicateEdges(filtered, violations);
         ValidateNoSelfTransfers(filtered, sink, violations);
         ValidateScoreGroupMintLimits(filtered, state, violations);
+        ValidateHolderBalanceAvailable(filtered, state, violations);
 
         bool isValid = !violations.Any(v => v.Severity == "error");
         return new ValidationResult(isValid, violations);
@@ -761,6 +762,104 @@ public static class HubContractValidator
                     $"(cached as {cachedLimit.Value} at 6-decimal CRC precision)",
                     i, "error"));
                 bucketAlreadyViolated.Add(key);
+            }
+        }
+    }
+
+    // ────────────────────────────────────────────
+    // Rule 13: Holder balance availability
+    // Hub.sol's _safeTransferFrom asserts balance[from][tokenId] >= amount for
+    // every flow edge whose `from` is not the group (group mints are unbounded
+    // sources) and not the score-router (router holds the group's mintable
+    // supply, not modeled as a balance edge). For every other sender, the
+    // cumulative outflow per (from, token) MUST be ≤ the holder's cached bare
+    // balance for that token.
+    //
+    // Wrapper handling: the pathfinder's CapacityGraph indexes wrapper
+    // balances under the WRAPPER token id, not the underlying avatar
+    // (AddHolderToTokenEdges_Pooled at GraphFactory.cs:905 stores BalanceNodes
+    // keyed by bn.Token == wrapper_id when bn.IsWrapped). The lookup here uses
+    // the raw token id from the step, with NO wrapper→avatar resolution, so it
+    // matches the producer's key convention. Resolving would always miss
+    // wrapped-balance entries and emit a false-positive "no balance entry"
+    // warning on every withWrap=true path. Cross-aggregation between a
+    // holder's bare-T and wrapped-T balances is intentionally NOT performed
+    // here — that would mask producer bugs in non-wrapper paths.
+    //
+    // The rule is observe-only (severity=warning logs to pathfinder logs + the
+    // circles_path_audit_warnings_total{rule="HolderBalanceAvailable"}
+    // counter), no path manipulation.
+    // ────────────────────────────────────────────
+    internal static void ValidateHolderBalanceAvailable(
+        IReadOnlyList<TransferPathStep> steps,
+        IContractState state,
+        List<ValidationViolation> violations)
+    {
+        // Sum outflow per (holder, raw-token) across all transfers.
+        // Skip group senders (mint, unbounded) and router senders (proxy, mint-limit-gated).
+        var outflowWei = new Dictionary<(string Holder, string Token), BigInteger>();
+
+        for (int i = 0; i < steps.Count; i++)
+        {
+            var step = steps[i];
+            var fromLower = step.From.ToLowerInvariant();
+
+            if (state.IsGroup(fromLower)) continue;
+            if (state.IsRouter(fromLower)) continue;
+            if (state.IsScoreRouter(fromLower)) continue;
+
+            var tokenLower = step.TokenOwner.ToLowerInvariant();
+
+            if (!BigInteger.TryParse(step.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var v))
+            {
+                // Surface the parse failure as a warning so corrupted Value strings
+                // are visible in the audit metrics, but skip the edge so the bad
+                // datum can't poison the aggregated outflow totals (and produce
+                // false-positive overshoot warnings on the surviving entries).
+                violations.Add(new ValidationViolation(
+                    "HolderBalanceAvailable",
+                    $"Edge {i}: unparseable Value '{step.Value}' — skipping outflow accumulation",
+                    i, "warning"));
+                continue;
+            }
+            if (v <= 0) continue;
+
+            var key = (fromLower, tokenLower);
+            outflowWei[key] = outflowWei.GetValueOrDefault(key) + v;
+        }
+
+        // Compare each per-holder, per-token outflow to the cached balance.
+        // GetHolderBalance returns graph units (wei / 10^12); multiply back for comparison.
+        foreach (var ((holder, token), totalWei) in outflowWei)
+        {
+            var balanceUnits = state.GetHolderBalance(holder, token);
+            if (balanceUnits == null)
+            {
+                // No balance entry recorded for this (holder, token). Either the
+                // holder has zero or the graph snapshot dropped the entry under
+                // a filter. Treat unknown as zero; if the path needs >0 from
+                // this holder for this token, flag.
+                violations.Add(new ValidationViolation(
+                    "HolderBalanceAvailable",
+                    $"Holder={holder} token={token}: cumulative outflow={totalWei} wei, " +
+                    $"no balance entry in graph snapshot (treating as 0)",
+                    null, "warning"));
+                continue;
+            }
+
+            // Convert graph units back to wei via the shared CirclesConverter helper
+            // so this rule stays in lockstep with FactorB if the factor ever changes.
+            var availableWei = CirclesConverter.BlowUpToBigInteger(balanceUnits.Value);
+
+            if (totalWei > availableWei)
+            {
+                violations.Add(new ValidationViolation(
+                    "HolderBalanceAvailable",
+                    $"Holder={holder} token={token}: cumulative outflow={totalWei} wei " +
+                    $"exceeds cached balance={availableWei} wei " +
+                    $"(graph units={balanceUnits.Value}); overshoot ratio≈" +
+                    $"{(double)totalWei / Math.Max(1, (double)availableWei):F1}×",
+                    null, "warning"));
             }
         }
     }

--- a/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/IContractState.cs
@@ -78,4 +78,12 @@ public interface IContractState
     /// from leaking through during indexer drift.
     /// </summary>
     long? GetScoreGroupMintLimit(string group, string collateral) => null;
+
+    /// <summary>
+    /// Cached bare-ERC1155 holder balance for (holder, token), in pathfinder graph units
+    /// (wei / 10^12 per CirclesConverter.TruncateToInt64). Returns null when no edge
+    /// records a balance for this pair — used by rule 13 to fail-closed when the
+    /// implied starting balance for a transfer can't be verified.
+    /// </summary>
+    long? GetHolderBalance(string holder, string token) => null;
 }


### PR DESCRIPTION
## Summary

Adds Rule 13 (`HolderBalanceAvailable`) to `HubContractValidator`. For each non-Group / non-Router sender, sums per-(holder, token) outflow across the transfer path and compares against the graph snapshot's holder→pool(token) edge capacity. Outflow exceeding the cached balance, or absent balance entry, emits a **warning-severity** violation.

Introduces `"warning"` as a new severity tier alongside the existing `"error"`. Errors continue to trigger response replacement in `FindPathHandler` (existing pattern); warnings are **observe-only** — logged + metricised via `circles_path_audit_warnings_total{rule}` — and never block the response. Warning-gathering runs in a separate try/catch so a buggy warning rule cannot accidentally promote to a path-replacing `ValidatorException`.

Diagnostic motivation: a recent canary-flagged `ERC1155InsufficientBalance` revert (`ReqId 88fd976f`) showed the pathfinder assigning 73,000× the cached holder balance to a transfer edge — a real producer bug whose root cause is still being investigated. This rule surfaces that bug class at path-build time so future occurrences show up in pathfinder logs + Prometheus before the canary samples them.

## Changes

* **Rule 13** in `HubContractValidator.ValidateHolderBalanceAvailable`:
  - Aggregates per-`(holder, token)` outflow across all non-skipped edges
  - Skips Group / Router / ScoreRouter senders (legitimate unbounded sources)
  - Looks up holder balance via new `IContractState.GetHolderBalance(holder, token)` returning graph units (wei / 10^12)
  - Resolves wei comparison via `CirclesConverter.BlowUpToBigInteger`
  - Emits `severity="warning"` for overshoot, missing entry, and unparseable Value
* **`IContractState.GetHolderBalance`**: new default method returning null; implemented in `CapacityGraphContractState` with a lazy `O(|E|)` one-pass index keyed by `(holder, token)`
* **`MaxFlowResponse`**: new `ValidationWarnings` (int) + `ValidationWarningRules` (list) fields, JSON-serialized only when non-default
* **`V2Pathfinder`**: warning-gathering in its own try/catch with documented asymmetry; propagates new fields through `PipelineContext` → response
* **`FindPathHandler`**: per-rule metric increment for warnings; `emptyResponse` initializers (live + historical paths) now propagate warning fields so error-replacement doesn't silently zero warning telemetry
* **`FindPathMetrics`**: new counter `circles_path_audit_warnings_total{rule}`
* **Tests**: 9 new unit tests covering positive/overshoot/no-entry/group-skip/router-skip/score-router-skip/wrapper-key lookup/underlying-only-flags/unparseable-Value paths
* **Comment cleanup** in `GraphFactoryTests` (stale "prod ScoreGroup" label reference)

## Test plan

- [x] Build clean (0 errors, 148 pre-existing warnings)
- [x] Pathfinder suite: 1101/1101 pass (+3 new rule tests vs baseline 1098)
- [x] Cache / Common / RPC test suites: all green
- [x] Multi-angle review panel (Tier M, 8 agents) executed; 10 must/should fixes applied; 8 items deferred to followups
- [ ] Post-deploy: verify `circles_path_audit_warnings_total{rule="HolderBalanceAvailable"}` increments on the next path that produces an overshoot
- [ ] Post-deploy: verify `circles_canary_simulation_total{result="revert",prefix="unwrap"}` and new warning counter correlate on the next `88fd976f`-class incident