### PR TITLE
fix(metrics): graceful degradation when RepScoreDb not configured

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -389,6 +389,7 @@ services:
       - Balancer__ApiUrl=${BALANCER_API_URL:-https://api-v3.balancer.fi/graphql}
       - Balancer__ReferenceScrcAddress=${BALANCER_REFERENCE_SCRC:-}
       - Deployment__Environments__Staging=${DEPLOYMENT__ENVIRONMENTS__STAGING:-}
+      - ConnectionStrings__RepScoreDb=${METRICS_REP_SCORE_DB_CONN:-}
     deploy:
       resources:
         limits:

--- a/src/Metrics/Circles.Metrics.Exporter/Program.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Program.cs
@@ -52,7 +52,7 @@ builder.Services.AddHostedService<TrustHistorySnapshotService>();
 
 // Rep score monitoring (AA circles_rep_score DB — bad actor radar + ScoreGroup distribution)
 // Optional: skip if RepScoreDb is not configured (AA may not be deployed in all environments)
-if (repScoreConnectionString is not null)
+if (!string.IsNullOrWhiteSpace(repScoreConnectionString))
 {
     builder.Services.AddSingleton(sp =>
         new RepScoreRepository(

--- a/src/Metrics/Circles.Metrics.Exporter/appsettings.json
+++ b/src/Metrics/Circles.Metrics.Exporter/appsettings.json
@@ -8,8 +8,7 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "CirclesDb": "Host=localhost;Database=postgres;Username=postgres;Password=postgres",
-    "RepScoreDb": "Host=localhost;Database=circles_rep_score;Username=postgres;Password=postgres"
+    "CirclesDb": "Host=localhost;Database=postgres;Username=postgres;Password=postgres"
   },
   "RepScore": {
     "GroupId": "score_group",


### PR DESCRIPTION
## Summary

- Removes `RepScoreDb` from `appsettings.json` defaults — without this, missing `METRICS_REP_SCORE_DB_CONN` env var fell back to `Host=localhost` which failed on nodes without the `circles_rep_score` DB
- Changes `is not null` → `!string.IsNullOrWhiteSpace` so empty string env var also degrades gracefully
- Adds `ConnectionStrings__RepScoreDb=${METRICS_REP_SCORE_DB_CONN:-}` to metrics-exporter in `docker-compose.gnosis.yml`

## Test plan

- [ ] Deploy to staging1: confirm warning log, no crashes
- [ ] Set `METRICS_REP_SCORE_DB_CONN` on staging2, deploy, confirm new metrics appear