### PR TITLE
feat(pathfinder): ScoreGroup support in historical (block-pinned) graph loader

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -157,7 +157,7 @@ public sealed class HistoricalLoadGraph : ILoadGraph
                 g."mint" = LOWER(@mintPolicy)
                 OR (LOWER(g."mint") = ANY(@scoreMintPolicies) AND sg.router_address IS NOT NULL)
               )
-        ), registered_avatars AS (
+        ), registered_avatars AS MATERIALIZED (
             SELECT avatar FROM "CrcV2_RegisterHuman" WHERE "blockNumber" <= {0}
             UNION ALL
             SELECT "group" AS avatar FROM "CrcV2_RegisterGroup" WHERE "blockNumber" <= {0}
@@ -250,6 +250,51 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         WHERE approved = true
         """;
 
+    // Pre-ScoreGroup fallback templates — used on indexer schemas that don't yet
+    // contain the CrcV2_ScoreGroup_GroupInitialized table. Mirrors
+    // groupQuery.fallback.sql / groupTrustQuery.fallback.sql / LoadBaseGroupRouters
+    // in the live LoadGraph, with the block-ceiling applied. Without these the
+    // whole historical graph load would throw 42P01 undefined_table.
+    private const string GroupQueryFallbackTemplate = """
+        SELECT "group" AS group_address
+        FROM "CrcV2_RegisterGroup"
+        WHERE "mint" = LOWER(@mintPolicy)
+          AND "blockNumber" <= {0}
+        """;
+
+    private const string GroupTrustQueryFallbackTemplate = """
+        WITH trust_state AS (
+            SELECT truster, trustee, "expiryTime",
+                   row_number() OVER (PARTITION BY truster, trustee
+                       ORDER BY "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC) AS rn
+            FROM "CrcV2_Trust"
+            WHERE "blockNumber" <= {0}
+        ), active_trust AS (
+            SELECT truster, trustee FROM trust_state
+            WHERE rn = 1 AND "expiryTime" > (SELECT max("timestamp") FROM "System_Block" WHERE "blockNumber" <= {0})::numeric
+        ), registered_avatars AS (
+            SELECT avatar FROM "CrcV2_RegisterHuman" WHERE "blockNumber" <= {0}
+            UNION ALL
+            SELECT "group" AS avatar FROM "CrcV2_RegisterGroup" WHERE "blockNumber" <= {0}
+            UNION ALL
+            SELECT organization AS avatar FROM "CrcV2_RegisterOrganization" WHERE "blockNumber" <= {0}
+        )
+        SELECT t.truster AS group_address, t.trustee AS trusted_token
+        FROM active_trust t
+        INNER JOIN "CrcV2_RegisterGroup" g
+            ON g."group" = t.truster
+           AND g."blockNumber" <= {0}
+           AND g."mint" = LOWER(@mintPolicy)
+        INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
+        """;
+
+    private const string BaseGroupRoutersFallbackTemplate = """
+        SELECT "group" AS group_address, LOWER(@standardRouter) AS router_address
+        FROM "CrcV2_RegisterGroup"
+        WHERE "mint" = LOWER(@mintPolicy)
+          AND "blockNumber" <= {0}
+        """;
+
     public HistoricalLoadGraph(NpgsqlDataSource dataSource, long blockNumber, Settings settings, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(dataSource);
@@ -260,6 +305,21 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         _blockNumber = blockNumber;
         _settings = settings;
         _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Checks whether the ScoreGroup tables exist in the indexer schema.
+    /// Mirrors live LoadGraph.ScoreGroupTablesAvailable — without this guard the
+    /// historical loaders would throw 42P01 on indexer schemas that predate the
+    /// score-group migration.
+    /// </summary>
+    private bool ScoreGroupTablesAvailable()
+    {
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT to_regclass('public.\"CrcV2_ScoreGroup_GroupInitialized\"') IS NOT NULL";
+        cmd.CommandTimeout = 10;
+        return cmd.ExecuteScalar() is bool available && available;
     }
 
     /// <summary>
@@ -381,14 +441,18 @@ public sealed class HistoricalLoadGraph : ILoadGraph
 
     public IEnumerable<string> LoadGroups()
     {
-        var sql = string.Format(GroupQueryTemplate, _blockNumber);
+        var scoreGroupsAvailable = ScoreGroupTablesAvailable();
+        var template = scoreGroupsAvailable ? GroupQueryTemplate : GroupQueryFallbackTemplate;
+        var sql = string.Format(template, _blockNumber);
         var results = new List<string>();
 
+        var sw = Stopwatch.StartNew();
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
-        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+        if (scoreGroupsAvailable)
+            cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
         cmd.CommandTimeout = 60;
 
         using var reader = cmd.ExecuteReader();
@@ -398,8 +462,8 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         }
 
         _logger.LogInformation(
-            "[HistoricalLoadGraph] Block {Block}: {Count} groups",
-            _blockNumber, results.Count);
+            "[HistoricalLoadGraph] Block {Block}: {Count} groups in {Elapsed}ms",
+            _blockNumber, results.Count, sw.ElapsedMilliseconds);
         return results;
     }
 
@@ -407,14 +471,17 @@ public sealed class HistoricalLoadGraph : ILoadGraph
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        var sql = string.Format(GroupTrustQueryTemplate, _blockNumber);
+        var scoreGroupsAvailable = ScoreGroupTablesAvailable();
+        var template = scoreGroupsAvailable ? GroupTrustQueryTemplate : GroupTrustQueryFallbackTemplate;
+        var sql = string.Format(template, _blockNumber);
         var results = new List<(string, string)>();
 
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
-        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+        if (scoreGroupsAvailable)
+            cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
         cmd.CommandTimeout = 60;
 
         using var reader = cmd.ExecuteReader();
@@ -463,7 +530,9 @@ public sealed class HistoricalLoadGraph : ILoadGraph
 
     public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
     {
-        var sql = string.Format(GroupRouterQueryTemplate, _blockNumber);
+        var scoreGroupsAvailable = ScoreGroupTablesAvailable();
+        var template = scoreGroupsAvailable ? GroupRouterQueryTemplate : BaseGroupRoutersFallbackTemplate;
+        var sql = string.Format(template, _blockNumber);
         var results = new List<(string, string)>();
 
         var sw = Stopwatch.StartNew();
@@ -471,8 +540,9 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
-        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
         cmd.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+        if (scoreGroupsAvailable)
+            cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
         cmd.CommandTimeout = 60;
 
         using var reader = cmd.ExecuteReader();
@@ -492,6 +562,10 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         // Match the live LoadGraph short-circuit: when no score-mint policies are
         // configured the table query is a no-op anyway, so skip the round-trip.
         if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+        // Match live LoadGraph.LoadScoreRouters: also bail out if the ScoreGroup
+        // tables don't exist on this indexer schema.
+        if (!ScoreGroupTablesAvailable())
             return [];
 
         var sql = string.Format(ScoreRoutersQueryTemplate, _blockNumber);
@@ -517,6 +591,10 @@ public sealed class HistoricalLoadGraph : ILoadGraph
     public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
     {
         if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+        // Match live LoadGraph: skip the read entirely on schemas that predate the
+        // ScoreGroup migration (ScoreGroupMintLimitReader queries those tables).
+        if (!ScoreGroupTablesAvailable())
             return [];
 
         var sw = Stopwatch.StartNew();

--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -97,13 +97,39 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         WHERE t2."group" IS NULL
         """;
 
+    // Block-aware group enumeration that mirrors live groupQuery.sql:
+    // a group is "supported" if it's either a BaseGroup (mint=@mintPolicy) OR
+    // a ScoreGroup (mint in @scoreMintPolicies AND has a GroupInitialized event).
+    // The ScoreGroup branch is no-op when @scoreMintPolicies is empty (ANY('{}') is false),
+    // preserving BaseGroup-only behaviour for callers without ScoreGroup configuration.
     private const string GroupQueryTemplate = """
-        SELECT "group" AS group_address
-        FROM "CrcV2_RegisterGroup"
-        WHERE "mint" = LOWER(@mintPolicy)
-          AND "blockNumber" <= {0}
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        supported_groups AS (
+            SELECT g."group" AS group_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                g."mint" = LOWER(@mintPolicy)
+                OR (LOWER(g."mint") = ANY(@scoreMintPolicies) AND sg.router_address IS NOT NULL)
+              )
+        )
+        SELECT group_address FROM supported_groups
         """;
 
+    // Block-aware group→trustee trust query, mirrors live groupTrustQuery.sql.
+    // Filters trustees through a block-filtered registered_avatars CTE (matches the
+    // production fix from 2026-02-14 that prevents AvatarMustBeRegistered reverts).
+    // Includes both BaseGroup and ScoreGroup-managed groups via the same
+    // supported_groups CTE as GroupQueryTemplate above.
     private const string GroupTrustQueryTemplate = """
         WITH trust_state AS (
             SELECT truster, trustee, "expiryTime",
@@ -114,12 +140,34 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         ), active_trust AS (
             SELECT truster, trustee FROM trust_state
             WHERE rn = 1 AND "expiryTime" > (SELECT max("timestamp") FROM "System_Block" WHERE "blockNumber" <= {0})::numeric
+        ), latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ), supported_groups AS (
+            SELECT g."group" AS group_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                g."mint" = LOWER(@mintPolicy)
+                OR (LOWER(g."mint") = ANY(@scoreMintPolicies) AND sg.router_address IS NOT NULL)
+              )
+        ), registered_avatars AS (
+            SELECT avatar FROM "CrcV2_RegisterHuman" WHERE "blockNumber" <= {0}
+            UNION ALL
+            SELECT "group" AS avatar FROM "CrcV2_RegisterGroup" WHERE "blockNumber" <= {0}
+            UNION ALL
+            SELECT organization AS avatar FROM "CrcV2_RegisterOrganization" WHERE "blockNumber" <= {0}
         )
         SELECT t.truster AS group_address, t.trustee AS trusted_token
         FROM active_trust t
-        INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
-        WHERE g."mint" = LOWER(@mintPolicy)
-          AND g."blockNumber" <= {0}
+        INNER JOIN supported_groups g ON g.group_address = t.truster
+        INNER JOIN registered_avatars ra ON ra.avatar = t.trustee
         """;
 
     private const string RegisteredAvatarsQueryTemplate = """
@@ -140,6 +188,66 @@ public sealed class HistoricalLoadGraph : ILoadGraph
     private const string BlockTimestampQuery = """
         SELECT "timestamp" FROM "System_Block" WHERE "blockNumber" <= {0}
         ORDER BY "blockNumber" DESC LIMIT 1
+        """;
+
+    // Block-aware group→router resolution. Mirrors live groupRouterQuery.sql:
+    // ScoreGroups get their per-group pathMintRouter from the GroupInitialized event;
+    // BaseGroups (and ScoreGroups without an init event) fall back to the standard router.
+    private const string GroupRouterQueryTemplate = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        supported_groups AS (
+            SELECT
+                g."group" AS group_address,
+                g."mint",
+                sg.router_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (g."mint" = LOWER(@mintPolicy)
+                   OR (LOWER(g."mint") = ANY(@scoreMintPolicies) AND sg.router_address IS NOT NULL))
+        )
+        SELECT
+            group_address,
+            CASE
+                WHEN router_address IS NOT NULL THEN router_address
+                ELSE LOWER(@standardRouter)
+            END AS router_address
+        FROM supported_groups
+        """;
+
+    // Distinct ScoreGroup pathMintRouter addresses, used by GraphFactory to recognise
+    // score-router membership for the OperatorApprovals gating logic.
+    private const string ScoreRoutersQueryTemplate = """
+        SELECT DISTINCT LOWER("pathMintRouter") AS router_address
+        FROM "CrcV2_ScoreGroup_GroupInitialized"
+        WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+          AND "blockNumber" <= {0}
+        """;
+
+    // Block-aware operator approvals (latest-per-pair = true), filtered to the
+    // requested account list. Mirrors the inline SQL in LoadGraph.LoadOperatorApprovals
+    // with the addition of the blockNumber ceiling.
+    private const string OperatorApprovalsQueryTemplate = """
+        SELECT account, operator FROM (
+            SELECT DISTINCT ON (LOWER("account"), LOWER("operator"))
+                LOWER("account") AS account,
+                LOWER("operator") AS operator,
+                "approved" AS approved
+            FROM "CrcV2_ApprovalForAll"
+            WHERE LOWER("account") = ANY(@accounts)
+              AND "blockNumber" <= {0}
+            ORDER BY LOWER("account"), LOWER("operator"),
+                     "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ) latest
+        WHERE approved = true
         """;
 
     public HistoricalLoadGraph(NpgsqlDataSource dataSource, long blockNumber, Settings settings, ILogger? logger = null)
@@ -274,7 +382,25 @@ public sealed class HistoricalLoadGraph : ILoadGraph
     public IEnumerable<string> LoadGroups()
     {
         var sql = string.Format(GroupQueryTemplate, _blockNumber);
-        return ExecuteParameterizedStringListQuery(sql, "groups");
+        var results = new List<string>();
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
+        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+        cmd.CommandTimeout = 60;
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add(reader.GetString(0));
+        }
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} groups",
+            _blockNumber, results.Count);
+        return results;
     }
 
     public IEnumerable<string> LoadOrganizations() => [];
