### PR TITLE
fix(pathfinder): net inflow in balance-drift probe; classify SoftLock revert

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BalanceProbe.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BalanceProbe.cs
@@ -17,9 +17,12 @@ namespace Circles.Pathfinder.Host.Canary;
 /// unclassified <c>0x66ef7607</c> revert routing through the same phantom-prone arb+group-token
 /// pair — and those evade both the payload detector AND the Prometheus/Loki alerts
 /// (<c>category=unknown</c> is not <c>category=bug</c>). This probe closes that gap: on any revert
-/// the payload path did not already explain, it compares each holder's required outflow per token
-/// (summed from the path) against the holder's REAL on-chain balance, and emits the same
-/// <c>CACHE BALANCE DRIFT</c> signal when the path demands more than exists.</para>
+/// the payload path did not already explain, it compares each holder's NET required outflow per
+/// token (outflow minus the in-path inflow it receives of that token) against the holder's REAL
+/// on-chain balance, and emits the same <c>CACHE BALANCE DRIFT</c> signal when the path demands
+/// more than exists. Netting is essential: a group-mint router that forwards collateral it received
+/// is a balanced pass-through (real balance legitimately zero), not a phantom — see
+/// <see cref="AggregateRequiredOutflow"/>.</para>
 ///
 /// <para><b>Soundness vs withWrap paths.</b> A naive <c>balanceOf</c> at graphBlock would
 /// false-positive whenever the holder's supply comes from unwrapping wrapper ERC20 into 1155
@@ -63,7 +66,8 @@ internal sealed partial class SimulationCanaryService
     /// <summary>
     /// Probes on-chain balances for each holder the path requires to send, after replaying the
     /// given unwrap prefix, and emits <c>CACHE BALANCE DRIFT</c> for any (holder, token) where the
-    /// path's required outflow exceeds the real balance by ≥2× (or the holder holds nothing).
+    /// path's NET required outflow (outflow minus in-path inflow) exceeds the real balance by ≥2×
+    /// (or the holder holds nothing).
     /// </summary>
     /// <param name="item">The work item whose path transfers are checked.</param>
     /// <param name="unwrapCalls">The unwrap prefix to replay before reading balances. Empty for the
