### PR TITLE
fix(pathfinder): load score-group features in the historical graph path

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Data/HistoricalLoadGraph.cs
@@ -142,6 +142,84 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         ORDER BY "blockNumber" DESC LIMIT 1
         """;
 
+    // Score-group / operator-approval / wrapper queries, block-filtered to {0}.
+    // These mirror the live LoadGraph SQL (groupRouterQuery.sql, scoreRoutersQuery.sql,
+    // CrcV2_ApprovalForAll, wrapperMappingQuery.sql, organizationQuery.sql) but pin every
+    // source table to the target block. Without them these loaders inherit the empty
+    // ILoadGraph defaults, so historical (X-Max-Block-Number) requests degrade every score
+    // group to a regular group — no operator gate (operator_not_approved on-chain) and
+    // unbounded Group→Avatar mint edges — diverging from what the live graph computed.
+
+    // Group → path-mint router. Score groups use their indexed pathMintRouter; standard
+    // groups fall back to @standardRouter. Mirrors groupRouterQuery.sql.
+    private const string GroupRoutersQueryTemplate = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY(@scoreMintPolicies)
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        supported_groups AS (
+            SELECT g."group" AS group_address, g."mint", sg.router_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                  g."mint" = LOWER(@mintPolicy)
+                  OR (LOWER(g."mint") = ANY(@scoreMintPolicies) AND sg.router_address IS NOT NULL)
+              )
+        )
+        SELECT group_address,
+               CASE WHEN router_address IS NOT NULL THEN router_address ELSE LOWER(@standardRouter) END
+        FROM supported_groups
+        """;
+
+    // Standard-only group → router fallback when score-group tables are absent.
+    private const string BaseGroupRoutersQueryTemplate = """
+        SELECT "group", LOWER(@standardRouter)
+        FROM "CrcV2_RegisterGroup"
+        WHERE "mint" = LOWER(@mintPolicy) AND "blockNumber" <= {0}
+        """;
+
+    // Score-group path-mint routers. Mirrors scoreRoutersQuery.sql.
+    private const string ScoreRoutersQueryTemplate = """
+        SELECT DISTINCT LOWER("pathMintRouter") AS router_address
+        FROM "CrcV2_ScoreGroup_GroupInitialized"
+        WHERE LOWER("emitter") = ANY(@scoreMintPolicies) AND "blockNumber" <= {0}
+        """;
+
+    // Latest operator approvals for the given accounts. Mirrors LoadGraph.LoadOperatorApprovals.
+    private const string OperatorApprovalsQueryTemplate = """
+        SELECT account, operator FROM (
+            SELECT DISTINCT ON (LOWER("account"), LOWER("operator"))
+                LOWER("account") AS account,
+                LOWER("operator") AS operator,
+                "approved" AS approved
+            FROM "CrcV2_ApprovalForAll"
+            WHERE LOWER("account") = ANY(@accounts) AND "blockNumber" <= {0}
+            ORDER BY LOWER("account"), LOWER("operator"),
+                     "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ) latest
+        WHERE approved = true
+        """;
+
+    // ERC20 wrapper → underlying avatar, block-filtered via registered_avatars CTE ({2}).
+    // Mirrors wrapperMappingQuery.sql.
+    private const string WrapperMappingsQueryTemplate = """
+        WITH {2}
+        SELECT d."erc20Wrapper", d.avatar, d."circlesType"
+        FROM "CrcV2_ERC20WrapperDeployed" d
+        JOIN registered_avatars ra ON ra.avatar = d.avatar
+        WHERE d."blockNumber" <= {0}
+        """;
+
+    private const string OrganizationsQueryTemplate = """
+        SELECT organization FROM "CrcV2_RegisterOrganization" WHERE "blockNumber" <= {0}
+        """;
+
     public HistoricalLoadGraph(NpgsqlDataSource dataSource, long blockNumber, Settings settings, ILogger? logger = null)
     {
         ArgumentNullException.ThrowIfNull(dataSource);
@@ -277,7 +355,117 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         return ExecuteParameterizedStringListQuery(sql, "groups");
     }
 
