### PR TITLE
fix(cache): harden V2 balance live-delta path (monotonic flush + deep-reorg detection)

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/BackgroundServiceTests.cs
@@ -262,6 +262,59 @@ public class NotificationListenerServiceTests
         caches.V1Avatars.Count.Should().Be(0);
     }
 
+    [Fact]
+    public async Task DeepReorg_BeyondRollbackCapacity_WithinDetectionWindow_TriggersFullRewarmup()
+    {
+        // The reorg-detection window (12) is wider than the rollback capacity (3). A reorg 8 blocks
+        // deep (block 12 with head 20) is OUTSIDE the rollback window but INSIDE the detection
+        // window, so the block ring buffer still retains block 12 and detects the hash change.
+        // Because it's deeper than the rollback capacity, RollbackAll throws "beyond stored history"
+        // (caught) → full re-warmup, the safe recovery. With a buffer sized only to RollbackCapacity
+        // (the pre-decoupling behavior) block 12 would have been evicted and the reorg silently
+        // missed, leaving balances desynced.
+        var settings = new CacheServiceSettings
+        {
+            RollbackCapacity = 3,
+            ReorgDetectionWindow = 12,
+            PostgresConnectionString = "Host=localhost"
+        };
+        var state = new CacheServiceState(settings.RollbackCapacity, settings.ReorgDetectionWindow)
+        {
+            LastProcessedBlock = 20,
+            WarmupComplete = true,
+            WarmupTargetBlock = 5,
+            CurrentBlockTimestamp = 12345
+        };
+
+        // Seed the detection-window buffer with blocks 9..20 (old hashes).
+        state.BlockRingBuffer.UpdateFromBlocks(
+            Enumerable.Range(9, 12).Select(b => ((long)b, $"0x{b}-old")).ToArray());
+
+        var caches = new CacheContainer(settings.RollbackCapacity);
+        SeedAllCachesAtBlock(caches, 17);
+        // Only the last RollbackCapacity (3) blocks of diffs are retained → oldest is 18, so a
+        // rollback to block 12 is beyond stored history and throws.
+        caches.V1Avatars.Add(18, "0xa", ("CrcV1_Signup", "0xt"));
+        caches.V1Avatars.Add(19, "0xb", ("CrcV1_Signup", "0xt"));
+        caches.V1Avatars.Add(20, "0xc", ("CrcV1_Signup", "0xt"));
+
+        // Block 12's hash changed (reorg 8 deep, above the warmup boundary 5).
+        var blocks = Enumerable.Range(9, 12)
+            .Select(b => ((long)b, b == 12 ? "0x12-new" : $"0x{b}-old"))
+            .ToList();
+
+        var service = new TestNotificationListenerService(settings, state, caches, blocks);
+
+        await service.InvokeHandleAsync("{}", CancellationToken.None);
+
+        // Deep reorg detected → RollbackAll threw → full re-warmup (not a silent miss, not a normal
+        // forward process).
+        service.ProcessedRanges.Should().BeEmpty();
+        state.WarmupComplete.Should().BeFalse();
+        state.LastProcessedBlock.Should().Be(-1);
+        caches.V1Avatars.Count.Should().Be(0);
+    }
+
     private sealed class TestNotificationListenerService : NotificationListenerService
     {
         private readonly List<(long BlockNumber, string BlockHash)> _blocks;

--- a/src/Cache/Circles.Cache.Service.Tests/CacheServiceStateTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CacheServiceStateTests.cs
@@ -20,6 +20,27 @@ public class CacheServiceStateTests
     }
 
     [Fact]
+    public void ReorgDetectionWindow_DetectsReorgsDeeperThanRollbackCapacity()
+    {
+        // With the detection window decoupled from (and larger than) the rollback window, the
+        // block ring buffer retains enough hashes to DETECT a reorg deeper than the rollback
+        // window. The listener then triggers a safe full re-warmup instead of silently missing it.
+        const int rollbackCapacity = 12;
+        const int detectionWindow = 256;
+        var wide = new CacheServiceState(rollbackCapacity, detectionWindow).BlockRingBuffer;
+        for (long b = 1; b <= 200; b++) wide.Add(b, $"0xhash{b}");
+
+        // A reorg 100 blocks deep (within the 256 detection window) is detected.
+        wide.UpdateFromBlocks(new[] { (100L, "0xCHANGED") }).Should().Be(100L);
+
+        // A buffer sized to the rollback capacity alone (the pre-decoupling behavior, i.e. no
+        // detection window supplied) evicted block 100 long ago, so the same reorg is invisible.
+        var narrow = new CacheServiceState(rollbackCapacity).BlockRingBuffer;
+        for (long b = 1; b <= 200; b++) narrow.Add(b, $"0xhash{b}");
+        narrow.UpdateFromBlocks(new[] { (100L, "0xCHANGED") }).Should().BeNull();
+    }
+
+    [Fact]
     public void IsReady_ShouldRequireWarmupListenerAndAcceptableLag()
     {
         var state = new CacheServiceState(rollbackCapacity: 4)

--- a/src/Cache/Circles.Cache.Service.Tests/CacheServiceStateTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/CacheServiceStateTests.cs
@@ -41,6 +41,38 @@ public class CacheServiceStateTests
     }
 
     [Fact]
