### PR TITLE
build: central package management, CI test-tier restoration, configuration reference

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -97,8 +97,7 @@ jobs:
           dotnet test --no-build -c Release \
             --filter "Category=Snapshot" \
             --logger "trx;LogFileName=snapshot-tests.trx" \
-            --results-directory TestResults/snapshot \
-            || true  # Don't fail if tests skip due to unavailable test-env
+            --results-directory TestResults/snapshot
 
       - name: Upload snapshot test results
         if: always()
@@ -138,8 +137,7 @@ jobs:
           dotnet test --no-build -c Release \
             --filter "Category=Regression" \
             --logger "trx;LogFileName=regression-tests.trx" \
-            --results-directory TestResults/regression \
-            || true  # Don't fail if tests skip
+            --results-directory TestResults/regression
 
       - name: Upload regression test results
         if: always()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -369,6 +369,7 @@ This will:
 - **Circles.Pathfinder.Tests** - Pathfinding algorithm tests
 - **Circles.Index.Query.Tests** - Query system tests
 - **Circles.Index.CirclesV2.Tests** - V2 contract indexing tests
+- **Circles.Index.CirclesViews.Tests** - View DDL and schema projection tests
 - **Circles.Common.Tests** - Common utilities tests
 - **Circles.Rpc.Host.Tests** - RPC endpoint tests
 - **Circles.Cache.Service.Tests** - Cache service tests

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,9 @@
     <PackageVersion Include="Nethereum.Web3" Version="6.1.0" />
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     <!-- Must stay compatible with the Nethermind runtime image in docker/Index.Dockerfile
-         (currently nethermind/nethermind:1.37.2) — bump both together. -->
+         (currently nethermind/nethermind:1.37.2). The ref-assemblies package may trail the
+         runtime image by a patch release (currently 1.37.1 vs image 1.37.2); keep both within
+         the same minor and bump together once the matching ref-assemblies release exists. -->
     <PackageVersion Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,47 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Autofac" Version="9.1.0" />
+    <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="Dapper" Version="2.1.72" />
+    <PackageVersion Include="FluentAssertions" Version="6.12.2" />
+    <PackageVersion Include="Google.OrTools" Version="9.15.6755" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.OpenApi" Version="2.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Nethereum.Util" Version="5.8.0" />
+    <PackageVersion Include="Nethereum.Web3" Version="6.1.0" />
+    <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <!-- Must stay compatible with the Nethermind runtime image in docker/Index.Dockerfile
+         (currently nethermind/nethermind:1.37.2) — bump both together. -->
+    <PackageVersion Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
+    <PackageVersion Include="Npgsql" Version="10.0.1" />
+    <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
+    <PackageVersion Include="NUnit" Version="4.6.0" />
+    <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
+    <PackageVersion Include="prometheus-net" Version="8.2.1" />
+    <PackageVersion Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageVersion Include="Scalar.AspNetCore" Version="2.4.18" />
+    <PackageVersion Include="System.Collections.Immutable" Version="10.0.6" />
+    <PackageVersion Include="System.CommandLine" Version="2.0.3" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="10.0.5" />
+    <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ If you're developing the plugin, building packages, or running services locally,
 - **[Rpc](src/Rpc/Circles.Rpc.Host/README.md)** - Rpc service
 - **[Cache](src/Cache/README.md)** - Cache service
 - **[Metrics Exporter](src/Metrics/Circles.Metrics.Exporter/README.md)** - Prometheus metrics exporter
+- **[Configuration Reference](docs/configuration.md)** - Every environment variable across all five services
 - **[Score-group mint along path](docs/score-group-mint-along-path.md)** - Score-group routing, cache graph fields, and mint-limit capacity
 - **[Reindexing Guide](docs/partial-table-reindexing.md)** - Full and selected-table reindex/backfill procedures
 

--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /src
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy .csproj files first for better caching (preserving original directory structure)
 COPY src/Index/Circles.Index/Circles.Index.csproj ./Index/Circles.Index/

