### PR TITLE
feat(canary): active balance-drift probe for non-insufficient_balance reverts

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BalanceProbe.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BalanceProbe.cs
@@ -1,0 +1,333 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using System.Numerics;
+using System.Text.Json;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Simulation;
+
+namespace Circles.Pathfinder.Host.Canary;
+
+/// <summary>
+/// Active cache-balance-drift probe (#74), the selector-agnostic complement to the payload-based
+/// detector in <see cref="EmitBalanceDriftIfDetected"/>.
+///
+/// <para>The payload detector only fires on <c>ERC1155InsufficientBalance</c> (<c>0x03dee4c5</c>):
+/// it reads the holder/balance/needed straight out of the revert args for free. But a phantom
+/// (cache-inflated) balance can trip a DIFFERENT terminal error first — observed live as an
+/// unclassified <c>0x66ef7607</c> revert routing through the same phantom-prone arb+group-token
+/// pair — and those evade both the payload detector AND the Prometheus/Loki alerts
+/// (<c>category=unknown</c> is not <c>category=bug</c>). This probe closes that gap: on any revert
+/// the payload path did not already explain, it compares each holder's required outflow per token
+/// (summed from the path) against the holder's REAL on-chain balance, and emits the same
+/// <c>CACHE BALANCE DRIFT</c> signal when the path demands more than exists.</para>
+///
+/// <para><b>Soundness vs withWrap paths.</b> A naive <c>balanceOf</c> at graphBlock would
+/// false-positive whenever the holder's supply comes from unwrapping wrapper ERC20 into 1155
+/// (the balance only materialises after the unwrap). To avoid that — and because the Loki alert
+/// fires on the log LINE regardless of metric bucket — the probe runs as a single
+/// <c>eth_simulateV1</c> bundle that REPLAYS the same unwrap prefix the real simulation used and
+/// THEN reads <c>balanceOf</c>. The returned balance is exactly the 1155 balance
+/// <c>operateFlowMatrix</c> would see, so <c>required &gt; balanceOf</c> can only mean the served
+/// graph sourced a balance no real on-chain state supports. The chain does all the
+/// demurrage / unit / unwrap math; the probe does no unit conversion of its own.</para>
+///
+/// <para>Only ≥2× over-asks (and true zero-balance sends) are surfaced: a sub-2× overshoot is
+/// indistinguishable from benign demurrage discretisation between the pathfinder's cached value
+/// and the freshly-fetched chain value, whereas the phantom class is orders of magnitude
+/// (~2834× observed). The metric reuses <see cref="BalanceDriftTotal"/> so existing alerts on
+/// <c>{bucket}</c> keep working; holder/token stay in the log only (unbounded cardinality).</para>
+/// </summary>
+internal sealed partial class SimulationCanaryService
+{
+    // ERC1155 balanceOf(address account, uint256 id) — keccak256("balanceOf(address,uint256)")[:4].
+    private const string Erc1155BalanceOfSelector = "0x00fdd58e";
+
+    // Hard cap on distinct (holder, token) probes per revert. Reverts are rare (best-effort canary,
+    // queue size 10) and distinct holders per path are typically < 10, but a pathological dense path
+    // could enumerate many pairs — bound the eth_simulateV1 fan-out and log when we truncate so a
+    // capped probe never reads as "checked everything".
+    private const int MaxBalanceProbePairs = 64;
+
+    // Default ON — this is the whole point of the hardening. Operators can disable with
+    // CANARY_BALANCE_PROBE_ENABLED=false if the extra eth_simulateV1 per revert ever needs muting.
+    private static readonly bool BalanceProbeEnabled =
+        !string.Equals(
+            Environment.GetEnvironmentVariable("CANARY_BALANCE_PROBE_ENABLED"),
+            "false", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>One detected (holder, token) drift: the path needed <see cref="Needed"/> but the
+    /// holder held only <see cref="OnChain"/> on-chain, bucketed by the needed/on-chain ratio.</summary>
+    internal readonly record struct BalanceDriftRecord(
+        string Holder, string Token, BigInteger OnChain, BigInteger Needed, string Bucket);
+
+    /// <summary>
+    /// Probes on-chain balances for each holder the path requires to send, after replaying the
+    /// given unwrap prefix, and emits <c>CACHE BALANCE DRIFT</c> for any (holder, token) where the
+    /// path's required outflow exceeds the real balance by ≥2× (or the holder holds nothing).
+    /// </summary>
+    /// <param name="item">The work item whose path transfers are checked.</param>
+    /// <param name="unwrapCalls">The unwrap prefix to replay before reading balances. Empty for the
+    /// plain eth_call path (no wrapper supply); the resolved bundle list for the unwrap path.</param>
+    /// <param name="blockTag">The block to simulate at (the graph block the path was built from).</param>
+    /// <param name="client">HTTP client for the JSON-RPC call.</param>
+    /// <param name="ct">Cancellation token (shutdown propagates).</param>
+    /// <returns><c>true</c> if at least one drift was emitted; <c>false</c> otherwise.</returns>
+    private async Task<bool> ProbeBalanceDriftAsync(
+        CanaryWorkItem item,
+        IReadOnlyList<ResolvedUnwrapCall> unwrapCalls,
+        string blockTag,
+        HttpClient client,
+        CancellationToken ct)
+    {
+        try
+        {
+            // Aggregate required outflow per (holder, token) from the avatar-resolved transfers —
+            // Hub.balanceOf is keyed by the avatar token id, not the wrapper contract.
+            var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
+            var required = AggregateRequiredOutflow(transfers);
+            if (required.Count == 0)
+                return false;
+
+            // Drop malformed addresses here rather than encoding a zero id-word for them: a zero word
+            // makes balanceOf return 0, which would alias onto a spurious zero_balance "drift".
+            var pairs = new List<(string Holder, string Token, BigInteger Required)>(required.Count);
+            foreach (var ((holder, token), amount) in required)
+                if (IsHexAddress(holder) && IsHexAddress(token))
+                    pairs.Add((holder, token, amount));
+            if (pairs.Count == 0)
+                return false;
+
+            if (pairs.Count > MaxBalanceProbePairs)
+            {
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: balance probe capped at {Cap} of {Total} (holder,token) pairs — drift in the remainder is not checked",
+                    item.ReqId, MaxBalanceProbePairs, pairs.Count);
+                pairs = pairs.GetRange(0, MaxBalanceProbePairs);
+            }
+
+            // One eth_simulateV1: [ replayed unwrap prefix..., balanceOf(holder,token)... ].
+            // Sharing one blockStateCalls entry means the balanceOf calls observe post-unwrap state,
+            // exactly as operateFlowMatrix would in the real bundle.
+            var calls = new List<object>(unwrapCalls.Count + pairs.Count);
+            foreach (var u in unwrapCalls)
+                calls.Add(new { from = u.From, to = u.Wrapper, data = EncodeUnwrapCalldata(u.Amount) });
+            foreach (var p in pairs)
+                calls.Add(new
+                {
+                    from = ZeroSenderForReadOnly,
+                    to = FlowMatrixEncoder.CirclesHubAddress,
+                    data = EncodeBalanceOfCalldata(p.Holder, p.Token)
+                });
+
+            var rpc = new
+            {
+                jsonrpc = "2.0",
+                id = 1,
+                method = "eth_simulateV1",
+                @params = new object[]
+                {
+                    new { blockStateCalls = new[] { new { calls } }, validation = false, traceTransfers = false },
+                    blockTag
+                }
+            };
+
+            // Network failure and parse failure are distinct error classes — keep their catches
+            // separate so a non-JSON response isn't logged as "network/timeout" (matches the
+            // SimulateBundleAsync / ResolveInflationaryAmountsAsync convention).
+            HttpResponseMessage response;
+            try
+            {
+                response = await client.PostAsJsonAsync(_rpcUrl, rpc, ct);
+            }
+            catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+            catch (Exception ex)
+            {
+                _log.LogWarning(ex, "[{ReqId}] SimulationCanary: balance probe RPC failed (network/timeout)", item.ReqId);
+                return false;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _log.LogWarning("[{ReqId}] SimulationCanary: balance probe eth_simulateV1 HTTP {StatusCode}",
+                    item.ReqId, (int)response.StatusCode);
+                return false;
+            }
+
+            JsonElement json;
+            try
+            {
+                json = await response.Content.ReadFromJsonAsync<JsonElement>(ct);
+            }
+            catch (JsonException jex)
+            {
+                _log.LogWarning(jex, "[{ReqId}] SimulationCanary: balance probe non-JSON response", item.ReqId);
+                return false;
+            }
+
+            // Top-level JSON-RPC error (method unsupported, batch rejected) — surface it instead of
+            // silently returning false, so a structurally broken probe is diagnosable.
+            if (json.ValueKind == JsonValueKind.Object
+                && json.TryGetProperty("error", out var rpcErr)
+                && rpcErr.ValueKind != JsonValueKind.Null)
+            {
+                var errMsg = rpcErr.ValueKind == JsonValueKind.Object && rpcErr.TryGetProperty("message", out var m)
+                    ? m.GetString() : rpcErr.ToString();
+                _log.LogWarning("[{ReqId}] SimulationCanary: balance probe eth_simulateV1 rejected at RPC layer: {Error}",
+                    item.ReqId, errMsg);
+                return false;
+            }
+
+            if (!json.TryGetProperty("result", out var result)
+                || result.ValueKind != JsonValueKind.Array
+                || result.GetArrayLength() == 0
+                || !result[0].TryGetProperty("calls", out var innerCalls)
+                || innerCalls.ValueKind != JsonValueKind.Array)
+            {
+                _log.LogWarning("[{ReqId}] SimulationCanary: balance probe got an unusable eth_simulateV1 envelope", item.ReqId);
+                return false;
+            }
+
+            var drifts = InterpretBalanceProbeResults(innerCalls, pairs, unwrapCalls.Count, out var truncated);
+            if (truncated)
+                _log.LogWarning(
+                    "[{ReqId}] SimulationCanary: balance probe response truncated — some (holder,token) pairs were not checked",
+                    item.ReqId);
+
+            foreach (var d in drifts)
+            {
+                BalanceDriftTotal.WithLabels(d.Bucket).Inc();
+                _log.LogError(
+                    "[{ReqId}] SimulationCanary: CACHE BALANCE DRIFT holder={Holder} token={Token} " +
+                    "graphBlock={Block} onChainBalance={OnChain} needed={Needed} ratioBucket={Bucket} detector=probe",
+                    item.ReqId, d.Holder, d.Token,
+                    item.GraphBlock, d.OnChain, d.Needed, d.Bucket);
+            }
+
+            return drifts.Count > 0;
+        }
+        catch (TaskCanceledException) when (ct.IsCancellationRequested) { throw; }
+        catch (Exception ex)
+        {
+            // Distinct error surface so a future probe regression doesn't masquerade as RPC noise.
+            _log.LogError(ex, "[{ReqId}] SimulationCanary: balance probe failed", item.ReqId);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Pure interpretation of the probe's <c>eth_simulateV1</c> per-call results, isolated from HTTP so
+    /// the drift gate is unit-testable (mirrors <see cref="ParseSimulateV1Response"/>). For each pair,
+    /// reads the <c>balanceOf</c> result at offset <c>unwrapCount + j</c> (the prefix calls precede the
+    /// balance reads), compares the path's required outflow to the on-chain balance, and yields a drift
+    /// record ONLY for ≥2× over-asks (<c>ge_2x|ge_10x|ge_100x</c>) or a true zero-balance send. A
+    /// failed/empty balanceOf sub-call (<c>null</c>) is skipped, never treated as zero. Stops at the
+    /// first index beyond the response and reports it via <paramref name="truncated"/> — it never
+    /// fabricates a balance for a missing result.
+    /// </summary>
+    internal static IReadOnlyList<BalanceDriftRecord> InterpretBalanceProbeResults(
+        JsonElement innerCalls,
+        IReadOnlyList<(string Holder, string Token, BigInteger Required)> pairs,
+        int unwrapCount,
+        out bool truncated)
+    {
+        truncated = false;
+        var drifts = new List<BalanceDriftRecord>();
+        if (innerCalls.ValueKind != JsonValueKind.Array)
+            return drifts;
+
+        int total = innerCalls.GetArrayLength();
+        for (int j = 0; j < pairs.Count; j++)
+        {
+            int idx = unwrapCount + j;
+            if (idx >= total)
+            {
+                truncated = true;
+                break; // don't fabricate a balance for a missing result
+            }
+
+            // ParseConvertCallReturnData is a generic single-ABI-uint256-word decoder shared with the
+            // inflationary resolver; here it decodes the balanceOf return. null ⇒ sub-call failed.
+            var onChain = ParseConvertCallReturnData(innerCalls[idx]);
+            if (onChain is null)
+                continue; // balanceOf sub-call failed — can't compare, skip rather than false-positive
+
+            var p = pairs[j];
+            var bucket = RevertClassifier.DriftBucket(p.Required, onChain.Value);
+
+            // Suppress sub-2× overshoot: indistinguishable from benign demurrage rounding.
+            // zero_balance (onChain==0, required>0) is a real phantom (nothing to send), keep it.
+            if (bucket is not ("ge_2x" or "ge_10x" or "ge_100x" or "zero_balance"))
+                continue;
+
+            drifts.Add(new BalanceDriftRecord(p.Holder, p.Token, onChain.Value, p.Required, bucket));
+        }
+
+        return drifts;
+    }
+
+    /// <summary>
+    /// Sums per-(holder, token) required outflow from the resolved transfers. Skips edges that do
+    /// not require a pre-existing balance: mints from the zero address, and self-issuance where the
+    /// sender IS the token's avatar (personal-token issuance and group mint, where <c>from == token</c>).
+    /// Keys are lowercased addresses.
+    /// </summary>
+    internal static Dictionary<(string Holder, string Token), BigInteger> AggregateRequiredOutflow(
+        IReadOnlyList<TransferPathStep> transfers)
+    {
+        var required = new Dictionary<(string, string), BigInteger>();
+        foreach (var t in transfers)
+        {
+            var holder = t.From.ToLowerInvariant();
+            var token = t.TokenOwner.ToLowerInvariant();
+
+            if (holder is "0x0000000000000000000000000000000000000000")
+                continue; // mint — no prior balance
+            if (holder == token)
+                continue; // self-issuance / group mint — sender mints its own token
+
+            if (!BigInteger.TryParse(t.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
+                || value <= 0)
+                continue;
+
+            var key = (holder, token);
+            required[key] = required.TryGetValue(key, out var existing) ? existing + value : value;
+        }
+
+        return required;
+    }
+
+    /// <summary>
+    /// Encodes <c>balanceOf(address account, uint256 id)</c> calldata for the Circles Hub (ERC1155),
+    /// where the token id is <c>uint256(uint160(tokenAvatarAddress))</c>. Callers pre-filter malformed
+    /// addresses via <see cref="IsHexAddress"/>; the all-zero fallback in <see cref="AddressWord"/> is
+    /// defence-in-depth so encoding can never throw inside the probe.
+    /// </summary>
+    internal static string EncodeBalanceOfCalldata(string holder, string token)
+        => Erc1155BalanceOfSelector + AddressWord(holder) + AddressWord(token);
+
+    /// <summary>True if <paramref name="address"/> is a 20-byte hex address (optionally 0x-prefixed).</summary>
+    internal static bool IsHexAddress(string address)
+    {
+        var hex = address.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? address[2..] : address;
+        if (hex.Length != 40)
+            return false;
+        foreach (var c in hex)
+            if (!Uri.IsHexDigit(c))
+                return false;
+        return true;
+    }
+
+    // A 20-byte address right-aligned into a 32-byte ABI word. Falls back to all-zero on a malformed
+    // address so encoding never throws inside the probe (pairs are pre-filtered by IsHexAddress).
+    private static string AddressWord(string address)
+    {
+        var hex = address.StartsWith("0x", StringComparison.OrdinalIgnoreCase) ? address[2..] : address;
+        hex = hex.ToLowerInvariant();
+        if (hex.Length != 40)
+            return new string('0', 64);
+        foreach (var c in hex)
+            if (!Uri.IsHexDigit(c))
+                return new string('0', 64);
+        return hex.PadLeft(64, '0');
+    }
+}

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
@@ -158,7 +158,14 @@ internal sealed partial class SimulationCanaryService
                 // identically to the plain eth_call path and, being wrapped/ScoreGroup-token-tied,
                 // is the most likely carrier of the signal. Decode from the SAME source Classify
                 // used (revertData ?? revertMsg) — see ParseSimulateV1Response.
-                EmitBalanceDriftIfDetected(item, parsed.Label!, parsed.RevertData ?? parsed.RevertMessage);
+                var driftEmitted = EmitBalanceDriftIfDetected(item, parsed.Label!, parsed.RevertData ?? parsed.RevertMessage);
+
+                // Fall back to the active probe when the payload didn't explain the revert (e.g. the
+                // unclassified 0x66ef7607 class). Skip category=simulation (valid-path canary
+                // artifacts, no balance shortfall). Replay this bundle's unwrap prefix so balanceOf
+                // reflects post-unwrap state — see ProbeBalanceDriftAsync.
+                if (!driftEmitted && BalanceProbeEnabled && parsed.Category != "simulation")
+                    await ProbeBalanceDriftAsync(item, unwrapCalls, blockTag, client, ct);
                 return;
 
             case BundleOutcome.Success:

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.InflationaryUnits.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.InflationaryUnits.cs
@@ -86,6 +86,13 @@ internal sealed partial class SimulationCanaryService
     /// Returns null if the call did not succeed, the payload is empty, or the hex
     /// does not decode.
     /// </summary>
+    /// <remarks>
+    /// This is a GENERIC single-ABI-uint256-word decoder, despite the "Convert" in the name (it
+    /// predates its second consumer). It is shared by <c>ExtractInflationaryAmounts</c> (decoding
+    /// <c>convertDemurrageToInflationaryValue</c>) AND the balance probe (decoding <c>balanceOf</c>
+    /// in <c>InterpretBalanceProbeResults</c>). Do NOT specialise it for inflationary conversion —
+    /// that would silently change how the probe reads balances.
+    /// </remarks>
     internal static BigInteger? ParseConvertCallReturnData(JsonElement call)
     {
         if (!call.TryGetProperty("status", out var status) || status.GetString() != "0x1")

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
@@ -157,7 +157,15 @@ internal sealed partial class SimulationCanaryService
                 // balance and the amount the pathfinder's path required, both at graphBlock. Decode
                 // from the SAME source Classify used (revertData ?? revertMsg) — the selector hex can
                 // arrive in the message field on some nodes.
-                EmitBalanceDriftIfDetected(item, label, revertData ?? revertMsg);
+                var driftEmitted = EmitBalanceDriftIfDetected(item, label, revertData ?? revertMsg);
+
+                // Fall back to the active probe when the payload didn't explain the revert (any other
+                // selector). Skip category=simulation (e.g. operator_not_approved): those paths are
+                // valid w.r.t. balances — the revert is a canary msg.sender artifact, not a shortfall —
+                // so probing them adds no signal and only risks alert noise on the recurring class.
+                // Plain path ⇒ no unwrap prefix to replay.
+                if (!driftEmitted && BalanceProbeEnabled && category != "simulation")
+                    await ProbeBalanceDriftAsync(item, Array.Empty<ResolvedUnwrapCall>(), blockTag, client, ct);
 
                 if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)
                 {
@@ -195,27 +203,33 @@ internal sealed partial class SimulationCanaryService
     // The whole body is wrapped in its own narrow try/catch so a future decode/emit regression
     // surfaces as a DISTINCT error rather than masquerading as a surrounding "eth_call
     // network/timeout" catch.
-    private void EmitBalanceDriftIfDetected(CanaryWorkItem item, string label, string? revertPayload)
+    //
+    // Returns true if a drift was emitted from the revert payload. When false, the caller falls back
+    // to the active <see cref="ProbeBalanceDriftAsync"/> probe (see SimulationCanaryService.BalanceProbe.cs),
+    // which catches phantom balances behind revert selectors this payload path cannot decode.
+    private bool EmitBalanceDriftIfDetected(CanaryWorkItem item, string label, string? revertPayload)
     {
         if (label != "insufficient_balance")
-            return;
+            return false;
 
         try
         {
             if (RevertClassifier.TryDecodeInsufficientBalance(revertPayload) is not { } drift)
-                return;
+                return false;
 
             var bucket = RevertClassifier.DriftBucket(drift.Needed, drift.Balance);
             BalanceDriftTotal.WithLabels(bucket).Inc();
             _log.LogError(
                 "[{ReqId}] SimulationCanary: CACHE BALANCE DRIFT holder={Holder} token={Token} " +
-                "graphBlock={Block} onChainBalance={OnChain} needed={Needed} ratioBucket={Bucket}",
+                "graphBlock={Block} onChainBalance={OnChain} needed={Needed} ratioBucket={Bucket} detector=revert_payload",
                 item.ReqId, drift.Holder, drift.Token,
                 item.GraphBlock, drift.Balance, drift.Needed, bucket);
+            return true;
         }
         catch (Exception ex)
         {
             _log.LogError(ex, "[{ReqId}] SimulationCanary: balance-drift decode/emit failed", item.ReqId);
+            return false;
         }
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryBalanceProbeTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryBalanceProbeTests.cs
@@ -1,0 +1,291 @@
+using System.Numerics;
+using System.Text;
+using System.Text.Json;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Host.Canary;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Unit tests for the active cache-balance-drift probe's pure logic (#74):
+/// per-(holder, token) outflow aggregation and ERC1155 balanceOf calldata encoding.
+/// The HTTP-driven ProbeBalanceDriftAsync is exercised against staging's eth_simulateV1;
+/// these cover the soundness-critical filtering and ABI encoding in isolation.
+/// </summary>
+[TestFixture, Parallelizable]
+public class SimulationCanaryBalanceProbeTests
+{
+    private const string Arb = "0x2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1";
+    private const string GroupToken = "0xc19bc204eb1c1d5b3fe500e5e5dfabab625f286c";
+    private const string Sink = "0xd4cf9afd3ae777c24454b70dd28e32d1bd516f05";
+    private const string Zero = "0x0000000000000000000000000000000000000000";
+
+    private static TransferPathStep Step(string from, string to, string tokenOwner, string value) =>
+        new() { From = from, To = to, TokenOwner = tokenOwner, Value = value };
+
+    #region AggregateRequiredOutflow
+
+    [Test]
+    public void Aggregate_SumsMultipleOutflowsOfSamePair()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Arb, Sink, GroupToken, "1000000000000"),
+            Step(Arb, Sink, GroupToken, "2000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required, Has.Count.EqualTo(1));
+        Assert.That(required[(Arb, GroupToken)], Is.EqualTo(BigInteger.Parse("3000000000000")));
+    }
+
+    [Test]
+    public void Aggregate_SkipsMintFromZeroAddress()
+    {
+        // Group mint arrives as from=0x0 — no prior balance required.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Zero, Arb, GroupToken, "5000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required, Is.Empty);
+    }
+
+    [Test]
+    public void Aggregate_SkipsSelfIssuance_WhenSenderIsTokenAvatar()
+    {
+        // from == tokenOwner: personal-token issuance / group mint (group sends its own token).
+        // The sender mints rather than spends a prior balance, so it must not be probed.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(GroupToken, Arb, GroupToken, "5000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required, Is.Empty);
+    }
+
+    [Test]
+    public void Aggregate_SkipsNonPositiveAndUnparseableValues()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Arb, Sink, GroupToken, "0"),
+            Step(Arb, Sink, GroupToken, "-100"),
+            Step(Arb, Sink, GroupToken, "notanumber")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required, Is.Empty);
+    }
+
+    [Test]
+    public void Aggregate_KeepsDistinctPairsSeparate()
+    {
+        const string otherHolder = "0x1111111111111111111111111111111111111111";
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Arb, Sink, GroupToken, "1000000000000"),
+            Step(otherHolder, Sink, GroupToken, "7000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required, Has.Count.EqualTo(2));
+        Assert.That(required[(Arb, GroupToken)], Is.EqualTo(BigInteger.Parse("1000000000000")));
+        Assert.That(required[(otherHolder, GroupToken)], Is.EqualTo(BigInteger.Parse("7000000000000")));
+    }
+
+    [Test]
+    public void Aggregate_LowercasesKeys()
+    {
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Arb.ToUpperInvariant(), Sink, GroupToken.ToUpperInvariant(), "1000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required.ContainsKey((Arb, GroupToken)), Is.True);
+    }
+
+    #endregion
+
+    #region EncodeBalanceOfCalldata
+
+    [Test]
+    public void EncodeBalanceOf_ProducesSelectorAndTwoAddressWords()
+    {
+        var calldata = SimulationCanaryService.EncodeBalanceOfCalldata(Arb, GroupToken);
+
+        var expected = "0x00fdd58e"
+                       + "000000000000000000000000" + "2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1"
+                       + "000000000000000000000000" + "c19bc204eb1c1d5b3fe500e5e5dfabab625f286c";
+        Assert.That(calldata, Is.EqualTo(expected));
+        Assert.That(calldata.Length, Is.EqualTo(2 + 8 + 64 + 64));
+    }
+
+    [Test]
+    public void EncodeBalanceOf_LowercasesMixedCaseAddresses()
+    {
+        var calldata = SimulationCanaryService.EncodeBalanceOfCalldata(
+            "0x2CEB1B41A7E926BAE3BFB4D4DAAD0B877697D8D1", GroupToken);
+
+        Assert.That(calldata, Does.Contain("2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1"));
+        Assert.That(calldata, Does.Not.Contain("2CEB1B41"));
+    }
+
+    [Test]
+    public void EncodeBalanceOf_MalformedAddress_FallsBackToZeroWord_NoThrow()
+    {
+        // Non-hex / wrong-length holder → zero word (eth_call returns 0 ⇒ treated as no balance).
+        var calldata = SimulationCanaryService.EncodeBalanceOfCalldata("0xnothex", GroupToken);
+
+        var expected = "0x00fdd58e"
+                       + new string('0', 64)
+                       + "000000000000000000000000" + "c19bc204eb1c1d5b3fe500e5e5dfabab625f286c";
+        Assert.That(calldata, Is.EqualTo(expected));
+    }
+
+    #endregion
+
+    #region IsHexAddress
+
+    [TestCase("0x2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1", true)]
+    [TestCase("2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1", true)]  // no 0x prefix
+    [TestCase("0xC19BC204EB1C1D5B3FE500E5E5DFABAB625F286C", true)] // uppercase
+    [TestCase("0xnothex", false)]
+    [TestCase("0x2ceb1b41", false)]                                // too short
+    [TestCase("0x2ceb1b41a7e926bae3bfb4d4daad0b877697d8d1ff", false)] // too long
+    [TestCase("0x2ceb1b41a7e926bae3bfb4d4daad0b877697d8dg", false)] // non-hex char
+    public void IsHexAddress_ValidatesShapeAndChars(string address, bool expected)
+    {
+        Assert.That(SimulationCanaryService.IsHexAddress(address), Is.EqualTo(expected));
+    }
+
+    #endregion
+
+    #region InterpretBalanceProbeResults (drift gate)
+
+    // Builds an eth_simulateV1 "calls" JSON array; each entry is (status, returnData-or-null).
+    private static JsonElement CallsArray(params (string Status, string? ReturnData)[] calls)
+    {
+        var sb = new StringBuilder("[");
+        for (int i = 0; i < calls.Length; i++)
+        {
+            if (i > 0) sb.Append(',');
+            sb.Append("{\"status\":\"").Append(calls[i].Status).Append('"');
+            if (calls[i].ReturnData != null)
+                sb.Append(",\"returnData\":\"").Append(calls[i].ReturnData).Append('"');
+            sb.Append('}');
+        }
+        sb.Append(']');
+        return JsonDocument.Parse(sb.ToString()).RootElement.Clone();
+    }
+
+    // A balanceOf return word: uint256 right-aligned in 32 bytes.
+    private static string BalanceWord(BigInteger v) => "0x" + v.ToString("x").TrimStart('0').PadLeft(64, '0');
+
+    private static (string, string, BigInteger) Pair(BigInteger required) => (Arb, GroupToken, required);
+
+    [Test]
+    public void Interpret_ExactlyTwoX_Emitted_ge2x()
+    {
+        var calls = CallsArray(("0x1", BalanceWord(100)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(200) }, unwrapCount: 0, out var truncated);
+
+        Assert.That(truncated, Is.False);
+        Assert.That(drifts, Has.Count.EqualTo(1));
+        Assert.That(drifts[0].Bucket, Is.EqualTo("ge_2x"));
+        Assert.That(drifts[0].OnChain, Is.EqualTo((BigInteger)100));
+        Assert.That(drifts[0].Needed, Is.EqualTo((BigInteger)200));
+    }
+
+    [Test]
+    public void Interpret_SubTwoX_Suppressed_ge1x()
+    {
+        // required 150 vs balance 100 ⇒ floor ratio 1 ⇒ ge_1x ⇒ suppressed (demurrage-rounding band).
+        var calls = CallsArray(("0x1", BalanceWord(100)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(150) }, unwrapCount: 0, out _);
+
+        Assert.That(drifts, Is.Empty);
+    }
+
+    [Test]
+    public void Interpret_ZeroBalanceWithRequired_Emitted()
+    {
+        var calls = CallsArray(("0x1", BalanceWord(0)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(5) }, unwrapCount: 0, out _);
+
+        Assert.That(drifts, Has.Count.EqualTo(1));
+        Assert.That(drifts[0].Bucket, Is.EqualTo("zero_balance"));
+    }
+
+    [Test]
+    public void Interpret_RequiredWithinBalance_Suppressed_le1x()
+    {
+        var calls = CallsArray(("0x1", BalanceWord(100)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(80) }, unwrapCount: 0, out _);
+
+        Assert.That(drifts, Is.Empty);
+    }
+
+    [Test]
+    public void Interpret_HundredX_Emitted_ge100x()
+    {
+        var calls = CallsArray(("0x1", BalanceWord(1)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(100) }, unwrapCount: 0, out _);
+
+        Assert.That(drifts.Single().Bucket, Is.EqualTo("ge_100x"));
+    }
+
+    [Test]
+    public void Interpret_FailedBalanceOfSubCall_Skipped_NotFalsePositive()
+    {
+        // status 0x0 ⇒ ParseConvertCallReturnData null ⇒ skip, NOT a zero_balance drift.
+        var calls = CallsArray(("0x0", null));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(200) }, unwrapCount: 0, out _);
+
+        Assert.That(drifts, Is.Empty);
+    }
+
+    [Test]
+    public void Interpret_RespectsUnwrapOffset()
+    {
+        // index 0 is the replayed unwrap result (must be ignored); index 1 is the balanceOf.
+        var calls = CallsArray(("0x1", "0x"), ("0x1", BalanceWord(1)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls, new[] { Pair(100) }, unwrapCount: 1, out _);
+
+        Assert.That(drifts.Single().Bucket, Is.EqualTo("ge_100x"));
+        Assert.That(drifts[0].OnChain, Is.EqualTo((BigInteger)1));
+    }
+
+    [Test]
+    public void Interpret_TruncatedResponse_FlagsTruncated_DoesNotFabricate()
+    {
+        // Two pairs but only one balanceOf result present ⇒ second pair is beyond the array.
+        const string other = "0x1111111111111111111111111111111111111111";
+        var calls = CallsArray(("0x1", BalanceWord(1)));
+        var drifts = SimulationCanaryService.InterpretBalanceProbeResults(
+            calls,
+            new[] { Pair(100), (other, GroupToken, (BigInteger)100) },
+            unwrapCount: 0, out var truncated);
+
+        Assert.That(truncated, Is.True);
+        Assert.That(drifts, Has.Count.EqualTo(1)); // only the first, read; never fabricated for the tail
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

The cache-balance-drift detector previously fired only on `ERC1155InsufficientBalance` (`0x03dee4c5`) reverts, decoded from the revert payload. A cache-inflated (phantom) balance can trip a **different** terminal error first (e.g. an unclassified selector), evading both the detector and its Prometheus/Loki alerts (`category=unknown` is not `category=bug`).

This adds an active probe that closes that gap.

## What changed

- **`ProbeBalanceDriftAsync`** (new `SimulationCanaryService.BalanceProbe.cs`): on any revert the payload path can't explain, it sums each holder's required outflow per token from the path and runs **one** `eth_simulateV1` of `[replayed unwrap prefix..., Hub.balanceOf(holder, uint160(token))...]` at the graph block. Because `balanceOf` is read after replaying the same unwrap prefix, it reflects the exact post-unwrap 1155 balance `operateFlowMatrix` sees — so there are no `withWrap` false positives. The chain does all demurrage/unit/unwrap math.
- Emits the **existing** `CACHE BALANCE DRIFT` log (`+detector=probe`) and `circles_canary_balance_drift_total{bucket}` metric → existing alerts keep working unchanged.
- Only `>=2x` over-asks (and true zero-balance sends) surface; sub-2x is suppressed as benign demurrage rounding (the payload path still catches exact insufficient_balance at any ratio).
- Skips `category=simulation` reverts (valid-path canary artifacts, no balance shortfall).
- Pure, unit-tested `InterpretBalanceProbeResults` gate; malformed addresses filtered before encoding.
- Gated by `CANARY_BALANCE_PROBE_ENABLED` (default on).
- `EmitBalanceDriftIfDetected` now returns a bool (payload-already-emitted) so the probe only runs as a fallback. Both revert branches (plain `eth_call` + `eth_simulateV1` bundle) wire it identically.

## Test plan

- [x] `Circles.Pathfinder.Host` + tests build with 0 errors
- [x] Pathfinder suite: 1139 pass / 0 fail / 270 skipped (+24 new canary tests: aggregation filters, balanceOf ABI encoding, the >=2x/zero_balance/null-skip/unwrap-offset/truncation gate, address validation)
- [ ] Post-deploy: confirm no spurious `CACHE BALANCE DRIFT detector=probe` lines on the recurring `operator_not_approved` traffic (should be skipped via the `category=simulation` gate)