@@ -288,6 +414,7 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
+        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
         cmd.CommandTimeout = 60;
 
         using var reader = cmd.ExecuteReader();
@@ -334,28 +461,116 @@ public sealed class HistoricalLoadGraph : ILoadGraph
     public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
         => Array.Empty<(string, string, CirclesType)>();
 
-    /// <summary>
-    /// Executes a query with @mintPolicy parameter and returns a list of strings from column 0.
-    /// </summary>
-    private List<string> ExecuteParameterizedStringListQuery(string sql, string label)
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
     {
-        var results = new List<string>();
+        var sql = string.Format(GroupRouterQueryTemplate, _blockNumber);
+        var results = new List<(string, string)>();
 
+        var sw = Stopwatch.StartNew();
         using var conn = _dataSource.OpenConnection();
         using var cmd = conn.CreateCommand();
         cmd.CommandText = sql;
         cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress ?? "");
+        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+        cmd.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
         cmd.CommandTimeout = 60;
 
         using var reader = cmd.ExecuteReader();
         while (reader.Read())
         {
-            results.Add(reader.GetString(0));
+            results.Add((reader.GetString(0), reader.GetString(1)));
         }
 
         _logger.LogInformation(
-            "[HistoricalLoadGraph] Block {Block}: {Count} {Label}",
-            _blockNumber, results.Count, label);
+            "[HistoricalLoadGraph] Block {Block}: {Count} group routers in {Elapsed}ms",
+            _blockNumber, results.Count, sw.ElapsedMilliseconds);
+        return results;
+    }
+
+    public IEnumerable<string> LoadScoreRouters()
+    {
+        // Match the live LoadGraph short-circuit: when no score-mint policies are
+        // configured the table query is a no-op anyway, so skip the round-trip.
+        if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+
+        var sql = string.Format(ScoreRoutersQueryTemplate, _blockNumber);
+        var results = new List<string>();
+
+        var sw = Stopwatch.StartNew();
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+        cmd.CommandTimeout = 60;
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add(reader.GetString(0));
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} score routers in {Elapsed}ms",
+            _blockNumber, results.Count, sw.ElapsedMilliseconds);
+        return results;
+    }
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+    {
+        if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+
+        var sw = Stopwatch.StartNew();
+        using var connection = _dataSource.OpenConnection();
+
+        // ScoreGroupMintLimitReader already supports maxBlock end-to-end across its
+        // three sub-queries (base rows, historical supply, personal minted).
+        // Pin demurrage to the block timestamp so historical computations are
+        // deterministic — TargetDemurrageTimestamp is set in HistoricalGraphCache.LoadGraph.
+        var rows = ScoreGroupMintLimitReader.Read(
+            connection,
+            _settings.ScoreGroupMintPolicies,
+            _settings.TargetDemurrageTimestamp,
+            _settings.DemurrageSafetyMargin,
+            commandTimeoutSeconds: 60,
+            maxBlock: _blockNumber,
+            subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries);
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} score group mint limits in {Elapsed}ms",
+            _blockNumber, rows.Count, sw.ElapsedMilliseconds);
+        return rows.Select(row => (row.GroupAddress, row.CollateralToken, row.AvailableLimit)).ToList();
+    }
+
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var accountSet = accounts
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Select(a => a.ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+
+        if (accountSet.Length == 0)
+            return [];
+
+        var sql = string.Format(OperatorApprovalsQueryTemplate, _blockNumber);
+        var results = new List<(string, string)>();
+
+        var sw = Stopwatch.StartNew();
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.Parameters.AddWithValue("accounts", accountSet);
+        cmd.CommandTimeout = 60;
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+        {
+            results.Add((reader.GetString(0), reader.GetString(1)));
+        }
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} operator approvals across {Accounts} accounts in {Elapsed}ms",
+            _blockNumber, results.Count, accountSet.Length, sw.ElapsedMilliseconds);
         return results;
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -174,8 +174,9 @@ public sealed class HistoricalGraphCache
         var registeredAvatars = loader.LoadRegisteredAvatars().ToList();
         var wrapperMappings = loader.LoadWrapperMappings().ToList();
 