-    public IEnumerable<string> LoadOrganizations() => [];
+    public IEnumerable<string> LoadOrganizations()
+    {
+        var sql = string.Format(OrganizationsQueryTemplate, _blockNumber);
+        return ExecuteStringListQuery(sql, "organizations");
+    }
+
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+    {
+        bool scoreTables = _settings.ScoreGroupMintPolicies.Length > 0 && ScoreGroupTablesAvailable();
+        var sql = string.Format(
+            scoreTables ? GroupRoutersQueryTemplate : BaseGroupRoutersQueryTemplate, _blockNumber);
+        var results = new List<(string, string)>(1_000);
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+        cmd.Parameters.AddWithValue("mintPolicy", _settings.StandardMintPolicyAddress);
+        cmd.Parameters.AddWithValue("standardRouter", _settings.GroupRouterAddress);
+        if (scoreTables)
+            cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add((reader.GetString(0), reader.GetString(1)));
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} group routers (scoreTables={ScoreTables})",
+            _blockNumber, results.Count, scoreTables);
+        return results;
+    }
+
+    public IEnumerable<string> LoadScoreRouters()
+    {
+        if (_settings.ScoreGroupMintPolicies.Length == 0 || !ScoreGroupTablesAvailable())
+            return [];
+
+        var sql = string.Format(ScoreRoutersQueryTemplate, _blockNumber);
+        var results = new List<string>(128);
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+        cmd.Parameters.AddWithValue("scoreMintPolicies", _settings.ScoreGroupMintPolicies);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add(reader.GetString(0));
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} score routers", _blockNumber, results.Count);
+        return results;
+    }
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits()
+    {
+        if (_settings.ScoreGroupMintPolicies.Length == 0 || !ScoreGroupTablesAvailable())
+            return [];
+
+        // Block-filtered via maxBlock: the group→collateral→policy mapping and the
+        // historical/personal supply tables are pinned to {block}. NOTE: the available-limit
+        // magnitude still reads the unpinned V_CrcV2_BalancesByAccountAndToken view for
+        // treasury supply, so the limit number reflects current treasury balances — the
+        // mapping is historically exact, the cap magnitude is approximate. Far better than
+        // the empty default, which erases score groups from historical graphs entirely.
+        using var conn = _dataSource.OpenConnection();
+        var rows = ScoreGroupMintLimitReader.Read(
+            conn,
+            _settings.ScoreGroupMintPolicies,
+            _settings.TargetDemurrageTimestamp,
+            _settings.DemurrageSafetyMargin,
+            _settings.PathfinderGroupTimeoutSeconds,
+            maxBlock: _blockNumber,
+            subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries);
+
+        var results = rows.Select(r => (r.GroupAddress, r.CollateralToken, r.AvailableLimit)).ToList();
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} score group mint limits", _blockNumber, results.Count);
+        return results;
+    }
+
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var accountSet = accounts
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Select(a => a.ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+
+        if (accountSet.Length == 0)
+            return [];
+
+        var sql = string.Format(OperatorApprovalsQueryTemplate, _blockNumber);
+        var results = new List<(string, string)>(64);
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+        cmd.Parameters.AddWithValue("accounts", accountSet);
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add((reader.GetString(0), reader.GetString(1)));
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} operator approvals ({Accounts} accounts queried)",
+            _blockNumber, results.Count, accountSet.Length);
+        return results;
+    }
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
@@ -328,11 +516,59 @@ public sealed class HistoricalLoadGraph : ILoadGraph
         return results.Select(a => a.ToLowerInvariant()).ToList();
     }
 
-    // Historical canary path: wrapper mappings are not yet block-filtered, so the canary
-    // is effectively skipped for historical requests. Acceptable today because the canary's
-    // job is detecting LIVE graph drift; historical traffic doesn't broadcast on-chain.
     public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> LoadWrapperMappings()
