### PR TITLE
feat(rpc): bypass head-only cache for block-pinned group-membership and common-trust reads

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Groups.cs
@@ -123,8 +123,12 @@ public partial class CirclesRpcModule
     {
         groupAddress = ValidateAndNormalizeAddress(groupAddress, nameof(groupAddress));
 
-        // If cache service is enabled and no cursor (first page), try cache first
-        if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor))
+        // If cache service is enabled and no cursor (first page), try cache first.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to GetGroupMembershipInternal, which fully pins: it reads V_CrcV2_GroupMemberships,
+        // which has a circles_at_block twin.
+        if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor)
+            && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {
@@ -183,8 +187,12 @@ public partial class CirclesRpcModule
     {
         memberAddress = ValidateAndNormalizeAddress(memberAddress, nameof(memberAddress));
 
-        // If cache service is enabled and no cursor (first page), try cache first
-        if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor))
+        // If cache service is enabled and no cursor (first page), try cache first.
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to GetGroupMembershipInternal, which fully pins: it reads V_CrcV2_GroupMemberships,
+        // which has a circles_at_block twin.
+        if (_settings.UseCacheService && _cacheServiceClient != null && string.IsNullOrEmpty(cursor)
+            && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Trust.cs
@@ -326,7 +326,12 @@ public partial class CirclesRpcModule
         address1 = ValidateAndNormalizeAddress(address1, nameof(address1));
         address2 = ValidateAndNormalizeAddress(address2, nameof(address2));
 
-        if (_settings.UseCacheService && _cacheServiceClient != null)
+        // Block-pinned requests (X-Max-Block-Number present) bypass the head-only cache and fall
+        // through to the DB path. PARTIAL PIN: the trust-graph intersection pins (it reads
+        // V_Crc_TrustRelations, which has a circles_at_block twin), but the IsV2Human branch-selector
+        // for address2 reads CrcV2_RegisterHuman at head (registration is effectively static). This is
+        // a strict improvement over the head-only cache result.
+        if (_settings.UseCacheService && _cacheServiceClient != null && GetMaxBlockNumberFromHeader() is null)
         {
             try
             {


### PR DESCRIPTION
## Summary
Extends the `X-Max-Block-Number` cache-bypass (shipped for balances/tokens/trust/profile/avatar) to three more cache-served RPC methods, now that their DB-fallback views have block-pinned twins. Inert without the header (production path unchanged).

## Gates
| Method | Pin quality | Twin used |
|---|---|---|
| `circles_getGroupMembers` | **Full** | `V_CrcV2_GroupMemberships` |
| `circles_getGroupMemberships` | **Full** | `V_CrcV2_GroupMemberships` |
| `circles_getCommonTrust` | Partial — trust-graph intersection pins; `IsV2Human` branch-selector reads head (registration is static) | `V_Crc_TrustRelations` |

The guard is the same predicate used by the existing bypasses and by the connection-level pin, so cache-skip and DB-pin stay aligned.

## ⚠️ Deploy ordering
The `V_CrcV2_GroupMemberships` and `V_Crc_TrustRelations` twins must be installed (test-env schema) **before** this change is deployed. Until then a header-bearing request to these methods falls open to head — no error, no wrong-block data, just unpinned.

## Test plan
- [x] `Circles.Rpc.Host` builds (0 errors)
- [x] `./scripts/test.sh rpc` passes
- [ ] Staging (after twins deployed): `circles_getGroupMembers` / `circles_getCommonTrust` return as-of-block results under `X-Max-Block-Number`, head without it