### PR TITLE
perf(metrics): raise whale transfer threshold 5000 → 10000 CRC

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/Services/LiquidityRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/LiquidityRepository.cs
@@ -23,8 +23,8 @@ public class LiquidityRepository
     // Combined list for queries
     private static readonly string[] BalancerVaultAddresses = { BalancerV2VaultAddress, BalancerV3VaultAddress };
 
-    // Whale threshold: 5000 tokens (5e21 wei for 18-decimal tokens)
-    private const decimal WhaleThreshold = 5_000_000_000_000_000_000_000m; // 5e21
+    // Whale threshold: 10000 tokens (1e22 wei for 18-decimal tokens)
+    private const decimal WhaleThreshold = 10_000_000_000_000_000_000_000m; // 1e22
 
     public LiquidityRepository(
         string connectionString,


### PR DESCRIPTION
## Summary

- Raises `WhaleThreshold` in `LiquidityRepository.cs` from 5000 CRC (5e21 wei) to 10000 CRC (1e22 wei)
- At ~100 CRC ≈ $1, the previous threshold of 5000 CRC (~$50) was too low, generating alert noise from routine large transfers
- 10000 CRC (~$100) is a more meaningful threshold for a "whale" event

## Test plan

- [ ] Deploy metrics-exporter on staging2 and verify `WhaleActivitySpike` alert no longer fires for the 540-transfer spike that was triggering on the old threshold
- [ ] Confirm `circles_whale_transfer_total` metric still increments for transfers above the new threshold