### PR TITLE
feat(metrics): add rep_score and blacklist metrics from AA service

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/Program.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Program.cs
@@ -10,6 +10,9 @@ builder.Configuration.AddEnvironmentVariables();
 var connectionString = builder.Configuration.GetConnectionString("CirclesDb")
     ?? throw new InvalidOperationException("ConnectionStrings:CirclesDb is required");
 
+// RepScoreDb is optional — exporter degrades gracefully without AA
+var repScoreConnectionString = builder.Configuration.GetConnectionString("RepScoreDb");
+
 // Register services
 builder.Services.AddSingleton(sp =>
     new KpiRepository(connectionString, sp.GetRequiredService<ILogger<KpiRepository>>()));
@@ -46,6 +49,27 @@ builder.Services.AddHostedService<TrustCollectorService>();
 
 // Trust score history snapshot service (runs daily for anomaly detection)
 builder.Services.AddHostedService<TrustHistorySnapshotService>();
+
+// Rep score monitoring (AA circles_rep_score DB — bad actor radar + ScoreGroup distribution)
+// Optional: skip if RepScoreDb is not configured (AA may not be deployed in all environments)
+if (repScoreConnectionString is not null)
+{
+    builder.Services.AddSingleton(sp =>
+        new RepScoreRepository(
+            repScoreConnectionString,
+            connectionString,
+            builder.Configuration.GetValue<string>("RepScore:GroupId", "score_group")!,
+            builder.Configuration.GetValue<int>("RepScore:HighScoreThreshold", 70),
+            builder.Configuration.GetValue<int>("RepScore:ScoreDropThreshold", 20),
+            sp.GetRequiredService<ILogger<RepScoreRepository>>()));
+
+    builder.Services.AddHostedService<RepScoreCollectorService>();
+}
+else
+{
+    var startupLogger = LoggerFactory.Create(b => b.AddConsole()).CreateLogger("Program");
+    startupLogger.LogWarning("ConnectionStrings:RepScoreDb not configured — rep score metrics disabled");
+}
 
 // Deployment status monitoring (probes RPC endpoints, no DB access needed)
 builder.Services.AddHttpClient<DeploymentProber>();

