### PR TITLE
feat(canary): detect cache-balance drift from ERC1155InsufficientBalance reverts

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
@@ -153,6 +153,12 @@ internal sealed partial class SimulationCanaryService
                     item.Source, item.Sink, item.GraphBlock, blockTag,
                     item.Transfers.Count, unwrapCalls.Count,
                     parsed.RevertMessage ?? parsed.RevertData, wrappers, flowMatrixCalldata);
+
+                // #74 cache-balance-drift: the bundle path classifies insufficient_balance
+                // identically to the plain eth_call path and, being wrapped/ScoreGroup-token-tied,
+                // is the most likely carrier of the signal. Decode from the SAME source Classify
+                // used (revertData ?? revertMsg) — see ParseSimulateV1Response.
+                EmitBalanceDriftIfDetected(item, parsed.Label!, parsed.RevertData ?? parsed.RevertMessage);
                 return;
 
             case BundleOutcome.Success:

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
@@ -153,6 +153,12 @@ internal sealed partial class SimulationCanaryService
                     item.Source, item.Sink, item.GraphBlock, blockTag,
                     item.Transfers.Count, revertMsg, calldata);
 
+                // #74 cache-balance-drift: ERC1155InsufficientBalance carries the holder's on-chain
+                // balance and the amount the pathfinder's path required, both at graphBlock. Decode
+                // from the SAME source Classify used (revertData ?? revertMsg) — the selector hex can
+                // arrive in the message field on some nodes.
+                EmitBalanceDriftIfDetected(item, label, revertData ?? revertMsg);
+
                 if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)
                 {
                     _log.LogWarning(
@@ -178,5 +184,38 @@ internal sealed partial class SimulationCanaryService
         }
 
         QueueDepth.Set(_channel.Reader.Count);
+    }
+
+    // #74 cache-balance-drift emit, shared by both simulation paths (plain eth_call in this file
+    // and the eth_simulateV1 bundle in BundleSimulation.cs). When needed ≫ on-chain the graph source
+    // fed an inflated balance; surface it the instant it happens — it self-heals on the next full
+    // cache refresh, so post-hoc probing misses it. Holder/token go to the LOG only (unbounded
+    // cardinality); the metric is bucketed by the needed/on-chain ratio.
+    //
+    // The whole body is wrapped in its own narrow try/catch so a future decode/emit regression
+    // surfaces as a DISTINCT error rather than masquerading as a surrounding "eth_call
+    // network/timeout" catch.
+    private void EmitBalanceDriftIfDetected(CanaryWorkItem item, string label, string? revertPayload)
+    {
+        if (label != "insufficient_balance")
+            return;
+
+        try
+        {
+            if (RevertClassifier.TryDecodeInsufficientBalance(revertPayload) is not { } drift)
+                return;
+
+            var bucket = RevertClassifier.DriftBucket(drift.Needed, drift.Balance);
+            BalanceDriftTotal.WithLabels(bucket).Inc();
+            _log.LogError(
+                "[{ReqId}] SimulationCanary: CACHE BALANCE DRIFT holder={Holder} token={Token} " +
+                "graphBlock={Block} onChainBalance={OnChain} needed={Needed} ratioBucket={Bucket}",
+                item.ReqId, drift.Holder, drift.Token,
+                item.GraphBlock, drift.Balance, drift.Needed, bucket);
+        }
+        catch (Exception ex)
+        {
+            _log.LogError(ex, "[{ReqId}] SimulationCanary: balance-drift decode/emit failed", item.ReqId);
+        }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.cs
@@ -75,6 +75,14 @@ internal sealed partial class SimulationCanaryService : BackgroundService
         "Work items skipped before enqueue, by reason",
         new CounterConfiguration { LabelNames = new[] { "reason" } });
 
+    // Cache-balance-drift detector (#74): decoded from ERC1155InsufficientBalance reverts.
+    // Holder/token are NOT labels (unbounded cardinality) — they go to the structured ERROR log;
+    // the metric is bucketed by the needed/on-chain ratio so dashboards can alert on magnitude.
+    internal static readonly Counter BalanceDriftTotal = Metrics.CreateCounter(
+        "circles_canary_balance_drift_total",
+        "Cache balance drift caught via ERC1155InsufficientBalance reverts, bucketed by needed/on-chain-balance ratio",
+        new CounterConfiguration { LabelNames = new[] { "bucket" } });
+
     // Observability for the 1ppt over-ask added in PR #426 (covers the on-chain
     // Math64x64 floor-floor roundtrip loss for InflationaryCircles wrappers).
     // Counter ticks once per inflationary unwrap whose raw resolver amount is

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
@@ -238,4 +238,63 @@ public class RevertClassifierTests
         var result = RevertClassifier.ExtractCodeByte(data, "0xc14c0700", codeByteOffset);
         Assert.That(result, Is.EqualTo(expected));
     }
