### PR TITLE
feat(pathfinder): V2_EXCLUDED_ROUTING_ADDRESSES routing blocklist

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,7 @@ Sources of truth: `src/Common/Circles.Common/Settings.cs`,
 | `PATHFINDER_FULL_REFRESH_INTERVAL_BLOCKS` | int | `200` | Blocks between full DB refreshes (drift correction). |
 | `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | bool | `true` | Exclude consented avatars from intermediary positions in flow paths. |
 | `PATHFINDER_DISABLE_CONSENTED_FLOW` | bool | — | Deprecated alias for `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` (read only when the new name is unset). |
+| `V2_EXCLUDED_ROUTING_ADDRESSES` | string | empty | Comma-separated addresses dropped from pathfinding entirely — deprecated groups, their wrappers, and custom sink-wrapper contracts. A listed **group** cascades to its indexed ERC20 wrappers; custom sink wrappers (not `ERC20WrapperDeployed` rows) must be listed **explicitly**. Default empty = no effect. Use to retire an owner-deprecated group/wrapper the chain still treats as valid. |
 | `USE_CACHE_GRAPH_SOURCE` | bool | `true` iff `CACHE_SERVICE_URL` set | Load graph data from the Cache Service instead of the DB. |
 | `CACHE_SERVICE_URL` | string | unset | Cache Service base URL. |
 | `CACHE_GRAPH_REQUEST_TIMEOUT_SECONDS` | int | `60` | Cache Service graph request timeout. |

--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -81,7 +81,8 @@ builder.Services.AddSingleton<CapacityGraphPool>(provider =>
     new CapacityGraphPool(
         settings.RouterAddress,
         provider.GetRequiredService<LoadGraph>(),
-        provider.GetRequiredService<ILoggerFactory>().CreateLogger<GraphFactory>()));
+        provider.GetRequiredService<ILoggerFactory>().CreateLogger<GraphFactory>(),
+        settings.ExcludedRoutingAddresses));
 builder.Services.AddSingleton<V2Pathfinder>();
 builder.Services.AddSingleton<HistoricalGraphCache>();
 builder.Services.AddSingleton<FindPathHandler>();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -2112,4 +2112,110 @@ public class GraphFactoryTests
     }
 
     #endregion
+
+    #region Routing exclusions (deprecated groups / sink wrappers)
+
+    // V2_EXCLUDED_ROUTING_ADDRESSES drops deprecated addresses (groups, their wrappers, and custom
+    // sink-wrapper contracts) from every graph. Models the real case: a live group is trusted by
+    // BOTH a deprecated and a current sink-wrapper org; only the deprecated one must be removed.
+
+    private const string OldSinkWrapper = "0xf1d4000000000000000000000000000000000016";
+    private const string NewSinkWrapper = "0xf1d7000000000000000000000000000000000017";
+
+    [Test]
+    public void ExcludedSinkWrapper_RemovedFromRouting_CurrentWrapperKeepsRouting()
+    {
+        // GroupG (live, regular) is trusted by an old + a new sink wrapper, so both receive the
+        // Group→avatar mint edge. Excluding ONLY the old wrapper must drop its edges while leaving
+        // the current wrapper fully routable — i.e. routing shifts to the current sink wrapper.
+        var mock = new HelperMock();
+        mock.AddGroup(GroupG);
+        mock.AddTrust(OldSinkWrapper, GroupG);
+        mock.AddTrust(NewSinkWrapper, GroupG);
+
+        int gId = AddressIdPool.IdOf(GroupG);
+        int oldW = AddressIdPool.IdOf(OldSinkWrapper);
+        int newW = AddressIdPool.IdOf(NewSinkWrapper);
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+
+        var baseFactory = new GraphFactory(RouterAddr, mock);
+        var cg0 = baseFactory.CreateCapacityGraph(
+            baseFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(baseFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg0.Edges.Any(e => e.From == gId && e.To == oldW && e.Token == gId), Is.True,
+            "Baseline: deprecated sink wrapper receives the group mint.");
+        Assert.That(cg0.Edges.Any(e => e.From == gId && e.To == newW && e.Token == gId), Is.True,
+            "Baseline: current sink wrapper receives the group mint.");
+
+        var exFactory = new GraphFactory(RouterAddr, mock, null, new[] { OldSinkWrapper });
+        var cg1 = exFactory.CreateCapacityGraph(
+            exFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(exFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg1.Edges.Any(e => e.From == oldW || e.To == oldW || e.Token == oldW), Is.False,
+            "No edge may route through the excluded (deprecated) sink wrapper.");
+        Assert.That(cg1.Edges.Any(e => e.From == gId && e.To == newW && e.Token == gId), Is.True,
+            "The current sink wrapper must keep receiving the group mint (no breakage).");
+    }
+
+    [Test]
+    public void ExcludedGroup_CascadesToErc20Wrappers()
+    {
+        // Listing only the GROUP address must also strip routing for its ERC20 wrapper token,
+        // via the WrapperToAvatar cascade — the wrapper need not be listed explicitly.
+        var mock = new HelperMock();
+        mock.AddGroup(GroupG);
+        mock.AddWrapperMapping(WrapperA, GroupG, CirclesType.InflationaryCircles);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(WrapperA), 100_000_000, isWrapped: true);
+
+        int wrapperId = AddressIdPool.IdOf(WrapperA);
+        var request = new FlowRequest { Source = Alice, Sink = Bob, WithWrap = true };
+
+        var baseFactory = new GraphFactory(RouterAddr, mock);
+        var cg0 = baseFactory.CreateCapacityGraph(
+            baseFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(baseFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg0.Edges.Any(e => e.Token == wrapperId), Is.True,
+            "Baseline: the group's wrapped ERC20 held by the source is routable under withWrap.");
+
+        var exFactory = new GraphFactory(RouterAddr, mock, null, new[] { GroupG });
+        var cg1 = exFactory.CreateCapacityGraph(
+            exFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(exFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg1.Edges.Any(e => e.Token == wrapperId), Is.False,
+            "Excluding the group cascades to its ERC20 wrapper: no edge carries the wrapper token.");
+    }
+
+    [Test]
+    public void NoExclusionsConfigured_GraphUnchanged()
+    {
+        // An explicit empty list (overriding any env var) must be a pure no-op.
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+        mock.AddTrust(Bob, TokenA);
+
+        int aliceId = AddressIdPool.IdOf(Alice);
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+
+        var baseline = new GraphFactory(RouterAddr, mock).CreateCapacityGraph(
+            new GraphFactory(RouterAddr, mock).V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(new GraphFactory(RouterAddr, mock).V2TrustGraph()),
+            request);
+        var withEmpty = new GraphFactory(RouterAddr, mock, null, System.Array.Empty<string>());
+        var cg = withEmpty.CreateCapacityGraph(
+            withEmpty.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(withEmpty.V2TrustGraph()),
+            request);
+
+        Assert.That(cg.Edges.Count, Is.EqualTo(baseline.Edges.Count),
+            "Empty exclusion list must not change the edge set.");
+        Assert.That(cg.Edges.Any(e => e.From == aliceId), Is.True);
+    }
+
+    #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -4,11 +4,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Circles.Pathfinder.Graphs;
 
-public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph, ILogger<GraphFactory>? graphFactoryLogger = null)
+public sealed class CapacityGraphPool(
+    string routerAddress,
+    ILoadGraph loadGraph,
+    ILogger<GraphFactory>? graphFactoryLogger = null,
+    IReadOnlyCollection<string>? excludedRoutingAddresses = null)
 {
     private volatile SnapshotState? _state;
     private volatile CapacityGraphSnapshot? _currentWrapped;
-    private readonly GraphFactory _gf = new(routerAddress, loadGraph, graphFactoryLogger);
+    private readonly GraphFactory _gf = new(routerAddress, loadGraph, graphFactoryLogger, excludedRoutingAddresses);
 
     /// <summary>
     /// Packs snapshot + cachedGroupData into a single reference so readers

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -7,11 +7,22 @@ using Nethermind.Int256;
 
 namespace Circles.Pathfinder.Graphs;
 
-public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<GraphFactory>? logger = null)
+public class GraphFactory(
+    string routerAddress,
+    ILoadGraph loadGraph,
+    ILogger<GraphFactory>? logger = null,
+    IReadOnlyCollection<string>? excludedRoutingAddresses = null)
 {
     private const string VirtualSinkSuffix = "_virtual_sink";
     private static int _createdCount;
     private readonly ILogger _logger = logger ?? NullLogger<GraphFactory>.Instance;
+
+    // Deprecated addresses (groups, their wrappers, and custom sink-wrapper contracts) to drop
+    // from every graph this factory builds. An explicit constructor argument wins; otherwise it
+    // falls back to the V2_EXCLUDED_ROUTING_ADDRESSES env var so the static snapshot builders
+    // (BuildFullGraph/BuildFullWrappedGraph), which have no Settings, are covered too.
+    private readonly HashSet<string> _excludedRoutingAddresses =
+        NormalizeExcludedRoutingAddresses(excludedRoutingAddresses);
 
     public static Dictionary<int, HashSet<int>> BuildTrustLookup(TrustGraph graph)
     {
@@ -145,6 +156,9 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         AddGroupMintingEdges(
             capacityGraph, trustLookup,
             sinkId: null, new HashSet<int>(), new HashSet<int>());
+
+        // Drop deprecated/excluded routing addresses from the shared snapshot too.
+        ApplyRoutingExclusions(capacityGraph);
 
         return capacityGraph;
     }
@@ -520,6 +534,10 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             sinkId,
             toTokensFilter,
             excludedToTokensFilter);
+
+        // Drop deprecated/excluded routing addresses (groups, wrappers, sink contracts) BEFORE the
+        // virtual-sink prune so a virtual sink orphaned by the removal is collapsed correctly.
+        ApplyRoutingExclusions(capacityGraph);
 
         // If a virtual sink was created but received no edges, prune it (mirror legacy behaviour)
         if (virtualSinkAddress != null)
@@ -1281,6 +1299,68 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 result.Add(id);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Normalizes the configured routing-exclusion addresses: explicit constructor list when
+    /// provided, else the V2_EXCLUDED_ROUTING_ADDRESSES env var. Trimmed, lowercased, de-duped.
+    /// </summary>
+    private static HashSet<string> NormalizeExcludedRoutingAddresses(IReadOnlyCollection<string>? configured)
+    {
+        IEnumerable<string>? source = configured;
+        if (source == null)
+            source = Environment.GetEnvironmentVariable("V2_EXCLUDED_ROUTING_ADDRESSES")?.Split(',');
+
+        if (source == null)
+            return new HashSet<string>();
+
+        return source
+            .Select(a => a.Trim().ToLowerInvariant())
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToHashSet();
+    }
+
+    /// <summary>
+    /// Drops configured deprecated addresses (groups, their ERC20 wrappers, and custom
+    /// sink-wrapper contracts) from the graph. A listed group cascades to its indexed wrappers
+    /// via <see cref="CapacityGraph.WrapperToAvatar"/>; non-wrapper contracts (e.g. the
+    /// SinkGroupWrapperInflationary) must be listed explicitly. Runs as a final post-build sweep
+    /// so it catches mint, trust, balance and sink edges regardless of which stage created them.
+    /// No-op when nothing is configured.
+    /// </summary>
+    private void ApplyRoutingExclusions(CapacityGraph g)
+    {
+        if (_excludedRoutingAddresses.Count == 0)
+            return;
+
+        // Resolve to node IDs without allocating new pool entries — an address absent from the
+        // pool cannot match any graph node, so there is nothing to exclude for it.
+        var excludedIds = new HashSet<int>();
+        foreach (var addr in _excludedRoutingAddresses)
+            if (AddressIdPool.TryIdOf(addr, out var id))
+                excludedIds.Add(id);
+
+        if (excludedIds.Count == 0)
+            return;
+
+        // Cascade an excluded group/avatar to its ERC20 wrapper token IDs.
+        ExpandFilterWithWrapperIds(excludedIds, g.WrapperToAvatar, "excludedRoutingAddresses");
+
+        // Stop treating excluded ids as live groups so no later logic re-adds mint edges.
+        int groupsRemoved = g.GroupNodes.RemoveWhere(excludedIds.Contains);
+
+        // Remove every edge whose source, target, or token is excluded.
+        int edgesBefore = g.Edges.Count;
+        g.Edges.RemoveAll(e =>
+            excludedIds.Contains(e.From)
+            || excludedIds.Contains(e.To)
+            || excludedIds.Contains(e.Token));
+        int edgesRemoved = edgesBefore - g.Edges.Count;
+
+        if (edgesRemoved > 0 || groupsRemoved > 0)
+            _logger.LogInformation(
+                "Routing exclusions: dropped {Edges} edge(s) and {Groups} group node(s) for {Addrs} excluded address(es)",
+                edgesRemoved, groupsRemoved, excludedIds.Count);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/README.md
+++ b/src/Pathfinder/Circles.Pathfinder/README.md
@@ -211,6 +211,7 @@ The pathfinder can load its trust graph from the **Cache Service** (recommended)
 | `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | `10` | MaxFlow solver timeout per request |
 | `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `0.999999` | Demurrage safety margin (~7 min drift coverage; 1.0 = disabled) |
 | `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | `true` | Exclude consented avatars from intermediary positions in paths |