--- a/docker/backfill.Dockerfile
+++ b/docker/backfill.Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /src
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy only the backfill project (it's self-contained, no internal dependencies)
 COPY src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj ./

--- a/docker/cache-service.Dockerfile
+++ b/docker/cache-service.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy entire Index directory (needed for project references)
 COPY src/Index ./Index

--- a/docker/metrics-exporter.Dockerfile
+++ b/docker/metrics-exporter.Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /src
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy Metrics Exporter project and its dependencies
 COPY src/Metrics ./Metrics

--- a/docker/pathfinder-host.Dockerfile
+++ b/docker/pathfinder-host.Dockerfile
@@ -7,6 +7,7 @@ RUN echo "Building for architecture: ${TARGETARCH}"
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy Index, Common, and Pathfinder sources (Pathfinder depends on Circles.Common)
 COPY ./src/Index ./Index

--- a/docker/rpc-host.Dockerfile
+++ b/docker/rpc-host.Dockerfile
@@ -7,6 +7,7 @@ RUN echo "Building for architecture: ${TARGETARCH}"
 
 # Copy shared build props (defines TFM)
 COPY Directory.Build.props ./
+COPY Directory.Packages.props ./
 
 # Copy Index, Common, and RPC sources (required for local project references)
 # RPC Host specifically depends on:

--- a/docs/ci-cd.md
+++ b/docs/ci-cd.md
@@ -51,6 +51,18 @@ feature/* (development)
 3. Uploads test results
 4. Comments results on PRs
 
+The workflow also contains two follow-up jobs that run against the staging
+test environment (`TEST_ENV_URL=https://staging.circlesubi.network/test-env`):
+
+- **snapshot-tests** — runs `dotnet test --filter "Category=Snapshot"`:
+  pinned-block snapshot comparisons (scenario batteries, query/RPC/cache
+  snapshot integration tests).
+- **regression-tests** — runs `dotnet test --filter "Category=Regression"`:
+  known-bug regression scenarios.
+
+Both jobs fail on real assertion failures; tests self-skip via
+`Assert.Ignore` when the test environment is unavailable.
+
 **Run locally**:
 ```bash
 make build

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,173 @@
+# Configuration Reference
+
+Every environment variable read by the five runtime services, in one place.
+Unless marked **required**, all variables are optional and fall back to the
+listed default. All variables are read once at process startup.
+
+The Index plugin, RPC Host, Pathfinder, and Cache Service read plain
+environment variables (`Environment.GetEnvironmentVariable`). The Metrics
+Exporter uses ASP.NET Core configuration — its keys live in
+`appsettings.json` and can be overridden via environment variables using the
+`__` separator (e.g. `ConnectionStrings__CirclesDb`).
+
+Sources of truth: `src/Common/Circles.Common/Settings.cs`,
+`src/Rpc/Circles.Rpc.Host/Settings.cs`,
+`src/Pathfinder/Circles.Pathfinder/Settings.cs`,
+`src/Pathfinder/Circles.Pathfinder.Host/Settings.cs`,
+`src/Cache/Circles.Cache.Service/CacheServiceSettings.cs`,
+`src/Metrics/Circles.Metrics.Exporter/appsettings.json`.
+
+## Shared (all DB-connected services)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `POSTGRES_CONNECTION_STRING` | string | — **required** | Primary PostgreSQL connection string (write access). Index plugin and Pathfinder Host throw at startup when missing. |
+| `POSTGRES_READONLY_CONNECTION_STRING` | string | falls back to `POSTGRES_CONNECTION_STRING` | Read-only connection string used for query paths. |
+| `CIRCLES_PG_NOTIFY_CHANNEL` | string | `circles_index_events` | PostgreSQL NOTIFY channel for new-block notifications. |
+
+## Index plugin (Nethermind)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `CIRCLES_PLUGIN_DISABLED` | bool | `false` | Disables the Circles indexing plugin entirely. |
+| `START_BLOCK` | long | `0` | First block to index. |
+| `BLOCK_BUFFER_SIZE` | int | `20000` | Blocks buffered before processing. |
+| `EVENT_BUFFER_SIZE` | int | `100000` | Events buffered before flushing to the DB. |
+| `INDEXER_WRITE_MODE` | enum | `Auto` | Batch write strategy: `Copy`, `Upsert`, or `Auto`. |
+| `REINDEX_FROM_BLOCK` | long | unset | Reindex from this block. Combine with `REINDEX_TABLES` or `REINDEX_ALL_TABLES`. Remove after the reindex completes. |
+| `REINDEX_ALL_TABLES` | bool | `false` | Reindex all tables from `REINDEX_FROM_BLOCK`. |
+| `REINDEX_TABLES` | string[] (comma-sep.) | `[]` | Specific tables to reindex from `REINDEX_FROM_BLOCK`. |
+| `REINDEX_ALLOW_PARTIAL_DEPENDENCIES` | bool | `false` | Allow a partial-table reindex even when dependent tables are not included. |
+| `EXTERNAL_PATHFINDER_URL` | string | unset | Delegate pathfinding RPC methods to an external pathfinder. |
+| `PATHFINDER_MAX_CONCURRENT_REQUESTS` | int | `cores` | Legacy concurrency limit for the in-plugin pathfinder delegation path. |
+
+### IPFS profile downloader (Index plugin)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `IPFS_GATEWAYS` | string[] (comma-sep.) | `https://circles-profiles.myfilebase.com` | Gateway URLs for profile downloads. |
+| `IPFS_MAX_PARALLELISM` | int | `192` | Max parallel downloads. |
+| `IPFS_HTTP_TIMEOUT_SEC` | int | `1` | Per-request HTTP timeout. |
+| `IPFS_MAX_BACKOFF_SEC` | int | `259200` | Max retry backoff (72 h). |
+| `IPFS_STATS_INTERVAL_SEC` | int | `30` | Statistics log interval. |
+| `IPFS_ERROR_MAX_LEN` | int | `1024` | Max stored error-message length. |
+| `IPFS_WRITER_BATCH_SIZE` | int | `256` | DB write batch size. |
+| `IPFS_MAX_DOWNLOAD_BYTES` | long | `167936` | Max bytes per profile download (160 KiB + 4 KiB). |
+
+## RPC Host (port 8081)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `NETHERMIND_RPC_URL` | string | `http://localhost:8545` | Upstream Nethermind JSON-RPC. |
+| `NETHERMIND_WS_URL` | string | derived from `NETHERMIND_RPC_URL` (`http→ws`) | Upstream WebSocket endpoint. |
+| `ETH_SUBSCRIBE_ENABLED` | bool | `true` | Enable `eth_subscribe` WebSocket subscriptions. |
+| `RPC_MAX_CONCURRENT_WS_SESSIONS` | int | `1000` | Global cap on concurrent WebSocket sessions; excess upgrades get HTTP 503. Values ≤ 0 disable the cap. |
+| `RPC_MAX_CONCURRENT_REQUESTS` | int | `max(cores×4, 32)` | Request-concurrency semaphore. |
+| `RPC_RATE_LIMIT_PER_SECOND` | int | `100` | Per-IP rate limit (calls/s); `0` disables. |
+| `RPC_RATE_LIMIT_BURST` | int | `200` | Per-IP burst allowance. |
+| `BALANCE_MODE` | string | `live` | Balance source: `live` (chain) or `database`. |
+| `USE_CACHE_SERVICE` | bool | `false` | Serve balance/avatar queries from the Cache Service (also needs `CACHE_SERVICE_URL`). |
+| `CACHE_SERVICE_URL` | string | unset | Cache Service base URL. |
+| `PROFILE_PINNING_SERVICE_URL` | string | unset | Fast profile-search proxy URL. |
+| `DATABASE_QUERY_TIMEOUT_SECONDS` | int | `30` | General DB query timeout. |
+| `PROFILE_SEARCH_TIMEOUT_SECONDS` | int | `30` | Profile search query timeout. |
+| `INDEXER_MAX_LAG_BLOCKS` | long | `100` | Max indexer lag before `/ready` reports unhealthy. |
+| `CORS_ALLOWED_ORIGINS` | string | `*` | Comma-separated allowed origins. |
+
+## Pathfinder (port 8080)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `NETHERMIND_RPC_URL` | string | — **required** | Upstream Nethermind JSON-RPC (host throws when missing). |
+| `MAX_CONCURRENT_REQUESTS` | int | `max(cores×2, 8)` | Request-concurrency semaphore. |
+| `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | int | `10` | MaxFlow solver timeout. |
+| `PATHFINDER_BALANCE_TIMEOUT_SECONDS` | int | `300` | Balance query timeout. |
+| `PATHFINDER_TRUST_TIMEOUT_SECONDS` | int | `120` | Trust query timeout. |
+| `PATHFINDER_GROUP_TIMEOUT_SECONDS` | int | `60` | Group query timeout. |
+| `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | double | `0.999999` | Safety factor on demurraged balances (absorbs clock drift between graph load and execution). |
+| `PATHFINDER_INCREMENTAL_ENABLED` | bool | `true` | Incremental graph updates; `false` = full refresh every block. |
+| `PATHFINDER_FULL_REFRESH_INTERVAL_BLOCKS` | int | `200` | Blocks between full DB refreshes (drift correction). |
+| `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | bool | `true` | Exclude consented avatars from intermediary positions in flow paths. |
+| `PATHFINDER_DISABLE_CONSENTED_FLOW` | bool | — | Deprecated alias for `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` (read only when the new name is unset). |
+| `USE_CACHE_GRAPH_SOURCE` | bool | `true` iff `CACHE_SERVICE_URL` set | Load graph data from the Cache Service instead of the DB. |
+| `CACHE_SERVICE_URL` | string | unset | Cache Service base URL. |
+| `CACHE_GRAPH_REQUEST_TIMEOUT_SECONDS` | int | `60` | Cache Service graph request timeout. |
+| `CACHE_GRAPH_FALLBACK_TO_DB` | bool | `true` | Fall back to the DB when the Cache Service is unavailable. |
+| `MATVIEW_REFRESH_ENABLED` | bool | `true` | Refresh materialized views from the pathfinder. |
+| `MATVIEW_REFRESH_FAST_BLOCKS` | int | `60` | Blocks between fast-tier matview refreshes (balances, avatars, groups). |
+| `MATVIEW_REFRESH_SLOW_BLOCKS` | int | `180` | Blocks between slow-tier matview refreshes (trust scores). |
+| `MATVIEW_REFRESH_INTERVAL_BLOCKS` | int | unset | Legacy: overrides both fast and slow tiers when set. |
+| `MATVIEW_DB_CONNECTION_STRING` | string | falls back to read-only conn. string | Connection used for matview refreshes (needs write access on the views). |
+| `HISTORICAL_GRAPH_CACHE_MAX_ENTRIES` | int | `5` | Max cached historical (block-pinned) graph snapshots. |
+| `HISTORICAL_MAX_CONCURRENT_LOADS` | int | `2` | Max concurrent historical graph loads. |
+| `CANARY_SIMULATION_ENABLED` | bool | `false` | Enable the on-chain simulation canary for solver results. |
+| `CANARY_SIMULATION_QUEUE_SIZE` | int | `10` | Canary background simulation queue size. |
+| `CANARY_BALANCE_PROBE_ENABLED` | bool | `false` | Enable the canary balance probe. |
+
+## Cache Service (port 5002)
+
+| Variable | Type | Default | Effect |
+|---|---|---|---|
+| `PORT` | int | `5002` | HTTP listen port. |
+| `ROLLBACK_CAPACITY` | int | `12` | Blocks of rollback history retained per cache. |
+| `REORG_DETECTION_WINDOW` | int | `256` | Recent block hashes kept for reorg detection (must be ≥ `ROLLBACK_CAPACITY`). |
+| `MAX_CATCHUP_LAG` | int | `10` | Max lag (blocks) before `/ready` reports not-ready. |
+| `RECONCILIATION_ENABLED` | bool | `true` | Tail self-heal: re-derive recently active account balances from the DB. |
+| `RECONCILIATION_WINDOW_BLOCKS` | int | `256` | Look-back window for reconciliation. |
+| `RECONCILIATION_INTERVAL_BLOCKS` | int | `8` | Minimum blocks between reconciliation passes. |
+| `RECONCILIATION_MAX_ACCOUNTS` | int | `5000` | Cap on accounts per reconciliation pass. |
+| `IPFS_CACHE_MAX_ENTRIES` | int | `50000` | Max cached IPFS profile entries. |
+| `CORS_ALLOWED_ORIGINS` | string | `*` | Comma-separated allowed origins. |
+
+## Metrics Exporter (port 9100)
+
+ASP.NET configuration keys (override with `__` separator as env vars):
+
+| Key | Default | Effect |
+|---|---|---|
+| `ConnectionStrings:CirclesDb` | — **required** | Main Circles indexer database. |
+| `ConnectionStrings:RepScoreDb` | unset | Reputation-score / blacklist database; rep_score metrics are disabled gracefully when missing. |
+| `Metrics:CollectionIntervalSeconds` | per `appsettings.json` | KPI collection cadence. |
+| `CoinGecko:ApiKey` | unset | Fiat pricing API key (falls back to Balancer GraphQL). |
+| `Balancer:ApiUrl` | per `appsettings.json` | Balancer V3 GraphQL endpoint for SCRC pricing. |
+
+See `src/Metrics/Circles.Metrics.Exporter/README.md` and its
+`appsettings.json` for the full key set (RepScore thresholds, deployment
+prober environments).
+
+## Backfill CLI
+
+| Source | Effect |
+|---|---|
+| `--connection-string` / `-c` | Explicit connection string; takes precedence. |
+| `POSTGRES_CONNECTION_STRING` | Fallback when the option is omitted. |
+| `POSTGRES_USER` + `POSTGRES_PASSWORD` | Last-resort fallback for a localhost connection. |
+
+## Contract addresses (shared)
+
+Defaults are the Gnosis Chain production deployments
+(`src/Common/Circles.Common/Settings.cs`); override only for other chains or
+test deployments. All values are lower-cased on read; list-valued variables
+are comma-separated.
+
+`V1_HUB_ADDRESS`, `V2_HUB_ADDRESS`, `V1_NAME_REGISTRY_ADDRESS`,
+`V2_NAME_REGISTRY_ADDRESS`, `V2_ERC20_LIFT_ADDRESS`,
+`V2_STANDARD_TREASURY_ADDRESS`, `V2_BASE_GROUP_ROUTER`,
+`V2_AFFILIATE_GROUP_REGISTRY_ADDRESS`, `V2_OIC_ADDRESS`,
+`BASE_GROUP_DEPLOYER`, `V2_LBP_FACTORY_ADDRESS`,
+`V2_TOKEN_OFFER_FACTORY_ADDRESS`, `V2_PAYMENT_GATEWAY_FACTORY_ADDRESS`,
+`V2_CMGROUP_DEPLOYER`, `SAFE_PROXY_FACTORY_ADDRESSES`,
+`V2_INVITATION_ESCROW_ADDRESS`, `V2_INVITATION_AT_SCALE_FARM_ADDRESSES`,
+`V2_INVITATION_AT_SCALE_MODULE_ADDRESSES`,
+`V2_INVITATION_AT_SCALE_REFERRALS_MODULE_ADDRESSES`,
+`V2_INVITATION_AT_SCALE_QUOTA_GRANT_MODULE_ADDRESSES`,
+`V2_SCORE_GROUP_MINT_POLICIES` (allowlist, default empty),
+`SCORE_TREASURY_SUBTREASURIES` (mapping, format `agg:sub1,sub2;agg2:sub3`),
+`V2_STANDARD_MINT_POLICY`.
+
+## Test-only variables
+
+| Variable | Effect |
+|---|---|
+| `TEST_ENV_URL` | Base URL of the circles-test-environment; gates scenario/E2E test suites. |
+| `RUN_CACHE_INTEGRATION_TESTS` | Tri-state: `true` force-on, `false` force-off, unset = auto-detect Docker for Testcontainers-based cache tests. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,9 @@
 
 Every environment variable read by the five runtime services, in one place.
 Unless marked **required**, all variables are optional and fall back to the
-listed default. All variables are read once at process startup.
+listed default. Variables are read once at process startup (the Pathfinder
+Host re-reads its settings on each access, but since the process environment
+is static this is effectively equivalent).
 
 The Index plugin, RPC Host, Pathfinder, and Cache Service read plain
 environment variables (`Environment.GetEnvironmentVariable`). The Metrics
@@ -24,6 +26,7 @@ Sources of truth: `src/Common/Circles.Common/Settings.cs`,
 | `POSTGRES_CONNECTION_STRING` | string | — **required** | Primary PostgreSQL connection string (write access). Index plugin and Pathfinder Host throw at startup when missing. |
 | `POSTGRES_READONLY_CONNECTION_STRING` | string | falls back to `POSTGRES_CONNECTION_STRING` | Read-only connection string used for query paths. |
 | `CIRCLES_PG_NOTIFY_CHANNEL` | string | `circles_index_events` | PostgreSQL NOTIFY channel for new-block notifications. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | string | unset | Enables OTLP trace export when set (read by the RPC Host, Pathfinder Host, and Cache Service). |
 
 ## Index plugin (Nethermind)
 
@@ -38,8 +41,7 @@ Sources of truth: `src/Common/Circles.Common/Settings.cs`,
 | `REINDEX_ALL_TABLES` | bool | `false` | Reindex all tables from `REINDEX_FROM_BLOCK`. |
 | `REINDEX_TABLES` | string[] (comma-sep.) | `[]` | Specific tables to reindex from `REINDEX_FROM_BLOCK`. |
 | `REINDEX_ALLOW_PARTIAL_DEPENDENCIES` | bool | `false` | Allow a partial-table reindex even when dependent tables are not included. |
-| `EXTERNAL_PATHFINDER_URL` | string | unset | Delegate pathfinding RPC methods to an external pathfinder. |
-| `PATHFINDER_MAX_CONCURRENT_REQUESTS` | int | `cores` | Legacy concurrency limit for the in-plugin pathfinder delegation path. |
+| `PATHFINDER_MAX_CONCURRENT_REQUESTS` | int | `cores` | Parsed but currently unused — superseded by `MAX_CONCURRENT_REQUESTS` in the Pathfinder Host. |
 
 ### IPFS profile downloader (Index plugin)
 
@@ -69,6 +71,7 @@ Sources of truth: `src/Common/Circles.Common/Settings.cs`,
 | `USE_CACHE_SERVICE` | bool | `false` | Serve balance/avatar queries from the Cache Service (also needs `CACHE_SERVICE_URL`). |
 | `CACHE_SERVICE_URL` | string | unset | Cache Service base URL. |
 | `PROFILE_PINNING_SERVICE_URL` | string | unset | Fast profile-search proxy URL. |
+| `EXTERNAL_PATHFINDER_URL` | string | unset | Delegate pathfinding RPC methods to an external pathfinder (also used by the health check, and read by the in-plugin RPC of the Index plugin). |
 | `DATABASE_QUERY_TIMEOUT_SECONDS` | int | `30` | General DB query timeout. |
 | `PROFILE_SEARCH_TIMEOUT_SECONDS` | int | `30` | Profile search query timeout. |
 | `INDEXER_MAX_LAG_BLOCKS` | long | `100` | Max indexer lag before `/ready` reports unhealthy. |
@@ -102,7 +105,9 @@ Sources of truth: `src/Common/Circles.Common/Settings.cs`,
 | `HISTORICAL_MAX_CONCURRENT_LOADS` | int | `2` | Max concurrent historical graph loads. |
 | `CANARY_SIMULATION_ENABLED` | bool | `false` | Enable the on-chain simulation canary for solver results. |
 | `CANARY_SIMULATION_QUEUE_SIZE` | int | `10` | Canary background simulation queue size. |
-| `CANARY_BALANCE_PROBE_ENABLED` | bool | `false` | Enable the canary balance probe. |
+| `CANARY_BALANCE_PROBE_ENABLED` | bool | `true` | Kill switch for the canary balance probe — set to `false` to disable. |
+| `CORS_ALLOWED_ORIGINS` | string | `*` | Comma-separated allowed origins. |
+| `PATHFINDER_BASE_PATH` | string | `/pathfinder` | Public base path used for the generated OpenAPI server URL when behind a prefix-stripping reverse proxy. |
 
 ## Cache Service (port 5002)
 
@@ -125,11 +130,11 @@ ASP.NET configuration keys (override with `__` separator as env vars):
 
 | Key | Default | Effect |
 |---|---|---|
-| `ConnectionStrings:CirclesDb` | — **required** | Main Circles indexer database. |
+| `ConnectionStrings:CirclesDb` | required (`appsettings.json` ships a localhost default — override in production) | Main Circles indexer database. |
 | `ConnectionStrings:RepScoreDb` | unset | Reputation-score / blacklist database; rep_score metrics are disabled gracefully when missing. |
 | `Metrics:CollectionIntervalSeconds` | per `appsettings.json` | KPI collection cadence. |
 | `CoinGecko:ApiKey` | unset | Fiat pricing API key (falls back to Balancer GraphQL). |
-| `Balancer:ApiUrl` | per `appsettings.json` | Balancer V3 GraphQL endpoint for SCRC pricing. |
+| `Balancer:ApiUrl` | `https://api-v3.balancer.fi/graphql` (hardcoded in `BalancerPriceService.cs`) | Balancer V3 GraphQL endpoint for SCRC pricing. |
 
 See `src/Metrics/Circles.Metrics.Exporter/README.md` and its
 `appsettings.json` for the full key set (RepScore thresholds, deployment
@@ -141,14 +146,16 @@ prober environments).
 |---|---|
 | `--connection-string` / `-c` | Explicit connection string; takes precedence. |
 | `POSTGRES_CONNECTION_STRING` | Fallback when the option is omitted. |
-| `POSTGRES_USER` + `POSTGRES_PASSWORD` | Last-resort fallback for a localhost connection. |
+| `POSTGRES_USER` + `POSTGRES_PASSWORD` | Last-resort fallback for a constructed connection string. |
+| `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_DB` | Optional overrides for the constructed connection string (defaults: `localhost` / `5432` / `postgres`). |
 
 ## Contract addresses (shared)
 
 Defaults are the Gnosis Chain production deployments
 (`src/Common/Circles.Common/Settings.cs`); override only for other chains or
-test deployments. All values are lower-cased on read; list-valued variables
-are comma-separated.
+test deployments. Values are lower-cased on read (one Pathfinder Host read
+site — `RouterAddress` reading `V2_BASE_GROUP_ROUTER` — preserves case);
+list-valued variables are comma-separated.
 
 `V1_HUB_ADDRESS`, `V2_HUB_ADDRESS`, `V1_NAME_REGISTRY_ADDRESS`,
 `V2_NAME_REGISTRY_ADDRESS`, `V2_ERC20_LIFT_ADDRESS`,
@@ -163,7 +170,8 @@ are comma-separated.
 `V2_INVITATION_AT_SCALE_QUOTA_GRANT_MODULE_ADDRESSES`,
 `V2_SCORE_GROUP_MINT_POLICIES` (allowlist, default empty),
 `SCORE_TREASURY_SUBTREASURIES` (mapping, format `agg:sub1,sub2;agg2:sub3`),
-`V2_STANDARD_MINT_POLICY`.
+`V2_STANDARD_MINT_POLICY` (default lives in
+`src/Pathfinder/Circles.Pathfinder/Settings.cs`, not Common).
 
 ## Test-only variables
 
@@ -171,3 +179,6 @@ are comma-separated.
 |---|---|
 | `TEST_ENV_URL` | Base URL of the circles-test-environment; gates scenario/E2E test suites. |
 | `RUN_CACHE_INTEGRATION_TESTS` | Tri-state: `true` force-on, `false` force-off, unset = auto-detect Docker for Testcontainers-based cache tests. |
+| `CIRCLES_CONNECTION_STRING` | Real indexer DB connection string; gates the Index CirclesV2 E2E tests (e.g. `TransferDataE2ETests`). |
+| `PATHFINDER_URL` | Running pathfinder base URL for network-dependent tests (`MetricsEndpointTests` skips when unset; `NetworkPathfinderTests` defaults to `http://localhost:8080`). |
+| `RUN_PATHFINDER_NETWORK_TESTS` | Opt-in switch for `NetworkPathfinderTests` (network-dependent). |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -110,13 +110,48 @@ Each test session provides:
 
 ## Test Projects
 
-| Project                         | Location          | Coverage Focus                           |
-| ------------------------------- | ----------------- | ---------------------------------------- |
-| **Circles.Pathfinder.Tests**    | `src/Pathfinder/` | Path algorithm, edge ordering, scenarios |
-| **Circles.Common.Tests**  | `src/Common/`      | Demurrage math, numeric precision        |
-| **Circles.Index.Query.Tests**   | `src/Index/`      | Query building, SQL generation           |
-| **Circles.Cache.Service.Tests** | `src/Cache/`      | Cache invalidation, state management     |
-| **Circles.Rpc.Host.Tests**      | `src/Rpc/`        | RPC handlers, ABI encoding               |
+| Project                            | Location          | Coverage Focus                           |
+| ---------------------------------- | ----------------- | ---------------------------------------- |
+| **Circles.Pathfinder.Tests**       | `src/Pathfinder/` | Path algorithm, edge ordering, scenarios |
+| **Circles.Common.Tests**           | `src/Common/`     | Demurrage math, numeric precision        |
+| **Circles.Index.Query.Tests**      | `src/Index/`      | Query building, SQL generation           |
+| **Circles.Index.CirclesV2.Tests**  | `src/Index/`      | V2 log parsing, event extraction         |
+| **Circles.Index.CirclesViews.Tests** | `src/Index/`    | View DDL, schema projections             |
+| **Circles.Cache.Service.Tests**    | `src/Cache/`      | Cache invalidation, state management     |
+| **Circles.Rpc.Host.Tests**         | `src/Rpc/`        | RPC handlers, ABI encoding               |
+
+`scripts/test.sh` discovers this list from `Circles.sln` — adding a test
+project to the solution is sufficient for it to run locally and in CI.
+
+---
+
+## Test Tiers
+
+Tests are tagged with class-level categories describing their external
+dependencies. Untagged tests run anywhere; tagged tests self-skip
+(`Assert.Ignore`) when their dependency is absent, and can be selected or
+excluded explicitly:
+
+| Category         | Needs                                            | Select with                              |
+| ---------------- | ------------------------------------------------ | ---------------------------------------- |
+| `RequiresTestEnv`| `TEST_ENV_URL` (circles-test-environment)        | `--filter "TestCategory=RequiresTestEnv"`|
+| `RequiresAnvil`  | Anvil fork (foundry) via the test environment    | `--filter "TestCategory=RequiresAnvil"`  |
+| `RequiresDb`     | `POSTGRES_CONNECTION_STRING` (real indexer DB)   | `--filter "TestCategory=RequiresDb"`     |
+| `Snapshot`       | Test-env; pinned-block snapshot comparisons (CI `snapshot-tests` job) | `--filter "TestCategory=Snapshot"` |
+| `Regression`     | Test-env; known-bug regression scenarios (CI `regression-tests` job)  | `--filter "TestCategory=Regression"` |
+
+Cache Service integration tests (xunit + Testcontainers) are gated on Docker
+availability instead: they auto-run when a Docker socket is detected and can
+be forced on/off via `RUN_CACHE_INTEGRATION_TESTS=true|false`.
+
+```bash
+# Pure-local tier only (skip everything that needs external services)
+dotnet test -c Release --filter "TestCategory!~Requires"
+
+# Everything that needs the test environment, against staging
+TEST_ENV_URL=https://staging.circlesubi.network/test-env \
+dotnet test -c Release --filter "TestCategory=RequiresTestEnv"
+```
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -136,13 +136,20 @@ excluded explicitly:
 | ---------------- | ------------------------------------------------ | ---------------------------------------- |
 | `RequiresTestEnv`| `TEST_ENV_URL` (circles-test-environment)        | `--filter "TestCategory=RequiresTestEnv"`|
 | `RequiresAnvil`  | Anvil fork (foundry) via the test environment    | `--filter "TestCategory=RequiresAnvil"`  |
-| `RequiresDb`     | `POSTGRES_CONNECTION_STRING` (real indexer DB)   | `--filter "TestCategory=RequiresDb"`     |
+| `RequiresDb`     | Test-env session with direct DB access (`IsDirectConnectionAvailable`) | `--filter "TestCategory=RequiresDb"`     |
+| `RequiresDocker` | Docker daemon for Testcontainers                 | `--filter "TestCategory=RequiresDocker"` |
 | `Snapshot`       | Test-env; pinned-block snapshot comparisons (CI `snapshot-tests` job) | `--filter "TestCategory=Snapshot"` |
 | `Regression`     | Test-env; known-bug regression scenarios (CI `regression-tests` job)  | `--filter "TestCategory=Regression"` |
 
-Cache Service integration tests (xunit + Testcontainers) are gated on Docker
-availability instead: they auto-run when a Docker socket is detected and can
-be forced on/off via `RUN_CACHE_INTEGRATION_TESTS=true|false`.
+(CI workflows use the `Category=` filter form — for NUnit3TestAdapter it is a
+synonym of `TestCategory=`; both select the same tests.)
+
+Cache Service Testcontainers integration tests (`IntegrationTests.cs`, xunit)
+are gated on Docker availability instead: they auto-run when a Docker socket
+is detected and can be forced on/off via `RUN_CACHE_INTEGRATION_TESTS=true|false`.
+The cache `SnapshotIntegrationTests.cs` is test-env-gated like the NUnit tiers:
+it carries `[Trait("Category", "RequiresTestEnv")]` and skips when
+`TEST_ENV_URL` is not set.
 
 ```bash
 # Pure-local tier only (skip everything that needs external services)
@@ -193,7 +200,7 @@ dotnet test --filter "Name~mint-path-bug-001"
 | --------------------- | ------------------------- | ----------------------- |
 | `TEST_ENV_URL`        | Test environment base URL | (none - tests skip)     |
 | `PATHFINDER_URL`      | Pathfinder service URL    | `http://localhost:8080` |
-| `BUILD_CONFIGURATION` | Build config for test.sh  | `Debug`                 |
+| `BUILD_CONFIGURATION` | Build config for test.sh  | `Release`               |
 | `TEST_VERBOSITY`      | Test output verbosity     | `normal`                |
 
 ---

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,11 +24,14 @@ VERBOSITY="${TEST_VERBOSITY:-normal}"
 # Test projects: discovered from the solution so a newly added test project
 # can never be silently missing here (a hand-maintained list previously
 # dropped Circles.Index.CirclesV2.Tests and Circles.Index.CirclesViews.Tests
-# from CI). Portable loop — macOS ships bash 3.2 without mapfile.
+# from CI). Capture the sln listing first so a dotnet failure aborts via
+# set -e instead of silently truncating the list inside process substitution.
+# Portable loop — macOS ships bash 3.2 without mapfile.
+sln_output=$(dotnet sln "$SOLUTION_FILE" list)
 TEST_PROJECTS=()
 while IFS= read -r project; do
   TEST_PROJECTS+=("$project")
-done < <(dotnet sln "$SOLUTION_FILE" list | tr '\\' '/' | grep -E 'Tests\.csproj$' | sort)
+done < <(printf '%s\n' "$sln_output" | tr '\\' '/' | grep -E 'Tests\.csproj$' | sort)
 
 if [ ${#TEST_PROJECTS[@]} -eq 0 ]; then
   echo -e "${RED}No test projects found in $SOLUTION_FILE${NC}"
@@ -62,6 +65,8 @@ for arg in "$@"; do
       RUN_ALL=false
       SPECIFIC_PROJECTS=(
         "src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj"
+        "src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj"
+        "src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj"
         "src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj"
       )
       shift
@@ -91,7 +96,7 @@ for arg in "$@"; do
       echo "  pathfinder    Run only Pathfinder tests"
       echo "  query         Run only Query tests"
       echo "  common        Run only Common tests"
-      echo "  index         Run only Index tests (query + common)"
+      echo "  index         Run only Index tests (query + circlesv2 + views + common)"
       echo "  cache         Run only Cache tests"
       echo "  rpc           Run only RPC tests"
       echo ""
@@ -100,7 +105,7 @@ for arg in "$@"; do
       echo "  --filter=<expression> Filter tests by expression"
       echo ""
       echo "Environment Variables:"
-      echo "  BUILD_CONFIGURATION   Build configuration (default: Debug)"
+      echo "  BUILD_CONFIGURATION   Build configuration (default: Release)"
       echo "  TEST_VERBOSITY        Test verbosity (default: normal)"
       echo ""
       echo "Examples:"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,14 +21,19 @@ echo -e "${BLUE}Running Circles Tests...${NC}\n"
 CONFIGURATION="${BUILD_CONFIGURATION:-Release}"
 VERBOSITY="${TEST_VERBOSITY:-normal}"
 
-# Test projects
-TEST_PROJECTS=(
-  "src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj"
-  "src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj"
-  "src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj"
-  "src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj"
-  "src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj"
-)
+# Test projects: discovered from the solution so a newly added test project
+# can never be silently missing here (a hand-maintained list previously
+# dropped Circles.Index.CirclesV2.Tests and Circles.Index.CirclesViews.Tests
+# from CI). Portable loop — macOS ships bash 3.2 without mapfile.
+TEST_PROJECTS=()
+while IFS= read -r project; do
+  TEST_PROJECTS+=("$project")
+done < <(dotnet sln "$SOLUTION_FILE" list | tr '\\' '/' | grep -E 'Tests\.csproj$' | sort)
+
+if [ ${#TEST_PROJECTS[@]} -eq 0 ]; then
+  echo -e "${RED}No test projects found in $SOLUTION_FILE${NC}"
+  exit 1
+fi
 
 # Parse arguments
 RUN_ALL=true

--- a/src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj
+++ b/src/Cache/Circles.Cache.Service.Tests/Circles.Cache.Service.Tests.csproj
@@ -7,20 +7,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="FluentAssertions" Version="6.12.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Testcontainers.PostgreSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Cache/Circles.Cache.Service.Tests/SnapshotIntegrationTests.cs
+++ b/src/Cache/Circles.Cache.Service.Tests/SnapshotIntegrationTests.cs
@@ -8,6 +8,7 @@ namespace Circles.Cache.Service.Tests;
 /// Integration tests that verify cache service queries work against real Circles data.
 /// These tests run by default but skip gracefully when TEST_ENV_URL is not set.
 /// </summary>
+[Trait("Category", "RequiresTestEnv")]
 public class SnapshotIntegrationTests : IAsyncLifetime
 {
     private static readonly bool TestEnvConfigured =

--- a/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
+++ b/src/Cache/Circles.Cache.Service/Circles.Cache.Service.csproj
@@ -21,32 +21,32 @@
 
   <ItemGroup>
     <!-- ASP.NET Core and Health Checks -->
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
 
     <!-- PostgreSQL -->
-    <PackageReference Include="Npgsql" Version="10.0.1" />
+    <PackageReference Include="Npgsql" />
 
     <!-- Dependency Injection -->
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" />
 
     <!-- Monitoring -->
-    <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageReference Include="prometheus-net" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
 
     <!-- OpenTelemetry Tracing -->
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
 
     <!-- Numerics for Circles calculations -->
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethermind.Numerics.Int256" />
 
     <!-- OpenAPI documentation -->
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.4.18" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+    <PackageReference Include="Scalar.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Common/Circles.Common.TestUtils/Circles.Common.TestUtils.csproj
+++ b/src/Common/Circles.Common.TestUtils/Circles.Common.TestUtils.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql" Version="10.0.1" />
+        <PackageReference Include="Npgsql" />
     </ItemGroup>
 
 </Project>

--- a/src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj
+++ b/src/Common/Circles.Common.Tests/Circles.Common.Tests.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
-        <PackageReference Include="NUnit" Version="4.6.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NUnit"/>
+        <PackageReference Include="NUnit.Analyzers"/>
+        <PackageReference Include="NUnit3TestAdapter"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
@@ -23,6 +23,7 @@ namespace Circles.Common.Tests;
 /// </summary>
 [TestFixture]
 [Category("Integration")]
+[Category("RequiresTestEnv")]
 public sealed class ScoreGroupBaseRowsQueryParityTests
 {
     private const string ScoreGroupMintPolicy = "0x450d68272e43c4cab7cbc7faa37893a50fae9569";

--- a/src/Common/Circles.Common/Circles.Common.csproj
+++ b/src/Common/Circles.Common/Circles.Common.csproj
@@ -21,13 +21,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="10.0.1" />
-    <PackageReference Include="Nethereum.Util" Version="5.8.0" />
+    <PackageReference Include="Npgsql" />
+    <PackageReference Include="Nethereum.Util" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethermind.ReferenceAssemblies" />
+    <PackageReference Include="Nethermind.Numerics.Int256" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
+++ b/src/Index/Circles.Index.Backfill/Circles.Index.Backfill.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.CommandLine" Version="2.0.3" />
-        <PackageReference Include="Npgsql" Version="10.0.1" />
-        <PackageReference Include="Nethereum.Util" Version="5.8.0" />
+        <PackageReference Include="System.CommandLine" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="Nethereum.Util" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
+++ b/src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj
@@ -22,11 +22,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="10.0.1" />
+      <PackageReference Include="Npgsql" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
+++ b/src/Index/Circles.Index.CirclesV2.LBP/Circles.Index.CirclesV2.LBP.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
+++ b/src/Index/Circles.Index.CirclesV2.NameRegistry/Circles.Index.CirclesV2.NameRegistry.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
+++ b/src/Index/Circles.Index.CirclesV2.OIC/Circles.Index.CirclesV2.OIC.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
+      <PackageReference Include="Nethermind.ReferenceAssemblies" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
+++ b/src/Index/Circles.Index.CirclesV2.StandardTreasury/Circles.Index.CirclesV2.StandardTreasury.csproj
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesV2.Tests/Circles.Index.CirclesV2.Tests.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
-        <PackageReference Include="NUnit" Version="4.6.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NUnit"/>
+        <PackageReference Include="NUnit.Analyzers"/>
+        <PackageReference Include="NUnit3TestAdapter"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.CirclesV2.Tests/TransferDataE2ETests.cs
+++ b/src/Index/Circles.Index.CirclesV2.Tests/TransferDataE2ETests.cs
@@ -5,13 +5,15 @@ namespace Circles.Index.CirclesV2.Tests;
 /// <summary>
 /// End-to-end tests for TransferData indexing against real blockchain data.
 ///
-/// These tests are marked as [Explicit] because they require:
-/// 1. PostgreSQL database with indexed data (staging or production)
-/// 2. Environment variables: CIRCLES_CONNECTION_STRING
+/// The schema/unit tests in this fixture run everywhere with no external
+/// dependencies. The two E2E placeholder methods carry method-level [Explicit]
+/// (skipped in normal runs; executed only when selected directly, e.g.
+/// dotnet test --filter "Name~E2E_") and additionally self-skip via
+/// Assert.Ignore when CIRCLES_CONNECTION_STRING is not set.
 ///
-/// To run these tests:
+/// To run the E2E methods:
 /// 1. Set up environment: source docker/.env (or staging env)
-/// 2. Run: dotnet test --filter "TransferDataE2E" -- NUnit.DefaultTestParams.Explicit=true
+/// 2. Run: dotnet test --filter "Name~E2E_VerifyTransferDataInDatabase"
 ///
 /// Alternatively, use the test-rpc.sh script to verify TransferData events via RPC.
 /// </summary>

--- a/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
+++ b/src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
+++ b/src/Index/Circles.Index.CirclesViews.Tests/Circles.Index.CirclesViews.Tests.csproj
@@ -8,11 +8,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
-        <PackageReference Include="NUnit" Version="4.6.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="coverlet.collector"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+        <PackageReference Include="NUnit"/>
+        <PackageReference Include="NUnit.Analyzers"/>
+        <PackageReference Include="NUnit3TestAdapter"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.ContractClient/Circles.Index.ContractClient.csproj
+++ b/src/Index/Circles.Index.ContractClient/Circles.Index.ContractClient.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethereum.Web3" Version="6.1.0" />
+      <PackageReference Include="Nethereum.Web3" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
+++ b/src/Index/Circles.Index.DatabaseSchemaProvider/Circles.Index.DatabaseSchemaProvider.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="10.0.6" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Index/Circles.Index.Postgres/Circles.Index.Postgres.csproj
+++ b/src/Index/Circles.Index.Postgres/Circles.Index.Postgres.csproj
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="10.0.1" />
+      <PackageReference Include="Npgsql" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
+++ b/src/Index/Circles.Index.Profiles/Circles.Index.Profiles.csproj
@@ -17,8 +17,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Dapper" Version="2.1.72" />
-      <PackageReference Include="Npgsql" Version="10.0.1" />
+      <PackageReference Include="Dapper" />
+      <PackageReference Include="Npgsql" />
     </ItemGroup>
 
 </Project>

--- a/src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj
+++ b/src/Index/Circles.Index.Query.Tests/Circles.Index.Query.Tests.csproj
@@ -9,17 +9,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-        <PackageReference Include="NUnit" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="NUnit3TestAdapter" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index.Query.Tests/SnapshotIntegrationTests.cs
+++ b/src/Index/Circles.Index.Query.Tests/SnapshotIntegrationTests.cs
@@ -10,6 +10,8 @@ namespace Circles.Index.Query.Tests;
 /// These tests run by default but skip gracefully when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class SnapshotIntegrationTests
 {
     private const long TestBlock = 43193632;

--- a/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
+++ b/src/Index/Circles.Index.Query/Circles.Index.Query.csproj
@@ -17,7 +17,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Npgsql" Version="10.0.1" />
+      <PackageReference Include="Npgsql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Index/Circles.Index/Circles.Index.csproj
+++ b/src/Index/Circles.Index/Circles.Index.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- NuGet Package Metadata -->
     <Version>0.0.7</Version>
-    <Authors>Daniel Janz (Gnosis Service GmbH)</Authors>
+    <Authors>Daniel Janz (Gnosis Service GmbH);Tobias Leinss (Gnosis Service GmbH)</Authors>
     <Copyright>Gnosis Service GmbH</Copyright>
     <Product>Circles</Product>
     <PackageId>Gnosis.Circles.Nethermind.Plugin</PackageId>

--- a/src/Index/Circles.Index/Circles.Index.csproj
+++ b/src/Index/Circles.Index/Circles.Index.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <!-- NuGet Package Metadata -->
-    <Version>0.0.1</Version>
-    <Authors>Gnosis Service GmbH</Authors>
+    <Version>0.0.7</Version>
+    <Authors>Daniel Janz (Gnosis Service GmbH)</Authors>
     <Copyright>Gnosis Service GmbH</Copyright>
     <Product>Circles</Product>
     <PackageId>Gnosis.Circles.Nethermind.Plugin</PackageId>
@@ -14,13 +14,8 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.0.7</Version>
-    <Authors>Daniel Janz (Gnosis Service GmbH)</Authors>
-    <Copyright>Gnosis Service GmbH</Copyright>
-    <Product>Circles</Product>
     <AssemblyVersion>1.25.0</AssemblyVersion>
     <FileVersion>1.25.0</FileVersion>
-    <PackageId>Gnosis.Circles.Nethermind.Plugin</PackageId>
     <OutputType>Library</OutputType>
     <!-- Copy all Circles.Index.*.dlls into the final nupkg -->
     <TargetsForTfmSpecificBuildOutput>
@@ -28,8 +23,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
   </ItemGroup>
 
 

--- a/src/Metrics/Circles.Metrics.Exporter/Circles.Metrics.Exporter.csproj
+++ b/src/Metrics/Circles.Metrics.Exporter/Circles.Metrics.Exporter.csproj
@@ -16,14 +16,14 @@
 
   <ItemGroup>
     <!-- ASP.NET Core -->
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
 
     <!-- PostgreSQL -->
-    <PackageReference Include="Npgsql" Version="10.0.1" />
+    <PackageReference Include="Npgsql" />
 
     <!-- Monitoring -->
-    <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+    <PackageReference Include="prometheus-net" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Circles.Pathfinder.Host.csproj
@@ -31,23 +31,23 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.OpenApi" Version="2.0.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-      <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-      <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
-      <PackageReference Include="prometheus-net" Version="8.2.1" />
-      <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
+      <PackageReference Include="Microsoft.OpenApi" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+      <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+      <PackageReference Include="Npgsql.OpenTelemetry" />
+      <PackageReference Include="prometheus-net" />
+      <PackageReference Include="prometheus-net.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+      <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
     <ItemGroup>
       <!-- OpenAPI documentation -->
-      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
-      <PackageReference Include="Scalar.AspNetCore" Version="2.4.18" />
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
+      <PackageReference Include="Scalar.AspNetCore" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/AnvilSimulationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/AnvilSimulationTests.cs
@@ -21,6 +21,8 @@ namespace Circles.Pathfinder.Tests;
 /// </summary>
 [TestFixture]
 [Category("Anvil")]
+[Category("RequiresTestEnv")]
+[Category("RequiresAnvil")]
 public class AnvilSimulationTests
 {
     [TestCaseSource(typeof(ScenarioLoader), nameof(ScenarioLoader.AnvilScenariosTestData))]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CacheSourceStagingTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CacheSourceStagingTests.cs
@@ -12,6 +12,7 @@ namespace Circles.Pathfinder.Tests;
 /// </summary>
 [TestFixture]
 [Category("Staging")]
+[Category("RequiresTestEnv")]
 public class CacheSourceStagingTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
@@ -22,20 +22,20 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0">
+        <PackageReference Include="coverlet.collector">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-        <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="BenchmarkDotNet" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/CrossVerificationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/CrossVerificationTests.cs
@@ -18,6 +18,7 @@ namespace Circles.Pathfinder.Tests;
 /// Requires TEST_ENV_URL with features: ["db", "rpc"] or ["db", "anvil"].
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class CrossVerificationTests
 {
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
@@ -20,7 +20,8 @@ namespace Circles.Pathfinder.Tests;
 /// - Tests create sessions with Anvil fork for contract execution
 ///
 /// The tests run by default but gracefully skip when TEST_ENV_URL is not set.
-/// CI triggers these tests automatically on merges to main/dev branches.
+/// Not selected by any CI job — run them explicitly (e.g.
+/// --filter "TestCategory=RequiresAnvil") with TEST_ENV_URL set.
 /// </summary>
 [TestFixture]
 [Category("RequiresTestEnv")]

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
@@ -23,6 +23,8 @@ namespace Circles.Pathfinder.Tests;
 /// CI triggers these tests automatically on merges to main/dev branches.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
+[Category("RequiresAnvil")]
 public class MintAlongPathE2ETests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/PaymentGatewayE2ETests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/PaymentGatewayE2ETests.cs
@@ -27,6 +27,8 @@ namespace Circles.Pathfinder.Tests;
 /// Then add the resulting fixture JSON to RegressionScenarios/
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
+[Category("RequiresAnvil")]
 public class PaymentGatewayE2ETests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RegressionTests.cs
@@ -141,6 +141,7 @@ public class RegressionTests
     [Test]
     [TestCaseSource(nameof(LoadScenarios))]
     [Category("Integration")]
+    [Category("RequiresTestEnv")]
     public async Task RegressionScenario_EdgeOrderingIsCorrect(RegressionScenario scenario)
     {
         // Check if TEST_ENV_URL is set

--- a/src/Pathfinder/Circles.Pathfinder.Tests/RegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RegressionTests.cs
@@ -23,6 +23,7 @@ namespace Circles.Pathfinder.Tests;
 /// CI triggers these tests automatically on merges to main/dev branches.
 /// </summary>
 [TestFixture]
+[Category("Regression")]
 public class RegressionTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ScenarioTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ScenarioTests.cs
@@ -21,6 +21,7 @@ namespace Circles.Pathfinder.Tests;
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class ScenarioTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -264,6 +265,7 @@ public class ScenarioTests
 /// Multiple pathfinder requests on the same session should not interfere.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class ConcurrentSessionTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -403,6 +405,8 @@ public class ConcurrentSessionTests
 /// CI triggers these tests automatically on merges to main/dev branches.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
+[Category("RequiresAnvil")]
 public class ScenarioE2ETests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ScenarioTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ScenarioTests.cs
@@ -21,6 +21,7 @@ namespace Circles.Pathfinder.Tests;
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
 [Category("RequiresTestEnv")]
 public class ScenarioTests
 {
@@ -402,9 +403,11 @@ public class ConcurrentSessionTests
 /// afterwards, so state mutations don't leak between tests.
 ///
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
-/// CI triggers these tests automatically on merges to main/dev branches.
+/// Selected by the CI snapshot-tests job (--filter "Category=Snapshot"), which
+/// runs on PRs and pushes to dev/main against the staging test environment.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
 [Category("RequiresTestEnv")]
 [Category("RequiresAnvil")]
 public class ScenarioE2ETests

--- a/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupRegressionTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/ScoreGroupRegressionTests.cs
@@ -35,6 +35,8 @@ namespace Circles.Pathfinder.Tests;
 /// </summary>
 [TestFixture]
 [NonParallelizable] // Serialize: each tier creates its own test-env session; concurrent creation flakes on staging.
+[Category("Regression")]
+[Category("RequiresTestEnv")]
 public class ScoreGroupRegressionTests
 {
     /// <summary>Standard group router used by GraphFactory; score routers are loaded from the DB.</summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SnapshotIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SnapshotIntegrationTests.cs
@@ -24,6 +24,8 @@ namespace Circles.Pathfinder.Tests;
 /// against remote test-env (staging), these tests will be skipped.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class SnapshotIntegrationTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -76,6 +78,9 @@ public class SnapshotIntegrationTests
 /// against remote test-env, they will skip unless direct connection is available.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
+[Category("RequiresDb")]
 public class MintAlongPathRegressionTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -304,6 +309,9 @@ public class MintAlongPathRegressionTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
+[Category("RequiresDb")]
 public class ConsentedFlowSnapshotTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -366,6 +374,8 @@ public class ConsentedFlowSnapshotTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class PathfinderQuerySnapshotTests
 {
     private const long TestBlock = 43193632;

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SubgraphEquivalenceTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SubgraphEquivalenceTests.cs
@@ -23,6 +23,7 @@ namespace Circles.Pathfinder.Tests;
 /// Requires TEST_ENV_URL for the full-graph comparison.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class SubgraphEquivalenceTests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SubgraphPopulateFixtures.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SubgraphPopulateFixtures.cs
@@ -21,6 +21,7 @@ namespace Circles.Pathfinder.Tests;
 /// </summary>
 [TestFixture]
 [Category("FixtureGeneration")]
+[Category("RequiresTestEnv")]
 public class SubgraphPopulateFixtures
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";

--- a/src/Pathfinder/Circles.Pathfinder.Tests/TestEnvironmentIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/TestEnvironmentIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Circles.Pathfinder.Tests;
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class TestEnvironmentIntegrationTests
 {
     private HttpClient _client = null!;

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -16,9 +16,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Google.OrTools" Version="9.15.6755" />
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
-        <PackageReference Include="Npgsql" Version="10.0.1" />
+        <PackageReference Include="Google.OrTools" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="Npgsql" />
     </ItemGroup>
 
     <ItemGroup>
@@ -70,7 +70,7 @@
 
     <ItemGroup>
         <ProjectReference Include="..\..\Common\Circles.Common\Circles.Common.csproj" />
-        <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+        <PackageReference Include="Nethermind.Numerics.Int256" />
     </ItemGroup>
 
 </Project>

--- a/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
+++ b/src/Pathfinder/Circles.Pathfinder/Circles.Pathfinder.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <Version>0.0.1</Version>
-        <Authors>Daniel Janz (Gnosis Service GmbH)</Authors>
+        <Authors>Daniel Janz (Gnosis Service GmbH);Tobias Leinss (Gnosis Service GmbH)</Authors>
         <Copyright>Gnosis Service GmbH</Copyright>
         <Product>Circles</Product>
         <PackageId>Gnosis.Circles.Pathfinder</PackageId>

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -52,7 +52,7 @@ public class Settings
         : 0.999999;
 
     /// <summary>
-    /// Timeout in seconds for the MaxFlow solver. Default 30s.
+    /// Timeout in seconds for the MaxFlow solver. Default 10s.
     /// Prevents a stuck solver from blocking a semaphore slot indefinitely.
     /// </summary>
     public int SolverTimeoutSeconds { get; set; } =

--- a/src/Rpc/Circles.Rpc.CacheServiceClient/Circles.Rpc.CacheServiceClient.csproj
+++ b/src/Rpc/Circles.Rpc.CacheServiceClient/Circles.Rpc.CacheServiceClient.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/src/Rpc/Circles.Rpc.Host.Tests/AvatarInfoSymbolSqlTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/AvatarInfoSymbolSqlTests.cs
@@ -23,6 +23,7 @@ namespace Circles.Rpc.Host.Tests;
 /// <see cref="long.MaxValue"/>, so the old join would have crashed on the very rows asserted here.
 /// </summary>
 [TestFixture]
+[Category("RequiresDocker")]
 public class AvatarInfoSymbolSqlTests
 {
     // A real V2 short name is a uint > 2^63 once base58-decoded; numeric, not text. The score group

--- a/src/Rpc/Circles.Rpc.Host.Tests/BlockPinningRoutingTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/BlockPinningRoutingTests.cs
@@ -44,6 +44,7 @@ public class BlockPinHeaderParsingTests
 /// without the Nethermind runtime — it touches only <see cref="ConnectionPinning"/> and Npgsql.
 /// </summary>
 [TestFixture]
+[Category("RequiresDocker")]
 public class BlockPinningRoutingTests
 {
     private PostgreSqlContainer? _postgres;

--- a/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
+++ b/src/Rpc/Circles.Rpc.Host.Tests/Circles.Rpc.Host.Tests.csproj
@@ -5,22 +5,21 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>
-        <NethermindReferenceAssembliesVersion>1.37.1</NethermindReferenceAssembliesVersion>
         <RepoRoot>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../..'))</RepoRoot>
         <NethermindRuntimeDir>$(RepoRoot)/nethermind-dev/nethermind</NethermindRuntimeDir>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-        <PackageReference Include="NUnit" Version="4.6.0" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.13.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="Npgsql" Version="10.0.1" />
-        <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
-        <PackageReference Include="System.Reflection.Metadata" Version="10.0.5" />
-        <PackageReference Include="Nethermind.ReferenceAssemblies" Version="$(NethermindReferenceAssembliesVersion)" PrivateAssets="all" />
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+        <PackageReference Include="System.Reflection.Metadata" />
+        <PackageReference Include="Nethermind.ReferenceAssemblies" PrivateAssets="all" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/CirclesRpcModuleTests.cs
@@ -23,6 +23,7 @@ namespace Circles.Rpc.Host.Tests;
 /// A Testcontainers-managed Postgres is started automatically so no manual setup is required.
 /// </summary>
 [TestFixture]
+[Category("RequiresDocker")]
 [Ignore("Requires Nethermind runtime; temporarily skipped until Nethermind build artifacts are available.")]
 public class CirclesRpcModuleTests
 {

--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -13,6 +13,8 @@ namespace Circles.Rpc.Host.Tests;
 /// </summary>
 [TestFixture]
 [Category("RpcRegression")]
+[Category("Regression")]
+[Category("RequiresTestEnv")]
 public class RpcMethodSnapshotTests
 {
     private static readonly string? TestEnvUrl = Environment.GetEnvironmentVariable("TEST_ENV_URL");

--- a/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
@@ -29,6 +29,7 @@ public record RpcScenario
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("RequiresTestEnv")]
 public class RpcScenarioTests
 {
     private static readonly JsonSerializerOptions JsonOptions = new()

--- a/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
@@ -29,6 +29,7 @@ public record RpcScenario
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
 [Category("RequiresTestEnv")]
 public class RpcScenarioTests
 {

--- a/src/Rpc/Circles.Rpc.Host.Tests/SnapshotIntegrationTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/SnapshotIntegrationTests.cs
@@ -21,6 +21,8 @@ namespace Circles.Rpc.Host.Tests;
 ///    TEST_ENV_URL=https://staging.circlesubi.network/test-env dotnet test
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class RpcSnapshotTests
 {
     [Test]
@@ -63,6 +65,8 @@ public class RpcSnapshotTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class RpcQuerySnapshotTests
 {
     // Block 43193632 = state at the time of the mint-along-path bug
@@ -201,6 +205,8 @@ public class RpcQuerySnapshotTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class SchemaValidationSnapshotTests
 {
     private const long TestBlock = 43193632;
@@ -356,6 +362,8 @@ public class SchemaValidationSnapshotTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class AvatarQuerySnapshotTests
 {
     private const long BugReproBlock = 43193632;
@@ -518,6 +526,8 @@ public class AvatarQuerySnapshotTests
 /// Tests run by default but gracefully skip when TEST_ENV_URL is not set.
 /// </summary>
 [TestFixture]
+[Category("Snapshot")]
+[Category("RequiresTestEnv")]
 public class TransactionHistorySnapshotTests
 {
     private const long TestBlock = 43193632;

--- a/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
+++ b/src/Rpc/Circles.Rpc.Host/Circles.Rpc.Host.csproj
@@ -18,25 +18,25 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Nethereum.Util" Version="5.8.0" />
-    <PackageReference Include="Nethermind.Numerics.Int256" Version="1.5.0" />
+    <PackageReference Include="Nethereum.Util" />
+    <PackageReference Include="Nethermind.Numerics.Int256" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageReference Include="Npgsql.OpenTelemetry" Version="10.0.1" />
-    <PackageReference Include="prometheus-net" Version="8.2.1" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="8.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="Npgsql.OpenTelemetry" />
+    <PackageReference Include="prometheus-net" />
+    <PackageReference Include="prometheus-net.AspNetCore" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="9.1.0" />
-    <PackageReference Include="Npgsql" Version="10.0.1" />
+    <PackageReference Include="Autofac" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Centralize NuGet package versions in `Directory.Packages.props` (ManagePackageVersionsCentrally); strip 118 per-project `Version` attributes across all 40 csproj. A stray version attribute is now a hard restore error, eliminating cross-project version drift.
- Restore the CI test categories the `snapshot-tests` and `regression-tests` workflow jobs filter on (`Category=Snapshot` / `Category=Regression`): the categories were removed in an earlier cleanup, leaving both jobs green while matching zero tests. Filters now select 12+ snapshot and 21+ regression tests, and `|| true` is removed so real assertion failures fail the jobs.
- `scripts/test.sh` discovers test projects from `Circles.sln` instead of a hand-maintained list, which had drifted: CI was not running `Circles.Index.CirclesV2.Tests` (104 tests) or `Circles.Index.CirclesViews.Tests` (79 tests).
- Tag environment-gated test fixtures with a dependency-tier taxonomy (`RequiresTestEnv`, `RequiresAnvil`, `RequiresDb`, `RequiresDocker`) — purely additive — enabling deliberate tier selection via `dotnet test --filter`.
- Add `docs/configuration.md`: every environment variable across all five services (name, type, default, effect), verified against the Settings classes; document the snapshot/regression CI jobs in `docs/ci-cd.md`; fix stale defaults in `scripts/test.sh` help, `docs/testing.md`, `DEVELOPMENT.md`, and a wrong solver-timeout doc comment.
- All six Dockerfiles `COPY Directory.Packages.props` before `dotnet restore` (required under central package management; restore fails with NU1015 otherwise).

## Version changes

- `Microsoft.AspNetCore.Mvc.Testing` 10.0.3 → 10.0.7 for `Circles.Cache.Service.Tests` (the solution had two pins; centralized on the higher in-use version). All other package versions preserved exactly.
- Open dependabot PRs targeting per-csproj versions will go stale; dependabot re-targets `Directory.Packages.props` on its next scan.

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `./scripts/test.sh` — 7/7 projects discovered, 1922 passed, 0 failed
- [x] `dotnet format --verify-no-changes` — clean
- [x] Restored filters match: `Category=Snapshot` → 12+ tests, `Category=Regression` → 21+ tests (self-skip without `TEST_ENV_URL`)
- [x] Docker build context simulated with the exact COPY layout: restore succeeds with `Directory.Packages.props`, fails NU1015 without
- [x] `bash -n scripts/test.sh`