@@ -81,8 +85,8 @@ internal sealed partial class SimulationCanaryService
     {
         try
         {
-            // Aggregate required outflow per (holder, token) from the avatar-resolved transfers —
-            // Hub.balanceOf is keyed by the avatar token id, not the wrapper contract.
+            // Net required outflow per (holder, token) from the avatar-resolved transfers (outflow
+            // minus in-path inflow) — Hub.balanceOf is keyed by the avatar token id, not the wrapper.
             var transfers = ResolveWrapperTokenOwners(item.Transfers, item.WrapperToAvatar);
             var required = AggregateRequiredOutflow(transfers);
             if (required.Count == 0)
@@ -266,31 +270,62 @@ internal sealed partial class SimulationCanaryService
     }
 
     /// <summary>
-    /// Sums per-(holder, token) required outflow from the resolved transfers. Skips edges that do
-    /// not require a pre-existing balance: mints from the zero address, and self-issuance where the
-    /// sender IS the token's avatar (personal-token issuance and group mint, where <c>from == token</c>).
-    /// Keys are lowercased addresses.
+    /// Computes per-(holder, token) NET required balance from the resolved transfers: the holder's
+    /// outflow of a token MINUS the inflow it receives of that same token within the same path.
+    /// Only strictly-positive net amounts are returned.
+    ///
+    /// <para>Netting is the soundness fix for pass-through intermediaries (#74): a group-mint router
+    /// receives a collateral token and forwards the SAME token+amount on to the group. Hub.sol
+    /// executes the flow matrix edge-by-edge in mint-sorted order (collateral-in before forward-out),
+    /// so the router is credited before it sends and never needs a standing balance — its real
+    /// <c>balanceOf</c> is legitimately zero. Summing outflow alone would report the full forwarded
+    /// amount as "needed" against a zero balance and raise a phantom <c>zero_balance</c> drift. By
+    /// subtracting the matching inflow, a balanced pass-through nets to zero (not flagged) while a
+    /// genuine over-source (outflow &gt; inflow, e.g. a cache-inflated balance) still surfaces its
+    /// unfunded excess.</para>
+    ///
+    /// <para>Outflow skips edges that need no pre-existing balance: mints from the zero address, and
+    /// self-issuance where the sender IS the token's avatar (<c>from == token</c>: personal-token
+    /// issuance and group mint). Inflow counts every positive credit of the token to the holder.
+    /// Keys are lowercased addresses.</para>
     /// </summary>
     internal static Dictionary<(string Holder, string Token), BigInteger> AggregateRequiredOutflow(
         IReadOnlyList<TransferPathStep> transfers)
     {
-        var required = new Dictionary<(string, string), BigInteger>();
+        const string zero = "0x0000000000000000000000000000000000000000";
+        var outflow = new Dictionary<(string, string), BigInteger>();
+        var inflow = new Dictionary<(string, string), BigInteger>();
+
         foreach (var t in transfers)
         {
-            var holder = t.From.ToLowerInvariant();
             var token = t.TokenOwner.ToLowerInvariant();
-
-            if (holder is "0x0000000000000000000000000000000000000000")
-                continue; // mint — no prior balance
-            if (holder == token)
-                continue; // self-issuance / group mint — sender mints its own token
-
             if (!BigInteger.TryParse(t.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var value)
                 || value <= 0)
                 continue;
 
-            var key = (holder, token);
-            required[key] = required.TryGetValue(key, out var existing) ? existing + value : value;
+            var from = t.From.ToLowerInvariant();
+            // Outflow: the sender must source 'token', unless it mints (from zero) or self-issues.
+            if (from != zero && from != token)
+            {
+                var k = (from, token);
+                outflow[k] = outflow.TryGetValue(k, out var e) ? e + value : value;
+            }
+
+            // Inflow: the receiver is credited 'token' in-path, available before any later send.
+            var to = t.To.ToLowerInvariant();
+            if (to != zero)
+            {
+                var k = (to, token);
+                inflow[k] = inflow.TryGetValue(k, out var e) ? e + value : value;
+            }
+        }
+
+        var required = new Dictionary<(string, string), BigInteger>();
+        foreach (var (key, outAmount) in outflow)
+        {
+            var net = outAmount - (inflow.TryGetValue(key, out var inAmount) ? inAmount : BigInteger.Zero);
+            if (net > 0)
+                required[key] = net;
         }
 
         return required;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
@@ -133,6 +133,17 @@ public class RevertClassifierTests
         Assert.That(label, Is.EqualTo("invalid_receiver"));
     }
 
+    [Test]
+    public void SoftLock_ClassifiedAsInput()
+    {
+        // ERC20TokenOfferCycle.SoftLock() — no-arg selector, bare 4 bytes. A token-offer-cycle sink
+        // rejects incoming CRC because the source over-claimed; not a pathfinder bug → category=input
+        // (excluded from the bug/error-rate alerts, mirroring invalid_receiver).
+        var (category, label) = RevertClassifier.Classify("execution reverted: 0x66ef7607");
+        Assert.That(category, Is.EqualTo("input"));
+        Assert.That(label, Is.EqualTo("soft_lock"));
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryBalanceProbeTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulationCanaryBalanceProbeTests.cs
@@ -114,6 +114,62 @@ public class SimulationCanaryBalanceProbeTests
         Assert.That(required.ContainsKey((Arb, GroupToken)), Is.True);
     }
 
+    // --- Inflow netting: a balanced pass-through is not a phantom source (#74 / 2026-06-05) ---
+    private const string Router = "0xdc287474114cc0551a81ddc2eb51783fbf34802f"; // BaseGroupMintRouter
+    private const string Upstream = "0x3333333333333333333333333333333333333333";
+    private const string Collateral = "0x0cd335ea5062f9e86369ff239f65b274e22a7d7e";
+
+    [Test]
+    public void Aggregate_NetsBalancedPassThroughRouter_NotFlagged()
+    {
+        // Group-mint router topology: Upstream forwards collateral INTO the router, the router
+        // forwards the SAME token+amount on to the group token. Hub credits the router (ordered
+        // collateral-in before forward-out) so it never needs a standing balance. The router must
+        // NOT be reported as a required-outflow holder; the genuine upstream source still is.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Upstream, Router, Collateral, "16896359000000000000"),
+            Step(Router, GroupToken, Collateral, "16896359000000000000")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required.ContainsKey((Router, Collateral)), Is.False,
+            "balanced pass-through (inflow == outflow) must net to zero, not flag a phantom");
+        Assert.That(required[(Upstream, Collateral)],
+            Is.EqualTo(BigInteger.Parse("16896359000000000000")));
+    }
+
+    [Test]
+    public void Aggregate_NetsPartialInflow_FlagsOnlyExcess()
+    {
+        // Receives 30, sends 100 → genuinely over-sources by 70. Only the unfunded 70 is required.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Upstream, Router, Collateral, "30"),
+            Step(Router, GroupToken, Collateral, "100")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required[(Router, Collateral)], Is.EqualTo(new BigInteger(70)));
+    }
+
+    [Test]
+    public void Aggregate_PureSourceWithNoInflow_StillFlaggedFully()
+    {
+        // Regression guard for the real phantom class (e.g. 88fd976f): a holder that sends a token
+        // it never receives in-path must still be flagged for its full outflow after netting.
+        var transfers = new List<TransferPathStep>
+        {
+            Step(Arb, Sink, GroupToken, "4574842999378176")
+        };
+
+        var required = SimulationCanaryService.AggregateRequiredOutflow(transfers);
+
+        Assert.That(required[(Arb, GroupToken)], Is.EqualTo(BigInteger.Parse("4574842999378176")));
+    }
+
     #endregion
 
     #region EncodeBalanceOfCalldata

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -34,6 +34,12 @@ public static class RevertClassifier
     // OpenZeppelin ERC1155 errors
     private const string ERC1155InsufficientBalance = "0x03dee4c5";
     private const string ERC1155InvalidReceiver = "0x57f447ce";