--- a/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
@@ -1,0 +1,123 @@
+using Prometheus;
+
+namespace Circles.Metrics.Exporter;
+
+public static class RepScoreMetrics
+{
+    // ===========================================
+    // Blacklist / Bad Actor Radar
+    // ===========================================
+
+    public static readonly Gauge BlacklistTotal = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_total",
+            "Total number of addresses in the TrustGard blacklist");
+
+    public static readonly Gauge BlacklistMembersTotal = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_members_total",
+            "Blacklisted addresses that are currently ScoreGroup members — alert if > 0");
+
+    public static readonly Gauge BlacklistAdditions24h = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_additions_24h",
+            "Addresses added to the blacklist in the last 24 hours (TrustGard spike detector)");
+
+    public static readonly Gauge BlacklistRemovals24h = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_removals_24h",
+            "Addresses removed from the blacklist in the last 24 hours (false-positive corrections)");
+
+    public static readonly Gauge BlacklistLastRefreshAgeSeconds = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_last_refresh_age_seconds",
+            "Seconds since the last successful TrustGard blacklist refresh — alert if > 7200");
+
+    // ===========================================
+    // Rep Score Distribution (ScoreGroup members)
+    // ===========================================
+
+    public static readonly Gauge MemberCount = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_member_count",
+            "Total number of avatars scored in the ScoreGroup");
+
+    public static readonly Gauge ScoreAvg = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_avg",
+            "Average reputation score across all ScoreGroup members (0-100)");
+
+    public static readonly Gauge ScoreMedian = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_median",
+            "Median reputation score (50th percentile, 0-100)");
+
+    public static readonly Gauge ScoreStdDev = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_stddev",
+            "Standard deviation of reputation scores — very low = gaming, very high = polarisation");
+
+    public static readonly Gauge ScorePercentile = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_percentile",
+            "Reputation score at key percentiles (0-100)",
+            new GaugeConfiguration { LabelNames = ["percentile"] });
+
+    public static readonly Gauge ScoreBucketCount = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_bucket_count",
+            "Number of members in each 10-point score bucket",
+            new GaugeConfiguration { LabelNames = ["bucket"] });
+
+    public static readonly Gauge ZeroScoreCount = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_zero_count",
+            "Members with score = 0 (blacklisted or gate-failed)");
+
+    public static readonly Gauge HighScoreShare = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_high_share",
+            "Fraction of members with score >= high threshold (0-1) — good citizen ratio");
+
+    public static readonly Gauge LastRefreshAgeSeconds = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_last_refresh_age_seconds",
+            "Seconds since the last AA rep_score refresh for this group — alert if > 600");
+
+    // ===========================================
+    // Anomaly Detection
+    // ===========================================
+
+    public static readonly Gauge ScoreDrops24h = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_drops_24h",
+            "Members with a score drop >= threshold in the last 24 hours (organised attack signal)");
+
+    public static readonly Gauge NewZeroScore24h = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_new_zero_24h",
+            "Members whose score hit 0 in the last 24 hours (new blacklisting or gate failures) — alert if > 5");
+
+    public static readonly Gauge NewMembers24h = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_new_members_24h",
+            "Members admitted to the ScoreGroup in the last 24 hours");
+
+    public static readonly Gauge LostMembers24h = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_lost_members_24h",
+            "Members removed from the ScoreGroup in the last 24 hours");
+
+    // ===========================================
+    // Cross-cutting: Rep Score vs Transfer Volume
+    // ===========================================
+
+    public static readonly Gauge HighRepTransferShare = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_high_rep_transfer_share",
+            "Fraction of CRC transfer volume sent by high-reputation members (score >= threshold, 0-1)",
+            new GaugeConfiguration { LabelNames = ["window"] });
+
+    public static readonly Gauge ZeroRepTransferShare = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_zero_rep_transfer_share",
+            "Fraction of CRC transfer volume sent by zero-score actors — bad actor economic footprint (0-1)",
+            new GaugeConfiguration { LabelNames = ["window"] });
+
+    // ===========================================
+    // Collection Metrics
+    // ===========================================
+
+    public static readonly Counter CollectionDuration = Prometheus.Metrics
+        .CreateCounter("circles_rep_score_collection_duration_seconds_total",
+            "Total time spent collecting rep score metrics");
+
+    public static readonly Counter CollectionErrors = Prometheus.Metrics
+        .CreateCounter("circles_rep_score_collection_errors_total",
+            "Total number of rep score metric collection errors",
+            new CounterConfiguration { LabelNames = ["metric"] });
+
+    public static readonly Gauge LastCollectionTimestamp = Prometheus.Metrics
+        .CreateGauge("circles_rep_score_last_collection_timestamp",
+            "Unix timestamp of last successful rep score metrics collection");
+}

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
@@ -1,0 +1,170 @@
+using System.Diagnostics;
+
+namespace Circles.Metrics.Exporter.Services;
+
+public class RepScoreCollectorService : BackgroundService
+{
+    private readonly RepScoreRepository _repository;
+    private readonly ILogger<RepScoreCollectorService> _logger;
+    private readonly TimeSpan _collectionInterval;
+
+    public RepScoreCollectorService(
+        RepScoreRepository repository,
+        ILogger<RepScoreCollectorService> logger,
+        IConfiguration configuration)
+    {
+        _repository = repository;
+        _logger = logger;
+        var intervalSeconds = configuration.GetValue<int>("RepScore:CollectionIntervalSeconds", 120);
+        _collectionInterval = TimeSpan.FromSeconds(intervalSeconds);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("RepScore Collector starting with {Interval}s interval", _collectionInterval.TotalSeconds);
+
+        // Offset from other collectors to avoid query pileup at startup
+        await Task.Delay(TimeSpan.FromSeconds(45), stoppingToken);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var sw = Stopwatch.StartNew();
+
+            try
+            {
+                await Task.WhenAll(
+                    CollectBlacklistAsync(stoppingToken),
+                    CollectDistributionAsync(stoppingToken),
+                    CollectAnomaliesAsync(stoppingToken),
+                    CollectTransferSharesAsync(stoppingToken));
+
+                sw.Stop();
+                RepScoreMetrics.CollectionDuration.Inc(sw.Elapsed.TotalSeconds);
+                RepScoreMetrics.LastCollectionTimestamp.Set(DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+
+                _logger.LogDebug("RepScore metrics collection completed in {Duration}ms", sw.ElapsedMilliseconds);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Error during rep score metrics collection");
+            }
+
+            await Task.Delay(_collectionInterval, stoppingToken);
+        }
+    }
+
+    private async Task CollectBlacklistAsync(CancellationToken ct)
+    {
+        try
+        {
+            var stats = await _repository.GetBlacklistStatsAsync(ct);
+
+            RepScoreMetrics.BlacklistTotal.Set(stats.Total);
+            RepScoreMetrics.BlacklistMembersTotal.Set(stats.MembersTotal);
+            RepScoreMetrics.BlacklistAdditions24h.Set(stats.Additions24h);
+            RepScoreMetrics.BlacklistRemovals24h.Set(stats.Removals24h);
+            RepScoreMetrics.BlacklistLastRefreshAgeSeconds.Set(stats.LastRefreshAgeSeconds);
+
+            if (stats.MembersTotal > 0)
+                _logger.LogWarning("Blacklisted ScoreGroup members detected: {Count}", stats.MembersTotal);
+
+            _logger.LogDebug("Blacklist: total={Total}, members={Members}, age={Age}s",
+                stats.Total, stats.MembersTotal, (int)stats.LastRefreshAgeSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to collect blacklist metrics");
+            RepScoreMetrics.CollectionErrors.WithLabels("blacklist").Inc();
+        }
+    }
+
+    private async Task CollectDistributionAsync(CancellationToken ct)
+    {
+        try
+        {
+            var dist = await _repository.GetScoreDistributionAsync(ct);
+
+            RepScoreMetrics.MemberCount.Set(dist.MemberCount);
+            RepScoreMetrics.ScoreAvg.Set(dist.Avg);
+            RepScoreMetrics.ScoreMedian.Set(dist.Median);
+            RepScoreMetrics.ScoreStdDev.Set(dist.StdDev);
+            RepScoreMetrics.ZeroScoreCount.Set(dist.ZeroCount);
+            RepScoreMetrics.HighScoreShare.Set(dist.HighShare);
+            RepScoreMetrics.LastRefreshAgeSeconds.Set(dist.LastRefreshAgeSeconds);
+
+            RepScoreMetrics.ScorePercentile.WithLabels("p25").Set(dist.P25);
+            RepScoreMetrics.ScorePercentile.WithLabels("p50").Set(dist.Median);
+            RepScoreMetrics.ScorePercentile.WithLabels("p75").Set(dist.P75);
+            RepScoreMetrics.ScorePercentile.WithLabels("p90").Set(dist.P90);
+
+            var buckets = new (string Label, long Count)[]
+            {
+                ("0-10",  dist.Bucket0_10),
+                ("10-20", dist.Bucket10_20),
+                ("20-30", dist.Bucket20_30),
+                ("30-40", dist.Bucket30_40),
+                ("40-50", dist.Bucket40_50),
+                ("50-60", dist.Bucket50_60),
+                ("60-70", dist.Bucket60_70),
+                ("70-80", dist.Bucket70_80),
+                ("80-90", dist.Bucket80_90),
+                ("90-100", dist.Bucket90_100),
+            };
+            foreach (var (label, count) in buckets)
+                RepScoreMetrics.ScoreBucketCount.WithLabels(label).Set(count);
+
+            _logger.LogDebug("RepScore distribution: members={Count}, avg={Avg:F1}, high_share={Share:P1}, refresh_age={Age}s",
+                dist.MemberCount, dist.Avg, dist.HighShare, (int)dist.LastRefreshAgeSeconds);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to collect rep score distribution metrics");
+            RepScoreMetrics.CollectionErrors.WithLabels("distribution").Inc();
+        }
+    }
+
+    private async Task CollectAnomaliesAsync(CancellationToken ct)
+    {
+        try
+        {
+            var anomaly = await _repository.GetAnomalyStatsAsync(ct);
+
+            RepScoreMetrics.ScoreDrops24h.Set(anomaly.Drops24h);
+            RepScoreMetrics.NewZeroScore24h.Set(anomaly.NewZero24h);
+            RepScoreMetrics.NewMembers24h.Set(anomaly.NewMembers24h);
+            RepScoreMetrics.LostMembers24h.Set(anomaly.LostMembers24h);
+
+            if (anomaly.NewZero24h > 0)
+                _logger.LogWarning("{Count} member(s) dropped to rep_score=0 in the last 24h", anomaly.NewZero24h);
+
+            if (anomaly.Drops24h > 0)
+                _logger.LogInformation("Rep score drops (>={Threshold}pts) in 24h: {Count}", _repository.ScoreDropThreshold, anomaly.Drops24h);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to collect rep score anomaly metrics");
+            RepScoreMetrics.CollectionErrors.WithLabels("anomalies").Inc();
+        }
+    }
+
+    private async Task CollectTransferSharesAsync(CancellationToken ct)
+    {
+        try
+        {
+            var shares = await _repository.GetTransferSharesAsync(ct);
+
+            RepScoreMetrics.HighRepTransferShare.WithLabels("24h").Set(shares.HighRepShare24h);
+            RepScoreMetrics.ZeroRepTransferShare.WithLabels("24h").Set(shares.ZeroRepShare24h);
+            RepScoreMetrics.HighRepTransferShare.WithLabels("7d").Set(shares.HighRepShare7d);
+            RepScoreMetrics.ZeroRepTransferShare.WithLabels("7d").Set(shares.ZeroRepShare7d);
+
+            _logger.LogDebug("Transfer shares: high_rep_24h={H24:P1}, zero_rep_24h={Z24:P1}",
+                shares.HighRepShare24h, shares.ZeroRepShare24h);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to collect transfer share metrics");
+            RepScoreMetrics.CollectionErrors.WithLabels("transfer_shares").Inc();
+        }
+    }
+}

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
@@ -1,0 +1,316 @@
+using Npgsql;
+using NpgsqlTypes;
+
+namespace Circles.Metrics.Exporter.Services;
+
+public class RepScoreRepository
+{
+    private readonly string _repScoreConn;
+    private readonly string _circlesDbConn;
+    private readonly string _groupId;
+    private readonly int _highScoreThreshold;
+    private readonly int _scoreDropThreshold;
+    public int ScoreDropThreshold => _scoreDropThreshold;
+    private readonly ILogger<RepScoreRepository> _logger;
+
+    public RepScoreRepository(
+        string repScoreConn,
+        string circlesDbConn,
+        string groupId,
+        int highScoreThreshold,
+        int scoreDropThreshold,
+        ILogger<RepScoreRepository> logger)
+    {
+        _repScoreConn = repScoreConn;
+        _circlesDbConn = circlesDbConn;
+        _groupId = groupId;
+        _highScoreThreshold = highScoreThreshold;
+        _scoreDropThreshold = scoreDropThreshold;
+        _logger = logger;
+    }
+
+    // ===========================================
+    // Blacklist Stats
+    // ===========================================
+
+    public record BlacklistStats(
+        long Total,
+        long MembersTotal,
+        long Additions24h,
+        long Removals24h,
+        double LastRefreshAgeSeconds);
+
+    public async Task<BlacklistStats> GetBlacklistStatsAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            WITH member_blacklist AS (
+                SELECT COUNT(DISTINCT s.avatar) AS members_total
+                FROM rep_score_state s
+                JOIN blacklist b ON b.address = s.avatar
+                WHERE s.group_id = @groupId
+            ),
+            refresh_stats AS (
+                SELECT
+                    COALESCE(EXTRACT(EPOCH FROM (NOW() - MAX(completed_at) FILTER (WHERE error IS NULL))), 999999) AS last_refresh_age,
+                    COALESCE(SUM(added) FILTER (WHERE completed_at > NOW() - INTERVAL '24 hours' AND error IS NULL), 0) AS additions_24h,
+                    COALESCE(SUM(removed) FILTER (WHERE completed_at > NOW() - INTERVAL '24 hours' AND error IS NULL), 0) AS removals_24h
+                FROM blacklist_refresh_log
+            )
+            SELECT
+                (SELECT COUNT(*) FROM blacklist) AS total,
+                mb.members_total,
+                rs.additions_24h,
+                rs.removals_24h,
+                rs.last_refresh_age
+            FROM member_blacklist mb, refresh_stats rs
+            """;
+
+        await using var conn = new NpgsqlConnection(_repScoreConn);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("groupId", _groupId);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        if (await reader.ReadAsync(ct))
+        {
+            return new BlacklistStats(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetInt64(2),
+                reader.GetInt64(3),
+                reader.GetDouble(4));
+        }
+
+        return new BlacklistStats(0, 0, 0, 0, 999999);
+    }
+
+    // ===========================================
+    // Score Distribution
+    // ===========================================
+
+    public record ScoreDistribution(
+        long MemberCount,
+        double Avg,
+        double Median,
+        double StdDev,
+        double P25,
+        double P75,
+        double P90,
+        long ZeroCount,
+        double HighShare,
+        double LastRefreshAgeSeconds,
+        long Bucket0_10,
+        long Bucket10_20,
+        long Bucket20_30,
+        long Bucket30_40,
+        long Bucket40_50,
+        long Bucket50_60,
+        long Bucket60_70,
+        long Bucket70_80,
+        long Bucket80_90,
+        long Bucket90_100);
+
+    public async Task<ScoreDistribution> GetScoreDistributionAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT
+                COUNT(*)                                                           AS member_count,
+                COALESCE(AVG(score), 0)                                            AS avg,
+                COALESCE(PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY score), 0)  AS median,
+                COALESCE(STDDEV(score), 0)                                         AS stddev,
+                COALESCE(PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY score), 0)  AS p25,
+                COALESCE(PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY score), 0)  AS p75,
+                COALESCE(PERCENTILE_CONT(0.90) WITHIN GROUP (ORDER BY score), 0)  AS p90,
+                COUNT(*) FILTER (WHERE score = 0)                                  AS zero_count,
+                COALESCE(COUNT(*) FILTER (WHERE score >= @high)::double precision
+                    / NULLIF(COUNT(*), 0), 0)                                      AS high_share,
+                COALESCE(EXTRACT(EPOCH FROM (NOW() - MAX(computed_at))), 999999)   AS refresh_age,
+                COUNT(*) FILTER (WHERE score >= 0   AND score < 10)   AS b0,
+                COUNT(*) FILTER (WHERE score >= 10  AND score < 20)   AS b10,
+                COUNT(*) FILTER (WHERE score >= 20  AND score < 30)   AS b20,
+                COUNT(*) FILTER (WHERE score >= 30  AND score < 40)   AS b30,
+                COUNT(*) FILTER (WHERE score >= 40  AND score < 50)   AS b40,
+                COUNT(*) FILTER (WHERE score >= 50  AND score < 60)   AS b50,
+                COUNT(*) FILTER (WHERE score >= 60  AND score < 70)   AS b60,
+                COUNT(*) FILTER (WHERE score >= 70  AND score < 80)   AS b70,
+                COUNT(*) FILTER (WHERE score >= 80  AND score < 90)   AS b80,
+                COUNT(*) FILTER (WHERE score >= 90  AND score <= 100) AS b90
+            FROM rep_score_state
+            WHERE group_id = @groupId
+            """;
+
+        await using var conn = new NpgsqlConnection(_repScoreConn);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("groupId", _groupId);
+        cmd.Parameters.AddWithValue("high", (double)_highScoreThreshold);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        if (await reader.ReadAsync(ct))
+        {
+            return new ScoreDistribution(
+                reader.GetInt64(0),
+                reader.GetDouble(1),
+                reader.GetDouble(2),
+                reader.GetDouble(3),
+                reader.GetDouble(4),
+                reader.GetDouble(5),
+                reader.GetDouble(6),
+                reader.GetInt64(7),
+                reader.GetDouble(8),
+                reader.GetDouble(9),
+                reader.GetInt64(10),
+                reader.GetInt64(11),
+                reader.GetInt64(12),
+                reader.GetInt64(13),
+                reader.GetInt64(14),
+                reader.GetInt64(15),
+                reader.GetInt64(16),
+                reader.GetInt64(17),
+                reader.GetInt64(18),
+                reader.GetInt64(19));
+        }
+
+        return new ScoreDistribution(0, 0, 0, 0, 0, 0, 0, 0, 0, 999999, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+
+    // ===========================================
+    // Anomaly Detection
+    // ===========================================
+
+    public record AnomalyStats(
+        long Drops24h,
+        long NewZero24h,
+        long NewMembers24h,
+        long LostMembers24h);
+
+    public async Task<AnomalyStats> GetAnomalyStatsAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            WITH window_24h AS (
+                SELECT avatar, prev_score, score, prev_is_member
+                FROM rep_score_history
+                WHERE group_id = @groupId
+                  AND snapshot_at > NOW() - INTERVAL '24 hours'
+            ),
+            lost AS (
+                SELECT COUNT(DISTINCT h.avatar) AS cnt
+                FROM rep_score_history h
+                LEFT JOIN rep_score_state s ON s.group_id = @groupId AND s.avatar = h.avatar
+                WHERE h.group_id = @groupId
+                  AND h.snapshot_at > NOW() - INTERVAL '24 hours'
+                  AND h.prev_is_member = true
+                  AND s.avatar IS NULL
+            )
+            SELECT
+                COUNT(*) FILTER (WHERE prev_score - score >= @drop AND prev_score > score) AS drops_24h,
+                COUNT(*) FILTER (WHERE prev_score > 0 AND score = 0)                       AS new_zero_24h,
+                COUNT(*) FILTER (WHERE prev_is_member = false OR prev_is_member IS NULL)   AS new_members_24h,
+                (SELECT cnt FROM lost)                                                     AS lost_members_24h
+            FROM window_24h
+            """;
+
+        await using var conn = new NpgsqlConnection(_repScoreConn);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("groupId", _groupId);
+        cmd.Parameters.AddWithValue("drop", (double)_scoreDropThreshold);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        if (await reader.ReadAsync(ct))
+        {
+            return new AnomalyStats(
+                reader.GetInt64(0),
+                reader.GetInt64(1),
+                reader.GetInt64(2),
+                reader.IsDBNull(3) ? 0 : reader.GetInt64(3));
+        }
+
+        return new AnomalyStats(0, 0, 0, 0);
+    }
+
+    // ===========================================
+    // Cross-DB Transfer Share
+    // ===========================================
+
+    public record TransferShareMetrics(
+        double HighRepShare24h,
+        double ZeroRepShare24h,
+        double HighRepShare7d,
+        double ZeroRepShare7d);
+
+    public async Task<TransferShareMetrics> GetTransferSharesAsync(CancellationToken ct = default)
+    {
+        var (highRep, zeroRep) = await LoadMemberAddressBuckets(ct);
+
+        if (highRep.Length == 0 && zeroRep.Length == 0)
+            return new TransferShareMetrics(0, 0, 0, 0);
+
+        const string sql = """
+            SELECT
+                -- 24h — timestamp is Unix epoch (bigint), not timestamptz
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "from" = ANY(@high) AND "timestamp" > EXTRACT(EPOCH FROM NOW()) - 86400), 0)  AS high_24h,
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "from" = ANY(@zero) AND "timestamp" > EXTRACT(EPOCH FROM NOW()) - 86400), 0)  AS zero_24h,
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "timestamp" > EXTRACT(EPOCH FROM NOW()) - 86400), 0)                           AS total_24h,
+                -- 7d
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "from" = ANY(@high) AND "timestamp" > EXTRACT(EPOCH FROM NOW()) - 604800), 0) AS high_7d,
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "from" = ANY(@zero) AND "timestamp" > EXTRACT(EPOCH FROM NOW()) - 604800), 0) AS zero_7d,
+                COALESCE(SUM(CAST(value AS numeric)) FILTER (WHERE "timestamp" > EXTRACT(EPOCH FROM NOW()) - 604800), 0)                         AS total_7d
+            FROM "CrcV2_TransferSingle"
+            WHERE "timestamp" > EXTRACT(EPOCH FROM NOW()) - 604800
+            """;
+
+        await using var conn = new NpgsqlConnection(_circlesDbConn);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.Add(new NpgsqlParameter("high", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = highRep });
+        cmd.Parameters.Add(new NpgsqlParameter("zero", NpgsqlDbType.Array | NpgsqlDbType.Text) { Value = zeroRep });
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        if (await reader.ReadAsync(ct))
+        {
+            var high24h = reader.GetDecimal(0);
+            var zero24h = reader.GetDecimal(1);
+            var total24h = reader.GetDecimal(2);
+            var high7d = reader.GetDecimal(3);
+            var zero7d = reader.GetDecimal(4);
+            var total7d = reader.GetDecimal(5);
+
+            return new TransferShareMetrics(
+                total24h > 0 ? (double)(high24h / total24h) : 0,
+                total24h > 0 ? (double)(zero24h / total24h) : 0,
+                total7d > 0 ? (double)(high7d / total7d) : 0,
+                total7d > 0 ? (double)(zero7d / total7d) : 0);
+        }
+
+        return new TransferShareMetrics(0, 0, 0, 0);
+    }
+
+    private async Task<(string[] HighRep, string[] ZeroRep)> LoadMemberAddressBuckets(CancellationToken ct)
+    {
+        const string sql = """
+            SELECT avatar, score FROM rep_score_state WHERE group_id = @groupId
+            """;
+
+        var highRep = new List<string>();
+        var zeroRep = new List<string>();
+
+        await using var conn = new NpgsqlConnection(_repScoreConn);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(sql, conn);
+        cmd.Parameters.AddWithValue("groupId", _groupId);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+
+        while (await reader.ReadAsync(ct))
+        {
+            var avatar = reader.GetString(0).ToLowerInvariant();
+            var score = reader.IsDBNull(1) ? 0.0 : reader.GetDouble(1);
+            if (score >= _highScoreThreshold)
+                highRep.Add(avatar);
+            else if (score < 0.001)
+                zeroRep.Add(avatar);
+        }
+
+        return (highRep.ToArray(), zeroRep.ToArray());
+    }
+}

--- a/src/Metrics/Circles.Metrics.Exporter/appsettings.json
+++ b/src/Metrics/Circles.Metrics.Exporter/appsettings.json
@@ -8,7 +8,14 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CirclesDb": "Host=localhost;Database=postgres;Username=postgres;Password=postgres"
+    "CirclesDb": "Host=localhost;Database=postgres;Username=postgres;Password=postgres",
+    "RepScoreDb": "Host=localhost;Database=circles_rep_score;Username=postgres;Password=postgres"
+  },
+  "RepScore": {
+    "GroupId": "score_group",
+    "CollectionIntervalSeconds": 120,
+    "HighScoreThreshold": 70,
+    "ScoreDropThreshold": 20
   },
   "Deployment": {
     "Environments": {


### PR DESCRIPTION
## Summary

- Adds `RepScoreCollectorService` + `RepScoreRepository` querying the `circles_rep_score` DB (AA service) every 120 s
- 23 new Prometheus metrics across 4 families: `circles_blacklist_*`, `circles_rep_score_*` distribution/percentiles/buckets, anomaly detection (drops/zero/churn), and cross-DB transfer share by reputation tier
- `RepScoreDb` connection string is optional — exporter starts normally without it (other metrics unaffected)

## Bugs fixed during review

- **Timestamp type mismatch**: `CrcV2_TransferSingle."timestamp"` is a Unix epoch integer; query now uses `EXTRACT(EPOCH FROM NOW()) - N` matching the pattern in `KpiRepository`/`TrustRepository`
- **Address case**: avatar addresses lowercased before `= ANY(@addresses)` to match lowercase hex stored in CirclesDb
- Collector failures logged at `LogError` (not `LogWarning`) to surface in alerting pipelines

## Test plan

- [ ] Deploy to staging1, verify `/metrics` emits `circles_rep_score_member_count > 0`
- [ ] Verify `circles_blacklist_total > 0` and `circles_blacklist_last_refresh_age_seconds < 7200`
- [ ] Verify existing `circles_trust_*` and `circles_kpi_*` metrics unchanged
- [ ] Remove `ConnectionStrings:RepScoreDb` from env, confirm service starts cleanly (LogWarning, no crash)