+| `V2_EXCLUDED_ROUTING_ADDRESSES` | (empty) | Comma-separated addresses dropped from routing (deprecated groups + their wrappers + custom sink wrappers). Groups cascade to their ERC20 wrappers; non-wrapper sink contracts must be listed explicitly. Empty = no effect. |
 
 ### Materialized View Refresh
 

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -165,4 +165,20 @@ public class Settings
         Circles.Common.EnvParsers.ParseAggregatorMap(
             "SCORE_TREASURY_SUBTREASURIES",
             Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES"));
+
+    /// <summary>
+    /// Addresses to drop from pathfinding entirely — deprecated groups, their wrappers, and
+    /// custom sink-wrapper contracts (e.g. SinkGroupWrapperInflationary) that should no longer
+    /// carry flow. A listed group cascades to its indexed ERC20 wrappers automatically (via the
+    /// wrapper→avatar map); contracts that are NOT standard ERC20WrapperDeployed rows must be
+    /// listed explicitly. "Deprecated" is an owner-driven, off-chain decision the pathfinder
+    /// cannot infer from on-chain state (the contract stays a valid registered group), so it is
+    /// supplied here. Reads V2_EXCLUDED_ROUTING_ADDRESSES (comma-separated, lowercased).
+    /// </summary>
+    public string[] ExcludedRoutingAddresses { get; set; } =
+        Environment.GetEnvironmentVariable("V2_EXCLUDED_ROUTING_ADDRESSES")?.Split(',')
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray()
+        ?? [];
 }