-        => Array.Empty<(string, string, CirclesType)>();
+    {
+        var registeredAvatarsCte = string.Format(RegisteredAvatarsCte, _blockNumber);
+        var sql = string.Format(WrapperMappingsQueryTemplate, _blockNumber, "", registeredAvatarsCte);
+        var results = new List<(string, string, CirclesType)>(10_000);
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.CommandTimeout = _settings.PathfinderGroupTimeoutSeconds;
+
+        using var reader = cmd.ExecuteReader();
+        while (reader.Read())
+            results.Add((reader.GetString(0), reader.GetString(1), (CirclesType)reader.GetInt32(2)));
+
+        _logger.LogInformation(
+            "[HistoricalLoadGraph] Block {Block}: {Count} wrapper mappings", _blockNumber, results.Count);
+        return results;
+    }
+
+    // Result of ScoreGroupTablesAvailable(), computed once per loader instance (one instance
+    // per block load). The three score loaders are called sequentially within a single
+    // HistoricalGraphCache.LoadGraph, so this needs no synchronization.
+    private bool? _scoreTablesAvailableCache;
+
+    // Mirrors LoadGraph.ScoreGroupTablesAvailable — guards score-group loaders in
+    // environments (e.g. older test DBs) where the CrcV2_ScoreGroup_* tables are absent.
+    // Evaluated once (cached): the live path threads a single bool through its *Internal
+    // variants; here we cache to get the same single-evaluation + internal-consistency
+    // guarantee across the three loaders, and to surface a degradation loudly.
+    private bool ScoreGroupTablesAvailable()
+    {
+        if (_scoreTablesAvailableCache.HasValue)
+            return _scoreTablesAvailableCache.Value;
+
+        using var conn = _dataSource.OpenConnection();
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT to_regclass('public.\"CrcV2_ScoreGroup_GroupInitialized\"') IS NOT NULL";
+        bool available = cmd.ExecuteScalar() is bool a && a;
+        _scoreTablesAvailableCache = available;
+
+        // Loud, not silent: a configured-but-missing score schema degrades every score group
+        // to a regular group (no operator gate, unbounded mint edges) — the exact failure this
+        // fix exists to prevent. Make it visible instead of an INFO/empty-list no-op.
+        if (!available && _settings.ScoreGroupMintPolicies.Length > 0)
+            _logger.LogError(
+                "[HistoricalLoadGraph] Block {Block}: {Count} score-group mint policies configured but " +
+                "CrcV2_ScoreGroup_GroupInitialized is absent — score groups degrade to regular groups " +
+                "(no operator gate, unbounded mint edges). Historical score-group paths may revert on-chain.",
+                _blockNumber, _settings.ScoreGroupMintPolicies.Length);
+
+        return available;
+    }
 
     /// <summary>
     /// Executes a query with @mintPolicy parameter and returns a list of strings from column 0.

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/HistoricalGraphCache.cs
@@ -132,10 +132,16 @@ public sealed class HistoricalGraphCache
         var sw = Stopwatch.StartNew();
         _logger.LogInformation("Loading historical graph for block {Block}...", blockNumber);
 
-        // Copy all relevant settings for consistent behavior between live and historical
+        // Copy all relevant settings for consistent behavior between live and historical.
+        // Score-group settings MUST be copied too — otherwise the historical score loaders
+        // (LoadGroupRouters/LoadScoreRouters/LoadScoreGroupMintLimits) see empty policy lists
+        // and silently degrade every score group to a regular group.
         var historicalSettings = new Settings
         {
             StandardMintPolicyAddress = _settings.StandardMintPolicyAddress,
+            GroupRouterAddress = _settings.GroupRouterAddress,
+            ScoreGroupMintPolicies = _settings.ScoreGroupMintPolicies,
+            ScoreTreasurySubTreasuries = _settings.ScoreTreasurySubTreasuries,
             ExcludeConsentedIntermediaries = _settings.ExcludeConsentedIntermediaries,
             DisableConsentedFlow = _settings.DisableConsentedFlow,
             DemurrageSafetyMargin = 1.0 // No safety margin needed for historical (deterministic timestamp)
@@ -166,10 +172,25 @@ public sealed class HistoricalGraphCache
         var registeredAvatars = loader.LoadRegisteredAvatars().ToList();
         var wrapperMappings = loader.LoadWrapperMappings().ToList();
 
+        // Score-group features — without these the materialized graph treats every score
+        // group as a regular group (no operator gate, unbounded mint edges), diverging from
+        // the live graph. Operator approvals are queried by GraphFactory for the group
+        // routers, so pre-materialize for exactly that account set.
+        var groupRouters = loader.LoadGroupRouters().ToList();
+        var scoreRouters = loader.LoadScoreRouters().ToList();
+        var scoreGroupMintLimits = loader.LoadScoreGroupMintLimits().ToList();
+        var routerAddresses = groupRouters
+            .Select(r => r.RouterAddress)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Distinct()
+            .ToList();
+        var operatorApprovals = loader.LoadOperatorApprovals(routerAddresses).ToList();
+
         // Create a factory backed by the materialized data (zero I/O on use)
         var cachedLoader = new MaterializedLoadGraph(
             balances, trust, groups, organizations, groupTrusts,
-            consentedFlags, registeredAvatars, wrapperMappings);
+            consentedFlags, registeredAvatars, wrapperMappings,
+            groupRouters, scoreRouters, scoreGroupMintLimits, operatorApprovals);
 
         var factory = new GraphFactory(_routerAddress, cachedLoader);
 