+
+    // ── ERC1155InsufficientBalance decode (#74 cache-balance-drift) ──
+
+    [Test]
+    public void DecodeInsufficientBalance_ExtractsHolderTokenBalanceNeeded()
+    {
+        // ERC1155InsufficientBalance(sender, balance, needed, tokenId), selector 0x03dee4c5.
+        // tokenId is uint160(token), so the token address is the word's low 20 bytes.
+        // Low-entropy placeholder 20-byte addresses (the decoder only cares about the
+        // low-20-byte extraction, not the specific value; keeps the secret scanner quiet).
+        var holder = new string('a', 40);
+        var token = new string('b', 40);
+        var data = "0x03dee4c5" + Word(holder) + Word("1") + Word("a") + Word(token);
+
+        var info = RevertClassifier.TryDecodeInsufficientBalance(data);
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.Value.Holder, Is.EqualTo("0x" + holder));
+        Assert.That(info.Value.Token, Is.EqualTo("0x" + token));
+        Assert.That(info.Value.Balance, Is.EqualTo((System.Numerics.BigInteger)1));
+        Assert.That(info.Value.Needed, Is.EqualTo((System.Numerics.BigInteger)10)); // 0xa
+    }
+
+    [Test]
+    public void DecodeInsufficientBalance_HandlesLargeUint256WithoutSignFlip()
+    {
+        // A balance whose top hex nibble is >= 8 must not be parsed as negative.
+        var big = "f".PadRight(64, 'f'); // 2^256 - 16^63-ish, top nibble 0xf
+        var data = "0x03dee4c5" + Word("aaa") + big + Word("1") + Word("bbb");
+
+        var info = RevertClassifier.TryDecodeInsufficientBalance(data);
+
+        Assert.That(info, Is.Not.Null);
+        Assert.That(info!.Value.Balance.Sign, Is.EqualTo(1)); // strictly positive
+    }
+
+    [Test]
+    public void DecodeInsufficientBalance_NullForWrongSelectorOrTruncated()
+    {
+        Assert.That(RevertClassifier.TryDecodeInsufficientBalance(AddressUintRevert("aaa", "bbb", "21")), Is.Null);
+        Assert.That(RevertClassifier.TryDecodeInsufficientBalance(null), Is.Null);
+        Assert.That(RevertClassifier.TryDecodeInsufficientBalance(""), Is.Null);
+        Assert.That(RevertClassifier.TryDecodeInsufficientBalance("0x03dee4c5" + Word("aaa")), Is.Null); // too short
+    }
+
+    // ── DriftBucket boundaries (feed the circles_canary_balance_drift_total metric label) ──
+
+    [TestCase(1, 1, "le_1x")]
+    [TestCase(3, 1, "ge_2x")]
+    [TestCase(10, 1, "ge_10x")]
+    [TestCase(100, 1, "ge_100x")]
+    [TestCase(5, 0, "zero_balance")]
+    [TestCase(0, 0, "none")]
+    public void DriftBucket_BucketsByNeededOverOnChainRatio(int needed, int onChain, string expected)
+    {
+        var bucket = RevertClassifier.DriftBucket(
+            (System.Numerics.BigInteger)needed, (System.Numerics.BigInteger)onChain);
+        Assert.That(bucket, Is.EqualTo(expected));
+    }
 }

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -1,3 +1,6 @@
+using System.Globalization;
+using System.Numerics;
+
 namespace Circles.Pathfinder.Simulation;
 
 /// <summary>
@@ -162,4 +165,85 @@ public static class RevertClassifier
 
     private static bool Contains(string data, string selector)
         => data.Contains(selector[2..]); // strip 0x prefix for matching
