### PR TITLE
feat(canary): log simulation-override counts; fix stale group-membership test

### DIFF
--- a/scripts/canary-replay.sh
+++ b/scripts/canary-replay.sh
@@ -219,7 +219,7 @@ parse_request_log() {
     }
     /source=.*sink=.*targetFlow=/ {
         route=""; source=""; sink=""; tf=""; mf="0"; xfers=0; mt="null"; gb=0; ms=0; st=0; wrap="false"; qm="false"; err=""
-        ft=""; tt=""; eft=""; ett=""; rid=""
+        ft=""; tt=""; eft=""; ett=""; rid=""; simb=0; simt=0; simc=0
         for (i=1; i<=NF; i++) {
             if ($i ~ /^(findPath|findMaxFlow)$/) route=$i
             else if ($i ~ /^source=/) source=substr($i, 8)
@@ -237,6 +237,9 @@ parse_request_log() {
             else if ($i ~ /^toTokens=/) tt=substr($i, 10)
             else if ($i ~ /^excludedFromTokens=/) eft=substr($i, 20)
             else if ($i ~ /^excludedToTokens=/) ett=substr($i, 18)
+            else if ($i ~ /^simBalances=/) { v=substr($i, 13); simb=(v ~ /^[0-9]+$/ ? v : 0) }
+            else if ($i ~ /^simTrusts=/) { v=substr($i, 11); simt=(v ~ /^[0-9]+$/ ? v : 0) }
+            else if ($i ~ /^simConsented=/) { v=substr($i, 14); simc=(v ~ /^[0-9]+$/ ? v : 0) }
             else if ($i ~ /^reqId=/) rid=substr($i, 7)
             else if ($i ~ /^error=/) err=substr($i, 7)
         }
@@ -248,7 +251,7 @@ parse_request_log() {
             gsub(/"/, "\\\"", mf)
             gsub(/"/, "\\\"", err)
             gsub(/"/, "\\\"", rid)
-            printf "{\"route\":\"%s\",\"source\":\"%s\",\"sink\":\"%s\",\"targetFlow\":\"%s\",\"maxFlow\":\"%s\",\"transfers\":%s,\"maxTransfers\":%s,\"graphBlock\":%s,\"durationMs\":%s,\"status\":%s,\"withWrap\":%s,\"quantizedMode\":%s,\"fromTokens\":%s,\"toTokens\":%s,\"excludedFromTokens\":%s,\"excludedToTokens\":%s,\"reqId\":\"%s\",\"error\":\"%s\"}\n", route, source, sink, tf, mf, xfers, mt, gb, ms, st, wrap, qm, jarr(ft), jarr(tt), jarr(eft), jarr(ett), rid, err
+            printf "{\"route\":\"%s\",\"source\":\"%s\",\"sink\":\"%s\",\"targetFlow\":\"%s\",\"maxFlow\":\"%s\",\"transfers\":%s,\"maxTransfers\":%s,\"graphBlock\":%s,\"durationMs\":%s,\"status\":%s,\"withWrap\":%s,\"quantizedMode\":%s,\"fromTokens\":%s,\"toTokens\":%s,\"excludedFromTokens\":%s,\"excludedToTokens\":%s,\"simBalances\":%s,\"simTrusts\":%s,\"simConsented\":%s,\"reqId\":\"%s\",\"error\":\"%s\"}\n", route, source, sink, tf, mf, xfers, mt, gb, ms, st, wrap, qm, jarr(ft), jarr(tt), jarr(eft), jarr(ett), simb, simt, simc, rid, err
         }
     }'
 }
@@ -336,7 +339,7 @@ RESULTS_FILE="$CACHE_DIR/canary-results.jsonl"
 > "$RESULTS_FILE"
 
 # Counters
