### PR TITLE
security(rpc): validate filter/order columns against table schema

### DIFF
--- a/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/RpcMethodSnapshotTests.cs
@@ -442,4 +442,84 @@ public class RpcMethodSnapshotTests
                 "If raw balance is non-zero, time-circles balance should also be non-zero");
         }
     }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // circles_query column validation
+    // ═══════════════════════════════════════════════════════════════════════
+
+    private async Task<JsonElement> CallRpcRaw(string method, params object[] parameters)
+    {
+        var request = new
+        {
+            jsonrpc = "2.0",
+            method,
+            @params = parameters,
+            id = 1
+        };
+
+        var response = await _client!.PostAsJsonAsync("/", request, new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+        });
+
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    [Test]
+    public async Task Query_UnknownFilterColumn_ReturnsErrorNotRows()
+    {
+        // A filter on a non-existent column must yield a JSON-RPC error, never rows.
+        // (With the schema column allowlist this is a clean validation error; without
+        // it the database rejects the column — either way the contract is "error".)
+        var envelope = await CallRpcRaw("circles_query", new
+        {
+            Namespace = "CrcV2",
+            Table = "RegisterHuman",
+            Columns = Array.Empty<string>(),
+            Limit = 1,
+            Filter = new object[]
+            {
+                new
+                {
+                    Type = "FilterPredicate",
+                    FilterType = "Equals",
+                    Column = "definitely_not_a_column",
+                    Value = "0x0000000000000000000000000000000000000000"
+                }
+            }
+        });
+
+        Assert.That(envelope.TryGetProperty("error", out _), Is.True,
+            "Unknown filter column must produce a JSON-RPC error");
+    }
+
+    [Test]
+    public async Task Query_ValidFilterColumn_StillReturnsResult()
+    {
+        // Positive control for the column allowlist: a legitimate schema column
+        // must not be rejected by the validation pre-pass.
+        var envelope = await CallRpcRaw("circles_query", new
+        {
+            Namespace = "CrcV2",
+            Table = "RegisterHuman",
+            Columns = Array.Empty<string>(),
+            Limit = 1,
+            Filter = new object[]
+            {
+                new
+                {
+                    Type = "FilterPredicate",
+                    FilterType = "Equals",
+                    Column = "avatar",
+                    Value = KnownV2Human
+                }
+            }
+        });
+
+        Assert.That(envelope.TryGetProperty("error", out var error), Is.False,
+            $"Valid filter column must not be rejected: {(envelope.TryGetProperty("error", out error) ? error.ToString() : "")}");
+        Assert.That(envelope.TryGetProperty("result", out _), Is.True);
+    }
 }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Query.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.Query.cs
@@ -79,6 +79,17 @@ public partial class CirclesRpcModule
         return normalized;
     }
 
+    private static IEnumerable<FilterPredicateDto> FlattenFilterPredicates(IEnumerable<IFilterPredicateDto> predicates)
+    {
+        foreach (var p in predicates)
+        {
+            if (p is FilterPredicateDto fp) yield return fp;
+            else if (p is ConjunctionDto cj && cj.Predicates != null)
+                foreach (var nested in FlattenFilterPredicates(cj.Predicates))
+                    yield return nested;
+        }
+    }
+
     private static string BuildInClause(
         string column,
         string parameterPrefix,
@@ -335,10 +346,35 @@ public partial class CirclesRpcModule
         {
             throw new ArgumentException($"Table '{fullTableName}' is not a known Circles table.");
         }
-        var hasEventColumns = tableColumns != null &&
-            tableColumns.ContainsKey("blockNumber") &&
+        var hasEventColumns = tableColumns.ContainsKey("blockNumber") &&
             tableColumns.ContainsKey("transactionIndex") &&
             tableColumns.ContainsKey("logIndex");
+
+        // Validate filter and order columns against the known schema to prevent
+        // column-name injection through the double-quoted identifier interpolation.
+        void AssertColumnExists(string col, string role)
+        {
+            if (!tableColumns.ContainsKey(col))
+                throw new ArgumentException($"{role} column '{col}' does not exist in table '{fullTableName}'.");
+        }
+
+        if (query.Filter != null)
+        {
+            foreach (var f in FlattenFilterPredicates(query.Filter))
+                if (f.Column != null) AssertColumnExists(f.Column, "Filter");
+        }
+
+        if (query.Order != null)
+        {
+            foreach (var o in query.Order)
+                if (o.Column != null) AssertColumnExists(o.Column, "Order");
+        }
+
+        if (query.Columns != null)
+        {
+            foreach (var c in query.Columns)
+                if (c != "*") AssertColumnExists(c, "Column");
+        }
 
         // Decode cursor if provided and table supports cursor-based pagination
         var (cursorBlockNumber, cursorTransactionIndex, cursorLogIndex) = hasEventColumns


### PR DESCRIPTION
## Summary

Brings the column-allowlist hardening (previously merged to `dev` in #476) onto `staging` so it soaks here before any production promotion.

- `circles_query` filter, order, and selected column names were interpolated into SQL with only regex validation (`^[a-zA-Z_][a-zA-Z0-9_]*$`) and double-quoting, without checking they exist in the target table's schema
- Adds a pre-pass in `Query()` that asserts each filter column, order column, and selected column against `DatabaseSchemaMap.GetTableColumns()` before any SQL is built — unknown columns fail with a clean validation error instead of reaching Postgres
- Column lists derive from `SchemaProvider.AllSchemas`, the same source the DDL is generated from, so legitimate columns cannot be rejected unless schema definitions and DDL have diverged
- Identical content to the conflict-resolved version prepared for the staging→dev promotion branch (verified byte-identical)

Adds two live regression tests (Regression category): unknown filter column → JSON-RPC error; valid schema column → not rejected.

## Test plan
- [x] Build clean, `dotnet format` clean
- [x] RPC host test project: full run green
- [x] Both new regression tests pass against the live staging endpoint