### PR TITLE
fix(score-group): correct block-pinned balance queries in ReadBaseRows

### DIFF
--- a/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
@@ -1,18 +1,25 @@
 using System.Numerics;
 using Circles.Common.TestUtils;
-using Npgsql;
+using NUnit.Framework;
 
 namespace Circles.Common.Tests;
 
 /// <summary>
-/// Integration tests that verify the optimized BaseRowsSql in
-/// <see cref="ScoreGroupMintLimitReader"/> produces numerically identical results
-/// to the original view-based query that used V_CrcV2_BalancesByAccountAndToken
-/// directly (before predicate-pushdown optimization).
+/// Integration tests that verify <see cref="ScoreGroupMintLimitReader.BaseRowsSqlHistorical"/>
+/// produces numerically identical results to the original view-based query that used
+/// V_CrcV2_BalancesByAccountAndToken directly (before the predicate-pushdown optimisation).
 ///
-/// Requires TEST_ENV_URL to be set; tests skip automatically when absent.
-/// Block 46406058 is a real Gnosis block where the OffchainScoreBasedMintPolicy
-/// score group was active (confirmed by the personal-mint regression scenario).
+/// Both queries execute through the test-environment HTTP query proxy, which pins
+/// search_path = circles_at_block, public and circles.max_block_number = N for every
+/// request. Under that search_path:
+///   - reference: V_CrcV2_BalancesByAccountAndToken → circles_at_block twin → raw tables
+///     with blockNumber &lt;= pin_block() and pin_timestamp() for demurrage. Correct.
+///   - historical: BaseRowsSqlHistorical → raw tables with blockNumber &lt;= @maxBlock and
+///     block timestamp from System_Block. Correct by construction; must match reference.
+///
+/// Requires TEST_ENV_URL; tests skip automatically when absent.
+/// Block 46406058 is a real Gnosis block where the OffchainScoreBasedMintPolicy score
+/// group was active (confirmed by the personal-mint regression scenario).
 /// </summary>
 [TestFixture]
 [Category("Integration")]
@@ -21,19 +28,18 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
     private const string ScoreGroupMintPolicy = "0x450d68272e43c4cab7cbc7faa37893a50fae9569";
     private const long TestBlock = 46_406_058;
 
-    /// <summary>
-    /// Original view-based SQL kept as the oracle reference. The optimized
-    /// version inlines the view's logic; this constant lets us run both and
-    /// compare results row-by-row.
-    /// </summary>
+    // Original view-based SQL with test values inlined — the oracle reference.
+    // The proxy resolves V_CrcV2_BalancesByAccountAndToken to the circles_at_block
+    // block-pinned twin so this gives correctly block-pinned, pin_timestamp()-demurraged
+    // results. Treasury overrides omitted (no override map needed for this fixture).
     private const string ReferenceBaseRowsSql = """
         WITH latest_score_group AS (
             SELECT DISTINCT ON ("group")
                 "group" AS group_address,
                 LOWER("emitter") AS policy
             FROM "CrcV2_ScoreGroup_GroupInitialized"
-            WHERE (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
-              AND LOWER("emitter") = ANY(@scoreMintPolicies)
+            WHERE "blockNumber" <= 46406058
+              AND LOWER("emitter") = ANY(ARRAY['0x450d68272e43c4cab7cbc7faa37893a50fae9569']::text[])
             ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
         ),
         score_groups AS (
@@ -43,27 +49,13 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
                 LOWER(COALESCE(lsg.policy, g."mint")) AS policy
             FROM "CrcV2_RegisterGroup" g
             LEFT JOIN latest_score_group lsg ON LOWER(lsg.group_address) = LOWER(g."group")
-            WHERE (@maxBlock::bigint IS NULL OR g."blockNumber" <= @maxBlock)
-              AND LOWER(g."mint") = ANY(@scoreMintPolicies)
+            WHERE g."blockNumber" <= 46406058
+              AND LOWER(g."mint") = ANY(ARRAY['0x450d68272e43c4cab7cbc7faa37893a50fae9569']::text[])
               AND lsg.group_address IS NOT NULL
-              AND (@groupAddressFilter::text IS NULL OR LOWER(g."group") = @groupAddressFilter)
-        ),
-        treasury_overrides AS (
-            SELECT
-                LOWER(agg) AS aggregator,
-                string_to_array(LOWER(subs_csv), ',') AS subs
-            FROM unnest(
-                @subTreasuryAggregators::text[],
-                @subTreasuryLists::text[]
-            ) AS u(agg, subs_csv)
         ),
         effective_treasuries AS (
-            SELECT
-                sg.group_address,
-                sg.policy,
-                COALESCE(o.subs, ARRAY[sg.treasury]::text[]) AS treasuries
-            FROM score_groups sg
-            LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury
+            SELECT group_address, policy, ARRAY[treasury]::text[] AS treasuries
+            FROM score_groups
         ),
         group_tokens AS (
             SELECT
@@ -74,7 +66,6 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
             FROM effective_treasuries et
             INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = et.group_address
             INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
-            WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
         ),
         token_supply AS (
             SELECT
@@ -98,107 +89,123 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
             COALESCE(ts.current_supply, '0') AS current_supply
         FROM group_tokens gt
         LEFT JOIN token_supply ts
-            ON ts."tokenAddress" = gt.trusted_token;
+            ON ts."tokenAddress" = gt.trusted_token
         """;
