### PR TITLE
fix(cache): cherry-pick self-heal tail reconciliation onto dev

### DIFF
--- a/src/Cache/Circles.Cache.Service.Tests/BalanceReconciliationTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/BalanceReconciliationTests.cs
@@ -1,0 +1,346 @@
+using Circles.Cache.Service;
+using Circles.Cache.Service.Caches;
+using Circles.Cache.Service.Metrics;
+using Circles.Cache.Service.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Xunit;
+
+namespace Circles.Cache.Service.Tests;
+
+/// <summary>
+/// Regression tests for the #74 self-heal: a transient one-sided over-credit in the cache's
+/// incremental V2 balance path (a reorg-triggered phantom balance on a group-mint router that
+/// nets to zero on-chain) must be reconciled away by re-deriving recently-active accounts from
+/// the authoritative DB aggregation. The DB reads are stubbed so the diff/correct/heal logic is
+/// exercised without a live PostgreSQL.
+///
+/// Ground truth driving this: BaseGroupMintRouter 0xdc287474… showed onChainBalance=0 and 0 DB
+/// balance rows, yet the live cache reported it sourcing 9–115 CRC of group tokens; the router is
+/// structurally flat (per-block cumulative balance is exactly 0 for every token). Faithful
+/// reconciliation against the DB therefore heals it: the router returns no authoritative row, so
+/// its cached balance is set to 0 and removed from the read index.
+/// </summary>
+public class BalanceReconciliationTests
+{
+    private const string Router = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+    private const string GroupToken = "0xc19bc204eb1c1d5b3fe500e5e5dfabab625f286c";
+    private const string OtherToken = "0x47684687ecc5c5375ac3144d91dd0274182f1632";
+
+    private static readonly NpgsqlDataSource DummyDataSource =
+        NpgsqlDataSource.Create("Host=localhost;Database=dummy");
+
+    private static string Key(string account, string token) => $"{account}:{token}";
+
+    private static (CacheServiceState state, CacheContainer caches) NewCache(long head)
+    {
+        var state = new CacheServiceState(rollbackCapacity: 64);
+        state.WarmupComplete = true;
+        state.WarmupTargetBlock = head - 100;
+        state.LastProcessedBlock = head;
+        var caches = new CacheContainer(rollbackCapacity: 64);
+        return (state, caches);
+    }
+
+    private static void SeedBalance(CacheContainer caches, long block, string account, string token, decimal balance)
+    {
+        var key = Key(account, token);
+        caches.V2BalancesByAccountAndToken.Add(block, key, balance);
+        caches.UpdateBalanceIndex(key, isV1: false, balance);
+    }
+
+    [Fact]
+    public async Task PhantomRouterBalance_WithNoAuthoritativeBacking_IsHealedToZeroAndDeindexed()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+
+        // Phantom: cache thinks the router holds 50 CRC of a group token it nets to 0 on-chain.
+        SeedBalance(caches, head, Router, GroupToken, 50m);
+        caches.GetTokenIdsForAddress(Router, isV1: false).Should().ContainSingle();
+
+        var before = CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("phantom_cleared").Value;
+
+        // DB authoritative says: router is active recently, but nets to zero → no balance rows.
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router },
+            authoritative: new()); // empty → router holds nothing
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(1);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, GroupToken), out var healed).Should().BeTrue();
+        healed.Should().Be(0m);
+        caches.GetTokenIdsForAddress(Router, isV1: false).Should().BeEmpty("the phantom token must drop out of the read index");
+        (CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("phantom_cleared").Value - before).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task OverstatedBalance_IsCorrectedDownToAuthoritative()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+        SeedBalance(caches, head, Router, GroupToken, 50m);
+
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router },
+            authoritative: new() { [Key(Router, GroupToken)] = (30m, head) });
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(1);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, GroupToken), out var v).Should().BeTrue();
+        v.Should().Be(30m);
+        caches.GetTokenIdsForAddress(Router, isV1: false).Should().ContainSingle("a positive corrected balance stays indexed");
+    }
+
+    [Fact]
+    public async Task MissingCredit_PresentInDbButNotCache_IsAdded()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+        // Cache has nothing for the account, DB authoritative says it holds 10 CRC.
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router },
+            authoritative: new() { [Key(Router, OtherToken)] = (10m, head) });
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(1);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, OtherToken), out var v).Should().BeTrue();
+        v.Should().Be(10m);
+        caches.GetTokenIdsForAddress(Router, isV1: false).Should().Contain(OtherToken);
+    }
+
+    [Fact]
+    public async Task CacheMatchesAuthoritative_NoCorrectionApplied()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+        SeedBalance(caches, head, Router, GroupToken, 30m);
+
+        var phantomBefore = CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("phantom_cleared").Value;
+        var valueBefore = CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("value_corrected").Value;
+
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router },
+            authoritative: new() { [Key(Router, GroupToken)] = (30m, head) });
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(0);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, GroupToken), out var v).Should().BeTrue();
+        v.Should().Be(30m);
+        (CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("phantom_cleared").Value - phantomBefore).Should().Be(0);
+        (CacheMetrics.ReconciliationCorrectionsTotal.WithLabels("value_corrected").Value - valueBefore).Should().Be(0);
+    }
+
+    [Fact]
+    public async Task NoRecentlyActiveAccounts_IsANoOp()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new(),
+            authoritative: new(),
+            failIfAuthoritativeQueried: true); // must not hit the (stubbed) authoritative path
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task MultipleAccountsAndTokens_OnlyDriftedEntriesCorrected()
+    {
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+        const string accountB = "0x402acd040000000000000000000000000000beef";
+
+        // Router: GroupToken phantom (50→0), OtherToken correct (12==auth, untouched).
+        SeedBalance(caches, head, Router, GroupToken, 50m);
+        SeedBalance(caches, head, Router, OtherToken, 12m);
+        // Account B: overstated (40→25).
+        SeedBalance(caches, head, accountB, GroupToken, 40m);
+
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router, accountB },
+            authoritative: new()
+            {
+                [Key(Router, OtherToken)] = (12m, head),   // matches → no correction
+                [Key(accountB, GroupToken)] = (25m, head), // corrected down
+                // Router:GroupToken absent → healed to 0
+            });
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(2);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, GroupToken), out var a1);
+        a1.Should().Be(0m);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(Router, OtherToken), out var a2);
+        a2.Should().Be(12m);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(accountB, GroupToken), out var b1);
+        b1.Should().Be(25m);
+        caches.GetTokenIdsForAddress(Router, isV1: false).Should().BeEquivalentTo(new[] { OtherToken });
+        caches.GetTokenIdsForAddress(accountB, isV1: false).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AuthoritativeAccountBeyondRecentList_IsStillReconciled()
+    {
+        // Exercises the accountSet union: an account surfaced only by the authoritative map (not the
+        // recent list) must still be applied.
+        const long head = 46497729;
+        var (state, caches) = NewCache(head);
+        const string extra = "0xabcdef0000000000000000000000000000001234";
+
+        var listener = new StubReconciliationListener(
+            state, caches,
+            recentAccounts: new() { Router },
+            authoritative: new() { [Key(extra, GroupToken)] = (7m, head) });
+
+        var corrections = await listener.ReconcileRecentV2BalancesAsync(head, CancellationToken.None);
+
+        corrections.Should().Be(1);
+        caches.V2BalancesByAccountAndToken.TryGetValue(Key(extra, GroupToken), out var v).Should().BeTrue();
+        v.Should().Be(7m);
+    }
+
+    [Fact]
+    public async Task Throttle_SkipsWithinInterval_FiresAtBoundary()
+    {
+        var settings = new CacheServiceSettings
+        {
+            PostgresConnectionString = "Host=localhost",
+            ReconciliationIntervalBlocks = 8
+        };
+        var listener = new ThrottleListener(settings);
+
+        await listener.MaybeReconcileAsync(50, CancellationToken.None);  // fires (cursor was -1)
+        await listener.MaybeReconcileAsync(57, CancellationToken.None);  // 7 < 8 → skip
+        await listener.MaybeReconcileAsync(58, CancellationToken.None);  // 8 >= 8 → fires
+
+        listener.CalledHeads.Should().Equal(50, 58);
+    }
+
+    [Fact]
+    public async Task Throttle_FailedPass_DoesNotAdvanceCursor_AndRetriesNextBlock()
+    {
+        var settings = new CacheServiceSettings
+        {
+            PostgresConnectionString = "Host=localhost",
+            ReconciliationIntervalBlocks = 8
+        };
+        var listener = new ThrottleListener(settings, throwFirstN: 1);
+
+        await listener.MaybeReconcileAsync(100, CancellationToken.None); // fires, throws → cursor stays -1
+        await listener.MaybeReconcileAsync(101, CancellationToken.None); // retries (cursor still -1), succeeds
+        await listener.MaybeReconcileAsync(105, CancellationToken.None); // 4 < 8 → skip
+        await listener.MaybeReconcileAsync(109, CancellationToken.None); // 8 >= 8 → fires
+
+        listener.CalledHeads.Should().Equal(100, 101, 109);
+    }
+
+    [Fact]
+    public async Task Throttle_Disabled_NeverRuns()
+    {
+        var settings = new CacheServiceSettings
+        {
+            PostgresConnectionString = "Host=localhost",
+            ReconciliationEnabled = false
+        };
+        var listener = new ThrottleListener(settings);
+
+        await listener.MaybeReconcileAsync(100, CancellationToken.None);
+
+        listener.CalledHeads.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Subclass that stubs the two DB reads (recent accounts + authoritative balances) and the
+    /// readonly-connection acquisition so the reconciliation diff/correct logic runs DB-free.
+    /// </summary>
+    private sealed class StubReconciliationListener : NotificationListenerService
+    {
+        private readonly List<string> _recentAccounts;
+        private readonly Dictionary<string, (decimal Balance, long LastActivity)> _authoritative;
+        private readonly bool _failIfAuthoritativeQueried;
+
+        public StubReconciliationListener(
+            CacheServiceState state,
+            CacheContainer caches,
+            List<string> recentAccounts,
+            Dictionary<string, (decimal Balance, long LastActivity)> authoritative,
+            bool failIfAuthoritativeQueried = false)
+            : base(
+                NullLogger<NotificationListenerService>.Instance,
+                new CacheServiceSettings { PostgresConnectionString = "Host=localhost" },
+                state,
+                caches,
+                DummyDataSource)
+        {
+            _recentAccounts = recentAccounts;
+            _authoritative = authoritative;
+            _failIfAuthoritativeQueried = failIfAuthoritativeQueried;
+        }
+
+        protected override Task WithReadonlyConnectionAsync(
+            Func<NpgsqlConnection, CancellationToken, Task> action, CancellationToken ct)
+            => action(null!, ct); // no real DB; the stubbed reads below ignore the connection
+
+        protected override Task<List<string>> GetRecentlyActiveAccountsAsync(
+            NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
+            => Task.FromResult(_recentAccounts);
+
+        protected override Task<Dictionary<string, (decimal Balance, long LastActivity)>>
+            FetchAuthoritativeV2BalancesAsync(
+                NpgsqlConnection conn, IReadOnlyCollection<string> accounts, long toBlock, CancellationToken ct)
+        {
+            if (_failIfAuthoritativeQueried)
+                throw new InvalidOperationException("authoritative query must not run when no accounts are active");
+            return Task.FromResult(_authoritative);
+        }
+    }
+
+    /// <summary>
+    /// Subclass that records each reconciliation call (and can fail the first N) so the throttle /
+    /// advance-on-success logic in <see cref="NotificationListenerService.MaybeReconcileAsync"/> is
+    /// testable without a DB.
+    /// </summary>
+    private sealed class ThrottleListener : NotificationListenerService
+    {
+        public readonly List<long> CalledHeads = new();
+        private int _throwFirstN;
+
+        public ThrottleListener(CacheServiceSettings settings, int throwFirstN = 0)
+            : base(
+                NullLogger<NotificationListenerService>.Instance,
+                settings,
+                new CacheServiceState(rollbackCapacity: 8) { WarmupComplete = true },
+                new CacheContainer(rollbackCapacity: 8),
+                DummyDataSource)
+        {
+            _throwFirstN = throwFirstN;
+        }
+
+        internal override async Task<int> ReconcileRecentV2BalancesAsync(long toBlock, CancellationToken ct)
+        {
+            CalledHeads.Add(toBlock);
+            await Task.Yield();
+            if (_throwFirstN > 0)
+            {
+                _throwFirstN--;
+                throw new InvalidOperationException("simulated reconcile failure");
+            }
+            return 0;
+        }
+    }
+}

--- a/src/Cache/Circles.Cache.Service/CacheMetrics.cs
+++ b/src/Cache/Circles.Cache.Service/CacheMetrics.cs
@@ -70,6 +70,33 @@ public static class CacheMetrics
         .CreateCounter("circles_cache_notifications_received_total",
             "Total number of pg_notify notifications received");
 
+    // Tail self-heal reconciliation (#74): re-derives recently-active accounts from the
+    // authoritative DB aggregation and overwrites incremental balances that drifted.
+    public static readonly Counter ReconciliationRunsTotal = Prometheus.Metrics
+        .CreateCounter("circles_cache_reconciliation_runs_total",
+            "Total number of tail balance-reconciliation passes attempted (incremented before any DB read, " +
+            "so a flatlining counter means reconciliation stopped running, not that the chain is quiet)");
+
+    public static readonly Counter ReconciliationFailuresTotal = Prometheus.Metrics
+        .CreateCounter("circles_cache_reconciliation_failures_total",
+            "Tail reconciliation passes that threw (DB down, query timeout, oversized window). A persistently " +
+            "rising counter means drift is no longer being healed — alert on it");
+
+    public static readonly Counter ReconciliationSkippedOversizedTotal = Prometheus.Metrics
+        .CreateCounter("circles_cache_reconciliation_skipped_oversized_total",
+            "Reconciliation passes skipped because the active-account set exceeded ReconciliationMaxAccounts " +
+            "(protects block ingestion from a pathological window)");
+
+    public static readonly Counter ReconciliationCorrectionsTotal = Prometheus.Metrics
+        .CreateCounter("circles_cache_reconciliation_corrections_total",
+            "Balance entries corrected by tail reconciliation, labeled by kind " +
+            "(phantom_cleared = drifted to 0; value_corrected = drifted to a different positive value)",
+            new CounterConfiguration { LabelNames = new[] { "kind" } });
+
+    public static readonly Gauge ReconciliationAccountsScanned = Prometheus.Metrics
+        .CreateGauge("circles_cache_reconciliation_accounts_scanned",
+            "Distinct recently-active accounts scanned by the last reconciliation pass");
+
     // API request metrics (supplement HTTP metrics)
     public static readonly Counter BalanceQueriesTotal = Prometheus.Metrics
         .CreateCounter("circles_cache_balance_queries_total",

--- a/src/Cache/Circles.Cache.Service/CacheServiceSettings.cs
+++ b/src/Cache/Circles.Cache.Service/CacheServiceSettings.cs
@@ -41,6 +41,49 @@ public class CacheServiceSettings
     public int MaxCatchupLag { get; init; } = 10;
 
     /// <summary>
+    /// Whether the tail self-heal reconciliation runs. When enabled, every
+    /// <see cref="ReconciliationIntervalBlocks"/> blocks the service re-derives the balances of
+    /// recently-active accounts directly from the authoritative DB aggregation and overwrites any
+    /// that drifted (e.g. a reorg-triggered one-sided over-credit on a group-mint router that the
+    /// incremental path advanced past and never re-read). Set false to disable without redeploying.
+    /// Environment variable: RECONCILIATION_ENABLED
+    /// Default: true
+    /// </summary>
+    public bool ReconciliationEnabled { get; init; } = true;
+
+    /// <summary>
+    /// Window (in blocks, back from the cache head) of accounts to re-derive on each reconciliation
+    /// pass. Must comfortably exceed <see cref="ReorgDetectionWindow"/> is NOT required, but it
+    /// should cover the depth at which reorg-induced drift can form; the wider it is, the longer a
+    /// stuck phantom keeps being re-checked. Bounded by the per-account composite index, so cost
+    /// scales with distinct accounts active in the window, not full history.
+    /// Environment variable: RECONCILIATION_WINDOW_BLOCKS
+    /// Default: 256 blocks
+    /// </summary>
+    public int ReconciliationWindowBlocks { get; init; } = 256;
+
+    /// <summary>
+    /// Minimum number of blocks the cache head must advance between reconciliation passes. Throttles
+    /// the (DB-bound) reconciliation off the per-block notification cadence. At ~5s/block, the
+    /// default ≈ 40s between passes.
+    /// Environment variable: RECONCILIATION_INTERVAL_BLOCKS
+    /// Default: 8 blocks
+    /// </summary>
+    public int ReconciliationIntervalBlocks { get; init; } = 8;
+
+    /// <summary>
+    /// Safety cap on the number of recently-active accounts a single reconciliation pass will
+    /// process. Because reconciliation runs inline on the block-ingestion path, a pathological
+    /// window (airdrop, bulk migration) returning tens of thousands of accounts could stall
+    /// ingestion. If the active-account set exceeds this, the pass is skipped (counted via
+    /// <c>circles_cache_reconciliation_skipped_oversized_total</c>) rather than risking a long
+    /// inline query; a smaller subsequent window then heals normally.
+    /// Environment variable: RECONCILIATION_MAX_ACCOUNTS
+    /// Default: 5000 accounts
+    /// </summary>
+    public int ReconciliationMaxAccounts { get; init; } = 5000;
+
+    /// <summary>
     /// HTTP port for the service (health checks and API endpoints).
     /// Environment variable: PORT
     /// Default: 5002
@@ -84,6 +127,24 @@ public class CacheServiceSettings
             throw new InvalidOperationException(
                 $"MAX_CATCHUP_LAG must be non-negative (got {MaxCatchupLag})");
         }
+
+        if (ReconciliationWindowBlocks < 1 || ReconciliationWindowBlocks > 100000)
+        {
+            throw new InvalidOperationException(
+                $"RECONCILIATION_WINDOW_BLOCKS must be between 1 and 100000 (got {ReconciliationWindowBlocks})");
+        }
+
+        if (ReconciliationIntervalBlocks < 1)
+        {
+            throw new InvalidOperationException(
+                $"RECONCILIATION_INTERVAL_BLOCKS must be >= 1 (got {ReconciliationIntervalBlocks})");
+        }
+
+        if (ReconciliationMaxAccounts < 1)
+        {
+            throw new InvalidOperationException(
+                $"RECONCILIATION_MAX_ACCOUNTS must be >= 1 (got {ReconciliationMaxAccounts})");
+        }
     }
 
     /// <summary>
