### PR TITLE
feat(pathfinder): V2_EXCLUDED_ROUTING_ADDRESSES routing blocklist

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/Program.cs
@@ -81,7 +81,8 @@ builder.Services.AddSingleton<CapacityGraphPool>(provider =>
     new CapacityGraphPool(
         settings.RouterAddress,
         provider.GetRequiredService<LoadGraph>(),
-        provider.GetRequiredService<ILoggerFactory>().CreateLogger<GraphFactory>()));
+        provider.GetRequiredService<ILoggerFactory>().CreateLogger<GraphFactory>(),
+        settings.ExcludedRoutingAddresses));
 builder.Services.AddSingleton<V2Pathfinder>();
 builder.Services.AddSingleton<HistoricalGraphCache>();
 builder.Services.AddSingleton<FindPathHandler>();

--- a/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/GraphFactoryTests.cs
@@ -2112,4 +2112,110 @@ public class GraphFactoryTests
     }
 
     #endregion
+
+    #region Routing exclusions (deprecated groups / sink wrappers)
+
+    // V2_EXCLUDED_ROUTING_ADDRESSES drops deprecated addresses (groups, their wrappers, and custom
+    // sink-wrapper contracts) from every graph. Models the real case: a live group is trusted by
+    // BOTH a deprecated and a current sink-wrapper org; only the deprecated one must be removed.
+
+    private const string OldSinkWrapper = "0xf1d4000000000000000000000000000000000016";
+    private const string NewSinkWrapper = "0xf1d7000000000000000000000000000000000017";
+
+    [Test]
+    public void ExcludedSinkWrapper_RemovedFromRouting_CurrentWrapperKeepsRouting()
+    {
+        // GroupG (live, regular) is trusted by an old + a new sink wrapper, so both receive the
+        // Group→avatar mint edge. Excluding ONLY the old wrapper must drop its edges while leaving
+        // the current wrapper fully routable — i.e. routing shifts to the current sink wrapper.
+        var mock = new HelperMock();
+        mock.AddGroup(GroupG);
+        mock.AddTrust(OldSinkWrapper, GroupG);
+        mock.AddTrust(NewSinkWrapper, GroupG);
+
+        int gId = AddressIdPool.IdOf(GroupG);
+        int oldW = AddressIdPool.IdOf(OldSinkWrapper);
+        int newW = AddressIdPool.IdOf(NewSinkWrapper);
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+
+        var baseFactory = new GraphFactory(RouterAddr, mock);
+        var cg0 = baseFactory.CreateCapacityGraph(
+            baseFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(baseFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg0.Edges.Any(e => e.From == gId && e.To == oldW && e.Token == gId), Is.True,
+            "Baseline: deprecated sink wrapper receives the group mint.");
+        Assert.That(cg0.Edges.Any(e => e.From == gId && e.To == newW && e.Token == gId), Is.True,
+            "Baseline: current sink wrapper receives the group mint.");
+
+        var exFactory = new GraphFactory(RouterAddr, mock, null, new[] { OldSinkWrapper });
+        var cg1 = exFactory.CreateCapacityGraph(
+            exFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(exFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg1.Edges.Any(e => e.From == oldW || e.To == oldW || e.Token == oldW), Is.False,
+            "No edge may route through the excluded (deprecated) sink wrapper.");
+        Assert.That(cg1.Edges.Any(e => e.From == gId && e.To == newW && e.Token == gId), Is.True,
+            "The current sink wrapper must keep receiving the group mint (no breakage).");
+    }
+
+    [Test]
+    public void ExcludedGroup_CascadesToErc20Wrappers()
+    {
+        // Listing only the GROUP address must also strip routing for its ERC20 wrapper token,
+        // via the WrapperToAvatar cascade — the wrapper need not be listed explicitly.
+        var mock = new HelperMock();
+        mock.AddGroup(GroupG);
+        mock.AddWrapperMapping(WrapperA, GroupG, CirclesType.InflationaryCircles);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(WrapperA), 100_000_000, isWrapped: true);
+
+        int wrapperId = AddressIdPool.IdOf(WrapperA);
+        var request = new FlowRequest { Source = Alice, Sink = Bob, WithWrap = true };
+
+        var baseFactory = new GraphFactory(RouterAddr, mock);
+        var cg0 = baseFactory.CreateCapacityGraph(
+            baseFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(baseFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg0.Edges.Any(e => e.Token == wrapperId), Is.True,
+            "Baseline: the group's wrapped ERC20 held by the source is routable under withWrap.");
+
+        var exFactory = new GraphFactory(RouterAddr, mock, null, new[] { GroupG });
+        var cg1 = exFactory.CreateCapacityGraph(
+            exFactory.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(exFactory.V2TrustGraph()),
+            request);
+        Assert.That(cg1.Edges.Any(e => e.Token == wrapperId), Is.False,
+            "Excluding the group cascades to its ERC20 wrapper: no edge carries the wrapper token.");
+    }
+
+    [Test]
+    public void NoExclusionsConfigured_GraphUnchanged()
+    {
+        // An explicit empty list (overriding any env var) must be a pure no-op.
+        var mock = new HelperMock();
+        mock.AddRegisteredAvatar(Alice);
+        mock.AddRegisteredAvatar(Bob);
+        mock.AddBalance(AddressIdPool.IdOf(Alice), AddressIdPool.IdOf(TokenA), 100_000_000);
+        mock.AddTrust(Bob, TokenA);
+
+        int aliceId = AddressIdPool.IdOf(Alice);
+        var request = new FlowRequest { Source = Alice, Sink = Bob };
+
+        var baseline = new GraphFactory(RouterAddr, mock).CreateCapacityGraph(
+            new GraphFactory(RouterAddr, mock).V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(new GraphFactory(RouterAddr, mock).V2TrustGraph()),
+            request);
+        var withEmpty = new GraphFactory(RouterAddr, mock, null, System.Array.Empty<string>());
+        var cg = withEmpty.CreateCapacityGraph(
+            withEmpty.V2BalanceGraph(),
+            GraphFactory.BuildTrustLookup(withEmpty.V2TrustGraph()),
+            request);
+
+        Assert.That(cg.Edges.Count, Is.EqualTo(baseline.Edges.Count),
+            "Empty exclusion list must not change the edge set.");
+        Assert.That(cg.Edges.Any(e => e.From == aliceId), Is.True);
+    }
+
+    #endregion
 }

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/CapacityGraphPool.cs
@@ -4,11 +4,15 @@ using Microsoft.Extensions.Logging;
 
 namespace Circles.Pathfinder.Graphs;
 
-public sealed class CapacityGraphPool(string routerAddress, ILoadGraph loadGraph, ILogger<GraphFactory>? graphFactoryLogger = null)
+public sealed class CapacityGraphPool(
+    string routerAddress,
+    ILoadGraph loadGraph,
+    ILogger<GraphFactory>? graphFactoryLogger = null,
+    IReadOnlyCollection<string>? excludedRoutingAddresses = null)
 {
     private volatile SnapshotState? _state;
     private volatile CapacityGraphSnapshot? _currentWrapped;
-    private readonly GraphFactory _gf = new(routerAddress, loadGraph, graphFactoryLogger);
+    private readonly GraphFactory _gf = new(routerAddress, loadGraph, graphFactoryLogger, excludedRoutingAddresses);
 
     /// <summary>
     /// Packs snapshot + cachedGroupData into a single reference so readers

--- a/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Graphs/GraphFactory.cs
@@ -7,11 +7,22 @@ using Nethermind.Int256;
 
 namespace Circles.Pathfinder.Graphs;
 
-public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<GraphFactory>? logger = null)
+public class GraphFactory(
+    string routerAddress,
+    ILoadGraph loadGraph,
+    ILogger<GraphFactory>? logger = null,
+    IReadOnlyCollection<string>? excludedRoutingAddresses = null)
 {
     private const string VirtualSinkSuffix = "_virtual_sink";
     private static int _createdCount;
     private readonly ILogger _logger = logger ?? NullLogger<GraphFactory>.Instance;
+
+    // Deprecated addresses (groups, their wrappers, and custom sink-wrapper contracts) to drop
+    // from every graph this factory builds. An explicit constructor argument wins; otherwise it
+    // falls back to the V2_EXCLUDED_ROUTING_ADDRESSES env var so the static snapshot builders
+    // (BuildFullGraph/BuildFullWrappedGraph), which have no Settings, are covered too.
+    private readonly HashSet<string> _excludedRoutingAddresses =
+        NormalizeExcludedRoutingAddresses(excludedRoutingAddresses);
 
     public static Dictionary<int, HashSet<int>> BuildTrustLookup(TrustGraph graph)
     {
@@ -145,6 +156,9 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
         AddGroupMintingEdges(
             capacityGraph, trustLookup,
             sinkId: null, new HashSet<int>(), new HashSet<int>());
+
+        // Drop deprecated/excluded routing addresses from the shared snapshot too.
+        ApplyRoutingExclusions(capacityGraph);
 
         return capacityGraph;
     }
@@ -520,6 +534,10 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
             sinkId,
             toTokensFilter,
             excludedToTokensFilter);
+
+        // Drop deprecated/excluded routing addresses (groups, wrappers, sink contracts) BEFORE the
+        // virtual-sink prune so a virtual sink orphaned by the removal is collapsed correctly.
+        ApplyRoutingExclusions(capacityGraph);
 
         // If a virtual sink was created but received no edges, prune it (mirror legacy behaviour)
         if (virtualSinkAddress != null)
@@ -1281,6 +1299,68 @@ public class GraphFactory(string routerAddress, ILoadGraph loadGraph, ILogger<Gr
                 result.Add(id);
         }
         return result;
+    }
+
+    /// <summary>
+    /// Normalizes the configured routing-exclusion addresses: explicit constructor list when
+    /// provided, else the V2_EXCLUDED_ROUTING_ADDRESSES env var. Trimmed, lowercased, de-duped.
+    /// </summary>
+    private static HashSet<string> NormalizeExcludedRoutingAddresses(IReadOnlyCollection<string>? configured)
+    {
+        IEnumerable<string>? source = configured;
+        if (source == null)
+            source = Environment.GetEnvironmentVariable("V2_EXCLUDED_ROUTING_ADDRESSES")?.Split(',');
+
+        if (source == null)
+            return new HashSet<string>();
+
+        return source
+            .Select(a => a.Trim().ToLowerInvariant())
+            .Where(a => !string.IsNullOrWhiteSpace(a))
+            .ToHashSet();
+    }
+
+    /// <summary>
+    /// Drops configured deprecated addresses (groups, their ERC20 wrappers, and custom
+    /// sink-wrapper contracts) from the graph. A listed group cascades to its indexed wrappers
+    /// via <see cref="CapacityGraph.WrapperToAvatar"/>; non-wrapper contracts (e.g. the
+    /// SinkGroupWrapperInflationary) must be listed explicitly. Runs as a final post-build sweep
+    /// so it catches mint, trust, balance and sink edges regardless of which stage created them.
+    /// No-op when nothing is configured.
+    /// </summary>
+    private void ApplyRoutingExclusions(CapacityGraph g)
+    {
+        if (_excludedRoutingAddresses.Count == 0)
+            return;
+
+        // Resolve to node IDs without allocating new pool entries — an address absent from the
+        // pool cannot match any graph node, so there is nothing to exclude for it.
+        var excludedIds = new HashSet<int>();
+        foreach (var addr in _excludedRoutingAddresses)
+            if (AddressIdPool.TryIdOf(addr, out var id))
+                excludedIds.Add(id);
+
+        if (excludedIds.Count == 0)
+            return;
+
+        // Cascade an excluded group/avatar to its ERC20 wrapper token IDs.
+        ExpandFilterWithWrapperIds(excludedIds, g.WrapperToAvatar, "excludedRoutingAddresses");
+
+        // Stop treating excluded ids as live groups so no later logic re-adds mint edges.
+        int groupsRemoved = g.GroupNodes.RemoveWhere(excludedIds.Contains);
+
+        // Remove every edge whose source, target, or token is excluded.
+        int edgesBefore = g.Edges.Count;
+        g.Edges.RemoveAll(e =>
+            excludedIds.Contains(e.From)
+            || excludedIds.Contains(e.To)
+            || excludedIds.Contains(e.Token));
+        int edgesRemoved = edgesBefore - g.Edges.Count;
+
+        if (edgesRemoved > 0 || groupsRemoved > 0)
+            _logger.LogInformation(
+                "Routing exclusions: dropped {Edges} edge(s) and {Groups} group node(s) for {Addrs} excluded address(es)",
+                edgesRemoved, groupsRemoved, excludedIds.Count);
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder/README.md
+++ b/src/Pathfinder/Circles.Pathfinder/README.md
@@ -211,6 +211,7 @@ The pathfinder can load its trust graph from the **Cache Service** (recommended)
 | `PATHFINDER_SOLVER_TIMEOUT_SECONDS` | `10` | MaxFlow solver timeout per request |
 | `PATHFINDER_DEMURRAGE_SAFETY_MARGIN` | `0.999999` | Demurrage safety margin (~7 min drift coverage; 1.0 = disabled) |
 | `PATHFINDER_EXCLUDE_CONSENTED_INTERMEDIARIES` | `true` | Exclude consented avatars from intermediary positions in paths |
+| `V2_EXCLUDED_ROUTING_ADDRESSES` | (empty) | Comma-separated addresses dropped from routing (deprecated groups + their wrappers + custom sink wrappers). Groups cascade to their ERC20 wrappers; non-wrapper sink contracts must be listed explicitly. Empty = no effect. |
 
 ### Materialized View Refresh
 

--- a/src/Pathfinder/Circles.Pathfinder/Settings.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Settings.cs
@@ -165,4 +165,20 @@ public class Settings
         Circles.Common.EnvParsers.ParseAggregatorMap(
             "SCORE_TREASURY_SUBTREASURIES",
             Environment.GetEnvironmentVariable("SCORE_TREASURY_SUBTREASURIES"));
+
+    /// <summary>
+    /// Addresses to drop from pathfinding entirely — deprecated groups, their wrappers, and
+    /// custom sink-wrapper contracts (e.g. SinkGroupWrapperInflationary) that should no longer
+    /// carry flow. A listed group cascades to its indexed ERC20 wrappers automatically (via the
+    /// wrapper→avatar map); contracts that are NOT standard ERC20WrapperDeployed rows must be
+    /// listed explicitly. "Deprecated" is an owner-driven, off-chain decision the pathfinder
+    /// cannot infer from on-chain state (the contract stays a valid registered group), so it is
+    /// supplied here. Reads V2_EXCLUDED_ROUTING_ADDRESSES (comma-separated, lowercased).
+    /// </summary>
+    public string[] ExcludedRoutingAddresses { get; set; } =
+        Environment.GetEnvironmentVariable("V2_EXCLUDED_ROUTING_ADDRESSES")?.Split(',')
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray()
+        ?? [];
 }