+
+    // BaseRowsSqlHistorical with the test values inlined for proxy execution.
+    // @maxBlock → literal 46406058
+    // @scoreMintPolicies → ARRAY literal
+    // Optional filters cleared to NULL / empty-array defaults
+    private static readonly string HistoricalBaseRowsSql =
+        ScoreGroupMintLimitReader.BaseRowsSqlHistorical
+            .Replace("@maxBlock", "46406058")
+            .Replace(
+                "ANY(@scoreMintPolicies)",
+                "ANY(ARRAY['0x450d68272e43c4cab7cbc7faa37893a50fae9569']::text[])")
+            .Replace(
+                "@groupAddressFilter::text IS NULL OR LOWER(g.\"group\") = @groupAddressFilter",
+                "TRUE")
+            .Replace(
+                "@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter",
+                "TRUE")
+            .Replace(
+                "@subTreasuryAggregators::text[]",
+                "ARRAY[]::text[]")
+            .Replace(
+                "@subTreasuryLists::text[]",
+                "ARRAY[]::text[]");
 
     private static bool TestEnvAvailable =>
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEST_ENV_URL"));
 
     [Test]
-    public async Task BaseRows_OptimizedQuery_MatchesViewBasedReference()
+    public async Task HistoricalBaseRowsSql_MatchesViewBasedReference()
     {
         if (!TestEnvAvailable)
             Assert.Ignore("TEST_ENV_URL not set — skipping integration test");
 
+        Assert.That(HistoricalBaseRowsSql, Does.Not.Contain("@"),
+            "SQL parameter substitution incomplete — a .Replace() pattern no longer matches BaseRowsSqlHistorical. " +
+            "Update the .Replace() calls to match the current parameter names in BaseRowsSqlHistorical.");
+
+        if (!await TestEnvironmentClient.BlockExistsAsync(TestBlock))
+            Assert.Ignore($"Block {TestBlock} not indexed in test environment — skipping");
+
         await using var session = await TestEnvironmentClient.CreateSessionAsync(TestBlock);
-        var connStr = session.PostgresConnectionString
-            ?? throw new InvalidOperationException("No postgres connection string from test environment");
 
-        await using var conn = new NpgsqlConnection(connStr);
-        await conn.OpenAsync();
+        // Both queries go through the block-pinned proxy (search_path = circles_at_block, public).
+        // Reference: V_CrcV2_BalancesByAccountAndToken → circles_at_block twin → raw tables + pin_timestamp().
+        // Historical: raw tables + block timestamp from System_Block.
+        // Both anchored to the same block; results must match within ±1 for integer rounding.
+        var referenceResponse = await session.ExecuteQueryAsync(ReferenceBaseRowsSql, maxRows: 1000);
+        var historicalResponse = await session.ExecuteQueryAsync(HistoricalBaseRowsSql, maxRows: 1000);
+        Assert.That(referenceResponse.Truncated, Is.False,
+            "Reference query truncated at 1000 rows — raise maxRows limit");
+        Assert.That(historicalResponse.Truncated, Is.False,
+            "Historical query truncated at 1000 rows — raise maxRows limit");
+        var referenceRows = ParseBaseRows(referenceResponse);
+        var historicalRows = ParseBaseRows(historicalResponse);
 
-        // Use a read-only transaction so both queries share the same snapshot and
-        // NOW() is frozen to a single point in time.  Without this, a UTC day
-        // boundary between the two statements would cause demurrage day indices
-        // to differ, producing CurrentSupply divergences of more than ±1 per token.
-        await using var tx = await conn.BeginTransactionAsync(
-            System.Data.IsolationLevel.RepeatableRead);
-
-        string[] policies = [ScoreGroupMintPolicy];
-        var referenceRows = await RunReferenceQueryAsync(conn, tx, policies, TestBlock);
-        var optimizedRows = ScoreGroupMintLimitReader.ReadBaseRows(
-            conn, policies, commandTimeoutSeconds: 60, maxBlock: TestBlock,
-            transaction: tx, groupAddressFilter: null, collateralTokenFilter: null,
-            subTreasuryOverrides: null);
-
-        await tx.RollbackAsync();
-
-        // Build lookup keyed by (group, collateral)
-        var refByKey = referenceRows.ToDictionary(
-            r => (r.GroupAddress, r.CollateralToken),
-            r => r);
-
-        Assert.That(optimizedRows, Is.Not.Empty,
+        Assert.That(historicalRows, Is.Not.Empty,
             $"Expected at least one score-group row at block {TestBlock}");
-        Assert.That(optimizedRows.Count, Is.EqualTo(refByKey.Count),
-            $"Row count mismatch: optimized={optimizedRows.Count} reference={refByKey.Count}");
+        Assert.That(historicalRows.Count, Is.EqualTo(referenceRows.Count),
+            $"Row count mismatch: historical={historicalRows.Count} reference={referenceRows.Count}");
 
-        foreach (var opt in optimizedRows)
+        var refByKey = referenceRows.ToDictionary(r => (r.GroupAddress, r.CollateralToken));
+
+        foreach (var opt in historicalRows)
         {
             var key = (opt.GroupAddress, opt.CollateralToken);
             Assert.That(refByKey.ContainsKey(key), Is.True,
-                $"Optimized row ({opt.GroupAddress}, {opt.CollateralToken}) missing from reference results");
+                $"Historical row ({opt.GroupAddress}, {opt.CollateralToken}) missing from reference");
 
             var @ref = refByKey[key];
 
-            // Treasury balance: exact BigInteger match
             Assert.That(opt.TreasuryBalance, Is.EqualTo(@ref.TreasuryBalance),
                 $"TreasuryBalance mismatch for ({opt.GroupAddress}, {opt.CollateralToken}): " +
-                $"optimized={opt.TreasuryBalance} ref={@ref.TreasuryBalance}");
+                $"historical={opt.TreasuryBalance} ref={@ref.TreasuryBalance}");
 
-            // Current supply: demurrage uses NOW() which is snapshot-frozen within the
-            // shared transaction, so both queries see the same day index.  Tolerate ±1
-            // for any remaining integer-rounding differences in demurrage arithmetic.
-            var supplyDelta = BigInteger.Abs(opt.CurrentSupply - @ref.CurrentSupply);
-            Assert.That(supplyDelta <= BigInteger.One,
-                $"CurrentSupply differs by {supplyDelta} for ({opt.GroupAddress}, {opt.CollateralToken}): " +
-                $"optimized={opt.CurrentSupply} ref={@ref.CurrentSupply}");
+            // ±1 tolerance: both paths use the same block timestamp for demurrage, but the
+            // POWER(gamma, days) floating-point result may differ by one integer after floor().
+            var delta = BigInteger.Abs(opt.CurrentSupply - @ref.CurrentSupply);
+            Assert.That(delta <= BigInteger.One,
+                $"CurrentSupply differs by {delta} for ({opt.GroupAddress}, {opt.CollateralToken}): " +
+                $"historical={opt.CurrentSupply} ref={@ref.CurrentSupply}");
         }
     }
 