@@ -108,6 +169,21 @@ public class CacheServiceSettings
                 int.TryParse(Environment.GetEnvironmentVariable("MAX_CATCHUP_LAG"), out var lag)
                     ? lag
                     : 10,
+            ReconciliationEnabled =
+                !bool.TryParse(Environment.GetEnvironmentVariable("RECONCILIATION_ENABLED"), out var reconEnabled)
+                || reconEnabled,
+            ReconciliationWindowBlocks =
+                int.TryParse(Environment.GetEnvironmentVariable("RECONCILIATION_WINDOW_BLOCKS"), out var reconWindow)
+                    ? reconWindow
+                    : 256,
+            ReconciliationIntervalBlocks =
+                int.TryParse(Environment.GetEnvironmentVariable("RECONCILIATION_INTERVAL_BLOCKS"), out var reconInterval)
+                    ? reconInterval
+                    : 8,
+            ReconciliationMaxAccounts =
+                int.TryParse(Environment.GetEnvironmentVariable("RECONCILIATION_MAX_ACCOUNTS"), out var reconMaxAccounts)
+                    ? reconMaxAccounts
+                    : 5000,
             Port = int.TryParse(Environment.GetEnvironmentVariable("PORT"), out var port) ? port : 5002,
             IpfsCacheMaxEntries = int.TryParse(Environment.GetEnvironmentVariable("IPFS_CACHE_MAX_ENTRIES"), out var ipfsMax) ? ipfsMax : 50000
         };