-        // ScoreGroup-aware loaders. Must run AFTER LoadGroups so operator approvals
-        // can be pre-loaded against the router set discovered by LoadGroupRouters.
+        // ScoreGroup-aware loaders. Operator approvals (below) depend on the router
+        // set produced by LoadGroupRouters — that's why LoadGroupRouters runs first
+        // and operatorApprovals is built off `routerAddresses`.
         var groupRouters = loader.LoadGroupRouters().ToList();
         var scoreRouters = loader.LoadScoreRouters().ToList();
         var scoreGroupMintLimits = loader.LoadScoreGroupMintLimits().ToList();
@@ -193,11 +194,25 @@ public sealed class HistoricalGraphCache
             ? loader.LoadOperatorApprovals(routerAddresses).ToList()
             : new List<(string Account, string Operator)>();
 
-        // Create a factory backed by the materialized data (zero I/O on use)
-        var cachedLoader = new MaterializedLoadGraph(
-            balances, trust, groups, organizations, groupTrusts,
-            consentedFlags, registeredAvatars, wrapperMappings,
-            groupRouters, scoreRouters, scoreGroupMintLimits, operatorApprovals);
+        // Create a factory backed by the materialized data (zero I/O on use).
+        // Pass via a named-property DTO so swapping any two List<string> args
+        // (groups / organizations / scoreRouters / registeredAvatars) fails at
+        // compile time instead of silently producing wrong-shaped data.
+        var cachedLoader = new MaterializedLoadGraph(new MaterializedGraphData
+        {
+            Balances = balances,
+            Trust = trust,
+            Groups = groups,
+            Organizations = organizations,
+            GroupTrusts = groupTrusts,
+            ConsentedFlags = consentedFlags,
+            RegisteredAvatars = registeredAvatars,
+            WrapperMappings = wrapperMappings,
+            GroupRouters = groupRouters,
+            ScoreRouters = scoreRouters,
+            ScoreGroupMintLimits = scoreGroupMintLimits,
+            OperatorApprovals = operatorApprovals,
+        });
 
         var factory = new GraphFactory(_routerAddress, cachedLoader);
 
