### PR TITLE
fix(metrics): build RepScoreDb connection string from component vars

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -389,7 +389,7 @@ services:
       - Balancer__ApiUrl=${BALANCER_API_URL:-https://api-v3.balancer.fi/graphql}
       - Balancer__ReferenceScrcAddress=${BALANCER_REFERENCE_SCRC:-}
       - Deployment__Environments__Staging=${DEPLOYMENT__ENVIRONMENTS__STAGING:-}
-      - ConnectionStrings__RepScoreDb=${METRICS_REP_SCORE_DB_CONN:-}
+      - ConnectionStrings__RepScoreDb=${METRICS_REP_SCORE_DB_HOST:+Server=${METRICS_REP_SCORE_DB_HOST};Port=${METRICS_REP_SCORE_DB_PORT:-5432};Database=circles_rep_score;User Id=${METRICS_DB_USER:-${POSTGRES_USER}};Password=${METRICS_DB_PASSWORD:-${POSTGRES_PASSWORD}};Application Name=metrics-exporter;Maximum Pool Size=3;}
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

Replaces the literal `METRICS_REP_SCORE_DB_CONN` (full connection string in .env) with a `METRICS_REP_SCORE_DB_HOST` host-only variable. Compose uses Docker's `${VAR:+expanded}` syntax to build the full Npgsql connection string inline, reusing existing `POSTGRES_USER`/`POSTGRES_PASSWORD` variables.

**Opt-in**: only nodes with `METRICS_REP_SCORE_DB_HOST` set in `.env` enable rep_score metrics. Nodes without it get an empty string → `IsNullOrWhiteSpace` check → graceful skip with LogWarning.

## Setup for staging2

Add to `/srv/circles-nethermind-plugin/.env`:
```
METRICS_REP_SCORE_DB_HOST=postgres-services
```

## Test plan

- [ ] staging1 (no env var): logs "rep score metrics disabled", no errors
- [ ] staging2 (with env var): `circles_rep_score_member_count > 0` in /metrics