### PR TITLE
feat(config): make TxLookupLimit configurable via env var

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -34,7 +34,7 @@ services:
       --Sync.AncientBodiesBarrier=12500000
       --Sync.AncientReceiptsBarrier=12500000
       --Receipt.StoreReceipts=true
-      --Receipt.TxLookupLimit=0
+      --Receipt.TxLookupLimit=${NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT:-0}
       --log=INFO
       --JsonRpc.Enabled=true
       --JsonRpc.Host=0.0.0.0


### PR DESCRIPTION
## Summary

- Replace hardcoded `--Receipt.TxLookupLimit=0` with `\${NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT:-0}`
- Default remains `0` (unlimited) — no behaviour change unless the env var is set
- Infra injects the value per environment via `.env` template

## Test plan

- [ ] Infra deploys with `NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT=6307200` on staging nodes
- [ ] `nethermind-gnosis` restarts cleanly; flag visible in container inspect
- [ ] Circles RPC endpoints healthy post-restart
- [ ] Production nodes unaffected (env var absent → `:-0` default applies)