-    private static async Task<List<ScoreGroupMintLimitBaseRow>> RunReferenceQueryAsync(
-        NpgsqlConnection conn,
-        NpgsqlTransaction? transaction,
-        string[] policies,
-        long maxBlock)
+    [Test]
+    public void ReadBaseRows_HistoricalSql_HasCorrectStructure()
+    {
+        // Verify BaseRowsSqlHistorical bypasses the matview and uses raw tables + block timestamp.
+        // The C# dispatch (maxBlock.HasValue ? BaseRowsSqlHistorical : BaseRowsSql) is not
+        // exercisable without a direct DB connection; this test validates the SQL constant used
+        // by that dispatch path has the expected shape.
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("block_ts"),
+            "Historical SQL must anchor demurrage to block timestamp via block_ts CTE");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("raw_tx"),
+            "Historical SQL must aggregate from raw transfer tables via raw_tx CTE");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Not.Contain("M_CrcV2_BalancesByAccountAndToken"),
+            "Historical SQL must NOT reference the matview (which only holds HEAD state)");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("\"blockNumber\" <= @maxBlock"),
+            "Historical SQL must filter all raw table reads by blockNumber <= @maxBlock");
+    }
+
+    private static List<ScoreGroupMintLimitBaseRow> ParseBaseRows(QueryResponse response)
     {
         var rows = new List<ScoreGroupMintLimitBaseRow>();
-        await using var cmd = new NpgsqlCommand(ReferenceBaseRowsSql, conn, transaction);
-        cmd.CommandTimeout = 120;
-        cmd.Parameters.AddWithValue("scoreMintPolicies", policies);
-        cmd.Parameters.AddWithValue("subTreasuryAggregators", Array.Empty<string>());
-        cmd.Parameters.AddWithValue("subTreasuryLists", Array.Empty<string>());
-
-        var maxBlockParam = cmd.Parameters.Add("maxBlock", NpgsqlTypes.NpgsqlDbType.Bigint);
-        maxBlockParam.Value = maxBlock;
-
-        var groupParam = cmd.Parameters.Add("groupAddressFilter", NpgsqlTypes.NpgsqlDbType.Text);
-        groupParam.Value = DBNull.Value;
-
-        var collateralParam = cmd.Parameters.Add("collateralTokenFilter", NpgsqlTypes.NpgsqlDbType.Text);
-        collateralParam.Value = DBNull.Value;
-
-        await using var reader = await cmd.ExecuteReaderAsync();
-        while (await reader.ReadAsync())
+        foreach (var row in response.Rows)
         {
             rows.Add(new ScoreGroupMintLimitBaseRow(
-                reader.GetString(0),
-                reader.GetString(1),
-                reader.GetString(2),
-                BigInteger.Parse(reader.GetString(3)),
-                BigInteger.Parse(reader.GetString(4))));
+                Str(row[0]).ToLowerInvariant(),
+                Str(row[1]).ToLowerInvariant(),
+                Str(row[2]).ToLowerInvariant(),
+                BigInteger.Parse(Str(row[3])),
+                BigInteger.Parse(Str(row[4]))));
         }
 
         return rows;
     }