@@ -231,7 +252,11 @@ internal sealed class MaterializedLoadGraph(
     List<(string GroupAddress, string TrustedToken)> groupTrusts,
     List<(string Avatar, bool HasConsentedFlow)> consentedFlags,
     List<string> registeredAvatars,
-    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings) : ILoadGraph
+    List<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)> wrapperMappings,
+    List<(string GroupAddress, string RouterAddress)> groupRouters,
+    List<string> scoreRouters,
+    List<(string GroupAddress, string CollateralToken, string AvailableLimit)> scoreGroupMintLimits,
+    List<(string Account, string Operator)> operatorApprovals) : ILoadGraph
 {
     public IEnumerable<(string Balance, int Account, int TokenAddress, bool IsWrapped, bool IsStatic)>
         LoadV2Balances() => balances;
@@ -252,4 +277,24 @@ internal sealed class MaterializedLoadGraph(
 
     public IEnumerable<(string WrapperAddress, string UnderlyingAvatar, CirclesType CirclesType)>
         LoadWrapperMappings() => wrapperMappings;
+
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters() => groupRouters;
+
+    public IEnumerable<string> LoadScoreRouters() => scoreRouters;
+
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)>
+        LoadScoreGroupMintLimits() => scoreGroupMintLimits;
+
+    // Operator approvals were pre-materialized for the group routers (the only accounts
+    // GraphFactory queries). Filter to the requested accounts to match the live semantics.
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var accountSet = accounts
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Select(a => a.ToLowerInvariant())
+            .ToHashSet();
+        return accountSet.Count == 0
+            ? []
+            : operatorApprovals.Where(a => accountSet.Contains(a.Account.ToLowerInvariant())).ToList();
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HistoricalScoreLoadersTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HistoricalScoreLoadersTests.cs
@@ -1,0 +1,106 @@
+using System.Reflection;
+using Circles.Common;
+using Circles.Pathfinder.Data;
+using Circles.Pathfinder.Host.Data;
+using Circles.Pathfinder.Host.State;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Regression tests for the historical score-group loaders.
+///
+/// Bug: HistoricalLoadGraph + MaterializedLoadGraph both inherited the empty ILoadGraph
+/// defaults (=> []) for LoadGroupRouters / LoadScoreRouters / LoadScoreGroupMintLimits /
+/// LoadOperatorApprovals. MaterializedLoadGraph is the loader GraphFactory actually consumes
+/// for historical (X-Max-Block-Number) requests, so score groups silently degraded to regular
+/// groups — no operator gate, unbounded mint edges — diverging from the live graph.
+///
+/// These tests are DB-free: they verify the materialized wrapper forwards the score data it is
+/// given (not []), and that HistoricalLoadGraph overrides the loaders rather than inheriting
+/// the empty defaults.
+/// </summary>
+[TestFixture]
+public class HistoricalScoreLoadersTests
+{
+    private static MaterializedLoadGraph BuildWithScoreData() => new(
+        balances: [],
+        trust: [],
+        groups: ["0x9999999999999999999999999999999999999999"],
+        organizations: [],
+        groupTrusts: [],
+        consentedFlags: [],
+        registeredAvatars: [],
+        wrapperMappings: [],
+        groupRouters: [("0xaaaa000000000000000000000000000000000001", "0xrouter00000000000000000000000000000000a1")],
+        scoreRouters: ["0xrouter00000000000000000000000000000000a1"],
+        scoreGroupMintLimits: [("0xaaaa000000000000000000000000000000000001",
+                                "0xcccc000000000000000000000000000000000001", "12345")],
+        operatorApprovals:
+        [
+            ("0xrouter00000000000000000000000000000000a1", "0xopprov0000000000000000000000000000000001"),
+            ("0xotheracct00000000000000000000000000000002", "0xopprov0000000000000000000000000000000003"),
+        ]);
+
+    [Test]
+    public void Materialized_GroupRouters_AreForwarded_NotEmpty()
+    {
+        var lg = BuildWithScoreData();
+        var routers = lg.LoadGroupRouters().ToList();
+        Assert.That(routers, Has.Count.EqualTo(1));
+        Assert.That(routers[0].RouterAddress, Is.EqualTo("0xrouter00000000000000000000000000000000a1"));
+    }
+
+    [Test]
+    public void Materialized_ScoreRouters_AreForwarded_NotEmpty()
+    {
+        Assert.That(BuildWithScoreData().LoadScoreRouters().ToList(), Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Materialized_ScoreGroupMintLimits_AreForwarded_NotEmpty()
+    {
+        var limits = BuildWithScoreData().LoadScoreGroupMintLimits().ToList();
+        Assert.That(limits, Has.Count.EqualTo(1));
+        Assert.That(limits[0].AvailableLimit, Is.EqualTo("12345"));
+    }
+
+    [Test]
+    public void Materialized_OperatorApprovals_FilterByRequestedAccounts()
+    {
+        var lg = BuildWithScoreData();
+
+        // GraphFactory queries approvals for specific router accounts — only those should return.
+        var forRouter = lg.LoadOperatorApprovals(["0xrouter00000000000000000000000000000000a1"]).ToList();
+        Assert.That(forRouter, Has.Count.EqualTo(1));
+        Assert.That(forRouter[0].Operator, Is.EqualTo("0xopprov0000000000000000000000000000000001"));
+
+        // An account with no approvals returns nothing; empty input returns nothing.
+        Assert.That(lg.LoadOperatorApprovals(["0xnobody00000000000000000000000000000000ff"]), Is.Empty);
+        Assert.That(lg.LoadOperatorApprovals([]), Is.Empty);
+    }
+
+    [Test]
+    public void HistoricalLoadGraph_Overrides_AllScoreLoaders_NotInheritedDefaults()
+    {
+        // Guards against re-introducing the silent gap: each score loader must be declared on
+        // HistoricalLoadGraph itself, not inherited from the ILoadGraph default interface method.
+        var type = typeof(HistoricalLoadGraph);
+        foreach (var name in new[]
+                 {
+                     nameof(ILoadGraph.LoadGroupRouters),
+                     nameof(ILoadGraph.LoadScoreRouters),
+                     nameof(ILoadGraph.LoadScoreGroupMintLimits),
+                     nameof(ILoadGraph.LoadOperatorApprovals),
+                     nameof(ILoadGraph.LoadOrganizations),
+                     nameof(ILoadGraph.LoadWrapperMappings),
+                 })
+        {
+            var method = type.GetMethod(name,
+                BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            Assert.That(method, Is.Not.Null,
+                $"HistoricalLoadGraph must declare {name} — inheriting the empty ILoadGraph default "
+                + "silently degrades historical score-group pathfinding.");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Historical (`X-Max-Block-Number`) pathfinder requests degraded every score group to a regular group because the historical loaders for score-group features were never wired end-to-end.

`HistoricalLoadGraph` inherited the empty `ILoadGraph` defaults (`=> []`) for `LoadGroupRouters`, `LoadScoreRouters`, `LoadScoreGroupMintLimits`, and `LoadOperatorApprovals` (plus `LoadOrganizations`/`LoadWrapperMappings`), and `HistoricalGraphCache` never called them — so `MaterializedLoadGraph`, the loader `GraphFactory` actually consumes for historical requests, returned empty for all four. The effect: no operator-approval gate and unbounded `Group→Avatar` mint edges on historical score-group paths, diverging from the live graph and producing transfer paths that revert on-chain (`operator_not_approved` / `ERC1155InsufficientBalance`).

## What changed
- Implement the six loaders in `HistoricalLoadGraph` with block-filtered SQL mirroring the live `LoadGraph` queries (`WHERE "blockNumber" <= N`).
- Wire them through `HistoricalGraphCache.LoadGraph` + `MaterializedLoadGraph`; operator approvals are pre-materialized for the group-router account set (the set `GraphFactory` queries) and filtered by requested accounts on read.
- Copy `ScoreGroupMintPolicies`/`GroupRouterAddress`/`ScoreTreasurySubTreasuries` into the historical settings so the score loaders are configured.
- Evaluate the score-table-availability probe once (was 3× on separate connections) and log an error when score policies are configured but the tables are absent — previously a silent degradation.
- Add DB-free regression tests asserting the materialized wrapper forwards the score data and that the loaders are not re-inherited as empty defaults.

## Known limitation
`LoadScoreGroupMintLimits` block-pins the group→collateral→policy mapping and the historical/personal supply tables, but the available-limit *magnitude* still reads the unpinned balances view (current treasury supply). The mapping is historically exact; the cap magnitude is approximate — far better than the empty default, which erased score groups from historical graphs entirely. Documented in code.

## Test plan
- [x] Build (Host + Tests): 0 errors
- [x] New regression tests pass (5/5): `HistoricalScoreLoadersTests`
- [x] End-to-end validation: a full-feature historical reload at a past block produces a correct path (intermediary sends exactly its real balance; zero sequential-balance violations) on real data
- [ ] Post-deploy: confirm historical (`X-Max-Block-Number`) score-group requests no longer emit operator-gate / insufficient-balance divergences