+    public void DefaultCtor_WithoutDetectionWindow_SizesBufferToRollbackCapacity()
+    {
+        // The optional reorgDetectionWindow defaults to rollbackCapacity, preserving the
+        // pre-decoupling behavior for every existing single-arg caller.
+        var buf = new CacheServiceState(rollbackCapacity: 5).BlockRingBuffer;
+        for (long b = 1; b <= 20; b++) buf.Add(b, $"0xhash{b}");
+        // Only the last 5 blocks are retained, so a reorg at block 10 (15 deep) is not detected.
+        buf.UpdateFromBlocks(new[] { (10L, "0xCHANGED") }).Should().BeNull();
+        // ...but a reorg within the last 5 (block 16) is.
+        buf.UpdateFromBlocks(new[] { (16L, "0xCHANGED") }).Should().Be(16L);
+    }
+
+    [Theory]
+    [InlineData(12, 12, true)]    // window == capacity: allowed (boundary)
+    [InlineData(12, 256, true)]   // window > capacity: allowed
+    [InlineData(12, 11, false)]   // window < capacity: rejected
+    [InlineData(12, 10001, false)] // window > max: rejected
+    public void Validate_EnforcesReorgDetectionWindowBounds(int rollbackCapacity, int detectionWindow, bool valid)
+    {
+        var settings = new CacheServiceSettings
+        {
+            PostgresConnectionString = "Host=localhost",
+            RollbackCapacity = rollbackCapacity,
+            ReorgDetectionWindow = detectionWindow
+        };
+
+        var act = () => settings.Validate();
+        if (valid) act.Should().NotThrow();
+        else act.Should().Throw<InvalidOperationException>().WithMessage("*REORG_DETECTION_WINDOW*");
+    }
+
+    [Fact]
     public void IsReady_ShouldRequireWarmupListenerAndAcceptableLag()
     {
         var state = new CacheServiceState(rollbackCapacity: 4)

--- a/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
@@ -648,6 +648,76 @@ public class IntegrationTests : IAsyncLifetime
         latestValue.Should().Be("after");
     }
 