-MATCH=0; DRIFT=0; DIVERGED=0; REPLAY_ERR=0
+MATCH=0; DRIFT=0; DIVERGED=0; REPLAY_ERR=0; SKIPPED_OVERRIDES=0
 SIM_PASS=0; SIM_REVERT=0; SIM_SKIP=0
 REVERT_REASONS=()
 IDX=0
@@ -359,12 +362,34 @@ while IFS= read -r entry; do
     excluded_from_tokens=$(printf '%s' "$entry" | jq -c '.excludedFromTokens // []')
     excluded_to_tokens=$(printf '%s' "$entry" | jq -c '.excludedToTokens // []')
     req_id=$(printf '%s' "$entry" | jq -r '.reqId // ""')
+    sim_balances=$(printf '%s' "$entry" | jq -r '.simBalances // 0')
+    sim_trusts=$(printf '%s' "$entry" | jq -r '.simTrusts // 0')
+    sim_consented=$(printf '%s' "$entry" | jq -r '.simConsented // 0')
 
     # Guard against empty maxFlow from parse failures
     [[ -z "$prod_max_flow" ]] && prod_max_flow="0"
 
     label="$(short_addr "$source_addr")→$(short_addr "$sink_addr")"
     prod_crc=$(format_crc "$prod_max_flow")
+
+    # Requests carrying what-if simulation overrides can't be faithfully replayed: the prod log
+    # records only their COUNTS (simBalances/simTrusts/simConsented), not the injected values. Replaying
+    # without them would inject a false maxFlow divergence, so classify as skipped and move on — don't
+    # POST to staging or simulate. Old prod logs predating these fields parse as 0 and are unaffected.
+    if [[ "${sim_balances:-0}" -gt 0 || "${sim_trusts:-0}" -gt 0 || "${sim_consented:-0}" -gt 0 ]] 2>/dev/null; then
+        SKIPPED_OVERRIDES=$((SKIPPED_OVERRIDES + 1))
+        log_warn "$label  ${DIM}skipped — simulation overrides (b=$sim_balances t=$sim_trusts c=$sim_consented)${NC}"
+        jq -n -c \
+            --arg reqId "$req_id" \
+            --arg source "$source_addr" --arg sink "$sink_addr" \
+            --arg targetFlow "$target_flow" \
+            --arg prodMaxFlow "$prod_max_flow" \
+            --argjson prodGraphBlock "$prod_graph_block" \
+            '{reqId, source, sink, targetFlow, prodMaxFlow, stagingMaxFlow: "",
+              comparison: "SKIPPED_OVERRIDES", simVerdict: "skip", simRevertName: "", prodGraphBlock}' \
+            >> "$RESULTS_FILE"
+        continue
+    fi
 
     # --- Replay on staging ---
     POST_BODY=$(jq -n \
@@ -563,10 +588,11 @@ if [[ "$JSON_OUTPUT" == true ]]; then
         --argjson diverged "$DIVERGED" --argjson replayErr "$REPLAY_ERR" \
         --argjson simPass "$SIM_PASS" --argjson simRevert "$SIM_REVERT" \
         --argjson simSkip "$SIM_SKIP" \
+        --argjson skippedOverrides "$SKIPPED_OVERRIDES" \
         --argjson revertReasons "$REVERT_AGG" \
         '{
             source: $src, since: $since, total: $total,
-            comparison: {match: $match, drift: $drift, diverged: $diverged, error: $replayErr},
+            comparison: {match: $match, drift: $drift, diverged: $diverged, error: $replayErr, skippedOverrides: $skippedOverrides},
             simulation: {pass: $simPass, revert: $simRevert, skip: $simSkip, revertReasons: $revertReasons}
         }'
 else
@@ -598,6 +624,7 @@ else
     echo -e "        Drift:      ${YELLOW}$DRIFT${NC} (<${TOLERANCE}%)"
     echo -e "        Diverged:   ${RED}$DIVERGED${NC} (>${TOLERANCE}%)"
     echo -e "        Error:      ${RED}$REPLAY_ERR${NC}"