@@ -251,45 +266,58 @@ public sealed class HistoricalGraphCache
 }
 
 /// <summary>
+/// Named-property bundle for the 12 materialized data slots backing
+/// <see cref="MaterializedLoadGraph"/>. Using named init properties prevents
+/// silent positional-argument mix-ups between the four <c>List&lt;string&gt;</c>
+/// slots (Groups / Organizations / ScoreRouters / RegisteredAvatars).
+/// All slots are read-only by contract; the snapshot is built once at load time.
+/// </summary>
+internal sealed record MaterializedGraphData
+{
+    public required IReadOnlyList<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> Balances { get; init; }
+    public required IReadOnlyList<(string Truster, string Trustee, int Limit)> Trust { get; init; }
+    public required IReadOnlyList<string> Groups { get; init; }
+    public required IReadOnlyList<string> Organizations { get; init; }
+    public required IReadOnlyList<(string GroupAddress, string TrustedToken)> GroupTrusts { get; init; }
+    public required IReadOnlyList<(string Avatar, bool HasConsentedFlow)> ConsentedFlags { get; init; }
+    public required IReadOnlyList<string> RegisteredAvatars { get; init; }
+    public required IReadOnlyList<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> WrapperMappings { get; init; }
+    public required IReadOnlyList<(string GroupAddress, string RouterAddress)> GroupRouters { get; init; }
+    public required IReadOnlyList<string> ScoreRouters { get; init; }
+    public required IReadOnlyList<(string GroupAddress, string CollateralToken, string AvailableLimit)> ScoreGroupMintLimits { get; init; }
+    public required IReadOnlyList<(string Account, string Operator)> OperatorApprovals { get; init; }
+}
+
+/// <summary>
 /// ILoadGraph implementation backed by pre-materialized in-memory data.
 /// All methods return cached lists — zero I/O.
 /// </summary>
