### PR TITLE
fix(canary): namespace replay cache dir by uid to avoid /tmp ownership collision

### DIFF
--- a/scripts/canary-replay.sh
+++ b/scripts/canary-replay.sh
@@ -62,7 +62,13 @@ NO_COLOR=false
 VERBOSE=false
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CACHE_DIR="/tmp/circles-canary"
+# Per-user cache path. A fixed /tmp/circles-canary is owned by whoever mkdir's it first; if a
+# root operator runs the script, the dir becomes root-owned and the unprivileged service account
+# running the scheduled timer then fails with "Permission denied". Namespacing by numeric uid keeps
+# the operator and service dirs separate. `id -u` is used (not `id -un`): it always exits 0 with a
+# single numeric line and needs no /etc/passwd entry, so it can't yield a multiline/empty suffix.
+# Override with CANARY_CACHE_DIR if a fixed path is needed.
+CACHE_DIR="${CANARY_CACHE_DIR:-/tmp/circles-canary-$(id -u)}"
 HUB_ADDR="0xc12C1E50ABB450d6205Ea2C3Fa861b3B834d13e8"
 
 # --- Known revert selectors ---


### PR DESCRIPTION
## Summary
The prod→staging pathfinder canary replay (`scripts/canary-replay.sh`) used a fixed `/tmp/circles-canary` cache directory. In `/tmp`, the directory is owned by whichever user `mkdir`s it first. When a privileged operator runs the script ad hoc, the directory becomes root-owned; the unprivileged service account running the scheduled replay then fails with `Permission denied` on its first write, aborting the run.

## What changed
- Namespace the cache directory by **numeric uid**: `CACHE_DIR="${CANARY_CACHE_DIR:-/tmp/circles-canary-$(id -u)}"`. Operator and service runs now use separate directories and never collide on ownership.
- `id -u` (numeric) is chosen over `id -un` deliberately: it always exits 0, emits a single numeric line, and needs no `/etc/passwd` entry, so it cannot produce a multiline or empty path suffix on accounts without a name mapping.
- Overridable via the `CANARY_CACHE_DIR` environment variable.

## Test plan
- [x] `bash -n scripts/canary-replay.sh` parses
- [x] Default resolves to a single-line `/tmp/circles-canary-<uid>`
- [x] `CANARY_CACHE_DIR` override honored
- [x] No other file in the repo references the old fixed `/tmp/circles-canary` path (grep clean)