### PR TITLE
fix(rpc-host): disambiguate dispatch-fallthrough from reflection drift

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/Exceptions.cs
+++ b/src/Rpc/Circles.Rpc.Host/Exceptions.cs
@@ -1,5 +1,14 @@
 namespace Circles.Rpc.Host;
 
+/// <summary>
+/// Thrown when the dispatch switch falls through — the requested method is not registered
+/// in any case arm. User-facing: surfaces as JSON-RPC <c>-32601 Method not found</c>, or
+/// proxies to Nethermind when the name is in the proxy allowlist (e.g. <c>eth_*</c>).
+/// </summary>
+/// <remarks>
+/// Do NOT throw this for internal dispatch drift (e.g. reflection lookup failures inside
+/// a dispatched handler) — those are server bugs and should surface as <c>-32603</c>.
+/// </remarks>
 public class RpcMethodNotFoundException : Exception
 {
     public string MethodName { get; }

--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -1206,7 +1206,11 @@ static async Task<object> ReflectionHandler(JsonRpcRequest request, CirclesRpcMo
     var method = typeof(CirclesRpcModule).GetMethod(methodName);
     if (method == null)
     {
-        throw new RpcMethodNotFoundException(request.Method);
+        // Dispatch drift: switch arm exists but CirclesRpcModule has no matching member.
+        // Not a user error — surfaces as -32603 via the generic catch in the dispatcher.
+        throw new InvalidOperationException(
+            $"Dispatched method '{request.Method}' has no matching public member " +
+            $"'{methodName}' on CirclesRpcModule.");
     }
 
     var parameters = JsonSerializer.Deserialize<JsonElement[]>(request.Params.GetRawText());


### PR DESCRIPTION
## Summary

\`RpcMethodNotFoundException\` was thrown in two semantically distinct places:

1. **Dispatch switch falls through** — user supplied an unknown method name. Correct -32601 path, with proxy fallback for \`eth_*\`/\`net_*\`/\`web3_*\`.
2. **ReflectionHandler can't find the C# method on CirclesRpcModule** — server-side dispatch drift (switch arm exists but the target member was renamed/removed).

Both surfaced as -32601 to the client. Case (2) is a server bug; the previous behavior masked it as a client error.

## Changes

- \`Program.cs:1206-1213\`: reflection-failure site now throws \`InvalidOperationException\`. Caught by the generic \`catch (Exception)\` at line 786 → -32603 with \`LogError(ex, ...)\` (stacktrace + method + remote IP + \`internal_error\` metric counter).
- \`Exceptions.cs\`: XML doc on \`RpcMethodNotFoundException\` documenting case (1) semantics and warning not to use it for case (2).

## Test plan

- [x] \`dotnet build -c Release\` — 0 errors, 61 warnings (baseline)
- [x] Existing tests pass (BatchSerializationTests 6/6)
- [ ] Manual verify: trigger a dispatch arm that points to a non-existent reflection target and observe \`-32603\` response + Loki error log (post-deploy on staging)
- [ ] Follow-up: add a regression test asserting \`-32603\` on reflection drift (deferred — needs dispatcher refactor for testability)

## No behavior change for case (1)

Case (1) — user supplied unknown method name — still throws \`RpcMethodNotFoundException\`, still catches at line 734, still returns -32601 (or proxies to Nethermind for allowlisted prefixes). No client-visible change for any pre-existing method name.