-internal sealed class MaterializedLoadGraph(
-    List<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)> balances,
-    List<(string Truster, string Trustee, int Limit)> trust,
-    List<string> groups,
-    List<string> organizations,
-    List<(string GroupAddress, string TrustedToken)> groupTrusts,
-    List<(string Avatar, bool HasConsentedFlow)> consentedFlags,
-    List<string> registeredAvatars,
-    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings,
-    List<(string GroupAddress, string RouterAddress)> groupRouters,
-    List<string> scoreRouters,
-    List<(string GroupAddress, string CollateralToken, string AvailableLimit)> scoreGroupMintLimits,
-    List<(string Account, string Operator)> operatorApprovals) : ILoadGraph
+internal sealed class MaterializedLoadGraph(MaterializedGraphData data) : ILoadGraph
 {
     public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
-        LoadV2Balances() => balances;
+        LoadV2Balances() => data.Balances;
 
     public IEnumerable<(string Truster, string Trustee, int Limit)>
-        LoadV2Trust() => trust;
+        LoadV2Trust() => data.Trust;
 
-    public IEnumerable<string> LoadGroups() => groups;
-    public IEnumerable<string> LoadOrganizations() => organizations;
+    public IEnumerable<string> LoadGroups() => data.Groups;
+    public IEnumerable<string> LoadOrganizations() => data.Organizations;
 
     public IEnumerable<(string GroupAddress, string TrustedToken)>
-        LoadGroupTrusts() => groupTrusts;
+        LoadGroupTrusts() => data.GroupTrusts;
 
     public IEnumerable<(string GroupAddress, string RouterAddress)>
-        LoadGroupRouters() => groupRouters;
+        LoadGroupRouters() => data.GroupRouters;
 
-    public IEnumerable<string> LoadScoreRouters() => scoreRouters;
+    public IEnumerable<string> LoadScoreRouters() => data.ScoreRouters;
 
     public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)>
-        LoadScoreGroupMintLimits() => scoreGroupMintLimits;
+        LoadScoreGroupMintLimits() => data.ScoreGroupMintLimits;
 
     // Pre-materialized at LoadGraph() against the known router set. Filter by the
     // caller's `accounts` so this method matches the live LoadGraph contract.
