### PR TITLE
fix(canary): classify ExceedsOfferLimit and NotExactlyRequiredAmount as input

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/RevertClassifierTests.cs
@@ -160,6 +160,29 @@ public class RevertClassifierTests
         Assert.That(label, Is.EqualTo("wrapper_unwrap_insufficient_balance"));
     }
 
+    [Test]
+    public void ExceedsOfferLimit_ClassifiedAsInput()
+    {
+        // ERC20TokenOfferCycle.ExceedsOfferLimit(uint256,uint256) — token offer sink rejects when
+        // the routed amount exceeds the offer's remaining limit. Receiver-side app guard; not a
+        // pathfinder bug → category=input (mirrors soft_lock). Real selector seen on staging2.
+        var revert = "execution reverted: 0xd4abbc77" + Word("1") + Word("2");
+        var (category, label) = RevertClassifier.Classify(revert);
+        Assert.That(category, Is.EqualTo("input"));
+        Assert.That(label, Is.EqualTo("exceeds_offer_limit"));
+    }
+
+    [Test]
+    public void NotExactlyRequiredAmount_ClassifiedAsInput()
+    {
+        // NotExactlyRequiredAmount() — sink requires an exact amount but a different amount was
+        // routed. No-arg selector, bare 4 bytes. Receiver-side constraint; not a pathfinder bug
+        // → category=input. Real selector seen on staging2.
+        var (category, label) = RevertClassifier.Classify("execution reverted: 0x9d0210ab");
+        Assert.That(category, Is.EqualTo("input"));
+        Assert.That(label, Is.EqualTo("not_exactly_required_amount"));
+    }
+
     // ── Edge cases ──────────────────────────────────────────────────
 
     [Test]

--- a/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Simulation/RevertClassifier.cs
@@ -48,6 +48,12 @@ public static class RevertClassifier
     // app guard orthogonal to the Circles trust/balance graph: the pathfinder builds a structurally
     // valid flow but the cycle rejects it because the source over-claimed. Not a pathfinder bug.
     private const string SoftLock = "0x66ef7607";
+    // ExceedsOfferLimit(uint256,uint256) — token offer sink rejects when the routed amount exceeds
+    // the offer's remaining limit. Receiver-side app guard; not a pathfinder bug.
+    private const string ExceedsOfferLimit = "0xd4abbc77";
+    // NotExactlyRequiredAmount() — sink requires an exact amount but the path routed a different
+    // amount. Receiver-side constraint; not a pathfinder bug.
+    private const string NotExactlyRequiredAmount = "0x9d0210ab";
 
     // ABI layout after selector: each param is 32 bytes (64 hex chars).
     // CirclesErrorAddressUintArgs: address(32) + uint256(32) + uint8(32) = 96 bytes.
@@ -96,6 +102,12 @@ public static class RevertClassifier
         // pathfinder bug — classify as input so it surfaces named instead of as a generic/unknown revert.
         if (Contains(lower, ERC20InsufficientBalance))
             return ("input", "wrapper_unwrap_insufficient_balance");
+
+        if (Contains(lower, ExceedsOfferLimit))
+            return ("input", "exceeds_offer_limit");
+
+        if (Contains(lower, NotExactlyRequiredAmount))
+            return ("input", "not_exactly_required_amount");
 
         // Generic revert string patterns
         if (lower.Contains("execution reverted"))


### PR DESCRIPTION
## Summary

- `0xd4abbc77` (`ExceedsOfferLimit(uint256,uint256)`): token-offer-cycle sink rejects when payment exceeds the offer's remaining limit — receiver-side app guard, not a pathfinder bug
- `0x9d0210ab` (`NotExactlyRequiredAmount()`): sink requires exact payment amount, different amount was routed — same class as the existing `SoftLock` classification
- Both selectors were landing in `category="unknown"`, which counts toward the `PathfinderCanaryErrorRate` alert numerator (unlike `simulation`/`input` which are excluded). A burst of 4 in a short window was enough to spike over the 5% threshold.

## Test plan

- [x] `./scripts/test.sh pathfinder` — all pass (no new failures)
- [ ] After deploy: verify `circles_canary_simulation_revert_total{category="unknown",label="unrecognized"}` stops accumulating; `circles_canary_simulation_revert_total{category="input",label="exceeds_offer_limit"}` appears on next occurrence