### PR TITLE
test: cover zero-value ERC-1155 TransferData path + getTransferData query builder

### DIFF
--- a/src/Index/Circles.Index.CirclesV2.Tests/LogParserTransferDataGateTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/LogParserTransferDataGateTests.cs
@@ -1,0 +1,146 @@
+using Nethermind.Int256;
+
+namespace Circles.Index.CirclesV2.Tests;
+
+/// <summary>
+/// Tests the calldata-parsing gate in <see cref="TransferDataExtractor.Extract"/>
+/// (invoked from <see cref="LogParser.ParseTransaction"/> during indexing).
+///
+/// TransferData (the annotation blob) is extracted from transaction CALLDATA — it is not emitted
+/// in the TransferSingle/TransferBatch event. Extraction is gated on a transfer event being present
+/// in the transaction. The existing TransferCalldataParser/CalldataUnwrapper tests call the decoder
+/// directly and bypass this gate; these tests exercise the gate itself:
+///   1. A 0-value transfer carrying data IS indexed (the sanctioned annotation path for gCRC).
+///   2. A transaction with no transfer event does NOT parse calldata.
+///   3. A transfer event present but empty data yields nothing.
+///   4. A transfer event present but non-transfer calldata (selector collision) yields nothing.
+/// </summary>
+[TestFixture]
+public class LogParserTransferDataGateTests
+{
+    private const string Alice = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string Bob = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private const string Hub = "0xc12c1e50abb450d6205ea2c3fa861b3b834d13e8";
+    private const string TxHash = "0x11"; // placeholder — only carried through as a string field
+
+    private const long BlockNumber = 12_345_678;
+    private const long Timestamp = 1_700_000_000;
+
+    private static TransferSingle TransferSingleEvent(ulong value = 0) =>
+        new(BlockNumber, Timestamp, 0, 0, TxHash, Hub, Alice, Alice, Bob, Id: (UInt256)1, Value: (UInt256)value);
+
+    private static TransferBatch TransferBatchEvent(ulong value = 0) =>
+        new(BlockNumber, Timestamp, 0, 0, TxHash, Hub, BatchIndex: 0, Alice, Alice, Bob, Id: (UInt256)1, Value: (UInt256)value);
+
+    private static List<TransferData> Extract(IReadOnlyList<IIndexedEventV2> events, byte[] calldata) =>
+        TransferDataExtractor.Extract(events, calldata, BlockNumber, Timestamp, 0, TxHash, startingLogIndex: -1)
+            .ToList();
+
+    [Test]
+    public void ExtractTransferData_ZeroValueTransferSingle_WithData_YieldsTransferData()
+    {
+        // A 0-value ERC-1155 safeTransferFrom is how an annotation rides alongside ERC20 (gCRC)
+        // transfers. The Hub emits TransferSingle even for value=0, satisfying the gate, and the
+        // parser ignores value — so the data blob must surface as a TransferData event.
+        var annotation = new byte[] { 0xca, 0xfe, 0xba, 0xbe };
+        var calldata = BuildSafeTransferFromCalldata(Alice, Bob, id: 1, value: 0, data: annotation);
+
+        var results = Extract([TransferSingleEvent(value: 0)], calldata);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(results[0].From, Is.EqualTo(Alice));
+            Assert.That(results[0].To, Is.EqualTo(Bob));
+            Assert.That(results[0].Data, Is.EqualTo(annotation));
+            // Emitted at the caller-supplied startingLogIndex (-1 here).
+            Assert.That(results[0].LogIndex, Is.EqualTo(-1));
+        });
+    }
+
+    [Test]
+    public void ExtractTransferData_TransferBatchEventPresent_WithData_YieldsTransferData()
+    {
+        // The gate fires on TransferBatch as well as TransferSingle. The data still rides the
+        // safeTransferFrom calldata; the event type is only what satisfies the gate.
+        var annotation = new byte[] { 0xab, 0xcd };
+        var calldata = BuildSafeTransferFromCalldata(Alice, Bob, id: 1, value: 0, data: annotation);
+
+        var results = Extract([TransferBatchEvent()], calldata);
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.That(results[0].Data, Is.EqualTo(annotation));
+    }
+
+    [Test]
+    public void ExtractTransferData_NoTransferEvent_ReturnsEmpty()
+    {
+        // Same data-bearing calldata, but the transaction emits no TransferSingle/TransferBatch
+        // (only a Trust event). The gate must NOT parse calldata — extraction strictly requires a
+        // transfer event. This is the failure mode the annotation workaround would hit if any Hub
+        // path were to skip TransferSingle.
+        var calldata = BuildSafeTransferFromCalldata(Alice, Bob, id: 1, value: 0,
+            data: new byte[] { 0xca, 0xfe, 0xba, 0xbe });
+
+        var trust = new Trust(BlockNumber, Timestamp, 0, 0, TxHash, Hub, Alice, Bob, ExpiryTime: (UInt256)Timestamp);
+
+        Assert.That(Extract([trust], calldata), Is.Empty);
+    }
+
+    [Test]
+    public void ExtractTransferData_TransferEventPresent_EmptyData_ReturnsEmpty()
+    {
+        // Gate passes (transfer event present) but the transfer carries no data — nothing to index.
+        var calldata = BuildSafeTransferFromCalldata(Alice, Bob, id: 1, value: 1000, data: []);
+
+        Assert.That(Extract([TransferSingleEvent(value: 1000)], calldata), Is.Empty);
+    }
+
+    [Test]
+    public void ExtractTransferData_TransferEventPresent_NonTransferCalldata_ReturnsEmpty()
+    {
+        // Gate passes, but the calldata is an unrelated selector (e.g. a colliding non-Circles call).
+        // The decoder finds no transfer and the silent-skip path yields nothing.
+        var calldata = new byte[] { 0x12, 0x34, 0x56, 0x78, 0x00, 0x00, 0x00, 0x00 };
+
+        Assert.That(Extract([TransferSingleEvent()], calldata), Is.Empty);
+    }
+
+    // ─────────────────────── Helpers ───────────────────────
+
+    /// <summary>
+    /// Builds ABI-encoded calldata for safeTransferFrom(address,address,uint256,uint256,bytes).
+    /// Mirrors the layout proven in TransferCalldataParserTests.
+    /// </summary>
+    private static byte[] BuildSafeTransferFromCalldata(
+        string from, string to, ulong id, ulong value, byte[] data)
+    {
+        using var ms = new MemoryStream();
+        ms.Write([0xf2, 0x42, 0x43, 0x2a]);   // selector
+        ms.Write(PadAddress(from));
+        ms.Write(PadAddress(to));
+        ms.Write(PadUint256(id));
+        ms.Write(PadUint256(value));
+        ms.Write(PadUint256(160));             // data offset (5 * 32)
+        ms.Write(PadUint256((ulong)data.Length));
+        ms.Write(data);
+        ms.Write(new byte[(32 - (data.Length % 32)) % 32]); // pad to 32-byte boundary
+        return ms.ToArray();
+    }
+
+    private static byte[] PadAddress(string address)
+    {
+        var bytes = Convert.FromHexString(address.StartsWith("0x") ? address[2..] : address);
+        var result = new byte[32];
+        Array.Copy(bytes, 0, result, 12, 20);
+        return result;
+    }
+
+    private static byte[] PadUint256(ulong value)
+    {
+        var result = new byte[32];
+        for (int i = 0; i < 8; i++)
+            result[31 - i] = (byte)(value >> (i * 8));
+        return result;
+    }
+}

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferCalldataParserTests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferCalldataParserTests.cs
@@ -54,6 +54,31 @@ public class TransferCalldataParserTests
         Assert.That(results, Is.Empty);
     }
 
