### PR TITLE
feat(rpc): bypass head-only cache for block-pinned trust/token/profile/avatar reads

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Avatars.cs
@@ -40,8 +40,18 @@ public partial class CirclesRpcModule
             throw new ArgumentOutOfRangeException(nameof(addresses), "Too many addresses. Max allowed are 1000.");
         }
 
-        // If cache service is enabled, try using it first
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // If cache service is enabled, try using it first.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path. PARTIAL PIN: avatar existence/type/name pin via the V_CrcV2_Avatars
+        // twin, but the metadata CID and short name are still computed from unfiltered base-table
+        // joins (CrcV2_UpdateMetadataDigest / CrcV2_RegisterShortName in FetchV2AvatarsAsync), so
+        // those secondary fields reflect head. This is a strict improvement over the previous
+        // head-only cache result (identity now pins) and is inert without the header. NOTE: the
+        // V_CrcV2_Avatars twin already exposes a pinned, latest-wins "cidV0Digest"; switching the CID
+        // source from the raw join to that twin column would close the CID gap without a new twin —
+        // deferred to a later phase (it is a head-behavior change requiring byte-identical-at-head
+        // verification). The short name has no twin column yet.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Profiles.cs
@@ -485,8 +485,12 @@ public partial class CirclesRpcModule
             return result;
         }
 
-        // Try cache service first, then fall back to database
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // Try cache service first, then fall back to database.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path. This lookup is content-addressed (ipfs_files keyed by CID, an
+        // immutable content hash), so its result is block-invariant — bypassing is correct at any
+        // pinned block. The block-sensitive step (which CID an address resolves to) lives upstream.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Tokens.cs
@@ -293,7 +293,7 @@ public partial class CirclesRpcModule
         // there (via the V_CrcV2_Avatars twin); the V1-signup and ERC20-wrapper lookups still read
         // head. Token type/owner is effectively static once created, so this is acceptable until
         // those lookups gain block filters in a later phase. The batch variant (GetTokenInfoBatch)
-        // is intentionally left cache-served for now — same follow-up.
+        // applies the same bypass — its fallback fans out to this exact method per address.
         if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
@@ -429,8 +429,12 @@ public partial class CirclesRpcModule
             throw new ArgumentOutOfRangeException(nameof(tokenAddresses), "Batch size exceeds 1000");
         }
 
-        // If cache service is enabled, try batch API for efficiency
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // If cache service is enabled, try batch API for efficiency.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache so the
+        // fallback below fans out to GetTokenInfo per address — which itself is block-pinned
+        // (V2-avatar classification via the V_CrcV2_Avatars twin; V1/wrapper lookups read head, same
+        // static-type rationale as the single variant). Matches GetTokenInfo's bypass exactly.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -125,7 +125,10 @@ public partial class CirclesRpcModule
     {
         var normalizedAvatar = ValidateAndNormalizeAddress(avatar, nameof(avatar));
 
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path, which fully pins: it reads only V_CrcV2_TrustRelations and
+        // V_CrcV2_Avatars, both of which have circles_at_block twins.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {


### PR DESCRIPTION
## Summary
Extends the `X-Max-Block-Number` cache-bypass (already shipped for balance reads) to four more cache-served RPC methods, so a block-pinned request falls through to the block-pinned DB path instead of the head-only Cache Service. Without the header the production path is unchanged (the added guard is a strict no-op).

## What changed
Adds `&& GetMaxBlockNumberFromHeader() is null` to four cache gates (+ a stale-comment fix on the already-bypassed `getTokenInfo`):

| Method | Pin quality |
|---|---|
| `circles_getAggregatedTrustRelations` | **Full** — fallback reads only `V_CrcV2_TrustRelations` + `V_CrcV2_Avatars`, both block-pinned twins |
| `circles_getTokenInfoBatch` | Partial — fans out to `circles_getTokenInfo`, which already applies the same bypass |
| `circles_getProfileByCid[Batch]` | **Full** — content-addressed (`ipfs_files` keyed by an immutable CID), block-invariant |
| `circles_getAvatarInfo[Batch]` | Partial — identity/type/name pin via the `V_CrcV2_Avatars` twin; metadata CID + short name still read head (documented) |

The added guard is the same predicate used by the existing balance/token bypasses and by the connection-level pin, so cache-skip and DB-pin stay aligned.

## Deliberately not bypassed
Gates whose DB fallback reads views with no block-pinned twin (`getGroupMembers`/`getGroupMemberships` → `V_CrcV2_GroupMemberships`, V1 `getTrustRelations` → `CrcV1_Trust`, `getProfileByAddress`/`getProfileCid` metadata) are left cache-served: guarding them would only move the head read from cache to DB without producing a pin. These follow once their twins land.

## Test plan
- [x] `Circles.Rpc.Host` builds (0 errors)
- [x] `./scripts/test.sh rpc` passes (shared header-parsing + routing tests cover the bypass predicate + the pinned DB destination)
- [ ] Staging: `circles_getAggregatedTrustRelations` / `circles_getAvatarInfo` return as-of-block results under `X-Max-Block-Number`, head results without it