+    [RequiresDockerFact]
+    public async Task NotificationListener_V2_WrapperBlockBeforeErc1155Block_InSameRange_DoesNotThrowAndBalancesCorrect()
+    {
+        // Repro for the cross-handler block-monotonicity crash.
+        // ProcessV2EventsAsync runs the ERC1155 transfer handler then the ERC20-wrapper transfer
+        // handler against the SAME V2BalancesByAccountAndToken cache. When a wrapper transfer sits
+        // at a LOWER block than the highest ERC1155 transfer block in the same range, the wrapper
+        // handler's per-block flush calls RollbackCache.Add with a block < the cache's last block,
+        // which throws "Block number must be monotonically increasing". Wrap/unwrap-heavy avatars
+        // (whose 1155 and wrapper transfers interleave across blocks in one batch) trigger this.
+        var avatar = "0x00000000000000000000000000000000000000a7";  // 1155 token owner
+        var wrapper = "0x00000000000000000000000000000000000000b7"; // erc20 wrapper contract
+        var holder = "0x00000000000000000000000000000000000000c7";
+        var zero = "0x0000000000000000000000000000000000000000";
+        const long wrapperBlock = 9400;  // LOWER
+        const long erc1155Block = 9401;   // HIGHER
+        var wei = BigInteger.Parse("5000000000000000000"); // 5 * 10^18 = 5 tokens
+
+        await using (var conn = new NpgsqlConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+
+            // Register the avatar (validates its 1155 token) and deploy a wrapper (validates the
+            // wrapper token) at the lower block — both are processed before transfers in ProcessV2EventsAsync.
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_RegisterHuman"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""avatar"",""inviter"")
+                  VALUES (@b,1,0,0,'0xrh',@a,'0x0')",
+                ("b", wrapperBlock), ("a", avatar));
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_ERC20WrapperDeployed"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",avatar,""erc20Wrapper"",""circlesType"")
+                  VALUES (@b,1,0,1,'0xwd',@a,@w,0)",
+                ("b", wrapperBlock), ("a", avatar), ("w", wrapper));
+
+            // Wrapper transfer (mint to holder) at the LOWER block.
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_Erc20WrapperTransfer"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""tokenAddress"",""from"",""to"",amount)
+                  VALUES (@b,1,0,2,'0xwt',@w,@z,@h,@amt)",
+                ("b", wrapperBlock), ("w", wrapper), ("z", zero), ("h", holder), ("amt", wei));
+
+            // ERC1155 transfer (mint to holder) at the HIGHER block.
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_TransferSingle"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""operator"",""from"",""to"",id,value,""tokenAddress"")
+                  VALUES (@b,1,0,0,'0xts','0xop',@z,@h,1,@amt,@t)",
+                ("b", erc1155Block), ("z", zero), ("h", holder), ("amt", wei), ("t", avatar));
+        }
+
+        var settings = new CacheServiceSettings { PostgresConnectionString = _connectionString! };
+        var state = new CacheServiceState(rollbackCapacity: 12);
+        var caches = new CacheContainer(rollbackCapacity: 12);
+        await using var dataSource = NpgsqlDataSource.Create(_connectionString!);
+        var listener = new TestableNotificationListenerService(settings, state, caches, dataSource);
+
+        // Before the fix this throws ArgumentException (monotonic violation). After: succeeds.
+        var act = async () => await listener.ProcessRangeAsync(wrapperBlock, erc1155Block, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        // Both balances must be present and correct (disjoint token namespaces).
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{holder}:{avatar}", out var erc1155Bal).Should().BeTrue();
+        erc1155Bal.Should().Be(5m);
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{holder}:{wrapper}", out var wrapperBal).Should().BeTrue();
+        wrapperBal.Should().Be(5m);
+    }
+
+    private static async Task ExecAsync(NpgsqlConnection conn, string sql, params (string Name, object Value)[] ps)
+    {
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        foreach (var (name, value) in ps) cmd.Parameters.AddWithValue(name, value);
+        await cmd.ExecuteNonQueryAsync();
+    }
+
     private sealed class TestableNotificationListenerService : NotificationListenerService
     {
         public TestableNotificationListenerService(

--- a/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
@@ -711,6 +711,69 @@ public class IntegrationTests : IAsyncLifetime
         wrapperBal.Should().Be(5m);
     }
 
+    [RequiresDockerFact]
+    public async Task NotificationListener_V2_SenderDebits_AcrossInterleavedBlocks_BalancesCorrect()
+    {
+        // Exercises the merged path's SENDER-DEBIT branch (from != 0x0) for BOTH token namespaces
+        // across interleaved blocks, with wrapper transfers at a lower block than 1155 transfers
+        // (the monotonicity-crash trigger). Verifies the debit arithmetic the #74 drift concerns.
+        var avatar = "0x00000000000000000000000000000000000000a8";  // 1155 token owner
+        var wrapper = "0x00000000000000000000000000000000000000b8"; // erc20 wrapper contract
+        var holder = "0x00000000000000000000000000000000000000c8";
+        var recipient = "0x00000000000000000000000000000000000000d8";
+        var zero = "0x0000000000000000000000000000000000000000";
+        var ten = BigInteger.Parse("10000000000000000000"); // 10
+        var three = BigInteger.Parse("3000000000000000000"); // 3
+        var four = BigInteger.Parse("4000000000000000000"); // 4
+
+        await using (var conn = new NpgsqlConnection(_connectionString))
+        {
+            await conn.OpenAsync();
+            // Registration + wrapper deploy at block 9499 (before transfers).
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_RegisterHuman"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""avatar"",""inviter"")
+                  VALUES (9499,1,0,0,'0xrh',@a,'0x0')", ("a", avatar));
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_ERC20WrapperDeployed"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",avatar,""erc20Wrapper"",""circlesType"")
+                  VALUES (9499,1,0,1,'0xwd',@a,@w,0)", ("a", avatar), ("w", wrapper));
+
+            // Block 9500 mints: 1155 to holder, wrapper to holder.
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_TransferSingle"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""operator"",""from"",""to"",id,value,""tokenAddress"")
+                  VALUES (9500,1,0,0,'0xm1','0xop',@z,@h,1,@v,@t)", ("z", zero), ("h", holder), ("v", ten), ("t", avatar));
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_Erc20WrapperTransfer"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""tokenAddress"",""from"",""to"",amount)
+                  VALUES (9500,1,0,1,'0xmw',@w,@z,@h,@v)", ("w", wrapper), ("z", zero), ("h", holder), ("v", ten));
+
+            // Block 9501 sends (DEBITS from holder): 1155 H->R (3), wrapper H->R (4).
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_TransferSingle"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""operator"",""from"",""to"",id,value,""tokenAddress"")
+                  VALUES (9501,1,0,0,'0xs1','0xop',@h,@r,1,@v,@t)", ("h", holder), ("r", recipient), ("v", three), ("t", avatar));
+            await ExecAsync(conn,
+                @"INSERT INTO ""CrcV2_Erc20WrapperTransfer"" (""blockNumber"",""timestamp"",""transactionIndex"",""logIndex"",""transactionHash"",""tokenAddress"",""from"",""to"",amount)
+                  VALUES (9501,1,0,1,'0xsw',@w,@h,@r,@v)", ("w", wrapper), ("h", holder), ("r", recipient), ("v", four));
+        }
+
+        var settings = new CacheServiceSettings { PostgresConnectionString = _connectionString! };
+        var state = new CacheServiceState(rollbackCapacity: 12);
+        var caches = new CacheContainer(rollbackCapacity: 12);
+        await using var dataSource = NpgsqlDataSource.Create(_connectionString!);
+        var listener = new TestableNotificationListenerService(settings, state, caches, dataSource);
+
+        var act = async () => await listener.ProcessRangeAsync(9499, 9501, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        // Holder debited on both tokens; recipient credited; arithmetic correct across the merged pass.
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{holder}:{avatar}", out var hA).Should().BeTrue();
+        hA.Should().Be(7m); // 10 - 3
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{recipient}:{avatar}", out var rA).Should().BeTrue();
+        rA.Should().Be(3m);
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{holder}:{wrapper}", out var hW).Should().BeTrue();
+        hW.Should().Be(6m); // 10 - 4
+        caches.V2BalancesByAccountAndToken.TryGetValue($"{recipient}:{wrapper}", out var rW).Should().BeTrue();
+        rW.Should().Be(4m);
+    }
+
     private static async Task ExecAsync(NpgsqlConnection conn, string sql, params (string Name, object Value)[] ps)
     {
         await using var cmd = new NpgsqlCommand(sql, conn);

--- a/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/PathfinderGraphControllerTests.cs
@@ -827,8 +827,10 @@ public class PathfinderGraphControllerTests
         source.Should().NotBeNull("ProcessV2TransfersAsync method definition should exist in some NotificationListenerService partial");
         methodStart.Should().BeGreaterThan(0, "ProcessV2TransfersAsync method definition should exist");
 
-        // Extract the method's SQL + reader section — SQL is ~800 chars, reader access ~400 more
-        var methodBody = source.Substring(methodStart, Math.Min(2000, source.Length - methodStart));
+        // Extract the method's SQL + reader section. The method merges three transfer sources
+        // (TransferSingle + TransferBatch + Erc20WrapperTransfer) into one UNION ALL, so the SQL +
+        // doc comment run longer than a single-table query; widen the window to reach the reader.
+        var methodBody = source.Substring(methodStart, Math.Min(3500, source.Length - methodStart));
 
         // The SQL SELECT should use tokenAddress (double-quoted in SQL verbatim string)
         // In the source code: ""tokenAddress"" (C# escaped) renders as "tokenAddress" in SQL

--- a/src/Cache/Circles.Cache.Service/BlockRingBuffer.cs
+++ b/src/Cache/Circles.Cache.Service/BlockRingBuffer.cs
@@ -13,7 +13,11 @@ public class BlockRingBuffer
     /// <summary>
     /// Creates a new block ring buffer with the specified capacity.
     /// </summary>
-    /// <param name="capacity">The number of blocks to retain (should match rollback capacity)</param>
+    /// <param name="capacity">
+    /// The number of recent block hashes to retain. Sized to the reorg-detection window
+    /// (REORG_DETECTION_WINDOW), which is decoupled from — and typically larger than — the
+    /// balance-diff rollback capacity, so reorgs deeper than the rollback window are still detected.
+    /// </param>
     public BlockRingBuffer(int capacity)
     {
         if (capacity < 1)

--- a/src/Cache/Circles.Cache.Service/CacheServiceSettings.cs
+++ b/src/Cache/Circles.Cache.Service/CacheServiceSettings.cs
@@ -34,6 +34,19 @@ public class CacheServiceSettings
     public int RollbackCapacity { get; init; } = 12;
 
     /// <summary>
+    /// Number of recent block hashes retained for reorg DETECTION (the BlockRingBuffer size and the
+    /// number of blocks fetched per notification). Decoupled from <see cref="RollbackCapacity"/>:
+    /// the rollback fast-path can only undo <see cref="RollbackCapacity"/> blocks of balance diffs,
+    /// but reorgs deeper than that must still be DETECTED so they trigger a safe full re-warmup
+    /// instead of being silently missed (which leaves the in-memory balances desynced from the DB
+    /// until the next rewarmup). Block hashes are cheap (~70 bytes each), so this can be much larger
+    /// than the rollback window. Must be >= RollbackCapacity.
+    /// Environment variable: REORG_DETECTION_WINDOW
+    /// Default: 256 blocks
+    /// </summary>
+    public int ReorgDetectionWindow { get; init; } = 256;
+
+    /// <summary>
     /// Maximum lag (in blocks) allowed before the service is considered "not ready".
     /// Environment variable: MAX_CATCHUP_LAG
     /// Default: 10 blocks
@@ -79,6 +92,12 @@ public class CacheServiceSettings
                 $"ROLLBACK_CAPACITY must be between 1 and 1000 (got {RollbackCapacity})");
         }
 
+        if (ReorgDetectionWindow < RollbackCapacity || ReorgDetectionWindow > 10000)
+        {
+            throw new InvalidOperationException(
+                $"REORG_DETECTION_WINDOW must be between RollbackCapacity ({RollbackCapacity}) and 10000 (got {ReorgDetectionWindow})");
+        }
+
         if (MaxCatchupLag < 0)
         {
             throw new InvalidOperationException(
@@ -104,6 +123,10 @@ public class CacheServiceSettings
                 int.TryParse(Environment.GetEnvironmentVariable("ROLLBACK_CAPACITY"), out var capacity)
                     ? capacity
                     : 12,
+            ReorgDetectionWindow =
+                int.TryParse(Environment.GetEnvironmentVariable("REORG_DETECTION_WINDOW"), out var detectionWindow)
+                    ? detectionWindow
+                    : 256,
             MaxCatchupLag =
                 int.TryParse(Environment.GetEnvironmentVariable("MAX_CATCHUP_LAG"), out var lag)
                     ? lag

--- a/src/Cache/Circles.Cache.Service/CacheServiceState.cs
+++ b/src/Cache/Circles.Cache.Service/CacheServiceState.cs
@@ -18,9 +18,15 @@ public class CacheServiceState
     /// </summary>
     public BlockRingBuffer BlockRingBuffer { get; }
 
-    public CacheServiceState(int rollbackCapacity)
+    /// <param name="rollbackCapacity">Blocks of balance-diff history retained for rollback.</param>
+    /// <param name="reorgDetectionWindow">
+    /// Block hashes retained for reorg detection. Defaults to <paramref name="rollbackCapacity"/>
+    /// when not supplied (preserves the pre-decoupling behavior). When larger, reorgs deeper than
+    /// the rollback window are still detected and trigger a safe full re-warmup.
+    /// </param>
+    public CacheServiceState(int rollbackCapacity, int? reorgDetectionWindow = null)
     {
-        BlockRingBuffer = new BlockRingBuffer(rollbackCapacity);
+        BlockRingBuffer = new BlockRingBuffer(reorgDetectionWindow ?? rollbackCapacity);
     }
 
     /// <summary>

--- a/src/Cache/Circles.Cache.Service/Program.cs
+++ b/src/Cache/Circles.Cache.Service/Program.cs
@@ -42,7 +42,7 @@ var readonlyDataSource = readonlyDsBuilder.Build();
 builder.Services.AddSingleton(readonlyDataSource);
 
 // Register cache infrastructure
-builder.Services.AddSingleton(sp => new CacheServiceState(settings.RollbackCapacity));
+builder.Services.AddSingleton(sp => new CacheServiceState(settings.RollbackCapacity, settings.ReorgDetectionWindow));
 builder.Services.AddSingleton(sp => new CacheContainer(settings.RollbackCapacity));
 builder.Services.AddSingleton(sp =>
 {
@@ -126,6 +126,7 @@ logger.LogInformation("PostgreSQL Pool: min={MinPool}, max={MaxPool}",
     readonlyDsBuilder.ConnectionStringBuilder.MaxPoolSize);
 logger.LogInformation("PG Notify Channel: {Channel}", settings.PgNotifyChannel);
 logger.LogInformation("Rollback Capacity: {Capacity} blocks", settings.RollbackCapacity);
+logger.LogInformation("Reorg Detection Window: {Window} blocks", settings.ReorgDetectionWindow);
 logger.LogInformation("Max Catchup Lag: {Lag} blocks", settings.MaxCatchupLag);
 logger.LogInformation("HTTP Port: {Port}", settings.Port);
 logger.LogInformation("=======================================");

--- a/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.V2Registry.cs
+++ b/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.V2Registry.cs
@@ -27,11 +27,10 @@ public partial class NotificationListenerService
         // Process V2 ERC20WrapperDeployed
         await ProcessV2Erc20WrapperDeployedAsync(conn, fromBlock, toBlock, ct);
 
-        // Process V2 Transfers (for balance updates)
+        // Process V2 Transfers for balance updates — ERC1155 (TransferSingle + TransferBatch)
+        // AND ERC20 wrapper transfers, merged into a single block-ordered pass so the shared
+        // balance cache receives a single monotonic flush sequence (see V2Transfers.cs).
         await ProcessV2TransfersAsync(conn, fromBlock, toBlock, ct);
-
-        // Process V2 ERC20 Wrapper Transfers (for balance updates)
-        await ProcessV2Erc20WrapperTransfersAsync(conn, fromBlock, toBlock, ct);
 
         // Process V2 UpdateMetadataDigest (for CID maps)
         await ProcessV2UpdateMetadataDigestAsync(conn, fromBlock, toBlock, ct);

--- a/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.V2Transfers.cs
+++ b/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.V2Transfers.cs
@@ -6,13 +6,28 @@ namespace Circles.Cache.Service.Services;
 
 /// <summary>
 /// Per-block incremental processing for Circles V2 transfer events.
-/// Covers both the 1155 hub (TransferSingle + TransferBatch) and ERC20 wrapper transfers.
+/// Covers the 1155 hub (TransferSingle + TransferBatch) AND ERC20 wrapper transfers in a single
+/// block-ordered pass.
+///
+/// These were previously two separate methods, each flushing per-block to the shared
+/// V2BalancesByAccountAndToken cache. Because the cache (a RollbackCache) requires monotonically
+/// non-decreasing block numbers across Add() calls, running the 1155 pass (advancing the cache to
+/// its highest 1155 block) and then the wrapper pass (starting at its lowest wrapper block) would
+/// throw "Block number must be monotonically increasing" whenever a wrapper transfer sat at a lower
+/// block than the highest 1155 transfer in the same batch — a recurring fault for wrap/unwrap-heavy
+/// avatars. Merging both sources into one block-ordered stream (mirroring the warmup builders)
+/// produces a single monotonic flush sequence. ERC1155 balances are keyed by the avatar's token
+/// address and wrapper balances by the wrapper contract address — disjoint namespaces — so unifying
+/// the pass changes only the flush ordering, never the per-key arithmetic.
 /// </summary>
 public partial class NotificationListenerService
 {
     private async Task ProcessV2TransfersAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
     {
-        // Process V2 TransferSingle and TransferBatch events together in block order
+        // Combine ERC1155 (TransferSingle + TransferBatch) and ERC20 wrapper transfers into one
+        // stream ordered by (blockNumber, transactionIndex, logIndex). tokenAddress is column index
+        // 2 in every arm (1155 token owner / wrapper contract); the wrapper table's "amount" is
+        // aliased to "value" so all three arms share the projection.
         const string sql = @"
             SELECT * FROM (
                 SELECT
@@ -23,8 +38,7 @@ public partial class NotificationListenerService
                     ""blockNumber"",
                     ""transactionIndex"",
                     ""logIndex"",
-                    ""timestamp"",
-                    'Single' as type
+                    ""timestamp""
                 FROM ""CrcV2_TransferSingle""
                 WHERE ""blockNumber"" >= @fromBlock AND ""blockNumber"" <= @toBlock
 
@@ -38,9 +52,22 @@ public partial class NotificationListenerService
                     ""blockNumber"",
                     ""transactionIndex"",
                     ""logIndex"",
-                    ""timestamp"",
-                    'Batch' as type
+                    ""timestamp""
                 FROM ""CrcV2_TransferBatch""
+                WHERE ""blockNumber"" >= @fromBlock AND ""blockNumber"" <= @toBlock
+
+                UNION ALL
+
+                SELECT
+                    ""from"",
+                    ""to"",
+                    ""tokenAddress"",
+                    amount AS value,
+                    ""blockNumber"",
+                    ""transactionIndex"",
+                    ""logIndex"",
+                    ""timestamp""
+                FROM ""CrcV2_Erc20WrapperTransfer""
                 WHERE ""blockNumber"" >= @fromBlock AND ""blockNumber"" <= @toBlock
             ) AS combined
             ORDER BY ""blockNumber"", ""transactionIndex"", ""logIndex""";
@@ -140,114 +167,7 @@ public partial class NotificationListenerService
 
         if (transferCount > 0)
         {
-            _logger.LogDebug("Processed {Count} V2 transfer events", transferCount);
-        }
-    }
-
-    private async Task ProcessV2Erc20WrapperTransfersAsync(NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
-    {
-        // Process V2 ERC20 Wrapper Transfer events incrementally
-        const string sql = @"
-            SELECT ""from"", ""to"", ""tokenAddress"", amount, ""blockNumber"", ""timestamp""
-            FROM ""CrcV2_Erc20WrapperTransfer""
-            WHERE ""blockNumber"" >= @fromBlock AND ""blockNumber"" <= @toBlock
-            ORDER BY ""blockNumber"", ""transactionIndex"", ""logIndex""";
-
-        await using var cmd = new NpgsqlCommand(sql, conn);
-        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
-        cmd.Parameters.AddWithValue("toBlock", toBlock);
-
-        var transferCount = 0;
-        var currentBalances = new Dictionary<string, decimal>();
-        long currentBlock = -1;
-
-        await using (var reader = await cmd.ExecuteReaderAsync(ct))
-        {
-            while (await reader.ReadAsync(ct))
-            {
-                var from = reader.GetString(0);
-                var to = reader.GetString(1);
-                var tokenAddress = reader.GetString(2);
-                var amountBig = reader.GetFieldValue<BigInteger>(3);
-                var blockNumber = reader.GetInt64(4);
-                var timestamp = reader.GetInt64(5);
-
-                // Convert from wei (18 decimals) to token units using CirclesConverter for proper precision
-                decimal amount;
-                try
-                {
-                    amount = CirclesConverter.AttoCirclesToCircles(amountBig);
-                }
-                catch (OverflowException)
-                {
-                    _logger.LogWarning("Skipping ERC20 wrapper transfer with amount {Amount} that would overflow decimal", amountBig);
-                    continue;
-                }
-
-                var tokenKey = tokenAddress.ToLowerInvariant();
-
-                if (blockNumber != currentBlock)
-                {
-                    if (currentBlock != -1)
-                    {
-                        // Flush balances for the previous block (index-before-balance ordering)
-                        foreach (var kvp in currentBalances)
-                        {
-                            _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
-                            _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-                        }
-                    }
-                    currentBlock = blockNumber;
-                }
-
-                var fromLower = from.ToLowerInvariant();
-                var toLower = to.ToLowerInvariant();
-
-                // Update sender balance — token must be valid (account may be stopped)
-                if (from != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
-                {
-                    var fromKey = $"{fromLower}:{tokenKey}";
-                    if (!currentBalances.ContainsKey(fromKey))
-                    {
-                        _caches.V2BalancesByAccountAndToken.TryGetValue(fromKey, out var existingBalance);
-                        currentBalances[fromKey] = existingBalance;
-                    }
-                    currentBalances[fromKey] -= amount;
-                    _caches.V2LastActivity.Add(blockNumber, fromKey, timestamp);
-                }
-
-                // Update receiver balance — token must be valid
-                if (to != "0x0000000000000000000000000000000000000000"
-                    && CirclesInvariants.IsValidToken(tokenKey, _registrations, _wrapperLookup))
-                {
-                    var toKey = $"{toLower}:{tokenKey}";
-                    if (!currentBalances.ContainsKey(toKey))
-                    {
-                        _caches.V2BalancesByAccountAndToken.TryGetValue(toKey, out var existingBalance);
-                        currentBalances[toKey] = existingBalance;
-                    }
-                    currentBalances[toKey] += amount;
-                    _caches.V2LastActivity.Add(blockNumber, toKey, timestamp);
-                }
-
-                transferCount++;
-            }
-        }
-
-        // Flush balances for the last block (index-before-balance ordering)
-        if (currentBlock != -1)
-        {
-            foreach (var kvp in currentBalances)
-            {
-                _caches.UpdateBalanceIndex(kvp.Key, isV1: false, kvp.Value);
-                _caches.V2BalancesByAccountAndToken.Add(currentBlock, kvp.Key, kvp.Value);
-            }
-        }
-
-        if (transferCount > 0)
-        {
-            _logger.LogDebug("Processed {Count} ERC20 wrapper transfer events", transferCount);
+            _logger.LogDebug("Processed {Count} V2 transfer events (ERC1155 + ERC20 wrapper)", transferCount);
         }
     }
 }

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -16,7 +16,7 @@ namespace Circles.Cache.Service.Services;
 /// - Listeners/NotificationListenerService.V2Registry.cs  — ProcessV2EventsAsync, ProcessV2RegisterHumanAsync, ProcessV2RegisterOrganizationAsync, ProcessV2RegisterGroupAsync
 /// - Listeners/NotificationListenerService.V2Trust.cs     — ProcessV2TrustAsync
 /// - Listeners/NotificationListenerService.V2Wrappers.cs  — ProcessV2Erc20WrapperDeployedAsync
-/// - Listeners/NotificationListenerService.V2Transfers.cs — ProcessV2TransfersAsync, ProcessV2Erc20WrapperTransfersAsync
+/// - Listeners/NotificationListenerService.V2Transfers.cs — ProcessV2TransfersAsync (ERC1155 + ERC20 wrapper, single block-ordered pass)
 /// - Listeners/NotificationListenerService.V2Metadata.cs  — ProcessV2UpdateMetadataDigestAsync, ProcessV2RegisterShortNameAsync, ProcessV2SetAdvancedUsageFlagAsync
 /// </summary>
 public partial class NotificationListenerService : BackgroundService
@@ -176,7 +176,11 @@ public partial class NotificationListenerService : BackgroundService
 
             await WithReadonlyConnectionAsync(async (conn, token) =>
             {
-                recentBlocks = await GetRecentBlocksAsync(conn, _settings.RollbackCapacity, token);
+                // Fetch the reorg-detection window (>= RollbackCapacity) so reorgs deeper than the
+                // rollback fast-path are still detected — they then trigger a safe full re-warmup
+                // (RollbackAll throws "beyond stored history" → caught below) rather than going
+                // silently undetected and leaving balances desynced until the next rewarmup.
+                recentBlocks = await GetRecentBlocksAsync(conn, _settings.ReorgDetectionWindow, token);
             }, ct);
 
             if (recentBlocks.Count == 0)

--- a/src/Cache/Circles.Cache.Service/Services/Warmup/CacheWarmupService.GapReplay.cs
+++ b/src/Cache/Circles.Cache.Service/Services/Warmup/CacheWarmupService.GapReplay.cs
@@ -25,7 +25,9 @@ public partial class CacheWarmupService
         // listener just added).
         _state.BlockRingBuffer.Clear();
 
-        var capacity = _settings.RollbackCapacity;
+        // Seed the full reorg-detection window (>= RollbackCapacity) so deep reorgs are detectable
+        // immediately after warmup, not only once the buffer has refilled from live notifications.
+        var capacity = _settings.ReorgDetectionWindow;
         var startBlock = Math.Max(0, fromBlock - capacity + 1);
 
         _logger.LogInformation("Initializing block ring buffer with blocks {StartBlock} to {EndBlock}...",


### PR DESCRIPTION
Two fixes to the cache-service V2 balance live-delta path, plus tests.

## 1. Cross-handler block-monotonicity crash (confirmed, deterministic)

The live path ran the ERC1155 transfer handler and the ERC20-wrapper transfer handler sequentially against the same `V2BalancesByAccountAndToken` cache. That cache requires monotonically non-decreasing block numbers across `Add()` calls, so once the ERC1155 pass advanced the cache to its highest block, the wrapper pass flushing a lower block threw `"Block number must be monotonically increasing"` — a recurring fault for wrap/unwrap-heavy avatars whose 1155 and wrapper transfers interleave across blocks in one notification batch. Each occurrence forced a recovery rollback + 5s listener reconnect (full rewarmup if beyond rollback capacity).

Fix: merge `TransferSingle` + `TransferBatch` + `Erc20WrapperTransfer` into one `UNION ALL` ordered by `(blockNumber, transactionIndex, logIndex)`, processed in one pass with one carry-forward dict and one monotonic flush (mirrors the warmup builders). ERC1155 balances are keyed by the avatar token address and wrapper balances by the wrapper contract address (disjoint namespaces), so the merge changes only flush ordering, not per-key arithmetic.

## 2. Reorg detection decoupled from rollback capacity (robustness hardening)

Reorg detection and rollback both used `RollbackCapacity` (12), so reorgs deeper than 12 blocks were silently missed, leaving in-memory balances desynced from the DB until the next rewarmup. New `REORG_DETECTION_WINDOW` (default 256, must be >= `RollbackCapacity`) sizes the block-hash ring + the per-notification fetch + the warmup seed. A reorg deeper than the rollback window is now detected → `RollbackAll` throws "beyond stored history" (already caught) → safe full rewarmup, instead of silent desync. Block hashes are cheap, so the detection window can be far larger than the balance-diff rollback window.

## Tests
- New real-Postgres integration tests: the wrapper-block-before-1155 monotonicity case (threw before); sender debits across interleaved blocks on both token namespaces.
- Deep-reorg end-to-end test (non-Docker): detected → full rewarmup.
- `REORG_DETECTION_WINDOW` validation boundary + default-ctor tests.

## Test plan
- [x] `dotnet build` (Debug + Release): 0 errors
- [x] 233/233 non-Docker cache tests pass
- [x] Docker integration tests pass (RUN_CACHE_INTEGRATION_TESTS=true); one pre-existing unrelated failure (`NotificationListener_V2Trust_GroupMembership_UsesGroupAsTruster`) noted separately
- [ ] Rolling staging deploy of cache-service; verify warmup completes + balances serve