+    // Materialize the filter result (.ToList()) so re-enumeration is cheap and
+    // matches live LoadGraph.LoadOperatorApprovals returning a List.
     public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
     {
         var accountSet = accounts
@@ -298,14 +326,14 @@ internal sealed class MaterializedLoadGraph(
             .ToHashSet();
         if (accountSet.Count == 0)
             return [];
-        return operatorApprovals.Where(row => accountSet.Contains(row.Account));
+        return data.OperatorApprovals.Where(row => accountSet.Contains(row.Account)).ToList();
     }
 
     public IEnumerable<(string Avatar, bool HasConsentedFlow)>
-        LoadConsentedFlowFlags() => consentedFlags;
+        LoadConsentedFlowFlags() => data.ConsentedFlags;
 
-    public IEnumerable<string> LoadRegisteredAvatars() => registeredAvatars;
+    public IEnumerable<string> LoadRegisteredAvatars() => data.RegisteredAvatars;
 
     public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>
-        LoadWrapperMappings() => wrapperMappings;
+        LoadWrapperMappings() => data.WrapperMappings;
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -132,10 +132,18 @@ public sealed class HistoricalGraphCache
         var sw = Stopwatch.StartNew();
         _logger.LogInformation("Loading historical graph for block {Block}...", blockNumber);
 
-        // Copy all relevant settings for consistent behavior between live and historical
+        // Copy all relevant settings for consistent behavior between live and historical.
+        // ScoreGroupMintPolicies + ScoreTreasurySubTreasuries are required for ScoreGroup
+        // enumeration, mint-limit, and router resolution in the historical loaders
+        // (LoadGroups, LoadGroupTrusts, LoadScoreGroupMintLimits, LoadScoreRouters,
+        // LoadGroupRouters). Empty arrays preserve BaseGroup-only behaviour for callers
+        // without ScoreGroup configuration.
         var historicalSettings = new Settings
         {
             StandardMintPolicyAddress = _settings.StandardMintPolicyAddress,
+            GroupRouterAddress = _settings.GroupRouterAddress,
+            ScoreGroupMintPolicies = _settings.ScoreGroupMintPolicies,
+            ScoreTreasurySubTreasuries = _settings.ScoreTreasurySubTreasuries,
             ExcludeConsentedIntermediaries = _settings.ExcludeConsentedIntermediaries,
             DisableConsentedFlow = _settings.DisableConsentedFlow,
             DemurrageSafetyMargin = 1.0 // No safety margin needed for historical (deterministic timestamp)
@@ -166,19 +174,42 @@ public sealed class HistoricalGraphCache
         var registeredAvatars = loader.LoadRegisteredAvatars().ToList();
         var wrapperMappings = loader.LoadWrapperMappings().ToList();
 
+        // ScoreGroup-aware loaders. Must run AFTER LoadGroups so operator approvals
+        // can be pre-loaded against the router set discovered by LoadGroupRouters.
+        var groupRouters = loader.LoadGroupRouters().ToList();
+        var scoreRouters = loader.LoadScoreRouters().ToList();
+        var scoreGroupMintLimits = loader.LoadScoreGroupMintLimits().ToList();
+
+        // Pre-load operator approvals for every known group router so a cache hit
+        // never has to hit the DB. GraphFactory only ever calls this with router
+        // addresses (GraphFactory.cs:773), so the bounded router set is the right
+        // input. MaterializedLoadGraph filters by `accounts` defensively on call.
+        var routerAddresses = groupRouters
+            .Select(r => r.RouterAddress)
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var operatorApprovals = routerAddresses.Count > 0
+            ? loader.LoadOperatorApprovals(routerAddresses).ToList()
+            : new List<(string Account, string Operator)>();
+
         // Create a factory backed by the materialized data (zero I/O on use)
         var cachedLoader = new MaterializedLoadGraph(
             balances, trust, groups, organizations, groupTrusts,
-            consentedFlags, registeredAvatars, wrapperMappings);
+            consentedFlags, registeredAvatars, wrapperMappings,
+            groupRouters, scoreRouters, scoreGroupMintLimits, operatorApprovals);
 
         var factory = new GraphFactory(_routerAddress, cachedLoader);
 
         sw.Stop();
         _logger.LogInformation(
             "Historical graph for block {Block} loaded: {Trust} trust, {Balances} balances, " +
-            "{Groups} groups, {Avatars} avatars in {Elapsed}ms",
+            "{Groups} groups, {Avatars} avatars, {GroupRouters} group routers, " +
+            "{ScoreRouters} score routers, {ScoreLimits} score mint limits, " +
+            "{Approvals} operator approvals in {Elapsed}ms",
             blockNumber, trust.Count, balances.Count, groups.Count,
-            registeredAvatars.Count, sw.ElapsedMilliseconds);
+            registeredAvatars.Count, groupRouters.Count, scoreRouters.Count,
+            scoreGroupMintLimits.Count, operatorApprovals.Count, sw.ElapsedMilliseconds);
 
         return factory;
     }
@@ -231,7 +262,11 @@ internal sealed class MaterializedLoadGraph(
     List<(string GroupAddress, string TrustedToken)> groupTrusts,
     List<(string Avatar, bool HasConsentedFlow)> consentedFlags,
     List<string> registeredAvatars,
-    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings) : ILoadGraph
+    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings,
+    List<(string GroupAddress, string RouterAddress)> groupRouters,
+    List<string> scoreRouters,
+    List<(string GroupAddress, string CollateralToken, string AvailableLimit)> scoreGroupMintLimits,
+    List<(string Account, string Operator)> operatorApprovals) : ILoadGraph
 {
     public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
         LoadV2Balances() => balances;
@@ -244,6 +279,27 @@ internal sealed class MaterializedLoadGraph(
 
     public IEnumerable<(string GroupAddress, string TrustedToken)>
         LoadGroupTrusts() => groupTrusts;
+
+    public IEnumerable<(string GroupAddress, string RouterAddress)>
+        LoadGroupRouters() => groupRouters;
+
+    public IEnumerable<string> LoadScoreRouters() => scoreRouters;
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)>
+        LoadScoreGroupMintLimits() => scoreGroupMintLimits;
+
+    // Pre-materialized at LoadGraph() against the known router set. Filter by the
+    // caller's `accounts` so this method matches the live LoadGraph contract.
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var accountSet = accounts
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Select(a => a.ToLowerInvariant())
+            .ToHashSet();
+        if (accountSet.Count == 0)
+            return [];
+        return operatorApprovals.Where(row => accountSet.Contains(row.Account));
+    }
 
     public IEnumerable<(string Avatar, bool HasConsentedFlow)>
         LoadConsentedFlowFlags() => consentedFlags;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MaterializedLoadGraphTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MaterializedLoadGraphTests.cs