### PR DESCRIPTION
## Summary

Adds an env-gated, **default-off** routing blocklist to the pathfinder. Setting `V2_EXCLUDED_ROUTING_ADDRESSES` drops the listed addresses — and any listed group's ERC20 wrappers (cascaded automatically) — from every capacity graph the pathfinder builds. Empty/unset = no behavioral change.

## Why

A deprecated ERC20 sink-wrapper contract can remain trusted by an **active** group, so the pathfinder keeps routing the active group's token mints through the deprecated contract. This deprecation is not observable on-chain (the contract stays a valid registered avatar), so the addresses to drop are supplied via configuration rather than inferred. A newer sink wrapper for the same group exists, so excluding the deprecated one redirects routing without breaking current minting.

## What changed

- **Settings**: `ExcludedRoutingAddresses` reads `V2_EXCLUDED_ROUTING_ADDRESSES` (comma-separated, lowercased; empty = no effect).
- **GraphFactory**: `ApplyRoutingExclusions()` runs as a final post-build edge sweep — removes any edge whose `from`/`to`/`token` is excluded. A listed **group** cascades to its indexed ERC20 wrappers via `WrapperToAvatar`; non-wrapper sink contracts (not `ERC20WrapperDeployed` rows) must be listed **explicitly**. Explicit constructor arg wins; otherwise falls back to the env var so the snapshot/historical builders are also covered.
- **CapacityGraphPool / Program**: thread the configured list to the factory.
- **Tests**: deprecated-sink-wrapper redirect (current wrapper unaffected), group→ERC20-wrapper cascade, empty-list no-op.
- **Docs**: `configuration.md` + pathfinder `README.md`.

## Risk / rollback

- Inert until `V2_EXCLUDED_ROUTING_ADDRESSES` is set, so the code carries no behavioral risk on its own.
- Reversible at runtime by clearing the env var (no redeploy needed to revert behavior).

## Test plan

- [x] `dotnet build -c Release` — 0 errors
- [x] `GraphFactoryTests` — 76/76 pass (incl. 3 new exclusion tests)
- [x] No new regressions (the 6 `SnapshotCacheTests` mixed-batch failures are pre-existing test-isolation flakiness — identical on the base branch; the class passes 12/12 in isolation)
- [ ] Staging: set `V2_EXCLUDED_ROUTING_ADDRESSES`, restart pathfinder, confirm routing no longer flows through the deprecated sink wrapper and shifts to the current one; watch `findPath`/`findMaxFlow` for reverts