### PR TITLE
feat(pathfinder): classify ERC20InsufficientBalance canary reverts

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.BundleSimulation.cs
@@ -164,7 +164,12 @@ internal sealed partial class SimulationCanaryService
                 // unclassified 0x66ef7607 class). Skip category=simulation (valid-path canary
                 // artifacts, no balance shortfall). Replay this bundle's unwrap prefix so balanceOf
                 // reflects post-unwrap state — see ProbeBalanceDriftAsync.
-                if (!driftEmitted && BalanceProbeEnabled && parsed.Category != "simulation")
+                // Also skip wrapper_unwrap_insufficient_balance: the failing call IS the unwrap, so the
+                // probe's replay can't materialise the 1155 balance → balanceOf reads 0 → a guaranteed
+                // false zero_balance "drift". This class is already explained (build-vs-exec gap on a
+                // volatile wrapper); the probe can't discriminate it from a real phantom anyway.
+                if (!driftEmitted && BalanceProbeEnabled && parsed.Category != "simulation"
+                    && parsed.Label != "wrapper_unwrap_insufficient_balance")
                     await ProbeBalanceDriftAsync(item, unwrapCalls, blockTag, client, ct);
                 return;
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Canary/SimulationCanaryService.Lifecycle.cs
@@ -164,7 +164,11 @@ internal sealed partial class SimulationCanaryService
                 // valid w.r.t. balances — the revert is a canary msg.sender artifact, not a shortfall —
                 // so probing them adds no signal and only risks alert noise on the recurring class.
                 // Plain path ⇒ no unwrap prefix to replay.
-                if (!driftEmitted && BalanceProbeEnabled && category != "simulation")
+                // Also skip wrapper_unwrap_insufficient_balance (kept symmetric with the bundle path):
+                // an unwrap-shortfall revert can't be a true 1155 cache drift, so probing it would only
+                // emit a false zero_balance signal.
+                if (!driftEmitted && BalanceProbeEnabled && category != "simulation"
+                    && label != "wrapper_unwrap_insufficient_balance")
                     await ProbeBalanceDriftAsync(item, Array.Empty<ResolvedUnwrapCall>(), blockTag, client, ct);
 
                 if (revertData == null && revertMsg?.Contains("revert", StringComparison.OrdinalIgnoreCase) == true)

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
@@ -144,6 +144,22 @@ public class RevertClassifierTests
         Assert.That(label, Is.EqualTo("soft_lock"));
     }
 
+    [Test]
+    public void ERC20InsufficientBalance_ClassifiedAsInput()
+    {
+        // OZ ERC20InsufficientBalance(sender, balance, needed), selector 0xe450d38c — an ERC20 wrapper
+        // unwrap() asking for more than the holder's live balance (a streamed/volatile demurraged
+        // wrapper whose balance moved between graph-build and execution). Tx-builder (SDK) gap, not a
+        // pathfinder bug → category=input, kept out of the bug/error-rate alerts (mirrors soft_lock).
+        // Classify only inspects the selector, so the trailing words are placeholders (the balance and
+        // needed args are not decoded here).
+        var revert = "execution reverted: 0xe450d38c"
+            + Word("abc") + Word("1") + Word("64");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("input"));
+        Assert.That(label, Is.EqualTo("wrapper_unwrap_insufficient_balance"));
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -34,6 +34,14 @@ public static class RevertClassifier
     // OpenZeppelin ERC1155 errors
     private const string ERC1155InsufficientBalance = "0x03dee4c5";
     private const string ERC1155InvalidReceiver = "0x57f447ce";
+    // OpenZeppelin ERC20InsufficientBalance(address sender, uint256 balance, uint256 needed).
+    // Surfaces when an ERC20 wrapper `unwrap()` asks for more than the holder's live balance — i.e. a
+    // demurraged-wrapper source whose on-chain balance moved between graph-build and execution
+    // (e.g. a streaming "proxy inviter" wrapper that is filled and drained continuously). The
+    // pathfinder reported the balance correctly at graphBlock; the gap is build-time-vs-exec-time, so
+    // the tx-builder (SDK) must clamp the unwrap to the live balance. Not a pathfinder/cache bug, and
+    // distinct from the ERC1155 cache-drift signal above.
+    private const string ERC20InsufficientBalance = "0xe450d38c";
     // ERC20TokenOfferCycle anti-dump guard (circles-token-offer/src/ERC20TokenOfferCycle.sol):
     // SoftLock() — a token-offer-cycle SINK's onERC1155Received pre-claim branch reverts when the
     // CRC sender has over-claimed (totalClaimed[from] > OFFER_TOKEN.balanceOf(from)). A receiver-side
@@ -82,6 +90,12 @@ public static class RevertClassifier
 
         if (Contains(lower, SoftLock))
             return ("input", "soft_lock");
+
+        // ERC20 wrapper unwrap asked for more than the holder's live balance (volatile/streamed
+        // demurraged wrapper). Build-time-vs-execution-time gap, fixed in the tx-builder (SDK), not a
+        // pathfinder bug — classify as input so it surfaces named instead of as a generic/unknown revert.
+        if (Contains(lower, ERC20InsufficientBalance))
+            return ("input", "wrapper_unwrap_insufficient_balance");
 
         // Generic revert string patterns
         if (lower.Contains("execution reverted"))


### PR DESCRIPTION
## Summary
The simulation canary classified ERC20 wrapper `unwrap()` reverts (`ERC20InsufficientBalance`, selector `0xe450d38c`) as `("unknown","generic_revert")`, and the active balance-drift probe fired on them. Because the failing call *is* the unwrap, the probe's unwrap-replay can never materialise the ERC1155 balance, so `balanceOf` reads `0` and emits a false `zero_balance` cache-drift signal — tripping `PathfinderCacheBalanceDriftSevere`.

This revert class is a build-time-vs-execution-time shortfall on a volatile/streamed demurraged ERC20 wrapper (the spendable balance moves between graph-build and execution). It is a transaction-builder concern, not a pathfinder/cache fault, and the probe cannot discriminate it from a real phantom.

## Changes
- `RevertClassifier`: map `0xe450d38c` -> `("input","wrapper_unwrap_insufficient_balance")`, so it surfaces named and stays out of the bug/error-rate alerts (mirrors `soft_lock`/`invalid_receiver`).
- Exclude the label from the drift-probe fallback in both the bundle and plain canary paths, eliminating the false `zero_balance` signal.
- Add a `RevertClassifier` unit test for the new selector.

## Test plan
- [x] `dotnet build -c Release` - 0 errors
- [x] `RevertClassifierTests` 45/45 pass
- [x] `RevertClassifier` + `SimulationCanary` tests 143/143 pass