### PR TITLE
fix(metrics): blacklisted member alert fires on nonzero score + parameterise backup retention

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -270,7 +270,7 @@ services:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - BACKUP_DIR=/backups
       - SCHEDULE=0 3 * * *
-      - KEEP_DAYS=7
+      - KEEP_DAYS=${POSTGRES_BACKUP_KEEP_DAYS:-7}
     depends_on:
       - postgres-gnosis
     volumes:

--- a/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
@@ -14,7 +14,11 @@ public static class RepScoreMetrics
 
     public static readonly Gauge BlacklistMembersTotal = Prometheus.Metrics
         .CreateGauge("circles_blacklist_members_total",
-            "Blacklisted addresses that are currently ScoreGroup members — alert if > 0");
+            "Blacklisted addresses that are currently ScoreGroup members");
+
+    public static readonly Gauge BlacklistMembersNonzeroScore = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_members_nonzero_score",
+            "Blacklisted ScoreGroup members whose rep score is still > 0 — alert if > 0");
 
     public static readonly Gauge BlacklistAdditions24h = Prometheus.Metrics
         .CreateGauge("circles_blacklist_additions_24h",

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
@@ -61,12 +61,15 @@ public class RepScoreCollectorService : BackgroundService
 
             RepScoreMetrics.BlacklistTotal.Set(stats.Total);
             RepScoreMetrics.BlacklistMembersTotal.Set(stats.MembersTotal);
+            RepScoreMetrics.BlacklistMembersNonzeroScore.Set(stats.MembersNonzeroScore);
             RepScoreMetrics.BlacklistAdditions24h.Set(stats.Additions24h);
             RepScoreMetrics.BlacklistRemovals24h.Set(stats.Removals24h);
             RepScoreMetrics.BlacklistLastRefreshAgeSeconds.Set(stats.LastRefreshAgeSeconds);
 
-            if (stats.MembersTotal > 0)
-                _logger.LogWarning("Blacklisted ScoreGroup members detected: {Count}", stats.MembersTotal);
+            if (stats.MembersNonzeroScore > 0)
+                _logger.LogWarning("Blacklisted ScoreGroup members with nonzero score: {Count}", stats.MembersNonzeroScore);
+            else if (stats.MembersTotal > 0)
+                _logger.LogInformation("Blacklisted ScoreGroup members present but all scored 0 (grace period ok): {Count}", stats.MembersTotal);
 
             _logger.LogDebug("Blacklist: total={Total}, members={Members}, age={Age}s",
                 stats.Total, stats.MembersTotal, (int)stats.LastRefreshAgeSeconds);

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
@@ -36,6 +36,7 @@ public class RepScoreRepository
     public record BlacklistStats(
         long Total,
         long MembersTotal,
+        long MembersNonzeroScore,
         long Additions24h,
         long Removals24h,
         double LastRefreshAgeSeconds);
@@ -44,7 +45,9 @@ public class RepScoreRepository
     {
         const string sql = """
             WITH member_blacklist AS (
-                SELECT COUNT(DISTINCT s.avatar) AS members_total
+                SELECT
+                    COUNT(DISTINCT s.avatar)                             AS members_total,
+                    COUNT(DISTINCT s.avatar) FILTER (WHERE s.score > 0) AS members_nonzero_score
                 FROM rep_score_state s
                 JOIN blacklist b ON b.address = s.avatar
                 WHERE s.group_id = @groupId
@@ -59,6 +62,7 @@ public class RepScoreRepository
             SELECT
                 (SELECT COUNT(*) FROM blacklist) AS total,
                 mb.members_total,
+                mb.members_nonzero_score,
                 rs.additions_24h,
                 rs.removals_24h,
                 rs.last_refresh_age
@@ -78,10 +82,11 @@ public class RepScoreRepository
                 reader.GetInt64(1),
                 reader.GetInt64(2),
                 reader.GetInt64(3),
-                reader.GetDouble(4));
+                reader.GetInt64(4),
+                reader.GetDouble(5));
         }
 
-        return new BlacklistStats(0, 0, 0, 0, 999999);
+        return new BlacklistStats(0, 0, 0, 0, 0, 999999);
     }
 
     // ===========================================


### PR DESCRIPTION
## Summary

- New metric `circles_blacklist_members_nonzero_score`: blacklisted addresses in ScoreGroup with `score > 0`. A blacklisted member already zeroed during a grace period is acceptable — only nonzero score means the pipeline failed to penalise them.
- `BlacklistMembersPresent` alert expression: `circles_blacklist_members_total > 0` → `circles_blacklist_members_nonzero_score > 0`.
- `circles_blacklist_members_total` kept for dashboards.
- Log: `Warning` only on nonzero score; `Info` when member present but score already 0.
- `docker-compose.gnosis.yml`: `KEEP_DAYS` → `${POSTGRES_BACKUP_KEEP_DAYS:-7}` so staging can override to 2 days via `.env`.

## Test plan

- [ ] Deploy metrics-exporter — `circles_blacklist_members_nonzero_score` appears in `/metrics`
- [ ] Alert resolves on staging2 (blacklisted member already has score = 0)
- [ ] Alert fires if score > 0 for a blacklisted member