### PR TITLE
feat(rpc): bypass head-only cache for block-pinned balance requests

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Balances.cs
@@ -22,8 +22,11 @@ public partial class CirclesRpcModule
     {
         address = ValidateAndNormalizeAddress(address);
 
-        // If cache service is enabled and asTimeCircles is true (or null), use cache for performance
-        if (_settings.UseCacheService && _cacheServiceClient != null && (asTimeCircles == null || asTimeCircles == true))
+        // If cache service is enabled and asTimeCircles is true (or null), use cache for performance.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path, which reconstructs the balance as-of block N.
+        if (_settings.UseCacheService && _cacheServiceClient != null && (asTimeCircles == null || asTimeCircles == true)
+            && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {
@@ -218,8 +221,10 @@ public partial class CirclesRpcModule
     {
         address = ValidateAndNormalizeAddress(address);
 
-        // If cache service is enabled, use it (no DB fallback needed)
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // If cache service is enabled, use it (no DB fallback needed).
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path (GetTokenExposureIdsAsync), which reconstructs exposure as-of block N.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -287,8 +287,14 @@ public partial class CirclesRpcModule
     {
         var lowerTokenAddress = ValidateAndNormalizeAddress(tokenAddress, nameof(tokenAddress));
 
-        // If cache service is enabled, try using it first
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // If cache service is enabled, try using it first.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path. NOTE: only the V2-avatar (ERC1155) classification is block-pinned
+        // there (via the V_CrcV2_Avatars twin); the V1-signup and ERC20-wrapper lookups still read
+        // head. Token type/owner is effectively static once created, so this is acceptable until
+        // those lookups gain block filters in a later phase. The batch variant (GetTokenInfoBatch)
+        // is intentionally left cache-served for now — same follow-up.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {


### PR DESCRIPTION
## Summary
Completes the `circles_getTokenBalances` block-pin. The previous change pinned the DB query behind these methods, but on staging the **Cache Service** answers them first — and the cache is head-only and ignores `X-Max-Block-Number`, so a pinned request still returned head data. This adds `&& GetMaxBlockNumberFromHeader() is null` to three cache-service gates so a header-bearing request skips the cache and falls through to the block-pinned DB path.

## What changed
- `GetTotalBalance` (Balances.cs) — bypass cache when pinned → DB path (`GetTokenExposureIdsAsync`, fully pinned).
- `GetTokenBalances` (Balances.cs) — same.
- `GetTokenInfo` (Tokens.cs) — same; its DB path pins the V2-avatar classification via the `V_CrcV2_Avatars` twin (V1/wrapper metadata still head — static once created, documented for a later phase).

## Inertness
With no header, `GetMaxBlockNumberFromHeader()` is null, so each gate is byte-identical to before — the production path is unchanged.

## Verification
- Build green (0 errors).
- After deploy: `circles_getTokenBalances` with no header unchanged; with `X-Max-Block-Number` at a past block returns the as-of-N set (e.g. an address that acquired all tokens after block N returns empty).

## Scope note
Trust/Groups/Avatars/Profiles RPC methods and the batch token-info variant remain cache-served (their `/db` plane already pins via the twins); bypassing those is a separate consistency follow-up.

## Test plan
- [ ] Build green
- [ ] No-header `circles_getTokenBalances` unchanged vs head
- [ ] Pinned `circles_getTokenBalances` differs from head at a past block