### PR TITLE
docs(rpc-host): document /ready Degraded behavior

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/Program.cs
+++ b/src/Rpc/Circles.Rpc.Host/Program.cs
@@ -32,6 +32,8 @@ app.MapHealthChecks("/live", new HealthCheckOptions
 });
 
 // readiness: nethermind sync status + pathfinder connectivity + database connectivity + indexer sync
+// Degraded returns 200 today. Flipping to 503 (so load balancers drain a partially-broken node)
+// requires the surrounding probe + DNS-drain layer to also accept 503 — out of scope here.
 app.MapHealthChecks("/ready", new HealthCheckOptions
 {
     Predicate = hc => hc.Tags.Contains("nethermind-sync") || hc.Tags.Contains("pathfinder-connection") || hc.Tags.Contains("database-connection") || hc.Tags.Contains("indexer-sync"),


### PR DESCRIPTION
## Summary

\`/ready\` currently returns 200 for \`HealthStatus.Degraded\`. A future switch to 503 (so load balancers drain a partially-broken node) requires coordinated changes in the surrounding probe + DNS-drain layer that today expects 200/503 only.

This PR adds a 2-line comment documenting the intent so the next person touching this block knows the constraint. No status code change.

## Changes

- \`src/Rpc/Circles.Rpc.Host/Program.cs:34-36\` (+2 lines, comment only)

## Test plan

- [x] \`dotnet build -c Release\` — 0 errors, 61 warnings (baseline)
- [x] No functional change — diff is comment-only

## Out of scope

The actual 503 flip is deferred. When that work happens it needs to land coordinated with probe/healthcheck/drain-layer updates.