### PR TITLE
fix(metrics): read emitted score_uint for BlacklistMembersNonzeroScore

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
@@ -18,7 +18,7 @@ public static class RepScoreMetrics
 
     public static readonly Gauge BlacklistMembersNonzeroScore = Prometheus.Metrics
         .CreateGauge("circles_blacklist_members_nonzero_score",
-            "Blacklisted ScoreGroup members whose rep score is still > 0 — alert if > 0");
+            "Blacklisted ScoreGroup members whose last-emitted score_uint is still > 0 — alert if > 0");
 
     public static readonly Gauge BlacklistAdditions24h = Prometheus.Metrics
         .CreateGauge("circles_blacklist_additions_24h",

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
@@ -46,9 +46,9 @@ public class RepScoreRepository
         const string sql = """
             WITH member_blacklist AS (
                 SELECT
-                    COUNT(DISTINCT s.avatar)                             AS members_total,
-                    COUNT(DISTINCT s.avatar) FILTER (WHERE s.score > 0) AS members_nonzero_score
-                FROM rep_score_state s
+                    COUNT(DISTINCT s.avatar)                                  AS members_total,
+                    COUNT(DISTINCT s.avatar) FILTER (WHERE s.score_uint > 0)  AS members_nonzero_score
+                FROM rep_score_emitted_state s
                 JOIN blacklist b ON b.address = s.avatar
                 WHERE s.group_id = @groupId
             ),


### PR DESCRIPTION
## Summary

- Switches `circles_blacklist_members_nonzero_score` query from `rep_score_state` to `rep_score_emitted_state`
- Uses `score_uint > 0` instead of `score > 0` to match the emitted table's column
- Updates gauge description to reflect the source

## Why

`rep_score_state` holds raw pipeline scores that are never zeroed for blacklisted members — the zero is applied at the API layer on every read. `rep_score_emitted_state` records the last `score_uint` actually pushed to SGB via `/changes`, which is `0` for blacklisted members after the API's blacklist gate fires.

The old query caused the alert to fire immediately on every new blacklist addition, even though SGB had already received `score_uint=0`. The new query only fires if SGB was genuinely served a nonzero score for a blacklisted member — which, combined with the `for: 2h` window on the alert rule (infra PR #721), gives the blacklist cache cycle time to propagate before paging.

## Test plan

- [ ] Verify `circles_blacklist_members_nonzero_score` reads 0 for the known blacklisted address `0x5161a4f2d1a18156a5e482d5dbddc1dbcaa0d583` after deploy (its `rep_score_emitted_state.score_uint = 0`)
- [ ] Confirm `BlacklistMembersPresent` alert clears on staging