+    echo -e "        Skipped:    ${DIM}$SKIPPED_OVERRIDES${NC} (simulation overrides — not replayable)"
 fi
 
 # Exit non-zero if any reverts detected — this is the primary signal

--- a/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/IntegrationTests.cs
@@ -534,6 +534,11 @@ public class IntegrationTests : IAsyncLifetime
         var state = new CacheServiceState(rollbackCapacity: 8);
         var caches = new CacheContainer(rollbackCapacity: 8);
         caches.Groups.Add(1, group, ("Test Group", "0xmint", "TG"));
+        // The trustee must be a registered avatar for ProcessV2TrustAsync to record the membership
+        // (the registration gate added to NotificationListenerService.V2Trust.cs:68). Register the
+        // included member so the group→member membership is upserted; the excluded member stays
+        // unregistered and is excluded by trust direction (its only edge is member→group).
+        caches.V2Avatars.Add(block, includedMember, ("CrcV2_RegisterHuman", 12345));
 
         await using var dataSource = NpgsqlDataSource.Create(_connectionString!);
         var listener = new TestableNotificationListenerService(settings, state, caches, dataSource);

--- a/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/FindPathHandler.cs
@@ -132,6 +132,14 @@ internal sealed class FindPathHandler(
             : string.Join(",", tokens.Select(t => SanitizeForLog(t)));
 
     /// <summary>
+    /// Count of a simulation-override list for the structured request log (0 when null/empty).
+    /// A non-zero count means the request injected what-if balances/trusts/consent the solver used
+    /// but the log can't carry verbatim, so the canary replay can't faithfully reconstruct it — the
+    /// replay classifies such requests as skipped rather than as a (false) maxFlow divergence.
+    /// </summary>
+    private static int SimCount<T>(IReadOnlyCollection<T>? list) => list?.Count ?? 0;
+
+    /// <summary>
     /// Extracts X-Max-Block-Number header from the current HTTP request, if present.
     /// When set, the pathfinder uses a historical graph at that block instead of the live graph.
     /// </summary>
@@ -364,26 +372,28 @@ internal sealed class FindPathHandler(
                 }
 
                 log.LogInformation(
-                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} reqId={ReqId}",
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} simBalances={SimBalances} simTrusts={SimTrusts} simConsented={SimConsented} reqId={ReqId}",
                     route, safeSource, safeSink, safeTargetFlow,
                     mfr.MaxFlow, mfr.Transfers?.Count ?? 0, request.MaxTransfers ?? -1,
                     graphBlock, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false,
                     SanitizeTokenList(request.FromTokens), SanitizeTokenList(request.ToTokens),
                     SanitizeTokenList(request.ExcludedFromTokens), SanitizeTokenList(request.ExcludedToTokens),
+                    SimCount(request.SimulatedBalances), SimCount(request.SimulatedTrusts), SimCount(request.SimulatedConsentedAvatars),
                     mfr.ReqId ?? "-");
             }
             else
             {
                 // /findMaxFlow returns long, not MaxFlowResponse
                 log.LogInformation(
-                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} reqId={ReqId}",
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} simBalances={SimBalances} simTrusts={SimTrusts} simConsented={SimConsented} reqId={ReqId}",
                     route, safeSource, safeSink, safeTargetFlow,
                     result, 0, request.MaxTransfers ?? -1,
                     graphBlock, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false,
                     SanitizeTokenList(request.FromTokens), SanitizeTokenList(request.ToTokens),
                     SanitizeTokenList(request.ExcludedFromTokens), SanitizeTokenList(request.ExcludedToTokens),
+                    SimCount(request.SimulatedBalances), SimCount(request.SimulatedTrusts), SimCount(request.SimulatedConsentedAvatars),
                     "-");
             }
 