### PR DESCRIPTION
Cherry-pick of #490 (staging) to the production-tracked branch.

Adds an env-gated, default-off blocklist that drops configured addresses
(deprecated groups, their ERC20 wrappers, and custom sink-wrapper contracts)
from every capacity graph the pathfinder builds.

A deprecated ERC20 sink-wrapper contract can remain trusted by an active
group, so the pathfinder keeps routing the active group's token mints through
the deprecated contract. Such deprecation is not observable on-chain (the
contract stays a valid registered avatar), so the addresses to drop are
supplied via configuration.

- Settings: `ExcludedRoutingAddresses` from `V2_EXCLUDED_ROUTING_ADDRESSES`
  (comma-separated, lowercased; empty = no effect)
- GraphFactory: post-build edge sweep removes any edge whose from/to/token is
  excluded; a listed group cascades to its indexed ERC20 wrappers via
  `WrapperToAvatar`; non-wrapper sink contracts must be listed explicitly.
  Explicit constructor arg wins, else falls back to the env var so the
  snapshot/historical builders are covered too.
- CapacityGraphPool/Program: thread the configured list to the factory
- Tests: sink-wrapper redirect, group->wrapper cascade, empty no-op

Default empty list keeps this inert until configured. The configuration
reference doc (docs/configuration.md) is omitted here as it does not yet exist
on this branch; it arrives with the configuration-reference promotion.

## Test plan
- [x] `GraphFactoryTests` 76/76 pass (built in isolation against this branch)