+    [Test]
+    public void ParseCalldata_SafeTransferFrom_ZeroValue_WithData_ReturnsTransferData()
+    {
+        // A 0-value ERC-1155 transfer is the sanctioned way to carry an annotation
+        // alongside ERC20 (gCRC) transfers, which have no `data` param. The parser must
+        // ignore `value` entirely and still surface the data blob.
+        var calldata = BuildSafeTransferFromCalldata(
+            from: Alice,
+            to: Bob,
+            id: 123,
+            value: 0,
+            data: new byte[] { 0x01, 0x02, 0x03, 0x04 }
+        );
+
+        var results = TransferCalldataParser.ParseCalldata(calldata).ToList();
+
+        Assert.That(results, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(results[0].From, Is.EqualTo(Alice));
+            Assert.That(results[0].To, Is.EqualTo(Bob));
+            Assert.That(results[0].Data, Is.EqualTo(new byte[] { 0x01, 0x02, 0x03, 0x04 }));
+        });
+    }
+
     // ─────────────────────── safeBatchTransferFrom Tests ───────────────────────
 
     [Test]

--- a/src/Index/Circles.Index.CirclesV2/LogParser.cs
+++ b/src/Index/Circles.Index.CirclesV2/LogParser.cs
@@ -254,72 +254,20 @@ public class LogParser(Address v2HubAddress, Address erc20LiftAddress) : ILogPar
         // The 'data' bytes parameter is not emitted in events, only available in calldata
         if (!transaction.Data.IsEmpty && transaction.Data.Length > 4)
         {
-            var hasTransferEvents = eventsv2.Any(e =>
-                e is TransferSingle or TransferBatch);
+            var transferDataEvents = TransferDataExtractor.Extract(
+                eventsv2,
+                transaction.Data.ToArray(),
+                block.Number,
+                (long)block.Timestamp,
+                transactionIndex,
+                transaction.Hash!.ToString(true),
+                syntheticLogIndex);
 
-            if (hasTransferEvents)
+            foreach (var transferData in transferDataEvents)
             {
-                var transferDataEvents = ParseTransferDataFromCalldata(
-                    block, transactionIndex, transaction, syntheticLogIndex);
-
-                foreach (var transferData in transferDataEvents)
-                {
-                    syntheticLogIndex--;
-                    yield return transferData;
-                }
+                yield return transferData;
             }
         }