+
+    /// <summary>
+    /// Decoded fields of an OpenZeppelin ERC1155InsufficientBalance revert (selector 0x03dee4c5):
+    /// ERC1155InsufficientBalance(address sender, uint256 balance, uint256 needed, uint256 tokenId).
+    /// For the Circles canary this is the cache-balance-drift signal: <see cref="Holder"/> tried to
+    /// send <see cref="Needed"/> of token <see cref="Token"/> but held only <see cref="Balance"/>
+    /// on-chain (at the eth_call's graphBlock). needed ≫ balance ⇒ the graph source fed an inflated
+    /// balance. tokenId is uint160(token), so <see cref="Token"/> is its low 20 bytes.
+    /// </summary>
+    public readonly record struct InsufficientBalanceInfo(
+        string Holder, BigInteger Balance, BigInteger Needed, string Token);
+
+    /// <summary>
+    /// Decode the four ABI words of an ERC1155InsufficientBalance revert. Returns null if the data
+    /// does not contain the selector, is too short, or is non-hex.
+    /// </summary>
+    public static InsufficientBalanceInfo? TryDecodeInsufficientBalance(string? revertData)
+    {
+        if (string.IsNullOrEmpty(revertData))
+            return null;
+
+        var lower = revertData.ToLowerInvariant();
+        var selectorHex = ERC1155InsufficientBalance[2..]; // "03dee4c5"
+        int selectorPos = lower.IndexOf(selectorHex, StringComparison.Ordinal);
+        if (selectorPos < 0)
+            return null;
+
+        // After the selector: sender(32) + balance(32) + needed(32) + tokenId(32) = 256 hex chars.
+        int start = selectorPos + selectorHex.Length;
+        if (start + 256 > lower.Length)
+            return null;
+
+        var holder = AddressFromWord(lower, start);
+        var balance = UintFromWord(lower, start + 64);
+        var needed = UintFromWord(lower, start + 128);
+        var token = AddressFromWord(lower, start + 192);
+
+        if (holder is null || token is null || balance is null || needed is null)
+            return null;
+
+        return new InsufficientBalanceInfo(holder, balance.Value, needed.Value, token);
+    }
+
+    // An ABI address word: 32 bytes (64 hex) with the 20-byte address right-aligned in the low bytes.
+    private static string? AddressFromWord(string lowerData, int wordHexStart)
+    {
+        var word = lowerData.AsSpan(wordHexStart, 64);
+        foreach (var c in word)
+            if (HexVal(c) < 0)
+                return null;
+        return "0x" + word[24..].ToString(); // last 40 hex = 20-byte address
+    }
+
+    // An ABI uint256 word as a non-negative BigInteger. The "0" prefix guards the sign bit
+    // (BigInteger.Parse treats a leading hex digit ≥ 8 as negative otherwise).
+    private static BigInteger? UintFromWord(string lowerData, int wordHexStart)
+    {
+        var word = lowerData.AsSpan(wordHexStart, 64);
+        foreach (var c in word)
+            if (HexVal(c) < 0)
+                return null;
+        return BigInteger.Parse("0" + word.ToString(), NumberStyles.HexNumber);
+    }
+
+    /// <summary>
+    /// Low-cardinality bucket for the needed/on-chain-balance ratio (used as a metric label
+    /// on <c>circles_canary_balance_drift_total</c>). Pure logic, kept next to the decoder so
+    /// both canary paths and the test suite share one definition.
+    /// </summary>
+    public static string DriftBucket(BigInteger needed, BigInteger onChain)
+    {
+        if (onChain <= 0)
+            return needed > 0 ? "zero_balance" : "none";
+        if (needed <= onChain)
+            return "le_1x";
+        var floorRatio = needed / onChain; // integer floor; needed > onChain ⇒ ≥ 1
+        if (floorRatio >= 100) return "ge_100x";
+        if (floorRatio >= 10) return "ge_10x";
+        if (floorRatio >= 2) return "ge_2x";
+        return "ge_1x";
+    }
 }


### PR DESCRIPTION
## What
Adds cache-balance-drift detection to the pathfinder simulation canary.

When a simulated path reverts on-chain with `ERC1155InsufficientBalance(holder, balance, needed, tokenId)`, the canary decodes that payload — which it already receives, evaluated at the graph block — and emits:
- metric `circles_canary_balance_drift_total{bucket}` — low-cardinality ratio buckets (`ge_2x`/`ge_10x`/`ge_100x`/…)
- a structured ERROR log identifying holder, token, on-chain balance, required amount, and drift bucket

This surfaces transient divergence between the served graph balance and on-chain state at the moment it occurs, before the graph self-heals on its next refresh — a signal that is otherwise invisible because a post-hoc probe reads already-healed state.

## How
- `RevertClassifier.TryDecodeInsufficientBalance` + `DriftBucket`: bounds- and hex-validated, sign-guarded `BigInteger` parse; holder/token kept out of metric labels (log only) to bound Prometheus cardinality
- emitted from both the `eth_call` and `eth_simulateV1` bundle simulation paths
- decodes from the same source the classifier uses (`data ?? message`)

## Test plan
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter RevertClassifier` — 43 passed (incl. 9 new: decoder positive/sign-guard/null + 6 bucket boundaries)
- [ ] Post-deploy: confirm `circles_canary_balance_drift_total` is exposed; existing canary alerts unaffected (new metric is purely additive)