### PR TITLE
feat(rpc): header-gated block pinning for test-environment historical reads

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/BlockPinningRoutingTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/BlockPinningRoutingTests.cs
@@ -1,0 +1,196 @@
+using Circles.Rpc.Host;
+using Npgsql;
+using NUnit.Framework;
+using Testcontainers.PostgreSql;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Pure-logic guard for the inertness-deciding header parse. Needs no database, so it runs in EVERY
+/// environment (including Docker-less runners where the Testcontainers fixture below would skip) —
+/// this is the part that decides whether a request is pinned at all, so it must never be skippable.
+/// </summary>
+[TestFixture]
+public class BlockPinHeaderParsingTests
+{
+    [TestCase("123", ExpectedResult = 123L, TestName = "Positive value pins")]
+    [TestCase("46400000", ExpectedResult = 46400000L, TestName = "Large positive value pins")]
+    [TestCase("  789  ", ExpectedResult = 789L, TestName = "Surrounding whitespace tolerated")]
+    [TestCase(null, ExpectedResult = null, TestName = "Null (no header) is no pin")]
+    [TestCase("", ExpectedResult = null, TestName = "Empty is no pin")]
+    [TestCase("   ", ExpectedResult = null, TestName = "Whitespace is no pin")]
+    [TestCase("abc", ExpectedResult = null, TestName = "Non-numeric is no pin")]
+    [TestCase("12.5", ExpectedResult = null, TestName = "Non-integer is no pin")]
+    [TestCase("0", ExpectedResult = null, TestName = "Zero is no pin (not a degenerate block-0 pin)")]
+    [TestCase("-5", ExpectedResult = null, TestName = "Negative is no pin")]
+    public long? ParseMaxBlockHeaderValue_HonorsPositivity(string? raw)
+        => ConnectionPinning.ParseMaxBlockHeaderValue(raw);
+}
+
+/// <summary>
+/// Guards the header-gated block-pinning seam (<see cref="ConnectionPinning.ApplyAsync"/>) that the
+/// test environment relies on. Proves the properties that matter for both correctness and prod safety:
+///   - INERTNESS: with no block (every production request) reads hit the public schema and no session
+///     state is set — byte-identical to pre-pinning behavior.
+///   - ROUTING: with a block, unqualified view names resolve to the pinned-schema twin and the GUC
+///     the pinned views read carries the block number.
+///   - NO LEAK: a pinned connection returned to the pool does not leak its search_path/GUC to the next
+///     caller that reuses the SAME physical connection (asserted via backend ProcessId).
+///   - GRACEFUL: a search_path naming a missing schema (production has no pinned schema) is not an
+///     error; unqualified names fall through to public.
+///   - NON-POSITIVE: 0 / negative blocks are a no-op, never a degenerate empty pin.
+///
+/// Unlike <see cref="CirclesRpcModuleTests"/>, this fixture never constructs the RPC module, so it runs
+/// without the Nethermind runtime — it touches only <see cref="ConnectionPinning"/> and Npgsql.
+/// </summary>
+[TestFixture]
+public class BlockPinningRoutingTests
+{
+    private PostgreSqlContainer? _postgres;
+    private NpgsqlDataSource? _dataSource;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        try
+        {
+            // postgres:15-alpine matches the project's "PostgreSQL 15+" requirement and the sibling fixtures.
+            _postgres = new PostgreSqlBuilder("postgres:15-alpine").Build();
+            await _postgres.StartAsync();
+        }
+        catch (Exception ex)
+        {
+            Assert.Ignore($"Docker/Postgres test container unavailable: {ex.Message}");
+            return;
+        }
+
+        // Max Pool Size = 1 forces the no-leak test to reuse the same physical connection.
+        var csb = new NpgsqlConnectionStringBuilder(_postgres.GetConnectionString()) { MaxPoolSize = 1 };
+        _dataSource = NpgsqlDataSource.Create(csb.ConnectionString);
+
+        // A probe view named identically in BOTH schemas with different payloads, so the schema a
+        // query resolves to is directly observable from the row it returns. The pinned schema name
+        // is taken from the production constant so a rename can't silently desync this test.
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = $@"
+            CREATE SCHEMA IF NOT EXISTS ""{ConnectionPinning.PinnedSchema}"";
+            CREATE TABLE public.""V_Probe"" (marker text);
+            INSERT INTO public.""V_Probe"" VALUES ('public');
+            CREATE TABLE ""{ConnectionPinning.PinnedSchema}"".""V_Probe"" (marker text);
+            INSERT INTO ""{ConnectionPinning.PinnedSchema}"".""V_Probe"" VALUES ('pinned');";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource != null)
+        {
+            await _dataSource.DisposeAsync();
+        }
+
+        if (_postgres != null)
+        {
+            await _postgres.DisposeAsync();
+        }
+    }
+
+    // Reads through an UNqualified name so the result reflects search_path resolution.
+    private static async Task<string?> ReadProbeMarkerAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = @"SELECT marker FROM ""V_Probe"" LIMIT 1";
+        // `as string` maps a SQL NULL (DBNull.Value) to C# null rather than throwing on the cast.
+        return await cmd.ExecuteScalarAsync() as string;
+    }
+
+    private static async Task<string?> ReadGucAsync(NpgsqlConnection conn)
+    {
+        await using var cmd = conn.CreateCommand();
+        // missing_ok = true → returns SQL NULL (never set) instead of erroring; surfaced as DBNull.
+        cmd.CommandText = "SELECT current_setting('circles.max_block_number', true)";
+        return await cmd.ExecuteScalarAsync() as string;
+    }
+
+    [Test]
+    public async Task NoBlock_ReadsPublicSchema_AndSetsNothing()
+    {
+        await using var conn = await _dataSource!.OpenConnectionAsync();
+        await ConnectionPinning.ApplyAsync(conn, null);
+
+        Assert.That(await ReadProbeMarkerAsync(conn), Is.EqualTo("public"),
+            "Without a block, unqualified names must resolve to the public schema.");
+        Assert.That(string.IsNullOrEmpty(await ReadGucAsync(conn)), Is.True,
+            "Without a block, the max_block_number GUC must be unset.");
+    }
+
+    [Test]
+    public async Task WithBlock_RoutesToPinnedSchema_AndSetsGuc()
+    {
+        await using var conn = await _dataSource!.OpenConnectionAsync();
+        await ConnectionPinning.ApplyAsync(conn, 12_345_678L);
+
+        Assert.That(await ReadProbeMarkerAsync(conn), Is.EqualTo("pinned"),
+            "With a block, unqualified names must resolve to the pinned-schema twin.");
+        Assert.That(await ReadGucAsync(conn), Is.EqualTo("12345678"),
+            "With a block, the pinned views' GUC must carry the block number.");
+    }
+
+    [Test]
+    public async Task NonPositiveBlock_IsNoOp()
+    {
+        await using var conn = await _dataSource!.OpenConnectionAsync();
+        await ConnectionPinning.ApplyAsync(conn, 0L);
+        Assert.That(await ReadProbeMarkerAsync(conn), Is.EqualTo("public"), "block 0 must not pin");
+
+        await ConnectionPinning.ApplyAsync(conn, -5L);
+        Assert.That(await ReadProbeMarkerAsync(conn), Is.EqualTo("public"), "negative block must not pin");
+        Assert.That(string.IsNullOrEmpty(await ReadGucAsync(conn)), Is.True,
+            "A non-positive block must not set the GUC.");
+    }
+
+    [Test]
+    public async Task Pin_DoesNotLeak_AcrossPooledConnections()
+    {
+        int pinnedBackendPid;
+
+        // Pin, then return the (single, pooled) physical connection.
+        await using (var pinned = await _dataSource!.OpenConnectionAsync())
+        {
+            pinnedBackendPid = pinned.ProcessID;
+            await ConnectionPinning.ApplyAsync(pinned, 999L);
+            Assert.That(await ReadProbeMarkerAsync(pinned), Is.EqualTo("pinned"));
+        }
+
+        // Reacquire with no block: it must come back clean.
+        await using var reused = await _dataSource!.OpenConnectionAsync();
+
+        // Guards against the test passing for the wrong reason: prove it's the SAME physical
+        // backend connection, so a "clean" read genuinely demonstrates reset-on-return, not a
+        // fresh connection that was never pinned.
+        Assert.That(reused.ProcessID, Is.EqualTo(pinnedBackendPid),
+            "MaxPoolSize=1 should hand back the same physical connection.");
+
+        await ConnectionPinning.ApplyAsync(reused, null);
+        Assert.That(await ReadProbeMarkerAsync(reused), Is.EqualTo("public"),
+            "A pinned connection returned to the pool must not leak its search_path to the next caller.");
+        Assert.That(string.IsNullOrEmpty(await ReadGucAsync(reused)), Is.True,
+            "A pinned connection returned to the pool must not leak its GUC to the next caller.");
+    }
+
+    [Test]
+    public async Task SearchPath_ToMissingSchema_DoesNotThrow_AndFallsThroughToPublic()
+    {
+        // The production safety property: prod has no pinned schema. Setting a search_path that names
+        // a non-existent schema must be accepted, with unqualified names resolving from the next
+        // existing entry (public). ApplyAsync issues exactly such a SET.
+        await using var conn = await _dataSource!.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        cmd.CommandText = "SET search_path = a_schema_that_does_not_exist, public";
+
+        Assert.DoesNotThrowAsync(async () => await cmd.ExecuteNonQueryAsync());
+        Assert.That(await ReadProbeMarkerAsync(conn), Is.EqualTo("public"),
+            "Unqualified names must fall through to public when the leading search_path schema is absent.");
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -47,5 +47,11 @@
     <ProjectReference Include="..\Circles.Rpc.CacheServiceClient\Circles.Rpc.CacheServiceClient.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expose internal helpers (e.g. ConnectionPinning) to the test project so the
+         security-critical block-pin logic is unit-testable without widening the public surface. -->
+    <InternalsVisibleTo Include="Circles.Rpc.Host.Tests" />
+  </ItemGroup>
+
 
 </Project>

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Core.cs
@@ -102,15 +102,21 @@ public partial class CirclesRpcModule : ICirclesRpcModule
     {
         var connection = await _dataSource.OpenConnectionAsync();
 
-        // Check for block filter header (used by test environment proxy)
-        var maxBlockNumber = GetMaxBlockNumberFromHeader();
-        if (maxBlockNumber.HasValue)
+        // Honor the test-environment block-filter header (X-Max-Block-Number). This is inert on
+        // every production request — the header is never present there — so the connection keeps
+        // its default behavior. See ConnectionPinning for the exact, header-gated SET statements
+        // (GUC + circles_at_block search_path) and their inertness/no-leak guarantees.
+        try
         {
-            await using var cmd = connection.CreateCommand();
-            cmd.CommandText = $"SET circles.max_block_number = {maxBlockNumber.Value}";
-            await cmd.ExecuteNonQueryAsync();
-
-            _logger?.LogDebug("Set circles.max_block_number = {BlockNumber} for request", maxBlockNumber.Value);
+            await ConnectionPinning.ApplyAsync(connection, GetMaxBlockNumberFromHeader(), _logger);
+        }
+        catch
+        {
+            // The pin SET only fails under DB misconfiguration; if it does, dispose the just-opened
+            // connection before propagating so a persistent failure can't exhaust the pool (the
+            // caller's `await using` never binds when CreateConnectionAsync throws).
+            await connection.DisposeAsync();
+            throw;
         }
 
         return connection;
@@ -127,10 +133,10 @@ public partial class CirclesRpcModule : ICirclesRpcModule
             return null;
         }
 
-        if (httpContext.Request.Headers.TryGetValue(MaxBlockNumberHeader, out var headerValue) &&
-            long.TryParse(headerValue.FirstOrDefault(), out var blockNumber))
+        if (httpContext.Request.Headers.TryGetValue(MaxBlockNumberHeader, out var headerValue))
         {
-            return blockNumber;
+            // Positivity/validity guard lives in the (CI-testable) parser.
+            return ConnectionPinning.ParseMaxBlockHeaderValue(headerValue.FirstOrDefault());
         }
 
         return null;

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -87,7 +87,11 @@ public partial class CirclesRpcModule
     private async Task<Dictionary<string, TokenExposureInfo>> GetTokenExposureIdsAsync(string address)
     {
         var lowerAddress = address; // already validated and lowered by caller
-        var cacheKey = $"tokenExposure:{lowerAddress}";
+        // Key the cache by the pinned block (or "head"): exposure is balance-derived and therefore
+        // block-sensitive, so a head-derived entry must not satisfy a block-N request (or vice
+        // versa) for the same address. Without this, the shared TTL cache would defeat the pin.
+        var pinnedBlock = GetMaxBlockNumberFromHeader();
+        var cacheKey = $"tokenExposure:{(pinnedBlock?.ToString() ?? "head")}:{lowerAddress}";
 
         // Check cache first (5 minute TTL for token exposure data)
         if (_tokenExposureCache.TryGetValue(cacheKey, out Dictionary<string, TokenExposureInfo>? cached) && cached != null)
@@ -202,7 +206,13 @@ public partial class CirclesRpcModule
             WHERE balance > 0
         ";
 
-        await using var connection = await _dataSource.OpenConnectionAsync();
+        // Route through CreateConnectionAsync (not the raw datasource) so this read joins the
+        // request's connection funnel and carries the same block GUC + search_path. Inert without
+        // the header (production). NOTE: the balance CTEs below are still `public."..."`-qualified,
+        // so they read head until their pinned twins land and the qualifiers are dropped (a later
+        // phase); for now this reroute propagates the GUC and pins only the unqualified register
+        // lookups. Pairing with the block-keyed cache above keeps head and block-N results separate.
+        await using var connection = await CreateConnectionAsync();
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("address", lowerAddress);
 

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/ConnectionPinning.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/ConnectionPinning.cs
@@ -1,0 +1,84 @@
+using Npgsql;
+
+namespace Circles.Rpc.Host;
+
+/// <summary>
+/// Header-gated, per-connection block pinning for the test environment.
+///
+/// This is deliberately a small, Nethermind-free static helper. The production
+/// <see cref="CirclesRpcModule"/> can only be constructed with the Nethermind runtime present
+/// (it implements a Nethermind RPC interface), but this security-critical pin logic must be
+/// unit-testable in plain CI against a real Postgres. Keeping it isolated here lets
+/// <c>BlockPinningRoutingTests</c> exercise the exact SET statements (and the header parsing)
+/// without loading any Nethermind assembly.
+///
+/// PHASED COVERAGE: a request carrying the header is pinned only for views that have a twin in
+/// <see cref="PinnedSchema"/>. Views without a twin resolve to <c>public</c> (head) by design —
+/// the pinned set grows as later phases add twins. Unqualified view names participate in pinning
+/// automatically; <c>public."..."</c>-qualified references in SQL intentionally stay on head until
+/// their twin lands. This means a not-yet-pinned view silently returns head under the header; that
+/// is an accepted, documented property of the incremental rollout, not a bug.
+///
+/// MECHANISM differs from the pathfinder's <c>HistoricalLoadGraph</c> (which inlines
+/// <c>WHERE "blockNumber" &lt;= N</c> into each query): here the block filter is per-connection
+/// session state (a GUC the twins read + a search_path prepend), so correctness depends on Npgsql's
+/// default reset-on-return clearing that state between pooled requests. The production connection
+/// string MUST therefore keep <c>No Reset On Close=false</c> (the default); see
+/// <c>BlockPinningRoutingTests.Pin_DoesNotLeak_AcrossPooledConnections</c>.
+/// </summary>
+internal static class ConnectionPinning
+{
+    /// <summary>
+    /// Schema holding block-reconstructing twins of the public views. It is created only by the
+    /// test-environment service and is absent from every production database. MUST match the schema
+    /// name installed by circles-test-environment (SchemaInstallerService) — the two repos are
+    /// coupled by this string, and a mismatch degrades silently to "always reads public" because
+    /// setting a search_path to a missing schema is not an error.
+    /// </summary>
+    public const string PinnedSchema = "circles_at_block";
+
+    /// <summary>
+    /// Parses an <c>X-Max-Block-Number</c> header value into a pin directive. Returns the block
+    /// number only when it is a valid, strictly-positive long; otherwise null (no pin). A
+    /// non-positive value (0 / negative) is treated as "no pin" rather than a degenerate pin to an
+    /// empty-history reconstruction. Extracted so the inertness-deciding parse is CI-testable.
+    /// </summary>
+    public static long? ParseMaxBlockHeaderValue(string? rawHeaderValue)
+        => long.TryParse(rawHeaderValue, out var block) && block > 0 ? block : null;
+
+    /// <summary>
+    /// Pins <paramref name="connection"/> to <paramref name="maxBlockNumber"/> when it is a
+    /// strictly-positive block: (1) sets the <c>circles.max_block_number</c> GUC that the pinned
+    /// views read via <c>current_setting()</c>, and (2) prepends <see cref="PinnedSchema"/> to the
+    /// <c>search_path</c> so unqualified view names (e.g. <c>"V_CrcV2_Avatars"</c>) resolve to the
+    /// pinned twin instead of the public view. Both are session-local to this pooled connection and
+    /// are cleared by Npgsql's reset-on-return, so they never leak to the next request that reuses
+    /// the physical connection.
+    ///
+    /// When <paramref name="maxBlockNumber"/> is null or non-positive — i.e. every production
+    /// request, which never carries the header — this is a no-op: the connection keeps its default
+    /// <c>public</c> search_path with no GUC set, byte-identical to pre-pinning behavior. Setting
+    /// the search_path to a schema that does not exist (production, or before the test-env installs
+    /// it) is not an error in Postgres; unqualified names simply fall through to <c>public</c>.
+    /// </summary>
+    public static async Task ApplyAsync(NpgsqlConnection connection, long? maxBlockNumber, ILogger? logger = null)
+    {
+        // null / 0 / negative → no pin. Keeps the production path inert and avoids a degenerate
+        // pin to a non-positive block.
+        if (maxBlockNumber is not > 0)
+        {
+            return;
+        }
+
+        await using var cmd = connection.CreateCommand();
+        // maxBlockNumber is a parsed long (header parsed to long?), never raw user text → safe to interpolate.
+        cmd.CommandText =
+            $"SET circles.max_block_number = {maxBlockNumber.Value}; " +
+            $"SET search_path = {PinnedSchema}, public";
+        await cmd.ExecuteNonQueryAsync();
+
+        logger?.LogDebug(
+            "Pinned connection to block {BlockNumber} (search_path={Schema},public)",
+            maxBlockNumber.Value, PinnedSchema);
+    }
+}


### PR DESCRIPTION
## Summary

The Circles RPC host now serves historical (block-N) reads when an `X-Max-Block-Number` request header is present — the header is set exclusively by the internal test-environment proxy. When the header is absent (every production request) the path is a no-op and behavior is **byte-identical** to before.

Mechanism (per-connection, header-gated): set the `circles.max_block_number` GUC that the pinned views read, and prepend the `circles_at_block` schema to the `search_path` so unqualified view names resolve to block-reconstructing twins. The `circles_at_block` schema exists only in the test-environment database; in any database without it (production), `search_path` falls through to `public` and reads head.

This is the RPC-host half of the block-pinning rollout. Currently effective for the views that have a twin (`V_CrcV2_Avatars`, `V_CrcV2_TrustRelations`); other views fall through to head until later phases add their twins.

## What changed

- **`ConnectionPinning`** (new) — a Nethermind-free static helper holding the pin logic (`ApplyAsync`) and the header parse (`ParseMaxBlockHeaderValue`), so the security-critical SET statements are unit-testable in plain CI without the Nethermind runtime. Non-positive block values (0/negative) are treated as no pin.
- **`CreateConnectionAsync`** delegates to the helper and disposes the connection if the pin SET throws (so a persistent misconfiguration can't exhaust the pool).
- **`GetTokenExposureIdsAsync`** routed through the connection funnel (no longer bypasses it) and its exposure cache is keyed by block to prevent head/historical cross-poisoning. (Its balance CTEs remain `public."..."`-qualified and read head until their twins land in a later phase.)
- **`BlockPinningRoutingTests`** (Testcontainers Postgres, no Nethermind) — proves inertness, routing, no-leak across pooled connections (same backend PID), and graceful missing-schema fallthrough; plus a Docker-free fixture covering the header-parse positivity cases so the inertness-deciding logic runs in any environment.

## Test plan

- [ ] `dotnet build -c Release src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj` — 0 errors
- [ ] `dotnet test -c Release src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj` — green (162 pass / 0 fail locally)
- [ ] Inertness: a request without the header reads the `public` schema with no session state set
- [ ] Routing: a request with `X-Max-Block-Number=N` resolves unqualified pinned-view names to `circles_at_block` and differs by block
- [ ] Production safety: with no `circles_at_block` schema present, a header (if ever sent) falls through to `public` without error