### PR TITLE
feat(pathfinder): block-pin GET /snapshot via X-Max-Block-Number

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -423,10 +423,56 @@ app.MapPost("/findPath", async (
     "**Solver timeout**: 30 seconds (configurable via PATHFINDER_SOLVER_TIMEOUT_SECONDS).")
 .Produces<MaxFlowResponse>();
 
-app.MapGet("/snapshot", (NetworkState state, SnapshotCache snapshotCache, HttpContext httpContext) =>
+app.MapGet("/snapshot", async (NetworkState state, SnapshotCache snapshotCache,
+    HistoricalGraphCache historicalGraphCache, ILoggerFactory loggerFactory, HttpContext httpContext) =>
 {
     // Check If-None-Match header for conditional request
     var ifNoneMatch = httpContext.Request.Headers.IfNoneMatch.FirstOrDefault();
+
+    // Block-pinned snapshot: when X-Max-Block-Number is present and positive, reconstruct the
+    // snapshot as-of that block from a block-pinned historical graph (HistoricalGraphCache),
+    // mirroring how /findPath and /findMaxFlow already pin. Inert — and byte-identical to the
+    // prior behavior — when the header is absent or non-positive (falls through to the live path).
+    if (httpContext.Request.Headers.TryGetValue("X-Max-Block-Number", out var headerValue)
+        && long.TryParse(headerValue.FirstOrDefault(), out var maxBlockNumber)
+        && maxBlockNumber > 0)
+    {
+        // The historical ETag is a per-block validator (state at block N is deterministic),
+        // namespaced (see SnapshotCache.HistoricalETag) so it never aliases the live ETag.
+        // Single source of truth — short-circuit repeat polls before loading any graph.
+        var histEtag = SnapshotCache.HistoricalETag(maxBlockNumber);
+        if (!string.IsNullOrEmpty(ifNoneMatch) && ifNoneMatch == histEtag)
+        {
+            return Results.StatusCode(StatusCodes.Status304NotModified);
+        }
+
+        byte[] histJson;
+        try
+        {
+            var factory = await historicalGraphCache.GetOrLoadFactoryAsync(maxBlockNumber);
+            (histJson, histEtag) = snapshotCache.GetOrBuildHistoricalSnapshot(factory, maxBlockNumber);
+        }
+        catch (ArgumentException ex)
+        {
+            // Block not found / not yet indexed — client error (mirrors the findPath historical path).
+            // Log so a spike of data-driven 400s (e.g. an indexing gap) is visible in telemetry.
+            loggerFactory.CreateLogger("Snapshot").LogWarning(ex,
+                "Historical snapshot unavailable for block {Block}", maxBlockNumber);
+            return Results.BadRequest(ex.Message);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            loggerFactory.CreateLogger("Snapshot").LogError(ex,
+                "Historical snapshot failed for block {Block}", maxBlockNumber);
+            return Results.StatusCode(StatusCodes.Status500InternalServerError);
+        }
+
+        httpContext.Response.Headers.ETag = histEtag;
+        httpContext.Response.Headers.CacheControl = "public, max-age=5";
+        return Results.Bytes(histJson, "application/json");
+    }
+
+    // Live path (unchanged behavior).
     var currentETag = snapshotCache.CurrentETag;
 
     // If client has current version, return 304 Not Modified
@@ -457,10 +503,15 @@ app.MapGet("/snapshot", (NetworkState state, SnapshotCache snapshotCache, HttpCo
     "**Large response** (can be several MB compressed).\n\n" +
     "**ETag support**: Responses include an ETag header. Send `If-None-Match` with the previous ETag to get " +
     "304 Not Modified if the graph hasn't changed. The graph updates every ~5 seconds.\n\n" +
+    "**Block-pinned (`X-Max-Block-Number`)**: set this header to a positive block number to get the snapshot " +
+    "reconstructed as-of that block from the historical graph. The ETag is the block number (state at a block " +
+    "is deterministic). Returns 400 if the block is not indexed. Without the header the live snapshot is served, " +
+    "byte-identical to before.\n\n" +
     "**Cache-Control**: `public, max-age=5` — clients can cache briefly.\n\n" +
-    "**503**: Returned if the graph has not been built yet (service starting up).\n\n" +
+    "**503**: Returned if the (live) graph has not been built yet (service starting up).\n\n" +
     "**Common use case**: Pre-loading the trust graph for client-side pathfinding or visualization.")
 .Produces<object>(200, "application/json")
+.ProducesProblem(400)
 .ProducesProblem(503);
 
 app.Run();

--- a/src/Pathfinder/Circles.Pathfinder.Host/SnapshotCache.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/SnapshotCache.cs
@@ -19,6 +19,13 @@ public sealed class SnapshotCache
     private byte[]? _cachedJson;
     private string? _etag;
 
+    // Single-slot cache for the most-recently-requested historical (block-pinned) snapshot.
+    // Independent of the live slot above; keyed by the requested block number.
+    private readonly object _histLock = new();
+    private long _histBlockNumber = -1;
+    private byte[]? _histJson;
+    private string? _histEtag;
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -58,38 +65,104 @@ public sealed class SnapshotCache
                 return (_cachedJson, _etag);
             }
 
-            // Rebuild the snapshot
-            var balancesByHolder = new Dictionary<int, List<BalanceNode>>(state.BalanceGraph!.BalanceNodes.Count);
-            foreach (var node in state.BalanceGraph.BalanceNodes.Values)
-            {
-                if (!balancesByHolder.TryGetValue(node.Holder, out var list))
-                {
-                    list = new List<BalanceNode>();
-                    balancesByHolder.Add(node.Holder, list);
-                }
-                list.Add(node);
-            }
-
-            var snapshot = new NetworkSnapshot
-            {
-                BlockNumber = currentBlock,
-                Addresses = AddressIdPool.GetAvatarSnapshot(),
-                Trust = state.AccountTrusts.ToDictionary(kvp => kvp.Key, kvp => new HashSet<int>(kvp.Value)),
-                Balance = balancesByHolder
-            };
-
-            // Serialize to JSON bytes — write order: json → block → etag
-            // ensures readers see _cachedJson before _cachedBlockNumber,
-            // and _etag (the public signal) is written last
-            var json = JsonSerializer.SerializeToUtf8Bytes(snapshot, JsonOptions);
+            var json = SerializeSnapshot(state.BalanceGraph!, state.AccountTrusts, currentBlock);
             var etag = $"\"{currentBlock}\"";
 
+            // Write order: json → block → etag ensures readers see _cachedJson before
+            // _cachedBlockNumber, and _etag (the public signal) is written last.
             Volatile.Write(ref _cachedJson, json);
             Volatile.Write(ref _cachedBlockNumber, currentBlock);
             Volatile.Write(ref _etag, etag); // last: etag is the public signal
 
             return (json, etag);
         }
+    }
+
+    /// <summary>
+    /// The ETag for a historical (block-pinned) snapshot. A per-block validator (state at block N
+    /// is deterministic), namespaced so it can never alias the live snapshot's ETag (which is just
+    /// the block number) — the two responses can differ slightly at the same block (demurrage
+    /// anchor). Single source of truth: used by both this cache and the /snapshot endpoint's
+    /// If-None-Match short-circuit.
+    /// </summary>
+    public static string HistoricalETag(long blockNumber) => $"\"historical-{blockNumber}\"";
+
+    /// <summary>
+    /// Builds (or returns a cached) snapshot for a historical block, reconstructed from a
+    /// block-pinned GraphFactory (loaded via HistoricalGraphCache) rather than the live
+    /// NetworkState. Single-slot cache keyed by block: repeated polls of the same historical
+    /// block reuse the serialized bytes, so the graph rebuild + multi-MB serialize only runs
+    /// when the requested block changes — which also bounds the cost of repeated
+    /// /snapshot + X-Max-Block-Number=N requests. The ETag (see HistoricalETag) is per-block,
+    /// so a client polling the same block gets 304s.
+    /// </summary>
+    public (byte[] Json, string ETag) GetOrBuildHistoricalSnapshot(GraphFactory factory, long blockNumber)
+    {
+        // Lock-free fast path (mirrors the live path): a consistent (json, block) pair; a stale
+        // read just falls through to the locked rebuild.
+        var cachedJson = Volatile.Read(ref _histJson);
+        var cachedBlock = Volatile.Read(ref _histBlockNumber);
+        if (cachedJson != null && cachedBlock == blockNumber)
+        {
+            return (cachedJson, Volatile.Read(ref _histEtag)!);
+        }
+
+        lock (_histLock)
+        {
+            if (_histJson != null && _histBlockNumber == blockNumber)
+            {
+                return (_histJson, _histEtag!);
+            }
+
+            // Build the same graph projections the live updater uses (NetworkStateUpdaterService),
+            // but from the block-pinned factory so the snapshot reflects state as of blockNumber.
+            var trustGraph = factory.V2TrustGraph();
+            var accountTrusts = GraphFactory.BuildTrustLookup(trustGraph);
+            var balanceGraph = factory.V2BalanceGraph();
+
+            var json = SerializeSnapshot(balanceGraph, accountTrusts, blockNumber);
+            var etag = HistoricalETag(blockNumber);
+
+            Volatile.Write(ref _histJson, json);
+            Volatile.Write(ref _histBlockNumber, blockNumber);
+            Volatile.Write(ref _histEtag, etag);
+
+            return (json, etag);
+        }
+    }
+
+    /// <summary>
+    /// Shared snapshot construction + serialization used by both the live and historical paths,
+    /// so the wire format (NetworkSnapshot shape, JSON options) lives in exactly one place. Each
+    /// caller computes its own ETag (live = block number; historical = HistoricalETag).
+    /// Addresses is the global AddressIdPool snapshot (a superset id→address lookup; the ids that
+    /// appear in Trust/Balance index into it, extra entries are harmless).
+    /// </summary>
+    private static byte[] SerializeSnapshot(
+        BalanceGraph balanceGraph,
+        IReadOnlyDictionary<int, HashSet<int>> accountTrusts,
+        long blockNumber)
+    {
+        var balancesByHolder = new Dictionary<int, List<BalanceNode>>(balanceGraph.BalanceNodes.Count);
+        foreach (var node in balanceGraph.BalanceNodes.Values)
+        {
+            if (!balancesByHolder.TryGetValue(node.Holder, out var list))
+            {
+                list = new List<BalanceNode>();
+                balancesByHolder.Add(node.Holder, list);
+            }
+            list.Add(node);
+        }
+
+        var snapshot = new NetworkSnapshot
+        {
+            BlockNumber = blockNumber,
+            Addresses = AddressIdPool.GetAvatarSnapshot(),
+            Trust = accountTrusts.ToDictionary(kvp => kvp.Key, kvp => new HashSet<int>(kvp.Value)),
+            Balance = balancesByHolder
+        };
+
+        return JsonSerializer.SerializeToUtf8Bytes(snapshot, JsonOptions);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SnapshotCacheTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SnapshotCacheTests.cs
@@ -1,6 +1,7 @@
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host;
 using Circles.Pathfinder.Host.State;
+using Circles.Pathfinder.Tests.Helpers;
 using NUnit.Framework;
 
 namespace Circles.Pathfinder.Tests;
@@ -103,6 +104,91 @@ public class SnapshotCacheTests
         cache.GetOrBuildSnapshot(state);
 
         Assert.That(cache.CachedBlockNumber, Is.EqualTo(100));
+    }
+
+    // ─────────────────────── Historical (block-pinned) snapshot ───────────────────────
+
+    /// <summary>
+    /// Builds a minimal in-memory GraphFactory (one trust + one balance) so the historical
+    /// snapshot path has non-empty trust/balance graphs to project.
+    /// </summary>
+    private static GraphFactory CreateFactory()
+    {
+        // Allocate ids in the global pool first (MockLoadGraph.AddTrust(int,int) resolves them
+        // back to addresses via AddressIdPool.StringOf, which requires prior registration).
+        var source = AddressIdPool.IdOf("0x0000000000000000000000000000000000000001");
+        var token = AddressIdPool.IdOf("0x000000000000000000000000000000000000000a");
+        var mock = new MockLoadGraph();
+        mock.AddTrust(source, token);
+        mock.AddBalance(source, token, 200_000_000L);
+        return new GraphFactory("0x0000000000000000000000000000000000000000", mock);
+    }
+
+    [Test]
+    public void GetOrBuildHistoricalSnapshot_ReturnsJsonWithBlockEtag()
+    {
+        var cache = new SnapshotCache();
+
+        var (json, etag) = cache.GetOrBuildHistoricalSnapshot(CreateFactory(), 42);
+
+        Assert.That(json, Is.Not.Null);
+        Assert.That(json.Length, Is.GreaterThan(0));
+        Assert.That(etag, Is.EqualTo("\"historical-42\""),
+            "Historical ETag should be namespaced by block (never aliases the live ETag)");
+        Assert.That(etag, Is.EqualTo(SnapshotCache.HistoricalETag(42)),
+            "Endpoint and cache must agree on the historical ETag format");
+    }
+
+    [Test]
+    public void GetOrBuildHistoricalSnapshot_SameBlock_ReturnsCached()
+    {
+        var cache = new SnapshotCache();
+        var factory = CreateFactory();
+
+        var (json1, etag1) = cache.GetOrBuildHistoricalSnapshot(factory, 42);
+        var (json2, etag2) = cache.GetOrBuildHistoricalSnapshot(factory, 42);
+
+        Assert.That(ReferenceEquals(json1, json2), Is.True,
+            "Same block should return the same cached byte[] reference (single-slot cache hit)");
+        Assert.That(etag1, Is.EqualTo(etag2));
+    }
+
+    [Test]
+    public void GetOrBuildHistoricalSnapshot_DifferentBlock_Rebuilds()
+    {
+        var cache = new SnapshotCache();
+        var factory = CreateFactory();
+
+        var (json1, etag1) = cache.GetOrBuildHistoricalSnapshot(factory, 42);
+        var (json2, etag2) = cache.GetOrBuildHistoricalSnapshot(factory, 99);
+
+        Assert.That(etag1, Is.EqualTo("\"historical-42\""));
+        Assert.That(etag2, Is.EqualTo("\"historical-99\""));
+        Assert.That(ReferenceEquals(json1, json2), Is.False,
+            "Different block should rebuild (single slot evicted)");
+    }
+
+    [Test]
+    public void HistoricalETag_NeverAliasesLiveETag_ForSameBlock()
+    {
+        // The live ETag is the bare block number; the historical ETag is namespaced. The two must
+        // differ for the same block so a client mixing modes can't get a cross-variant 304.
+        Assert.That(SnapshotCache.HistoricalETag(100), Is.Not.EqualTo("\"100\""));
+        Assert.That(SnapshotCache.HistoricalETag(100), Is.EqualTo("\"historical-100\""));
+    }
+
+    [Test]
+    public void GetOrBuildHistoricalSnapshot_DoesNotTouchLiveSlot()
+    {
+        var cache = new SnapshotCache();
+
+        cache.GetOrBuildHistoricalSnapshot(CreateFactory(), 42);
+
+        // The historical slot is independent of the live slot.
+        Assert.That(cache.CurrentETag, Is.Null,
+            "Historical builds must not populate the live ETag");
+        Assert.That(cache.CachedBlockNumber, Is.EqualTo(-1),
+            "Historical builds must not populate the live cached block number");
     }
 
     [Test]


### PR DESCRIPTION
## Summary
`/snapshot` was the last pathfinder endpoint that ignored the `X-Max-Block-Number` header — `/findPath` and `/findMaxFlow` already serve a block-pinned historical graph via `HistoricalGraphCache`. This makes `/snapshot` honor the header too: when present and positive, the snapshot is reconstructed as-of that block (the same `V2TrustGraph` / `V2BalanceGraph` projections the live updater uses). Absent or non-positive header → live snapshot, byte-identical to before.

## What changed
- `SnapshotCache.cs`: extract a shared `SerializeSnapshot` helper (one wire format for both paths); add `GetOrBuildHistoricalSnapshot` with an independent single-slot cache keyed by block (repeat polls reuse the serialized bytes — the heavy DB load is already memoized one layer down in `HistoricalGraphCache`). New `HistoricalETag` helper single-sources the per-block, namespaced ETag (`"historical-N"`) so it never aliases the live ETag.
- `Program.cs`: `/snapshot` is now async; historical branch reads the header, loads the pinned factory, and serves the reconstructed snapshot. `ArgumentException` (block not indexed) → 400 (logged); other failures → 500 (logged); `OutOfMemoryException` excluded from the catch to match the rest of the host.
- `SnapshotCacheTests.cs`: 5 new tests (block ETag, single-slot caching, rebuild-on-block-change, live-slot independence, anti-aliasing).

## Why
Completes the pathfinder side of test-env block-pinning so SDK developers get a reproducible graph snapshot at a past block through the same header used everywhere else. State as of block N is correct (the historical loader demurrages balances to block N's timestamp and loads ScoreGroup features).

## Test plan
- [x] `dotnet build -c Release` — 0 errors
- [x] `SnapshotCacheTests` 12/12; full pathfinder suite 1143 passed / 0 failed / 270 skipped
- [ ] Post-deploy: `GET /snapshot` (no header) unchanged; with `X-Max-Block-Number: N` returns `blockNumber: N` + a smaller graph than head; `If-None-Match` with the historical ETag → 304; an un-indexed/future block → 400