### PR TITLE
feat(rpc): block-pin circles_getTokenBalances token-exposure query

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -119,7 +119,9 @@ public partial class CirclesRpcModule
                 FROM public.""CrcV2_Erc20WrapperTransfer"" wt
                 JOIN public.""CrcV2_ERC20WrapperDeployed"" wd
                   ON wd.""erc20Wrapper"" = wt.""tokenAddress"" AND wd.""circlesType"" = 1
-                WHERE wt.""to"" = @address OR wt.""from"" = @address
+                  AND wd.""blockNumber"" <= @maxBlock
+                WHERE (wt.""to"" = @address OR wt.""from"" = @address)
+                  AND wt.""blockNumber"" <= @maxBlock
                 GROUP BY wt.""tokenAddress"", wd.avatar
                 HAVING SUM(CASE
                     WHEN wt.""to"" = @address THEN wt.amount
@@ -140,14 +142,20 @@ public partial class CirclesRpcModule
                              ELSE 0
                          END)
                          * POWER(0.9998013320085989574306481700129226782902039065082930593676448873,
-                             (EXTRACT(EPOCH FROM NOW())::bigint - 1602720000) / 86400
+                             (CASE WHEN @maxBlock >= 9223372036854775807
+                                   THEN EXTRACT(EPOCH FROM NOW())::bigint
+                                   ELSE (SELECT COALESCE(MAX(""timestamp""), EXTRACT(EPOCH FROM NOW())::bigint)
+                                         FROM ""System_Block"" WHERE ""blockNumber"" <= @maxBlock)
+                              END - 1602720000) / 86400
                              - (MAX(wt.""timestamp"") - 1602720000) / 86400
                          )
                        ) as balance
                 FROM public.""CrcV2_Erc20WrapperTransfer"" wt
                 JOIN public.""CrcV2_ERC20WrapperDeployed"" wd
                   ON wd.""erc20Wrapper"" = wt.""tokenAddress"" AND wd.""circlesType"" = 0
-                WHERE wt.""to"" = @address OR wt.""from"" = @address
+                  AND wd.""blockNumber"" <= @maxBlock
+                WHERE (wt.""to"" = @address OR wt.""from"" = @address)
+                  AND wt.""blockNumber"" <= @maxBlock
                 GROUP BY wt.""tokenAddress"", wd.avatar
                 HAVING SUM(CASE
                     WHEN wt.""to"" = @address THEN wt.amount
@@ -163,8 +171,9 @@ public partial class CirclesRpcModule
                      , s.""user"" as ""tokenOwner""
                      , v1.""totalBalance"" as balance
                      , false as ""isGroup""
-                FROM  public.""V_CrcV1_BalancesByAccountAndToken"" v1
+                FROM  ""V_CrcV1_BalancesByAccountAndToken"" v1
                 JOIN  public.""CrcV1_Signup"" s ON s.token = v1.""tokenAddress""
+                  AND s.""blockNumber"" <= @maxBlock
                 WHERE v1.account = @address
                   AND v1.""totalBalance"" > 0
 
@@ -182,8 +191,9 @@ public partial class CirclesRpcModule
                      , v2.""tokenAddress"" as ""tokenOwner""
                      , v2.""demurragedTotalBalance"" as balance
                      , rh.avatar IS NULL as ""isGroup""
-                FROM  public.""V_CrcV2_BalancesByAccountAndToken"" v2
+                FROM  ""V_CrcV2_BalancesByAccountAndToken"" v2
                 LEFT JOIN ""CrcV2_RegisterHuman"" rh ON rh.avatar = v2.""tokenAddress""
+                  AND rh.""blockNumber"" <= @maxBlock
                 WHERE v2.account = @address
                   AND v2.""totalBalance"" > 0
 
@@ -193,6 +203,7 @@ public partial class CirclesRpcModule
                 SELECT swb.*, rg.""group"" IS NOT NULL as ""isGroup""
                 FROM static_wrapped_balances swb
                 LEFT JOIN ""CrcV2_RegisterGroup"" rg ON rg.""group"" = swb.""tokenOwner""
+                  AND rg.""blockNumber"" <= @maxBlock
 
                 UNION ALL
 
@@ -200,6 +211,7 @@ public partial class CirclesRpcModule
                 SELECT dwb.*, rg.""group"" IS NOT NULL as ""isGroup""
                 FROM demurraged_wrapped_balances dwb
                 LEFT JOIN ""CrcV2_RegisterGroup"" rg ON rg.""group"" = dwb.""tokenOwner""
+                  AND rg.""blockNumber"" <= @maxBlock
             )
             SELECT ""tokenAddress"", ""type"", ""tokenOwner"", balance, ""isGroup""
             FROM tokens