@@ -556,25 +566,27 @@ internal sealed class FindPathHandler(
                 }
 
                 log.LogInformation(
-                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} reqId={ReqId}",
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} simBalances={SimBalances} simTrusts={SimTrusts} simConsented={SimConsented} reqId={ReqId}",
                     route, safeSource, safeSink, safeTargetFlow,
                     mfr.MaxFlow, mfr.Transfers?.Count ?? 0, request.MaxTransfers ?? -1,
                     blockNumber, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false,
                     SanitizeTokenList(request.FromTokens), SanitizeTokenList(request.ToTokens),
                     SanitizeTokenList(request.ExcludedFromTokens), SanitizeTokenList(request.ExcludedToTokens),
+                    SimCount(request.SimulatedBalances), SimCount(request.SimulatedTrusts), SimCount(request.SimulatedConsentedAvatars),
                     mfr.ReqId ?? "-");
             }
             else
             {
                 log.LogInformation(
-                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} reqId={ReqId}",
+                    "{Route} source={Source} sink={Sink} targetFlow={TargetFlow} maxFlow={MaxFlow} transfers={Transfers} maxTransfers={MaxTransfers} graphBlock={GraphBlock} durationMs={DurationMs} status={Status} withWrap={WithWrap} quantizedMode={QuantizedMode} fromTokens={FromTokens} toTokens={ToTokens} excludedFromTokens={ExcludedFromTokens} excludedToTokens={ExcludedToTokens} simBalances={SimBalances} simTrusts={SimTrusts} simConsented={SimConsented} reqId={ReqId}",
                     route, safeSource, safeSink, safeTargetFlow,
                     result, 0, request.MaxTransfers ?? -1,
                     blockNumber, sw.ElapsedMilliseconds, 200,
                     request.WithWrap ?? false, request.QuantizedMode ?? false,
                     SanitizeTokenList(request.FromTokens), SanitizeTokenList(request.ToTokens),
                     SanitizeTokenList(request.ExcludedFromTokens), SanitizeTokenList(request.ExcludedToTokens),
+                    SimCount(request.SimulatedBalances), SimCount(request.SimulatedTrusts), SimCount(request.SimulatedConsentedAvatars),
                     "-");
             }
 


### PR DESCRIPTION
## Summary
Two small changes for canary-replay fidelity and a stale-test fix.

### 1. Log simulation-override counts (and skip them on replay)
The pathfinder structured request log carries source/sink/targetFlow, the token filters, and flags — but not the three simulation-override inputs (`simulatedBalances`, `simulatedTrusts`, `simulatedConsentedAvatars`). A request carrying those injects what-if graph state the solver uses but the log cannot reconstruct, so the prod→staging canary replay rebuilds the request without them and reports a **false maxFlow divergence**.

- `FindPathHandler.cs`: add `simBalances`/`simTrusts`/`simConsented` **counts** to the four success-log lines via a null-safe `SimCount<T>` helper. Counts only — list contents are never logged.
- `canary-replay.sh`: parse the counts and classify override-bearing requests as **skipped** (not replayable) instead of replaying them and counting a spurious divergence. Surfaced in both the JSON (`comparison.skippedOverrides`) and text summary. The awk parser coerces the new fields to digits-or-0, so a malformed or pre-existing log line degrades gracefully (treated as no-override) rather than aborting the batch.

### 2. Fix stale V2 group-membership test
`ProcessV2TrustAsync` records a group membership only when the trustee is a registered avatar (the registration gate in `NotificationListenerService.V2Trust.cs`). The test inserted a group→member trust but never registered the member, so the membership was dropped and the assertion failed. Register the included member; the excluded member stays unregistered and is correctly excluded by trust direction.

## Test plan
- [x] `Circles.Pathfinder.Host` + `Circles.Cache.Service.Tests` build: 0 errors
- [x] `Circles.Pathfinder.Tests`: 1115 passed / 0 failed
- [x] The group-membership test proven RED→GREEN (fails at the membership assertion without the fix; passes with it, against a Testcontainer Postgres)
- [x] `bash -n` + awk offset/coercion checks pass; old/malformed logs parse the new fields as 0