+
+    private static string Str(object? v) => v?.ToString() ?? "0";
 }

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -176,6 +176,134 @@ public static class ScoreGroupMintLimitReader
             ON ts."tokenAddress" = gt.trusted_token;
         """;
 
+    /// <summary>
+    /// Historical variant of <see cref="BaseRowsSql"/> used when <c>maxBlock</c> is non-null.
+    /// Bypasses <c>M_CrcV2_BalancesByAccountAndToken</c> (the matview, which only holds HEAD
+    /// state and has no block-pinned twin in the test environment) and instead aggregates
+    /// directly from raw <c>CrcV2_TransferSingle/Batch</c> tables with
+    /// <c>WHERE "blockNumber" &lt;= @maxBlock</c>. Demurrage is anchored to the block's own
+    /// timestamp from <c>System_Block</c>, mirroring the <c>circles_at_block</c> schema's
+    /// <c>pin_timestamp()</c> function. This makes parity tests and any future historical
+    /// point-in-time queries produce correct results.
+    /// </summary>
+    internal const string BaseRowsSqlHistorical = """
+        WITH latest_score_group AS (
+            SELECT DISTINCT ON ("group")
+                "group" AS group_address,
+                LOWER("emitter") AS policy
+            FROM "CrcV2_ScoreGroup_GroupInitialized"
+            WHERE (@maxBlock::bigint IS NULL OR "blockNumber" <= @maxBlock)
+              AND LOWER("emitter") = ANY(@scoreMintPolicies)
+            ORDER BY "group", "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+        ),
+        score_groups AS (
+            SELECT
+                LOWER(g."group") AS group_address,
+                LOWER(g."treasury") AS treasury,
+                LOWER(COALESCE(lsg.policy, g."mint")) AS policy
+            FROM "CrcV2_RegisterGroup" g
+            LEFT JOIN latest_score_group lsg ON LOWER(lsg.group_address) = LOWER(g."group")
+            WHERE (@maxBlock::bigint IS NULL OR g."blockNumber" <= @maxBlock)
+              AND LOWER(g."mint") = ANY(@scoreMintPolicies)
+              AND lsg.group_address IS NOT NULL
+              AND (@groupAddressFilter::text IS NULL OR LOWER(g."group") = @groupAddressFilter)
+        ),
+        treasury_overrides AS (
+            SELECT
+                LOWER(agg) AS aggregator,
+                string_to_array(LOWER(subs_csv), ',') AS subs
+            FROM unnest(
+                @subTreasuryAggregators::text[],
+                @subTreasuryLists::text[]
+            ) AS u(agg, subs_csv)
+        ),
+        effective_treasuries AS (
+            SELECT
+                sg.group_address,
+                sg.policy,
+                COALESCE(o.subs, ARRAY[sg.treasury]::text[]) AS treasuries
+            FROM score_groups sg
+            LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury
+        ),
+        group_tokens AS (
+            SELECT
+                et.group_address,
+                et.treasuries,
+                et.policy,
+                t.trustee AS trusted_token
+            FROM effective_treasuries et
+            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = et.group_address
+            INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
+            WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
+        ),
+        block_ts AS (
+            SELECT MAX("timestamp") AS ts
+            FROM "System_Block"
+            WHERE "blockNumber" <= @maxBlock
+        ),
+        raw_tx AS (
+            SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
+            FROM "CrcV2_TransferSingle"
+            WHERE "blockNumber" <= @maxBlock
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+            UNION ALL
+            SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
+            FROM "CrcV2_TransferSingle"
+            WHERE "blockNumber" <= @maxBlock
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+            UNION ALL
+            SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
+            FROM "CrcV2_TransferBatch"
+            WHERE "blockNumber" <= @maxBlock
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+            UNION ALL
+            SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
+            FROM "CrcV2_TransferBatch"
+            WHERE "blockNumber" <= @maxBlock
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+        ),
+        raw_agg AS (
+            SELECT account, id::text AS "tokenId", "tokenAddress",
+                   MAX("timestamp") AS "lastActivity", SUM(delta) AS "totalBalance"
+            FROM raw_tx
+            GROUP BY account, id, "tokenAddress"
+        ),
+        balances AS (
+            SELECT account, "tokenId", "tokenAddress",
+                   floor("totalBalance" * power(
+                       0.9998013320085989574306481700129226782902039065082930593676448873,
+                       ((SELECT ts FROM block_ts) - 1602720000) / 86400
+                       - ("lastActivity" - 1602720000) / 86400
+                   )) AS "demurragedTotalBalance"
+            FROM raw_agg
+            WHERE account <> '0x0000000000000000000000000000000000000000'
+              AND "totalBalance" > 0
+        ),
+        token_supply AS (
+            SELECT
+                b."tokenAddress",
+                SUM(b."demurragedTotalBalance")::text AS current_supply
+            FROM balances b
+            INNER JOIN (SELECT DISTINCT trusted_token FROM group_tokens) gt
+                ON gt.trusted_token = b."tokenAddress"
+            GROUP BY b."tokenAddress"
+        )
+        SELECT
+            gt.group_address,
+            gt.trusted_token,
+            gt.policy,
+            COALESCE((
+                SELECT SUM(b."demurragedTotalBalance")
+                FROM balances b
+                WHERE b.account = ANY(gt.treasuries)
+                  AND b."tokenAddress" = gt.trusted_token
+            ), 0)::text AS treasury_balance,
+            COALESCE(ts.current_supply, '0') AS current_supply
+        FROM group_tokens gt
+        LEFT JOIN token_supply ts
+            ON ts."tokenAddress" = gt.trusted_token;
+        """;
+
     // HistoricalSupply is now per-(group, collateral) in the prod contract — the
     // event added `address indexed group`, so a single policy serving multiple
     // groups (via initializeGroup) tracks supply scoped to each group rather
@@ -313,20 +441,15 @@ public static class ScoreGroupMintLimitReader
         return rows;
     }
 
-    // NOTE — maxBlock partial coverage: group discovery CTEs (latest_score_group,
-    // score_groups, group_tokens) are correctly frozen at maxBlock. The balance
-    // computation (filtered_mat + delta_tx + balances) is NOT — it uses the current
-    // state of M_CrcV2_BalancesByAccountAndToken (a materialized view with no
-    // historical snapshots) plus live delta transfers, regardless of maxBlock.
-    // This matches the pre-existing behaviour of V_CrcV2_BalancesByAccountAndToken,
-    // which had the same limitation.
-    //
-    // In production maxBlock is always null, so this has no practical effect.
-    // In the test environment, block-pinned sessions freeze the matview at the
-    // pinned block, so results are correct there too. A fix would require replacing
-    // filtered_mat with a full raw-table aggregation (WHERE blockNumber <= maxBlock),
-    // bypassing the matview entirely — only worth doing if historical point-in-time
-    // mint-limit queries become a real requirement.
+    // Two SQL paths selected at runtime:
+    //   maxBlock IS NULL  → BaseRowsSql: fast matview + delta tail, demurrage at NOW().
+    //                       Used by the live pathfinder (HEAD state queries).
+    //   maxBlock IS NOT NULL → BaseRowsSqlHistorical: aggregates raw transfer tables with
+    //                       blockNumber <= @maxBlock, demurrage anchored to the block's
+    //                       own timestamp. Used by HistoricalLoadGraph (snapshot/historical-graph
+    //                       endpoint) and parity tests. NOTE: raw-table scan cost scales with
+    //                       transfer volume at the pinned block; acceptable for snapshot use-case
+    //                       but avoid using for tight latency paths.
     internal static IReadOnlyList<ScoreGroupMintLimitBaseRow> ReadBaseRows(
         NpgsqlConnection connection,
         string[] policies,
@@ -351,8 +474,9 @@ public static class ScoreGroupMintLimitReader
             .Select(kv => string.Join(",", kv.Value.Select(addr => addr.Trim().ToLowerInvariant())))
             .ToArray();
 
+        var sql = maxBlock.HasValue ? BaseRowsSqlHistorical : BaseRowsSql;
         var rows = new List<ScoreGroupMintLimitBaseRow>();
-        using var command = new NpgsqlCommand(BaseRowsSql, connection, transaction);
+        using var command = new NpgsqlCommand(sql, connection, transaction);
         command.CommandTimeout = commandTimeoutSeconds;
         command.Parameters.AddWithValue("scoreMintPolicies", policies);
         command.Parameters.AddWithValue("subTreasuryAggregators", subTreasuryAggregators);

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Helpers/ProxyLoadGraph.cs
@@ -392,13 +392,16 @@ public class ProxyLoadGraph : ILoadGraph
     }
 
     /// <summary>
-    /// Explicitly NOT supported via the test-env proxy — the production
-    /// <c>ScoreGroupMintLimitReader</c> needs a direct NpgsqlConnection. Returns empty so the
-    /// pathfinder models the score group with an UNBOUNDED mint cap. This is correct ONLY for
-    /// projection fixtures whose collateral has no mint-limit row (unbounded by definition); a
-    /// mint-limit-dependent case (e.g. P14 "limit reached") must NOT rely on this loader — it
-    /// would pass spuriously. Overridden explicitly (rather than inheriting the silent interface
-    /// default) to make the gap visible. See coverage tracker §5.E.
+    /// Not yet implemented via the test-env proxy — returns empty so the pathfinder
+    /// models the score group with an UNBOUNDED mint cap. This is correct for projection
+    /// fixtures whose scenario does not assert on a mint-limit ceiling; a fixture that
+    /// tests "limit reached" (e.g. P14) must NOT rely on this loader — it would pass
+    /// spuriously. Overridden explicitly to make the gap visible. See coverage tracker §5.E.
+    ///
+    /// Implementation is now possible: <c>ScoreGroupMintLimitReader.BaseRowsSqlHistorical</c>
+    /// works through the proxy (raw tables + block timestamp, no matview). A follow-up
+    /// PR can execute BaseRowsSqlHistorical + HistoricalSql + PersonalSql via
+    /// <c>ExecuteQueryAsync</c> and compute available limits in C#.
     /// </summary>
     public IEnumerable<(string GroupAddress, string CollateralToken, string AvailableLimit)> LoadScoreGroupMintLimits() => [];
 


### PR DESCRIPTION
## Summary

- Adds `BaseRowsSqlHistorical` to `ScoreGroupMintLimitReader` — aggregates raw `CrcV2_TransferSingle/Batch` tables with `blockNumber <= @maxBlock` and anchors demurrage to the block's own timestamp from `System_Block`
- `ReadBaseRows` now selects between the two SQL paths at runtime: matview-based fast path when `maxBlock` is null (production HEAD queries), raw-table historical path when non-null (used by `HistoricalLoadGraph` and parity tests)
- Root cause of the bug: `M_CrcV2_BalancesByAccountAndToken` (the matview) only holds HEAD state and has no block-pinned twin in `circles_at_block`, so historical queries silently returned wrong (over-demurraged) balances
- Rewrites the parity test to execute through the test-environment HTTP proxy — the old version always threw `InvalidOperationException` because `PostgresConnectionString` is never populated for external clients
- Adds structural assertions on `BaseRowsSqlHistorical` (no matview reference, has `block_ts`/`raw_tx` CTEs), truncation guards on proxy queries, and a `@`-token assertion to catch incomplete parameter substitution early
- Updates `ProxyLoadGraph.LoadScoreGroupMintLimits` comment to note the method is now implementable via proxy

## Test plan

- [ ] `dotnet build src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj` — 0 errors
- [ ] `ReadBaseRows_HistoricalSql_HasCorrectStructure` — runs without DB, verifies SQL shape
- [ ] `HistoricalBaseRowsSql_MatchesViewBasedReference` — requires `TEST_ENV_URL`; both proxy queries return matching results within ±1 demurrage rounding