@@ -1,0 +1,142 @@
+using Circles.Common;
+using Circles.Pathfinder.Data;
+using Circles.Pathfinder.Host.State;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Smoke tests for <see cref="MaterializedLoadGraph"/> — the in-memory snapshot
+/// backing <c>HistoricalGraphCache</c>. These exist because the type is built
+/// against the <c>ILoadGraph</c> interface, and a missing override would
+/// silently fall back to the interface-default-empty implementation
+/// (regressing ScoreGroup support across historical loads).
+///
+/// Coverage: the four ScoreGroup-aware methods (LoadGroupRouters,
+/// LoadScoreRouters, LoadScoreGroupMintLimits, LoadOperatorApprovals) plus the
+/// LoadOperatorApprovals lower-casing + empty-input short-circuit semantics.
+/// </summary>
+[TestFixture, Parallelizable]
+public class MaterializedLoadGraphTests
+{
+    private static MaterializedGraphData StubData(
+        IReadOnlyList<(string GroupAddress, string RouterAddress)>? groupRouters = null,
+        IReadOnlyList<string>? scoreRouters = null,
+        IReadOnlyList<(string GroupAddress, string CollateralToken, string AvailableLimit)>? scoreLimits = null,
+        IReadOnlyList<(string Account, string Operator)>? operatorApprovals = null) => new()
+    {
+        Balances = Array.Empty<(string, int, int, bool, bool)>(),
+        Trust = Array.Empty<(string, string, int)>(),
+        Groups = Array.Empty<string>(),
+        Organizations = Array.Empty<string>(),
+        GroupTrusts = Array.Empty<(string, string)>(),
+        ConsentedFlags = Array.Empty<(string, bool)>(),
+        RegisteredAvatars = Array.Empty<string>(),
+        WrapperMappings = Array.Empty<(string, string, CirclesType)>(),
+        GroupRouters = groupRouters ?? Array.Empty<(string, string)>(),
+        ScoreRouters = scoreRouters ?? Array.Empty<string>(),
+        ScoreGroupMintLimits = scoreLimits ?? Array.Empty<(string, string, string)>(),
+        OperatorApprovals = operatorApprovals ?? Array.Empty<(string, string)>(),
+    };
+
+    [Test]
+    public void LoadGroupRouters_RoundTripsData()
+    {
+        var data = new[]
+        {
+            ("0xaaaa000000000000000000000000000000000001", "0xbbbb000000000000000000000000000000000001"),
+            ("0xaaaa000000000000000000000000000000000002", "0xbbbb000000000000000000000000000000000002"),
+        };
+        var sut = new MaterializedLoadGraph(StubData(groupRouters: data));
+
+        var result = sut.LoadGroupRouters().ToList();
+
+        Assert.That(result, Is.EquivalentTo(data));
+    }
+
+    [Test]
+    public void LoadScoreRouters_RoundTripsData()
+    {
+        var data = new[]
+        {
+            "0xcccc000000000000000000000000000000000001",
+            "0xcccc000000000000000000000000000000000002",
+        };
+        var sut = new MaterializedLoadGraph(StubData(scoreRouters: data));
+
+        var result = sut.LoadScoreRouters().ToList();
+
+        Assert.That(result, Is.EquivalentTo(data));
+    }
+
+    [Test]
+    public void LoadScoreGroupMintLimits_RoundTripsData()
+    {
+        var data = new[]
+        {
+            ("0xdd00000000000000000000000000000000000001", "0xee00000000000000000000000000000000000001", "1000"),
+            ("0xdd00000000000000000000000000000000000002", "0xee00000000000000000000000000000000000002", "2500"),
+        };
+        var sut = new MaterializedLoadGraph(StubData(scoreLimits: data));
+
+        var result = sut.LoadScoreGroupMintLimits().ToList();
+
+        Assert.That(result, Is.EquivalentTo(data));
+    }
+
+    [Test]
+    public void LoadOperatorApprovals_FiltersByLowercasedAccountSet()
+    {
+        const string router = "0xff00000000000000000000000000000000000001";
+        const string avatar = "0xff00000000000000000000000000000000000002";
+        var data = new[]
+        {
+            (router, avatar),
+            ("0xff00000000000000000000000000000000000099", "0xff000000000000000000000000000000000000aa"),
+        };
+        var sut = new MaterializedLoadGraph(StubData(operatorApprovals: data));
+
+        // Mixed-case caller — must be lowercased before lookup.
+        var result = sut.LoadOperatorApprovals(new[] { router.ToUpperInvariant() }).ToList();
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].Account, Is.EqualTo(router));
+        Assert.That(result[0].Operator, Is.EqualTo(avatar));
+    }
+
+    [Test]
+    public void LoadOperatorApprovals_EmptyAccountsShortCircuitsToEmpty()
+    {
+        var sut = new MaterializedLoadGraph(StubData(
+            operatorApprovals: new[] { ("0x01", "0x02") }));
+
+        Assert.That(sut.LoadOperatorApprovals(Array.Empty<string>()), Is.Empty);
+        // Whitespace-only input is filtered out before the empty check.
+        Assert.That(sut.LoadOperatorApprovals(new[] { "", "  ", "\t" }), Is.Empty);
+    }
+
+    [Test]
+    public void LoadOperatorApprovals_UnknownAccountReturnsEmpty()
+    {
+        var data = new[] { ("0xff00000000000000000000000000000000000001", "0xff00000000000000000000000000000000000002") };
+        var sut = new MaterializedLoadGraph(StubData(operatorApprovals: data));
+
+        var result = sut.LoadOperatorApprovals(new[] { "0x0000000000000000000000000000000000000123" });
+
+        Assert.That(result, Is.Empty);
+    }
+
+    [Test]
+    public void LoadOperatorApprovals_ReturnsMaterializedResult()
+    {
+        // Regression: previous shape returned a deferred LINQ chain — re-enumeration
+        // re-ran the filter. The current contract is "materialized list".
+        const string router = "0xff00000000000000000000000000000000000001";
+        var data = new[] { (router, "0xff00000000000000000000000000000000000002") };
+        var sut = new MaterializedLoadGraph(StubData(operatorApprovals: data));
+
+        var first = sut.LoadOperatorApprovals(new[] { router });
+        Assert.That(first, Is.AssignableTo<IReadOnlyCollection<(string, string)>>(),
+            "LoadOperatorApprovals must return a materialized collection, not a deferred IEnumerable, " +
+            "to avoid re-running the filter on every enumeration.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the ScoreGroup gap in the block-pinned (historical) pathfinder loader. Before this change, `findPath` requests carrying `X-Max-Block-Number` saw **zero ScoreGroups** in the graph and returned "no path" for any ScoreGroup routing case at a historical block. Live (un-pinned) requests were unaffected.

## Problem

`HistoricalLoadGraph` ran only 8 of the 12 `ILoadGraph` methods. The 4 missing ones (`LoadGroupRouters`, `LoadScoreRouters`, `LoadScoreGroupMintLimits`, `LoadOperatorApprovals`) fell through to the interface defaults returning empty enumerables. Separately, the existing `LoadGroups` / `LoadGroupTrusts` queries filtered on `mint = @standardMintPolicy` only, excluding ScoreGroups outright — so even the methods that *did* run produced no ScoreGroup data downstream.

## Changes

**Commit 1 — feature**
- `GroupQueryTemplate` / `GroupTrustQueryTemplate` rewritten to mirror live `groupQuery.sql` / `groupTrustQuery.sql` (`latest_score_group` + `supported_groups` CTEs), with block filters added on every event-table reference.
- `GroupTrustQueryTemplate` gains the `registered_avatars` trustee filter matching the production fix that prevents `AvatarMustBeRegistered` reverts.
- The 4 missing loaders implemented against block-pinned queries; `HistoricalGraphCache` pre-loads them.
- `MaterializedLoadGraph` stores the four list slots so cached graphs reuse the materialized data.

**Commit 2 — review fixes**
- `ScoreGroupTablesAvailable()` guard + 3 fallback templates so indexer schemas predating the score-group migration don't hit `42P01 undefined_table`; mirrors the live `LoadGraph` guard.
- `MaterializedLoadGraph` takes a single `MaterializedGraphData` record (named-init properties, `IReadOnlyList<T>` slots) to eliminate positional-swap risk across the four `List<string>` slots.
- `registered_avatars` CTE gains the `MATERIALIZED` planner hint to match live `groupTrustQuery.sql`.
- Stopwatch/elapsed-ms logging parity across the new loaders.

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh pathfinder` — green, 0 failures (includes 7 new `MaterializedLoadGraphTests` covering each new loader, lowercase/empty-input semantics, and materialized-vs-deferred enumeration)
- [ ] Post-deploy: a historical `findPath` through a ScoreGroup at a recent block returns a path instead of empty (compare against live RPC without a block pin)

## Note

This closes the "ScoreGroup historical paths" divergence currently documented as a known limitation in the test-env SDK developer guide and the sdk-v2 test-env guide; those docs get a follow-up edit once this lands.