+    // ERC20TokenOfferCycle anti-dump guard (circles-token-offer/src/ERC20TokenOfferCycle.sol):
+    // SoftLock() — a token-offer-cycle SINK's onERC1155Received pre-claim branch reverts when the
+    // CRC sender has over-claimed (totalClaimed[from] > OFFER_TOKEN.balanceOf(from)). A receiver-side
+    // app guard orthogonal to the Circles trust/balance graph: the pathfinder builds a structurally
+    // valid flow but the cycle rejects it because the source over-claimed. Not a pathfinder bug.
+    private const string SoftLock = "0x66ef7607";
 
     // ABI layout after selector: each param is 32 bytes (64 hex chars).
     // CirclesErrorAddressUintArgs: address(32) + uint256(32) + uint8(32) = 96 bytes.
@@ -73,6 +79,9 @@ public static class RevertClassifier
 
         if (Contains(lower, ERC1155InvalidReceiver))
             return ("input", "invalid_receiver");
+
+        if (Contains(lower, SoftLock))
+            return ("input", "soft_lock");
 
         // Generic revert string patterns
         if (lower.Contains("execution reverted"))


### PR DESCRIPTION
## Summary

The active cache-balance-drift probe over-reported drift on group-mint routers — producing a sustained false `balance drift` alert — and a token-offer-cycle `SoftLock` revert was paging as an unrecognized class. Two targeted fixes; plugin-only, no infra change.

## Probe inflow-netting

`AggregateRequiredOutflow` summed each holder's per-token outflow without netting the inflow it receives of the *same* token within the path. A group-mint router forwards collateral it receives — a balanced pass-through whose real on-chain `balanceOf` is legitimately zero (Hub executes collateral-in before forward-out, so it is credited before it sends). The outflow-only sum compared that forwarded amount against a zero balance and emitted a phantom `zero_balance` drift on every such request.

- Now computes `max(0, outflow − inflow)` per `(holder, token)`. Balanced pass-throughs net to zero (not flagged); a genuine over-source (`outflow > inflow`, e.g. a cache-inflated balance) still surfaces its unfunded excess.

## SoftLock classification

`RevertClassifier` now maps selector `0x66ef7607` (`ERC20TokenOfferCycle.SoftLock`) to `category=input` / `soft_lock`. SoftLock is a receiver-side anti-dump guard (`totalClaimed[from] > OFFER_TOKEN.balanceOf(from)`) living in token-offer-cycle state — orthogonal to the Circles trust/balance graph, so it cannot be caused by a balance phantom and is not a pathfinder bug. `input` is excluded from the bug/error-rate alerts (mirrors `invalid_receiver`). The drift probe still runs on `input` reverts, so a real phantom hiding behind a SoftLock revert is still caught.

## Tests
- 3 probe tests: balanced pass-through → not flagged; partial inflow → only the excess flagged; pure source (no inflow) → still flagged fully (real-phantom regression guard).
- 1 classifier test: `0x66ef7607` → `("input","soft_lock")`.
- Full pathfinder suite: **1180 pass / 0 fail**.

## Notes
Both alerts clear at the emission point (the drift metric + log line stop being produced; the SoftLock revert leaves the bug bucket) rather than via alert-threshold tuning.