@@ -208,13 +220,17 @@ public partial class CirclesRpcModule
 
         // Route through CreateConnectionAsync (not the raw datasource) so this read joins the
         // request's connection funnel and carries the same block GUC + search_path. Inert without
-        // the header (production). NOTE: the balance CTEs below are still `public."..."`-qualified,
-        // so they read head until their pinned twins land and the qualifiers are dropped (a later
-        // phase); for now this reroute propagates the GUC and pins only the unqualified register
-        // lookups. Pairing with the block-keyed cache above keeps head and block-N results separate.
+        // the header (production): @maxBlock binds to bigint max, so every "blockNumber" <= @maxBlock
+        // filter is a no-op, the de-qualified V1/V2 balance views resolve to public (the twin schema
+        // does not exist on prod), and the demurrage anchor stays NOW() — byte-identical to prior
+        // behaviour. Under a header, ConnectionPinning has SET search_path = circles_at_block, public,
+        // so the de-qualified views resolve to the pinned twins and @maxBlock = the header block, so
+        // the raw-table CTEs (wrappers / signup / register) and the demurrage anchor all reconstruct
+        // as-of block N. The block-keyed cache above keeps head and block-N results separate.
         await using var connection = await CreateConnectionAsync();
         await using var command = new NpgsqlCommand(sql, connection);
         command.Parameters.AddWithValue("address", lowerAddress);
+        command.Parameters.AddWithValue("maxBlock", pinnedBlock ?? long.MaxValue);
 
         var tokenExposureIds = new Dictionary<string, TokenExposureInfo>();
         await using var reader = await command.ExecuteReaderAsync();


### PR DESCRIPTION
## Summary
Phase 2 (plugin side) of test-env block-pinning. Fully pins `GetTokenExposureIdsAsync` (behind `circles_getTokenBalances`) so a request carrying `X-Max-Block-Number` reconstructs token exposure as-of block N instead of returning a head/block-N mix.

## What changed (one method, `CirclesRpcModule.Tokens.cs`)
- Bind `@maxBlock` = header block, or `long.MaxValue` when absent.
- Add `"blockNumber" <= @maxBlock` to every raw-table scan: ERC20 wrapper transfers + `CrcV2_ERC20WrapperDeployed`, `CrcV1_Signup`, and the `CrcV2_RegisterHuman`/`CrcV2_RegisterGroup` classification joins.
- Anchor the demurraged-wrapper decay to the block-N timestamp when pinned (`CASE WHEN @maxBlock >= bigint-max THEN NOW() ELSE max(System_Block.timestamp where blockNumber <= N)`), keeping head behaviour byte-identical.
- De-qualify the `V_CrcV1_/V_CrcV2_BalancesByAccountAndToken` view references so they resolve to the pinned twins under the header-gated `search_path` (and to `public`, unchanged, without a header).

## Inertness (production path unchanged)
With no header, `@maxBlock = bigint max` makes every `blockNumber <= @maxBlock` a no-op, the demurrage `CASE` collapses to `NOW()`, and the de-qualified views resolve to `public` (the `circles_at_block` twin schema does not exist on production). The query is provably byte-identical to the previous one on the no-header path.

## Verification
- Live staging: rewritten query @ head (no pin) is byte-identical to the original (symmetric `EXCEPT` = 0, 8 = 8 rows for a wrapper-holding address); executes cleanly when pinned (8 → 0 at block 44M).
- Data invariant confirmed: `CrcV2_Erc20WrapperTransfer.timestamp` equals its block's `System_Block.timestamp` for all rows, so the demurrage exponent cannot go negative under pinning.
- `@maxBlock` and the `circles.max_block_number` GUC both derive from the same `GetMaxBlockNumberFromHeader()` call within a request — they cannot diverge.

## Deploy ordering
Deploy **after** the companion test-env change that adds the `V_CrcV1_/V_CrcV2_BalancesByAccountAndToken` twins to the `circles_at_block` schema — the de-qualified references resolve to those twins, which must already exist in the DB.

## Test plan
- [ ] Build green (`dotnet build -c Release`)
- [ ] After deploy: `circles_getTokenBalances` with no header returns unchanged results
- [ ] With `X-Max-Block-Number` at a past block, returned balances differ from head