--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -15,6 +15,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Allow the test project to drive internal reconciliation hooks directly. -->
+    <InternalsVisibleTo Include="Circles.Cache.Service.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- ASP.NET Core and Health Checks -->
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />

--- a/src/Cache/Circles.Cache.Service/Program.cs
+++ b/src/Cache/Circles.Cache.Service/Program.cs
@@ -127,6 +127,9 @@ logger.LogInformation("PostgreSQL Pool: min={MinPool}, max={MaxPool}",
 logger.LogInformation("PG Notify Channel: {Channel}", settings.PgNotifyChannel);
 logger.LogInformation("Rollback Capacity: {Capacity} blocks", settings.RollbackCapacity);
 logger.LogInformation("Max Catchup Lag: {Lag} blocks", settings.MaxCatchupLag);
+logger.LogInformation("Tail Reconciliation: {Enabled} (window={Window} blocks, every {Interval} blocks)",
+    settings.ReconciliationEnabled ? "enabled" : "disabled",
+    settings.ReconciliationWindowBlocks, settings.ReconciliationIntervalBlocks);
 logger.LogInformation("HTTP Port: {Port}", settings.Port);
 logger.LogInformation("=======================================");
 

--- a/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.Reconciliation.cs
+++ b/src/Cache/Circles.Cache.Service/Services/Listeners/NotificationListenerService.Reconciliation.cs
@@ -1,0 +1,309 @@
+using System.Numerics;
+using Circles.Cache.Service.Metrics;
+using Circles.Common;
+using Npgsql;
+
+namespace Circles.Cache.Service.Services;
+
+/// <summary>
+/// Tail self-heal reconciliation (#74).
+///
+/// <para>The incremental balance path (<see cref="ProcessV2TransfersAsync"/>) is an optimization:
+/// it applies per-block deltas and advances <c>LastProcessedBlock</c> past each block, never to
+/// re-read it. A reorg can leave a one-sided over-credit in that running total (an IN applied
+/// without its matching OUT), and because the block is never revisited, the drift sticks until a
+/// full re-warmup. Observed in production as a group-mint router (BaseGroupMintRouter) the cache
+/// reported sourcing 9–115 CRC of group tokens it nets to zero on-chain; a block-pinned (DB-backed)
+/// replay at the same height gave the correct ~0.</para>
+///
+/// <para>The DB is authoritative and self-consistent: aggregating all transfers <c>blockNumber &lt;=
+/// head</c> yields the correct balance for every account at every height. This pass re-derives the
+/// balances of accounts active in the recent window straight from that aggregation (the same
+/// <c>SUM(delta) HAVING &gt; 0</c> the warmup uses) and overwrites any cache entry that diverged.
+/// A net-zero account simply returns no row, so its phantom balance is healed to 0 and dropped from
+/// the read index. This is trigger-agnostic: it corrects the drift regardless of which reorg
+/// interleaving produced it.</para>
+///
+/// <para>Reconciliation runs inline under <c>_notificationGate</c> (never on a background thread):
+/// it writes via <see cref="RollbackCache{TKey,TValue}.Add"/> at the cache head, which requires
+/// monotonically non-decreasing block numbers — a concurrent pass at an older block while the next
+/// block is being processed would violate that invariant.</para>
+/// </summary>
+public partial class NotificationListenerService
+{
+    /// <summary>
+    /// Sub-µCRC tolerance below which a cache/authoritative difference is treated as equal. Raw
+    /// balance sums are exact in <see cref="decimal"/>, so a real drift (the #74 phantom is 9–115
+    /// CRC) is orders of magnitude above this; the guard only avoids churn on negligible noise.
+    /// </summary>
+    private const decimal ReconcileEpsilon = 0.0000005m;
+
+    /// <summary>
+    /// Re-derives the balances of accounts active in the recent window from the authoritative DB
+    /// aggregation (pinned to <paramref name="toBlock"/> = the cache head) and overwrites any cache
+    /// entry that drifted. Returns the number of corrections applied.
+    /// </summary>
+    internal virtual async Task<int> ReconcileRecentV2BalancesAsync(long toBlock, CancellationToken ct)
+    {
+        if (toBlock < 0)
+            return 0;
+
+        // Count the attempt up-front, before any DB read, so the runs counter reflects "did a pass
+        // run" regardless of where it might fail. A flatlining counter then means reconciliation
+        // stopped (vs the chain being quiet), and failures are tracked separately by the caller.
+        CacheMetrics.ReconciliationRunsTotal.Inc();
+
+        var window = Math.Max(1, _settings.ReconciliationWindowBlocks);
+        var fromBlock = Math.Max(0, toBlock - window + 1);
+        var corrections = 0;
+
+        await WithReadonlyConnectionAsync(async (conn, token) =>
+        {
+            var accounts = await GetRecentlyActiveAccountsAsync(conn, fromBlock, toBlock, token);
+            CacheMetrics.ReconciliationAccountsScanned.Set(accounts.Count);
+
+            if (accounts.Count == 0)
+                return;
+
+            // Reconciliation runs inline on the block-ingestion path. A pathological window
+            // (airdrop, bulk migration) could return a huge account set whose aggregation stalls
+            // ingestion — refuse it rather than block. A narrower later window heals normally.
+            if (accounts.Count > _settings.ReconciliationMaxAccounts)
+            {
+                CacheMetrics.ReconciliationSkippedOversizedTotal.Inc();
+                _logger.LogWarning(
+                    "Tail reconciliation skipped: {Count} active accounts in [{From},{To}] exceeds cap {Cap}",
+                    accounts.Count, fromBlock, toBlock, _settings.ReconciliationMaxAccounts);
+                return;
+            }
+
+            var authoritative = await FetchAuthoritativeV2BalancesAsync(conn, accounts, toBlock, token);
+            corrections = ApplyReconciliation(accounts, authoritative, toBlock);
+        }, ct);
+
+        return corrections;
+    }
+
+    /// <summary>
+    /// Diffs the cache against the authoritative balances for the active accounts and applies
+    /// corrections. Pure cache logic (no DB) so it is unit-testable with stubbed reads.
+    /// </summary>
+    private int ApplyReconciliation(
+        IReadOnlyCollection<string> accounts,
+        IReadOnlyDictionary<string, (decimal Balance, long LastActivity)> authoritative,
+        long toBlock)
+    {
+        // Group the authoritative "account:token" rows by account for O(1) per-account lookup.
+        var authByAccount = new Dictionary<string, Dictionary<string, (decimal Balance, long LastActivity)>>();
+        foreach (var (key, value) in authoritative)
+        {
+            var sep = key.IndexOf(':');
+            if (sep < 0)
+                continue;
+            var acct = key[..sep];
+            var token = key[(sep + 1)..];
+            if (!authByAccount.TryGetValue(acct, out var tokens))
+            {
+                tokens = new Dictionary<string, (decimal, long)>();
+                authByAccount[acct] = tokens;
+            }
+            tokens[token] = value;
+        }
+
+        // Reconcile every account we considered (recently-active) plus any the authoritative query
+        // surfaced — covers both directions: cached-but-not-authoritative (heal to 0) and
+        // authoritative-but-not-cached (add the missing credit).
+        var accountSet = new HashSet<string>(accounts.Select(a => a.ToLowerInvariant()));
+        foreach (var acct in authByAccount.Keys)
+            accountSet.Add(acct);
+
+        var corrections = 0;
+        foreach (var account in accountSet)
+        {
+            authByAccount.TryGetValue(account, out var authTokens);
+
+            var tokens = new HashSet<string>(_caches.GetTokenIdsForAddress(account, isV1: false));
+            if (authTokens != null)
+                foreach (var token in authTokens.Keys)
+                    tokens.Add(token);
+
+            foreach (var token in tokens)
+            {
+                var key = $"{account}:{token}";
+
+                decimal desired = 0m;
+                long lastActivity = 0;
+                if (authTokens != null && authTokens.TryGetValue(token, out var auth))
+                {
+                    desired = auth.Balance;
+                    lastActivity = auth.LastActivity;
+                }
+
+                _caches.V2BalancesByAccountAndToken.TryGetValue(key, out var current);
+                if (Math.Abs(current - desired) <= ReconcileEpsilon)
+                    continue;
+
+                _caches.V2BalancesByAccountAndToken.Add(toBlock, key, desired);
+                _caches.UpdateBalanceIndex(key, isV1: false, desired);
+                if (lastActivity > 0)
+                    _caches.V2LastActivity.Add(toBlock, key, lastActivity);
+
+                var kind = desired <= 0m ? "phantom_cleared" : "value_corrected";
+                CacheMetrics.ReconciliationCorrectionsTotal.WithLabels(kind).Inc();
+                corrections++;
+
+                _logger.LogWarning(
+                    "CACHE BALANCE RECONCILE corrected account={Account} token={Token} cached={Cached} " +
+                    "authoritative={Authoritative} kind={Kind} block={Block} recentReorgs=[{RecentReorgs}]",
+                    account, token, current, desired, kind, toBlock, RecentReorgPointsCsv());
+            }
+        }
+
+        return corrections;
+    }
+
+    /// <summary>
+    /// Distinct, non-zero accounts that appear as sender or receiver in any V2 transfer table within
+    /// [<paramref name="fromBlock"/>, <paramref name="toBlock"/>]. Addresses are stored lowercase in
+    /// the DB, so the result is already normalized. Bounded by the blockNumber index.
+    /// </summary>
+    protected virtual async Task<List<string>> GetRecentlyActiveAccountsAsync(
+        NpgsqlConnection conn, long fromBlock, long toBlock, CancellationToken ct)
+    {
+        const string sql = @"
+            SELECT DISTINCT account FROM (
+                SELECT ""from"" AS account FROM ""CrcV2_TransferSingle"" WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+                UNION
+                SELECT ""to""        FROM ""CrcV2_TransferSingle"" WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+                UNION
+                SELECT ""from""      FROM ""CrcV2_TransferBatch""  WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+                UNION
+                SELECT ""to""        FROM ""CrcV2_TransferBatch""  WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+                UNION
+                SELECT ""from""      FROM ""CrcV2_Erc20WrapperTransfer"" WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+                UNION
+                SELECT ""to""        FROM ""CrcV2_Erc20WrapperTransfer"" WHERE ""blockNumber"" BETWEEN @fromBlock AND @toBlock
+            ) s
+            WHERE account <> '0x0000000000000000000000000000000000000000'";
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("fromBlock", fromBlock);
+        cmd.Parameters.AddWithValue("toBlock", toBlock);
+        // Bounded: this runs inline on the block-ingestion path, so a slow query must fail fast
+        // (caught best-effort) rather than stall ingestion. The blockNumber-indexed window scan is
+        // sub-second in steady state.
+        cmd.CommandTimeout = 20;
+
+        var accounts = new List<string>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            accounts.Add(reader.GetString(0).ToLowerInvariant());
+
+        return accounts;
+    }
+
+    /// <summary>
+    /// Authoritative raw (non-demurraged) V2 balances for the given accounts, pinned to
+    /// <paramref name="toBlock"/>. Mirrors the warmup aggregation exactly: ERC1155 (TransferSingle +
+    /// TransferBatch) filtered by a registered token owner, plus ERC20 wrapper transfers filtered by
+    /// a registered holder, each kept only when the net is positive. Keyed by "account:token".
+    /// </summary>
+    protected virtual async Task<Dictionary<string, (decimal Balance, long LastActivity)>>
+        FetchAuthoritativeV2BalancesAsync(
+            NpgsqlConnection conn, IReadOnlyCollection<string> accounts, long toBlock, CancellationToken ct)
+    {
+        var result = new Dictionary<string, (decimal, long)>();
+        if (accounts.Count == 0)
+            return result;
+
+        const string sql = @"
+            WITH registered_avatars AS MATERIALIZED (
+                SELECT organization AS avatar FROM ""CrcV2_RegisterOrganization"" WHERE ""blockNumber"" <= @toBlock
+                UNION ALL
+                SELECT ""group"" AS avatar FROM ""CrcV2_RegisterGroup"" WHERE ""blockNumber"" <= @toBlock
+                UNION ALL
+                SELECT avatar FROM ""CrcV2_RegisterHuman"" WHERE ""blockNumber"" <= @toBlock
+            ),
+            erc1155 AS (
+                SELECT account, ""tokenAddress"", SUM(delta) AS balance, MAX(ts) AS last_activity
+                FROM (
+                    SELECT ""from"" AS account, ""tokenAddress"", -value AS delta, ""timestamp"" AS ts
+                    FROM ""CrcV2_TransferSingle"" WHERE ""blockNumber"" <= @toBlock AND ""from"" = ANY(@accounts)
+                    UNION ALL
+                    SELECT ""to"", ""tokenAddress"", value, ""timestamp""
+                    FROM ""CrcV2_TransferSingle"" WHERE ""blockNumber"" <= @toBlock AND ""to"" = ANY(@accounts)
+                    UNION ALL
+                    SELECT ""from"", ""tokenAddress"", -value, ""timestamp""
+                    FROM ""CrcV2_TransferBatch"" WHERE ""blockNumber"" <= @toBlock AND ""from"" = ANY(@accounts)
+                    UNION ALL
+                    SELECT ""to"", ""tokenAddress"", value, ""timestamp""
+                    FROM ""CrcV2_TransferBatch"" WHERE ""blockNumber"" <= @toBlock AND ""to"" = ANY(@accounts)
+                ) t
+                GROUP BY account, ""tokenAddress""
+                HAVING SUM(delta) > 0
+            ),
+            wrapper AS (
+                SELECT account, ""tokenAddress"", SUM(delta) AS balance, MAX(ts) AS last_activity
+                FROM (
+                    SELECT ""from"" AS account, ""tokenAddress"", -amount AS delta, ""timestamp"" AS ts
+                    FROM ""CrcV2_Erc20WrapperTransfer"" WHERE ""blockNumber"" <= @toBlock AND ""from"" = ANY(@accounts)
+                    UNION ALL
+                    SELECT ""to"", ""tokenAddress"", amount, ""timestamp""
+                    FROM ""CrcV2_Erc20WrapperTransfer"" WHERE ""blockNumber"" <= @toBlock AND ""to"" = ANY(@accounts)
+                ) t
+                GROUP BY account, ""tokenAddress""
+                HAVING SUM(delta) > 0
+            )
+            SELECT e.account, e.""tokenAddress"", e.balance, e.last_activity
+            FROM erc1155 e INNER JOIN registered_avatars ra ON ra.avatar = e.""tokenAddress""
+            UNION ALL
+            SELECT w.account, w.""tokenAddress"", w.balance, w.last_activity
+            FROM wrapper w INNER JOIN registered_avatars ra ON ra.avatar = w.account";
+
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("toBlock", toBlock);
+        cmd.Parameters.AddWithValue("accounts", accounts.ToArray());
+        // Bounded inline query (see GetRecentlyActiveAccountsAsync): the account set is capped and
+        // each account is served by the (from|to, tokenAddress) composite index.
+        cmd.CommandTimeout = 30;
+
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            var account = reader.GetString(0).ToLowerInvariant();
+            var tokenAddress = reader.GetString(1).ToLowerInvariant();
+            var balanceBig = reader.GetFieldValue<BigInteger>(2);
+            var lastActivity = reader.GetInt64(3);
+
+            decimal balance;
+            try
+            {
+                balance = CirclesConverter.AttoCirclesToCircles(balanceBig);
+            }
+            catch (OverflowException ex)
+            {
+                // A partial authoritative map is unsafe to drive corrections: downstream, a missing
+                // row reads as "desired = 0" and would zero a correct cached balance. Abort the whole
+                // pass instead of silently dropping one row. (Caught best-effort by MaybeReconcileAsync
+                // and counted as a failure.) Unreachable for real Circles balances (> ~7.9e28 CRC).
+                _logger.LogError(ex,
+                    "Reconcile aborted: balance {Value} for account={Account} token={Token} overflows decimal",
+                    balanceBig, account, tokenAddress);
+                throw;
+            }
+
+            if (balance <= 0)
+                continue;
+
+            // ERC1155 and wrapper keys are disjoint namespaces (token-owner vs wrapper contract),
+            // so a straight assignment is correct; tolerate a duplicate by summing defensively.
+            var key = $"{account}:{tokenAddress}";
+            if (result.TryGetValue(key, out var existing))
+                result[key] = (existing.Item1 + balance, Math.Max(existing.Item2, lastActivity));
+            else
+                result[key] = (balance, lastActivity);
+        }
+
+        return result;
+    }
+}

