### PR TITLE
test(pathfinder): score-group projection tier + P16 routing fixture

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -97,16 +97,150 @@ public class ProxyLoadGraph : ILoadGraph
         WHERE t2."group" IS NULL
         """;
 
-    // Group query with temporal filter — {1} = mint policy address from Settings.StandardMintPolicyAddress
+    // Group query with temporal filter. Score-aware (mirrors live groupQuery.sql): includes
+    // groups whose mint policy is the STANDARD policy ({1}) OR a SCORE policy ({2}) that has an
+    // indexed pathMintRouter. Without the score branch, score groups never become GroupNodes and
+    // the pathfinder degrades them to non-groups (no mint edges at all).
     private const string GroupQueryTemplate = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY({2})
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        supported_groups AS (
+            SELECT g."group" AS group_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                  g."mint" = LOWER('{1}')
+                  OR (LOWER(g."mint") = ANY({2}) AND sg.router_address IS NOT NULL)
+              )
+        )
+        SELECT group_address FROM supported_groups
+        """;
+
+    // Group trust query with temporal filter. Score-aware: the trusting group may use the STANDARD
+    // policy ({1}) or a SCORE policy ({2}) with a router. NB: unlike the live groupTrustQuery.sql this
+    // omits the trustee registered-avatars filter (acceptable for current fixtures whose collateral is
+    // a registered avatar; mirrors the pre-existing ProxyLoadGraph trust query). Follow-up if a fixture
+    // ever needs unregistered-trustee exclusion.
+    private const string GroupTrustQueryTemplate = """
+        WITH trust_state AS (
+            SELECT truster, trustee, "expiryTime",
+                   row_number() OVER (PARTITION BY truster, trustee
+                       ORDER BY "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC) AS rn
+            FROM "CrcV2_Trust"
+            WHERE "blockNumber" <= {0}
+        ), active_trust AS (
+            SELECT truster, trustee FROM trust_state
+            WHERE rn = 1 AND "expiryTime" > (SELECT max("timestamp") FROM "System_Block" WHERE "blockNumber" <= {0})::numeric
+        ), latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY({2}) AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ), supported_groups AS (
+            SELECT g."group" AS group_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                  g."mint" = LOWER('{1}')
+                  OR (LOWER(g."mint") = ANY({2}) AND sg.router_address IS NOT NULL)
+              )
+        )
+        SELECT t.truster AS group_address, t.trustee AS trusted_token
+        FROM active_trust t
+        INNER JOIN supported_groups g ON g.group_address = t.truster
+        """;
+
+    private const string RegisteredAvatarsQueryTemplate = """
+        SELECT avatar FROM "V_CrcV2_Avatars"
+        WHERE "blockNumber" <= {0}
+        """;
+
+    // ── Score-group loaders ───────────────────────────────────────────────
+    // Ported from HistoricalLoadGraph (the direct-DB loader). The proxy executes raw SQL with
+    // no parameter binding, so {1}=score-mint-policy array literal, {2}=standard mint policy,
+    // {3}=standard group router are inlined. All addresses come from Settings / DB rows (trusted,
+    // hex-only) — not user input — so inlining carries no injection surface. Block-pinned via {0}.
+
+    // Group → path-mint router. Score groups use their indexed pathMintRouter; standard groups
+    // fall back to the standard router. Mirrors GroupRoutersQueryTemplate.
+    private const string GroupRoutersQueryTemplate = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                "pathMintRouter" AS router_address
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE LOWER("emitter") = ANY({1})
+              AND "blockNumber" <= {0}
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        supported_groups AS (
+            SELECT g."group" AS group_address, g."mint", sg.router_address
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group sg ON sg.group_address = g."group"
+            WHERE g."blockNumber" <= {0}
+              AND (
+                  g."mint" = LOWER('{2}')
+                  OR (LOWER(g."mint") = ANY({1}) AND sg.router_address IS NOT NULL)
+              )
+        )
+        SELECT group_address,
+               CASE WHEN router_address IS NOT NULL THEN router_address ELSE LOWER('{3}') END
+        FROM supported_groups
+        """;
+
+    // Score-group path-mint routers. Mirrors ScoreRoutersQueryTemplate.
+    private const string ScoreRoutersQueryTemplate = """
+        SELECT DISTINCT LOWER("pathMintRouter") AS router_address
+        FROM "CrcV2_ScoreGroup_GroupInitialized"
+        WHERE LOWER("emitter") = ANY({1}) AND "blockNumber" <= {0}
+        """;
+
+    // Latest approved operator approvals for the given accounts. Mirrors OperatorApprovalsQueryTemplate.
+    // {1} = account array literal.
+    private const string OperatorApprovalsQueryTemplate = """
+        SELECT account, operator FROM (
+            SELECT DISTINCT ON (LOWER("account"), LOWER("operator"))
+                LOWER("account") AS account,
+                LOWER("operator") AS operator,
+                "approved" AS approved
+            FROM "CrcV2_ApprovalForAll"
+            WHERE LOWER("account") = ANY({1}) AND "blockNumber" <= {0}
+            ORDER BY LOWER("account"), LOWER("operator"),
+                     "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ) latest
+        WHERE approved = true
+        """;
+
+    private const string ConsentedFlowQueryTemplate = """
+        SELECT DISTINCT ON (avatar) avatar, flag
+        FROM "CrcV2_SetAdvancedUsageFlag"
+        WHERE "blockNumber" <= {0}
+        ORDER BY avatar, "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        """;
+
+    // Standard-only fallbacks used when no score policies are configured. These keep the exact
+    // pre-score behavior (and avoid referencing CrcV2_ScoreGroup_GroupInitialized) for the other
+    // suites that share ProxyLoadGraph (ScenarioTests etc.), mirroring the live loader's
+    // ScoreGroupTablesAvailable guard which falls back to the standard-only *.fallback.sql.
+    private const string GroupQueryStandardTemplate = """
         SELECT "group" AS group_address
         FROM "CrcV2_RegisterGroup"
         WHERE "mint" = LOWER('{1}')
           AND "blockNumber" <= {0}
         """;
 
-    // Group trust query with temporal filter — {1} = mint policy address
-    private const string GroupTrustQueryTemplate = """
+    private const string GroupTrustQueryStandardTemplate = """
         WITH trust_state AS (
             SELECT truster, trustee, "expiryTime",
                    row_number() OVER (PARTITION BY truster, trustee
@@ -122,18 +256,6 @@ public class ProxyLoadGraph : ILoadGraph
         INNER JOIN "CrcV2_RegisterGroup" g ON g."group" = t.truster
         WHERE g."mint" = LOWER('{1}')
           AND g."blockNumber" <= {0}
-        """;
-
-    private const string RegisteredAvatarsQueryTemplate = """
-        SELECT avatar FROM "V_CrcV2_Avatars"
-        WHERE "blockNumber" <= {0}
-        """;
-
-    private const string ConsentedFlowQueryTemplate = """
-        SELECT DISTINCT ON (avatar) avatar, flag
-        FROM "CrcV2_SetAdvancedUsageFlag"
-        WHERE "blockNumber" <= {0}
-        ORDER BY avatar, "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
         """;
 
     public ProxyLoadGraph(TestEnvironmentClient client, Settings settings)
@@ -226,7 +348,13 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<string> LoadGroups()
     {
-        var query = string.Format(GroupQueryTemplate, _client.BlockNumber, _settings.StandardMintPolicyAddress);
+        var scoreAware = _settings.ScoreGroupMintPolicies.Length > 0;
+        var query = scoreAware
+            ? string.Format(GroupQueryTemplate, _client.BlockNumber,
+                _settings.StandardMintPolicyAddress.ToLowerInvariant(),
+                SqlArrayLiteral(_settings.ScoreGroupMintPolicies))
+            : string.Format(GroupQueryStandardTemplate, _client.BlockNumber,
+                _settings.StandardMintPolicyAddress.ToLowerInvariant());
         var response = _client.ExecuteQueryAsync(query, maxRows: 10000).GetAwaiter().GetResult();
         var results = new List<string>();
 
@@ -243,7 +371,13 @@ public class ProxyLoadGraph : ILoadGraph
 
     public IEnumerable<(string GroupAddress, string TrustedToken)> LoadGroupTrusts()
     {
-        var query = string.Format(GroupTrustQueryTemplate, _client.BlockNumber, _settings.StandardMintPolicyAddress);
+        var scoreAware = _settings.ScoreGroupMintPolicies.Length > 0;
+        var query = scoreAware
+            ? string.Format(GroupTrustQueryTemplate, _client.BlockNumber,
+                _settings.StandardMintPolicyAddress.ToLowerInvariant(),
+                SqlArrayLiteral(_settings.ScoreGroupMintPolicies))
+            : string.Format(GroupTrustQueryStandardTemplate, _client.BlockNumber,
+                _settings.StandardMintPolicyAddress.ToLowerInvariant());
         var response = _client.ExecuteQueryAsync(query, maxRows: 100000).GetAwaiter().GetResult();
         var results = new List<(string GroupAddress, string TrustedToken)>();
 
@@ -255,6 +389,89 @@ public class ProxyLoadGraph : ILoadGraph
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Explicitly NOT supported via the test-env proxy — the production
+    /// <c>ScoreGroupMintLimitReader</c> needs a direct NpgsqlConnection. Returns empty so the
+    /// pathfinder models the score group with an UNBOUNDED mint cap. This is correct ONLY for
+    /// projection fixtures whose collateral has no mint-limit row (unbounded by definition); a
+    /// mint-limit-dependent case (e.g. P14 "limit reached") must NOT rely on this loader — it
+    /// would pass spuriously. Overridden explicitly (rather than inheriting the silent interface
+    /// default) to make the gap visible. See coverage tracker §5.E.
+    /// </summary>
+    public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits() => [];
+
+    public IEnumerable<(string GroupAddress, string RouterAddress)> LoadGroupRouters()
+    {
+        if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+
+        var query = string.Format(
+            GroupRoutersQueryTemplate,
+            _client.BlockNumber,
+            SqlArrayLiteral(_settings.ScoreGroupMintPolicies),
+            _settings.StandardMintPolicyAddress.ToLowerInvariant(),
+            _settings.GroupRouterAddress.ToLowerInvariant());
+
+        var response = _client.ExecuteQueryAsync(query, maxRows: 10000).GetAwaiter().GetResult();
+        var results = new List<(string GroupAddress, string RouterAddress)>();
+        foreach (var row in response.Rows)
+            results.Add((GetString(row[0]).ToLowerInvariant(), GetString(row[1]).ToLowerInvariant()));
+        return results;
+    }
+
+    public IEnumerable<string> LoadScoreRouters()
+    {
+        if (_settings.ScoreGroupMintPolicies.Length == 0)
+            return [];
+
+        var query = string.Format(
+            ScoreRoutersQueryTemplate,
+            _client.BlockNumber,
+            SqlArrayLiteral(_settings.ScoreGroupMintPolicies));
+
+        var response = _client.ExecuteQueryAsync(query, maxRows: 1000).GetAwaiter().GetResult();
+        var results = new List<string>();
+        foreach (var row in response.Rows)
+            results.Add(GetString(row[0]).ToLowerInvariant());
+        return results;
+    }
+
+    public IEnumerable<(string Account, string Operator)> LoadOperatorApprovals(IEnumerable<string> accounts)
+    {
+        var accountSet = accounts
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .Select(a => a.ToLowerInvariant())
+            .Distinct()
+            .ToArray();
+        if (accountSet.Length == 0)
+            return [];
+
+        var query = string.Format(
+            OperatorApprovalsQueryTemplate,
+            _client.BlockNumber,
+            SqlArrayLiteral(accountSet));
+
+        var response = _client.ExecuteQueryAsync(query, maxRows: 100000).GetAwaiter().GetResult();
+        var results = new List<(string Account, string Operator)>();
+        foreach (var row in response.Rows)
+            results.Add((GetString(row[0]).ToLowerInvariant(), GetString(row[1]).ToLowerInvariant()));
+        return results;
+    }
+
+    /// <summary>
+    /// Builds a Postgres text[] array literal — ARRAY['a','b'] — from address-like strings.
+    /// Values are lowercased and single quotes are doubled defensively; inputs are hex addresses
+    /// from Settings / DB rows, never user input.
+    /// </summary>
+    private static string SqlArrayLiteral(IEnumerable<string> values)
+    {
+        var quoted = values
+            .Select(v => $"'{v.ToLowerInvariant().Replace("'", "''")}'")
+            .ToList();
+        // Empty must be typed so Postgres can resolve "= ANY(...)" — ARRAY[] alone is untyped.
+        return quoted.Count == 0 ? "ARRAY[]::text[]" : $"ARRAY[{string.Join(",", quoted)}]";
     }
 
     public IEnumerable<(string Avatar, bool HasConsentedFlow)> LoadConsentedFlowFlags()

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Scenarios/TransferScenario.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Scenarios/TransferScenario.cs
@@ -264,6 +264,16 @@ public record TransferScenario
     public bool SkipProjection { get; init; }
 
     /// <summary>
+    /// Optional: when the projection tier finds a path, assert that at least one transfer
+    /// step carries this token owner (0x-prefixed address, case-insensitive). For ScoreGroup
+    /// routing cases this is the group address — a step minting the group's token proves the
+    /// path actually routed through the score group (and its router), not merely that some
+    /// path exists. Only checked when <see cref="ShouldFindPath"/> is true.
+    /// </summary>
+    [JsonPropertyName("expectedPathTokenOwner")]
+    public string? ExpectedPathTokenOwner { get; init; }
+
+    /// <summary>
     /// Whether this scenario should be executed against the live SDK (sdk-v2) in the
     /// TypeScript e2e suite. Informational marker for cross-repo coverage tracking.
     /// </summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupRegressionTests.cs
@@ -117,6 +117,17 @@ public class ScoreGroupRegressionTests
     [TestCaseSource(nameof(ProjectionCases))]
     public async Task Projection(TransferScenario scenario)
     {
+        // Authoring guard (runs even without staging): a score-group projection scenario that expects
+        // a path MUST assert which token gets minted, otherwise it silently degrades to a weak
+        // "found any path" check that wouldn't catch a regressed score-group loader.
+        if (scenario.ShouldFindPath
+            && scenario.Category.StartsWith("score-group", StringComparison.OrdinalIgnoreCase)
+            && string.IsNullOrEmpty(scenario.ExpectedPathTokenOwner))
+        {
+            Assert.Fail($"{scenario.Id}: a score-group projection scenario with shouldFindPath=true must set " +
+                        "expectedPathTokenOwner (the group token) to prove the path routes through group minting.");
+        }
+
         if (!TestEnvAvailable())
             return;
 
@@ -138,21 +149,24 @@ public class ScoreGroupRegressionTests
 
         try
         {
-            // Score-group features are only loaded by the direct LoadGraph (not the cached/proxy loaders),
-            // so this tier needs a direct, block-pinned DB connection.
-            if (!session.IsDirectConnectionAvailable)
-            {
-                Assert.Ignore("Score-group projection requires a direct DB connection (session.PostgresConnectionString)");
-                return;
-            }
-
+            // ProxyLoadGraph runs every query through the test-env HTTP query proxy with an
+            // inlined "WHERE blockNumber <= N" filter — so it is genuinely block-pinned AND
+            // reachable from a developer machine (no direct DB connection / credentials needed;
+            // staging does not expose Postgres remotely). It now implements the score-group
+            // loaders (group routers, score routers, operator approvals), so the pathfinder
+            // recognizes the score group and applies the router-trust / operator-approval gates
+            // instead of degrading it to a regular group.
+            //
+            // Demurrage is pinned to the block's own timestamp (not UtcNow) so balances match the
+            // historical block exactly — required for older-block tier-C cases to be correct.
             var settings = new Settings
             {
                 DisableConsentedFlow = false,
-                ScoreGroupMintPolicies = [ScoreGroupMintPolicy]
+                ScoreGroupMintPolicies = [ScoreGroupMintPolicy],
+                TargetDemurrageTimestamp = await BlockTimestampAsync(session, scenario.Block)
             };
 
-            var loadGraph = new LoadGraph(session.PostgresConnectionString!, settings);
+            var loadGraph = new ProxyLoadGraph(session, settings);
             var factory = new GraphFactory(RouterAddress, loadGraph);
 
             var trustGraph = factory.V2TrustGraph();
@@ -180,7 +194,26 @@ public class ScoreGroupRegressionTests
             {
                 Assert.That(response.Transfers, Is.Not.Null, $"{scenario.Id}: expected a path");
                 Assert.That(stepCount, Is.GreaterThan(0), $"{scenario.Id}: path has no steps");
-                TestContext.Out.WriteLine($"{scenario.Id}: found path with {stepCount} step(s), maxFlow={response.MaxFlow}");
+
+                // Routing assertion: prove the path actually went THROUGH the score group
+                // (a step mints the group's own token), not merely that some path exists.
+                if (!string.IsNullOrEmpty(scenario.ExpectedPathTokenOwner))
+                {
+                    var owners = response.Transfers!.Select(t => t.TokenOwner).ToList();
+                    Assert.That(
+                        owners.Any(o => string.Equals(o, scenario.ExpectedPathTokenOwner,
+                            StringComparison.OrdinalIgnoreCase)),
+                        Is.True,
+                        $"{scenario.Id}: expected a step minting token {scenario.ExpectedPathTokenOwner} " +
+                        $"(route through the score group), but none found. Token owners: [{string.Join(", ", owners)}]");
+                    TestContext.Out.WriteLine(
+                        $"{scenario.Id}: path routes through {scenario.ExpectedPathTokenOwner} " +
+                        $"({stepCount} step(s), maxFlow={response.MaxFlow})");
+                }
+                else
+                {
+                    TestContext.Out.WriteLine($"{scenario.Id}: found path with {stepCount} step(s), maxFlow={response.MaxFlow}");
+                }
             }
         }
         finally
@@ -363,6 +396,26 @@ public class ScoreGroupRegressionTests
     // =====================================================================
     //                              Helpers
     // =====================================================================
+
+    /// <summary>
+    /// Timestamp of the pinned block (max System_Block.timestamp at or below it), as a
+    /// DateTimeOffset, so the projection tier computes demurrage at the historical block time
+    /// rather than UtcNow. Falls back to UtcNow if the query returns nothing.
+    /// </summary>
+    private static async Task<DateTimeOffset> BlockTimestampAsync(TestEnvironmentClient session, long block)
+    {
+        var scalar = await session.ExecuteScalarAsync(
+            $"SELECT max(\"timestamp\") FROM \"System_Block\" WHERE \"blockNumber\" <= {block}");
+        if (scalar != null && long.TryParse(scalar.ToString(), out var ts) && ts > 0)
+            return DateTimeOffset.FromUnixTimeSeconds(ts);
+
+        // Fail loudly rather than silently falling back to UtcNow: for a pinned historical block
+        // that would compute demurrage at wall-clock time, invalidating every balance in the fixture.
+        // A real indexed block always has a System_Block row, so this only fires on a plumbing bug.
+        Assert.Fail($"Could not resolve System_Block timestamp for pinned block {block} (scalar='{scalar}'). " +
+                    "Refusing to compute demurrage at wall-clock time.");
+        return default; // unreachable — Assert.Fail throws
+    }
 
     private static bool TestEnvAvailable()
     {

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupScenarios/score-group-path-mint-through-router-001.json
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupScenarios/score-group-path-mint-through-router-001.json
@@ -1,0 +1,15 @@
+{
+  "id": "score-group-path-mint-through-router-001",
+  "name": "Pathfinder routes a payment through the ScoreGroupMintRouter into the score group (projection)",
+  "category": "score-group-router",
+  "description": "Block-pinned projection tier via ProxyLoadGraph (test-env HTTP query proxy; every query inlines WHERE blockNumber<=N, mirroring the LIVE groupQuery.sql / HistoricalLoadGraph score loaders — NOT the production HistoricalLoadGraph itself, which currently drops score groups; see task #44). The source is a member whose own personal CRC is trusted both by the score group (as collateral) and by the ScoreGroupMintRouter, and whom the router has approved as an ERC-1155 operator. The sink trusts the group token. Verified on staging at block 46488973: source/sink both registered humans; ApprovalForAll(account=SGR, operator=source)=true @46423855; SGR->source and SG->source trusts active (never-expire); sink->SG trust active @46408874; source holds 886 CRC of its own token; no mint-limit row for (SG,source) -> unbounded cap. toTokens is constrained to the group token so the sink can ONLY receive SG: a score group is wrapped-only / sink-only (the unwrapped ERC1155 cannot be held or forwarded by intermediaries), so the only way to deliver SG to the sink is a fresh group mint via the router — which in turn requires the score-group recognition + router-trust + operator-approval gates to all pass. expectedPathTokenOwner asserts a mint step carries the group token (TokenOwner == SG); path existence under toTokens=[SG] is what proves the route went through group minting (a regressed loader that dropped the score group yields ZERO steps). A stronger router-hop assertion (From==SGR) is future work. P16 / build-order #1.",
+  "block": 46488973,
+  "source": "0x1a24d8b3c424dad750423af7955a56aef3912905",
+  "sink": "0x122832c93e7c7bd7191b960513583d1a85735942",
+  "toTokens": ["0x93ed5a96347927ff6ff6b790f8cf5258240c321f"],
+  "shouldFindPath": true,
+  "expectedPathTokenOwner": "0x93ed5a96347927ff6ff6b790f8cf5258240c321f",
+  "runOnAnvil": false,
+  "skipProjection": false,
+  "tags": ["score-group", "router-mint", "projection", "C-path", "P16"]
+}


### PR DESCRIPTION
## What

Brings the ScoreGroup pathfinder **projection** test tier to life. It previously required a direct DB connection unavailable to remote test runners, so it silently skipped on every run. It now loads the graph through `ProxyLoadGraph` (the test-env HTTP query proxy), block-pinned by inlining `WHERE blockNumber <= N` into every query.

- Extend `ProxyLoadGraph` with score-group support: score-aware group and group-trust queries (include `mint = score-policy` groups) plus `LoadGroupRouters` / `LoadScoreRouters` / `LoadOperatorApprovals`. A standard-only fallback is kept for callers with no score policies configured, so the other suites that share `ProxyLoadGraph` are unchanged. `LoadScoreGroupMintLimits` is an explicit no-op (the proxy can't reach the direct reader) with a documented unbounded-cap caveat.
- Add `TransferScenario.ExpectedPathTokenOwner`. The projection tier asserts a mint step carries that token and **requires** it for score-group projection scenarios that expect a path (authoring guard). Demurrage is pinned to the block timestamp; resolution failure fails loud rather than falling back to wall-clock.
- New fixture forcing a payment **through the ScoreGroupMintRouter into the score group** (`toTokens=[group]`), asserting the resulting path mints the group token.

Test-only change (everything under `Circles.Pathfinder.Tests`); no production code touched.

## Test plan

- [x] Build: 0 errors
- [x] Offline harness (`ScoreGroupHarnessUnitTests`): 18/18
- [x] Projection fixture on staging: routes through the score group, 5 steps, maxFlow 1 CRC
- [x] Full ScoreGroup matrix on staging: 9 pass / 0 fail / 1 transient skip (session rate-limit)