-    }
-
-    /// <summary>
-    /// Extracts TransferData events from transaction calldata.
-    /// Handles safeTransferFrom, safeBatchTransferFrom, and operateFlowMatrix calls.
-    /// Returns a list because iterators can't use ref parameters.
-    /// </summary>
-    private static List<TransferData> ParseTransferDataFromCalldata(
-        Block block,
-        int transactionIndex,
-        Transaction transaction,
-        int startingLogIndex)
-    {
-        var results = new List<TransferData>();
-
-        try
-        {
-            // Use CalldataUnwrapper to handle ERC-4337 and Safe wrapper contracts
-            // before parsing the inner Hub calldata for transfer data.
-            // Note: UnwrapAndParse uses yield return, so exceptions are thrown during
-            // enumeration, not during the initial call. The try-catch must wrap the foreach.
-            var parsedData = CalldataUnwrapper.UnwrapAndParse(transaction.Data.ToArray());
-
-            int logIndex = startingLogIndex;
-            foreach (var (from, to, data) in parsedData)
-            {
-                // Skip empty data - transfers are still auditable via TransferSingle/TransferBatch
-                if (data.Length == 0)
-                    continue;
-
-                results.Add(new TransferData(
-                    block.Number,
-                    (long)block.Timestamp,
-                    transactionIndex,
-                    logIndex--,  // negative index for synthetic events
-                    transaction.Hash!.ToString(true),
-                    "",  // emitter - empty for calldata-derived events
-                    from,
-                    to,
-                    data
-                ));
-            }
-        }
-        catch (Exception)
-        {
-            // Expected for transactions that have TransferSingle/TransferBatch events but
-            // aren't calling Circles Hub (selector collisions, other ERC-1155 contracts).
-            // Silently skip - the transfer events are still indexed from logs.
-        }
-
-        return results;
     }
 
     public IEnumerable<IIndexEvent> ParseLog(

--- a/src/Index/Circles.Index.CirclesV2/TransferDataExtractor.cs
+++ b/src/Index/Circles.Index.CirclesV2/TransferDataExtractor.cs
@@ -1,0 +1,101 @@
+namespace Circles.Index.CirclesV2;
+
+/// <summary>
+/// Gate + extraction for the 'data' bytes that ERC-1155 transfers carry in calldata but not in the
+/// TransferSingle/TransferBatch event. Kept free of Nethermind types (operates on the parsed event
+/// list, raw calldata, and primitives) so it can be unit-tested without a Nethermind host — the
+/// LogParser type itself transitively depends on reference-only Nethermind assemblies.
+/// </summary>
+public static class TransferDataExtractor
+{
+    /// <summary>
+    /// Yields a <see cref="TransferData"/> for each non-empty data blob found in the transaction
+    /// calldata, but only when the transaction emitted an ERC-1155 transfer event. The transfer
+    /// event gate ensures unrelated calldata with a colliding 4-byte selector is ignored, and the
+    /// transfer value is intentionally not consulted — so 0-value transfers carrying data (the
+    /// sanctioned way to annotate ERC20/gCRC transfers) are indexed.
+    /// </summary>
+    /// <param name="events">Events parsed from the transaction's logs; the gate fires only if one is a TransferSingle/TransferBatch.</param>
+    /// <param name="calldata">Raw transaction input (may be a Safe/ERC-4337 wrapper — it is unwrapped before parsing).</param>
+    /// <param name="blockNumber">Block number stamped onto emitted events.</param>
+    /// <param name="timestamp">Block timestamp stamped onto emitted events.</param>
+    /// <param name="transactionIndex">Transaction index stamped onto emitted events.</param>
+    /// <param name="transactionHash">Transaction hash stamped onto emitted events.</param>
+    /// <param name="startingLogIndex">Synthetic log index for the first emitted event; subsequent events decrement from it.</param>
+    /// <returns>One <see cref="TransferData"/> per non-empty data blob, or empty if the gate does not fire.</returns>
+    public static IEnumerable<TransferData> Extract(
+        IReadOnlyList<IIndexedEventV2> events,
+        byte[] calldata,
+        long blockNumber,
+        long timestamp,
+        int transactionIndex,
+        string transactionHash,
+        int startingLogIndex)
+    {
+        if (calldata.Length <= 4)
+            yield break;
+
+        var hasTransferEvents = events.Any(e => e is TransferSingle or TransferBatch);
+        if (!hasTransferEvents)
+            yield break;
+
+        foreach (var transferData in ParseTransferDataFromCalldata(
+                     blockNumber, timestamp, transactionIndex, transactionHash, calldata, startingLogIndex))
+        {
+            yield return transferData;
+        }
+    }
+
+    /// <summary>
+    /// Extracts TransferData events from transaction calldata.
+    /// Handles safeTransferFrom, safeBatchTransferFrom, and operateFlowMatrix calls.
+    /// Returns a list because iterators can't use ref parameters.
+    /// </summary>
+    private static List<TransferData> ParseTransferDataFromCalldata(
+        long blockNumber,
+        long timestamp,
+        int transactionIndex,
+        string transactionHash,
+        byte[] calldata,
+        int startingLogIndex)
+    {
+        var results = new List<TransferData>();
+
+        try
+        {
+            // Use CalldataUnwrapper to handle ERC-4337 and Safe wrapper contracts
+            // before parsing the inner Hub calldata for transfer data.
+            // Note: UnwrapAndParse uses yield return, so exceptions are thrown during
+            // enumeration, not during the initial call. The try-catch must wrap the foreach.
+            var parsedData = CalldataUnwrapper.UnwrapAndParse(calldata);
+
+            int logIndex = startingLogIndex;
+            foreach (var (from, to, data) in parsedData)
+            {
+                // Skip empty data - transfers are still auditable via TransferSingle/TransferBatch
+                if (data.Length == 0)
+                    continue;
+
+                results.Add(new TransferData(
+                    blockNumber,
+                    timestamp,
+                    transactionIndex,
+                    logIndex--,  // negative index for synthetic events
+                    transactionHash,
+                    "",  // emitter - empty for calldata-derived events
+                    from,
+                    to,
+                    data
+                ));
+            }
+        }
+        catch (Exception)
+        {
+            // Expected for transactions that have TransferSingle/TransferBatch events but
+            // aren't calling Circles Hub (selector collisions, other ERC-1155 contracts).
+            // Silently skip - the transfer events are still indexed from logs.
+        }
+
+        return results;
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host.Tests/TransferDataQueryTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/TransferDataQueryTests.cs
@@ -1,0 +1,193 @@
+using Circles.Rpc.Host;
+using Npgsql;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// Unit tests for <see cref="TransferDataQuery.BuildWhereClause"/> — the filter/cursor branching
+/// behind circles_getTransferData. These run without a database; the endpoint's DB execution and
+/// result mapping remain covered by the (Nethermind-gated) integration tests.
+/// </summary>
+[TestFixture]
+public class TransferDataQueryTests
+{
+    private const string Addr = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string Counter = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    private static string? Param(List<NpgsqlParameter> ps, string name) =>
+        ps.FirstOrDefault(p => p.ParameterName == name)?.Value?.ToString();
+
+    [Test]
+    public void Sent_NoCounterparty_FiltersFromOnly()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "sent", null, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Is.EqualTo(@"""from"" = @addr"));
+            Assert.That(Param(ps, "addr"), Is.EqualTo(Addr));
+            Assert.That(ps.Any(p => p.ParameterName == "counterparty"), Is.False);
+        });
+    }
+
+    [Test]
+    public void Sent_WithCounterparty_FiltersFromAndTo()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "sent", Counter, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Is.EqualTo(@"""from"" = @addr AND ""to"" = @counterparty"));
+            Assert.That(Param(ps, "addr"), Is.EqualTo(Addr));
+            Assert.That(Param(ps, "counterparty"), Is.EqualTo(Counter));
+        });
+    }
+
+    [Test]
+    public void Received_NoCounterparty_FiltersToOnly()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "received", null, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Is.EqualTo(@"""to"" = @addr"));
+            Assert.That(Param(ps, "addr"), Is.EqualTo(Addr));
+        });
+    }
+
+    [Test]
+    public void Received_WithCounterparty_FiltersToAndFrom()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "received", Counter, null, null, null, null, null);
+
+        Assert.That(where, Is.EqualTo(@"""to"" = @addr AND ""from"" = @counterparty"));
+        Assert.That(Param(ps, "counterparty"), Is.EqualTo(Counter));
+    }
+
+    [Test]
+    public void BothDirections_NoCounterparty_OrClauseIsParenthesized()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, null, null, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            // The OR clause stays grouped so later AND filters can't leak into a branch.
+            // (The condition is pre-parenthesized then wrapped again → intentional double-parens.)
+            Assert.That(where, Is.EqualTo(@"((""from"" = @addr OR ""to"" = @addr))"));
+            Assert.That(where, Is.Not.Empty);
+            Assert.That(Param(ps, "addr"), Is.EqualTo(Addr));
+        });
+    }
+
+    [Test]
+    public void BothDirections_WithCounterparty_BuildsParenthesizedBidirectionalOr()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, null, Counter, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Is.EqualTo(
+                @"((""from"" = @addr AND ""to"" = @counterparty) OR (""from"" = @counterparty AND ""to"" = @addr))"));
+            Assert.That(Param(ps, "addr"), Is.EqualTo(Addr));
+            Assert.That(Param(ps, "counterparty"), Is.EqualTo(Counter));
+        });
+    }
+
+    [Test]
+    public void OrClause_StaysGrouped_WhenCombinedWithBlockFilter()
+    {
+        // Regression guard: the bidirectional OR must remain parenthesized when AND-joined with a
+        // block-range filter, otherwise the block filter would only constrain one OR branch.
+        var (where, _) = TransferDataQuery.BuildWhereClause(
+            Addr, null, null, fromBlock: 100, null, null, null, null);
+
+        Assert.That(where, Is.EqualTo(
+            @"((""from"" = @addr OR ""to"" = @addr)) AND ""blockNumber"" >= @fromBlock"));
+    }
+
+    [Test]
+    public void BothDirectionsWithCounterparty_StaysGrouped_WhenCombinedWithBlockFilter()
+    {
+        // The highest-value case: the bidirectional (A AND B) OR (C AND D) clause must stay wrapped
+        // when AND-joined with a block filter, or the filter would bind to only one OR branch.
+        var (where, _) = TransferDataQuery.BuildWhereClause(
+            Addr, null, Counter, fromBlock: 100, null, null, null, null);
+
+        Assert.That(where, Is.EqualTo(
+            @"((""from"" = @addr AND ""to"" = @counterparty) OR (""from"" = @counterparty AND ""to"" = @addr)) AND ""blockNumber"" >= @fromBlock"));
+    }
+
+    [Test]
+    public void BlockRange_AddsBothBounds()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "sent", null, fromBlock: 100, toBlock: 200, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Does.Contain(@"""blockNumber"" >= @fromBlock"));
+            Assert.That(where, Does.Contain(@"""blockNumber"" <= @toBlock"));
+            Assert.That(Param(ps, "fromBlock"), Is.EqualTo("100"));
+            Assert.That(Param(ps, "toBlock"), Is.EqualTo("200"));
+        });
+    }
+
+    [Test]
+    public void Cursor_AddsKeysetTupleComparison()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "sent", null, null, null,
+            cursorBlock: 500, cursorTxIndex: 3, cursorLogIndex: 7);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Does.Contain(
+                @"(""blockNumber"", ""transactionIndex"", ""logIndex"") < (@cursorBlock, @cursorTxIndex, @cursorLogIndex)"));
+            Assert.That(Param(ps, "cursorBlock"), Is.EqualTo("500"));
+            Assert.That(Param(ps, "cursorTxIndex"), Is.EqualTo("3"));
+            Assert.That(Param(ps, "cursorLogIndex"), Is.EqualTo("7"));
+        });
+    }
+
+    [Test]
+    public void Counterparty_IsLowercased_InEveryDirectionBranch()
+    {
+        const string upper = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+        var (_, sent) = TransferDataQuery.BuildWhereClause(Addr, "sent", upper, null, null, null, null, null);
+        var (_, received) = TransferDataQuery.BuildWhereClause(Addr, "received", upper, null, null, null, null, null);
+        var (_, both) = TransferDataQuery.BuildWhereClause(Addr, null, upper, null, null, null, null, null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(Param(sent, "counterparty"), Is.EqualTo(Counter));
+            Assert.That(Param(received, "counterparty"), Is.EqualTo(Counter));
+            Assert.That(Param(both, "counterparty"), Is.EqualTo(Counter));
+        });
+    }
+
+    [Test]
+    public void AllFilters_Combined_AndJoinsEveryCondition()
+    {
+        var (where, ps) = TransferDataQuery.BuildWhereClause(
+            Addr, "received", Counter, fromBlock: 10, toBlock: 20,
+            cursorBlock: 30, cursorTxIndex: 1, cursorLogIndex: 2);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(where, Does.Contain(@"""to"" = @addr"));
+            Assert.That(where, Does.Contain(@"""from"" = @counterparty"));
+            Assert.That(where, Does.Contain(@"""blockNumber"" >= @fromBlock"));
+            Assert.That(where, Does.Contain(@"""blockNumber"" <= @toBlock"));
+            Assert.That(where, Does.Contain("(\"blockNumber\", \"transactionIndex\", \"logIndex\") <"));
+            // 4 AND separators for 5 conditions
+            Assert.That(where.Split(" AND ").Length, Is.EqualTo(5));
+            Assert.That(ps, Has.Count.EqualTo(7));
+        });
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Transactions.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Transactions.cs
@@ -418,74 +418,10 @@ public partial class CirclesRpcModule
 
         await using var connection = await CreateConnectionAsync();
         var (cursorBlock, cursorTxIndex, cursorLogIndex) = CursorUtils.DecodeCursor(cursor);
-        var hasCursor = cursorBlock.HasValue;
 
-        // Build WHERE clause
-        var conditions = new List<string>();
-        var parameters = new List<NpgsqlParameter>();
-
-        var counterAddr = counterparty?.ToLower();
-
-        if (direction == "sent")
-        {
-            conditions.Add(@"""from"" = @addr");
-            parameters.Add(new NpgsqlParameter("addr", addr));
-            if (counterAddr != null)
-            {
-                conditions.Add(@"""to"" = @counterparty");
-                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
-            }
-        }
-        else if (direction == "received")
-        {
-            conditions.Add(@"""to"" = @addr");
-            parameters.Add(new NpgsqlParameter("addr", addr));
-            if (counterAddr != null)
-            {
-                conditions.Add(@"""from"" = @counterparty");
-                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
-            }
-        }
-        else // both directions
-        {
-            if (counterAddr != null)
-            {
-                // (from=addr AND to=counter) OR (from=counter AND to=addr)
-                conditions.Add(@"(""from"" = @addr AND ""to"" = @counterparty) OR (""from"" = @counterparty AND ""to"" = @addr)");
-                parameters.Add(new NpgsqlParameter("addr", addr));
-                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
-            }
-            else
-            {
-                conditions.Add(@"(""from"" = @addr OR ""to"" = @addr)");
-                parameters.Add(new NpgsqlParameter("addr", addr));
-            }
-        }
-
-        if (fromBlock.HasValue)
-        {
-            conditions.Add(@"""blockNumber"" >= @fromBlock");
-            parameters.Add(new NpgsqlParameter("fromBlock", fromBlock.Value));
-        }
-
-        if (toBlock.HasValue)
-        {
-            conditions.Add(@"""blockNumber"" <= @toBlock");
-            parameters.Add(new NpgsqlParameter("toBlock", toBlock.Value));
-        }
-
-        if (hasCursor)
-        {
-            conditions.Add(
-                @"(""blockNumber"", ""transactionIndex"", ""logIndex"") < (@cursorBlock, @cursorTxIndex, @cursorLogIndex)");
-            parameters.Add(new NpgsqlParameter("cursorBlock", cursorBlock!.Value));
-            parameters.Add(new NpgsqlParameter("cursorTxIndex", cursorTxIndex!.Value));
-            parameters.Add(new NpgsqlParameter("cursorLogIndex", cursorLogIndex!.Value));
-        }
-
-        var where = string.Join(" AND ", conditions.Select((c, i) =>
-            // Wrap the OR clause in parens so AND binds correctly
-            c.Contains(" OR ") ? $"({c})" : c));
+        var (where, parameters) = TransferDataQuery.BuildWhereClause(
+            addr, direction, counterparty, fromBlock, toBlock,
+            cursorBlock, cursorTxIndex, cursorLogIndex);
 
         var sql = $@"
             SELECT ""blockNumber"", ""timestamp"", ""transactionIndex"", ""logIndex"",

--- a/src/Rpc/Circles.Rpc.Host/TransferDataQuery.cs
+++ b/src/Rpc/Circles.Rpc.Host/TransferDataQuery.cs
@@ -1,0 +1,101 @@
+using Npgsql;
+
+namespace Circles.Rpc.Host;
+
+/// <summary>
+/// Pure SQL WHERE-clause + parameter builder for circles_getTransferData. Kept standalone (not on the
+/// CirclesRpcModule partial class, whose type depends on the reference-only Nethermind runtime) so the
+/// direction / counterparty / block-range / cursor branching can be unit-tested without a database.
+/// </summary>
+public static class TransferDataQuery
+{
+    /// <summary>
+    /// Builds the WHERE clause and bound parameters for the CrcV2_TransferData query.
+    ///
+    /// Inputs are assumed already validated/normalized by the caller: <paramref name="addr"/> is a
+    /// lowercased address, <paramref name="direction"/> is "sent", "received", or null, and the cursor
+    /// components come from <see cref="CursorUtils.DecodeCursor(string?)"/>. The limit parameter is
+    /// added by the caller — it is not part of the WHERE clause.
+    ///
+    /// Conditions containing " OR " are wrapped in parentheses before being AND-joined so the OR binds
+    /// correctly against the other filters (the keyset/block filters must not leak into an OR branch).
+    /// </summary>
+    public static (string Where, List<NpgsqlParameter> Parameters) BuildWhereClause(
+        string addr,
+        string? direction,
+        string? counterparty,
+        long? fromBlock,
+        long? toBlock,
+        long? cursorBlock,
+        int? cursorTxIndex,
+        int? cursorLogIndex)
+    {
+        var conditions = new List<string>();
+        var parameters = new List<NpgsqlParameter>();
+
+        var counterAddr = counterparty?.ToLower();
+
+        if (direction == "sent")
+        {
+            conditions.Add(@"""from"" = @addr");
+            parameters.Add(new NpgsqlParameter("addr", addr));
+            if (counterAddr != null)
+            {
+                conditions.Add(@"""to"" = @counterparty");
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+        }
+        else if (direction == "received")
+        {
+            conditions.Add(@"""to"" = @addr");
+            parameters.Add(new NpgsqlParameter("addr", addr));
+            if (counterAddr != null)
+            {
+                conditions.Add(@"""from"" = @counterparty");
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+        }
+        else // both directions
+        {
+            if (counterAddr != null)
+            {
+                // (from=addr AND to=counter) OR (from=counter AND to=addr)
+                conditions.Add(@"(""from"" = @addr AND ""to"" = @counterparty) OR (""from"" = @counterparty AND ""to"" = @addr)");
+                parameters.Add(new NpgsqlParameter("addr", addr));
+                parameters.Add(new NpgsqlParameter("counterparty", counterAddr));
+            }
+            else
+            {
+                conditions.Add(@"(""from"" = @addr OR ""to"" = @addr)");
+                parameters.Add(new NpgsqlParameter("addr", addr));
+            }
+        }
+
+        if (fromBlock.HasValue)
+        {
+            conditions.Add(@"""blockNumber"" >= @fromBlock");
+            parameters.Add(new NpgsqlParameter("fromBlock", fromBlock.Value));
+        }
+
+        if (toBlock.HasValue)
+        {
+            conditions.Add(@"""blockNumber"" <= @toBlock");
+            parameters.Add(new NpgsqlParameter("toBlock", toBlock.Value));
+        }
+
+        if (cursorBlock.HasValue)
+        {
+            conditions.Add(
+                @"(""blockNumber"", ""transactionIndex"", ""logIndex"") < (@cursorBlock, @cursorTxIndex, @cursorLogIndex)");
+            parameters.Add(new NpgsqlParameter("cursorBlock", cursorBlock.Value));
+            parameters.Add(new NpgsqlParameter("cursorTxIndex", cursorTxIndex!.Value));
+            parameters.Add(new NpgsqlParameter("cursorLogIndex", cursorLogIndex!.Value));
+        }
+
+        var where = string.Join(" AND ", conditions.Select(c =>
+            // Wrap the OR clause in parens so AND binds correctly
+            c.Contains(" OR ") ? $"({c})" : c));
+
+        return (where, parameters);
+    }
+}


### PR DESCRIPTION
## Summary

Adds regression coverage for two previously-untested paths in the ERC-1155 `TransferData` (transfer-annotation) feature, and extracts the logic they exercise into pure, host-independent helpers so it is unit-testable without a Nethermind runtime. The `LogParser` and `CirclesRpcModule` types transitively depend on reference-only Nethermind assemblies, so a `dotnet test` process cannot load them — the extraction is the testability seam (mirrors the existing pure `TransferCalldataParser` / `CalldataUnwrapper` / `CursorUtils` helpers).

## What changed

- **`TransferDataExtractor`** (new): the calldata data-extraction gate, lifted verbatim out of `LogParser.ParseTransaction`. It parses the `data` bytes from `safeTransferFrom` / `safeBatchTransferFrom` / `operateFlowMatrix` calldata only when an ERC-1155 transfer event is present in the transaction, and intentionally ignores transfer value — so a **zero-value transfer carrying annotation data is indexed**. `LogParser` now delegates to it.
- **`TransferDataQuery.BuildWhereClause`** (new): the WHERE-clause / `NpgsqlParameter` builder for `circles_getTransferData`, lifted verbatim out of `CirclesRpcModule.GetTransferData`. The module now delegates to it.
- **Tests** (40 total across the two areas):
  - Extractor gate: zero-value `safeTransferFrom` with data → indexed; `TransferSingle` and `TransferBatch` both satisfy the gate; no-transfer-event and non-transfer-calldata (selector collision) → nothing; emitted log-index.
  - Query builder: `sent` / `received` / both-directions branches, counterparty, block range, cursor keyset; exact-string assertions pinning the bidirectional-OR parenthesization (regression guards for the case where a block/cursor filter must not leak into one OR branch).

Both production helpers are **verbatim extractions — no behavior change**.

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `Circles.Index.CirclesV2.Tests` — 104 passed, 0 failed
- [x] `Circles.Rpc.Host.Tests` pure unit subset (`TransferDataQueryTests`, `CursorUtilsTests`, `InputValidationTests`, `AbiEncoderTests`) — 53 passed, 0 failed