--- a/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
+++ b/src/Cache/Circles.Cache.Service/Services/NotificationListenerService.cs
@@ -11,7 +11,7 @@ namespace Circles.Cache.Service.Services;
 /// Treats notifications as "pings" and queries the database directly for block information.
 /// Uses BlockRingBuffer to detect chain reorganizations.
 /// </summary>
-public class NotificationListenerService : BackgroundService
+public partial class NotificationListenerService : BackgroundService
 {
     private readonly ILogger<NotificationListenerService> _logger;
     private readonly CacheServiceSettings _settings;
@@ -27,6 +27,13 @@ public class NotificationListenerService : BackgroundService
     // block ranges, and double-apply cache mutations (or trigger spurious re-warmups from
     // RollbackCache.Add throwing on non-monotonic block numbers).
     private readonly SemaphoreSlim _notificationGate = new(1, 1);
+
+    // #74 tail self-heal: throttle reconciliation off the per-block notification cadence, and keep a
+    // small ring of recent reorg points so a correction log can name the likely trigger window.
+    // Both are touched only under _notificationGate.
+    private long _lastReconciledBlock = -1;
+    private readonly LinkedList<long> _recentReorgPoints = new();
+    private const int RecentReorgPointsCapacity = 16;
 
     protected CacheServiceSettings Settings => _settings;
     protected CacheServiceState State => _state;
@@ -182,6 +189,8 @@ public class NotificationListenerService : BackgroundService
 
             if (reorgPoint.HasValue)
             {
+                RecordReorgPoint(reorgPoint.Value);
+
                 if (reorgPoint.Value <= _state.WarmupTargetBlock)
                 {
                     _logger.LogWarning(
@@ -252,6 +261,12 @@ public class NotificationListenerService : BackgroundService
 
                     _logger.LogInformation("Completed processing blocks {FromBlock} → {ToBlock}. Cache now at block {CurrentBlock}",
                         fromBlock, latestBlock, _state.LastProcessedBlock);
+
+                    // #74 tail self-heal: re-derive recently-active accounts from the authoritative
+                    // DB aggregation and correct any incremental drift (e.g. a reorg-induced
+                    // one-sided over-credit on a group-mint router). Runs here, inside the gate, so
+                    // its monotonic Add at the cache head can't race the next block's writes.
+                    await MaybeReconcileAsync(latestBlock, ct);
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
@@ -349,6 +364,54 @@ public class NotificationListenerService : BackgroundService
     {
         RewarmupReset.Trigger(_state, ClearAllCaches);
     }
+
+    /// <summary>
+    /// Runs the #74 tail reconciliation, throttled to at most once per
+    /// <see cref="CacheServiceSettings.ReconciliationIntervalBlocks"/> blocks of head advance.
+    /// Best-effort: a failure is logged but never aborts block processing.
+    /// </summary>
+    internal async Task MaybeReconcileAsync(long head, CancellationToken ct)
+    {
+        if (!_settings.ReconciliationEnabled)
+            return;
+
+        if (_lastReconciledBlock >= 0 && head - _lastReconciledBlock < _settings.ReconciliationIntervalBlocks)
+            return;
+
+        try
+        {
+            var corrections = await ReconcileRecentV2BalancesAsync(head, ct);
+
+            // Advance the throttle cursor only on success, so a failed pass retries on the next
+            // block instead of marking itself "done" and suppressing retries for a whole interval.
+            _lastReconciledBlock = head;
+
+            if (corrections > 0)
+            {
+                _logger.LogWarning(
+                    "Tail reconciliation corrected {Count} drifted balance(s) at block {Block} (recentReorgs=[{RecentReorgs}])",
+                    corrections, head, RecentReorgPointsCsv());
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Best-effort: never break block processing. The failure is observable (so a persistently
+            // failing self-heal can be alerted on, not mistaken for a quiet chain), and the throttle
+            // cursor is left unadvanced so the next block retries.
+            CacheMetrics.ReconciliationFailuresTotal.Inc();
+            _logger.LogError(ex, "Tail reconciliation failed at block {Block}", head);
+        }
+    }
+
+    /// <summary>Appends a reorg point to the bounded recent-reorg ring (caller holds the gate).</summary>
+    private void RecordReorgPoint(long reorgBlock)
+    {
+        _recentReorgPoints.AddLast(reorgBlock);
+        while (_recentReorgPoints.Count > RecentReorgPointsCapacity)
+            _recentReorgPoints.RemoveFirst();
+    }
+
+    private string RecentReorgPointsCsv() => string.Join(",", _recentReorgPoints);
 
     protected virtual async Task<long> GetBlockTimestampAsync(long blockNumber, CancellationToken ct)
     {


### PR DESCRIPTION
## Summary

Cherry-picks the cache self-heal (tail reconciliation, originally PR #461 on `staging`) onto `dev` so it can reach production ahead of the full `staging→dev` promotion.

The incremental V2 balance path can leave a one-sided over-credit after a reorg (an IN applied without its matching OUT) that persists until a full re-warmup. This adds a throttled, bounded reconciliation that re-derives recently-active accounts' balances from the authoritative DB aggregation (the same `SUM` the warmup uses, pinned to the cache head) and overwrites drift; a net-zero account is healed to zero and dropped from the read index. Already verified live on staging — healed real phantom drift within minutes, 0 failures.

## Cherry-pick adaptation

`dev` predates the #432 partial-class split, so its `NotificationListenerService` is the monolith. The cherry-pick applied cleanly except for **one line**: the class declaration needed `partial` added so the new `NotificationListenerService.Reconciliation.cs` partial compiles. No other adaptation. `WithReadonlyConnectionAsync` and all referenced cache APIs already exist on dev.

## Verification (on this branch, off `dev`)

- [x] `dotnet build -c Release` — 0 errors
- [x] 10 reconciliation unit tests pass
- [x] Full cache suite green (236 passed, 0 failed, 26 skipped DB-integration)
- [x] `MaybeReconcileAsync` call site correctly placed after `LastProcessedBlock` is set, inside the success path; reorg-point recording in the reorg branch

## Note

This isolates the cache self-heal on dev without the other 30 staging-ahead commits. When the full `staging→dev` promotion later merges, the duplicate content reconciles (same logical change). Merging this to `dev` does not auto-deploy to prod (manual rolling deploy).
