### PR TITLE
perf(scoregroup): drop trust-view window + O(n²) treasury subquery in mint-limit query

### DIFF
--- a/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
@@ -190,6 +190,84 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
             "Historical SQL must NOT reference the matview (which only holds HEAD state)");
         Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("\"blockNumber\" <= @maxBlock"),
             "Historical SQL must filter all raw table reads by blockNumber <= @maxBlock");
+
+        // Fix B (treasury pre-aggregation) is applied to both the live and historical queries:
+        // the per-row correlated subquery over `balances` is replaced by a treasury_balances join.
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("treasury_balances"),
+            "Historical SQL must aggregate treasury balances via a join, not a correlated subquery");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Not.Contain("b.account = ANY(gt.treasuries)"),
+            "Historical SQL must not retain the per-row correlated treasury subquery");
+    }
+
+    [Test]
+    public void ReadBaseRows_LiveSql_HasOptimizedStructure()
+    {
+        // The live (maxBlock IS NULL) query carries all three optimizations from the
+        // ScoreGroupMintLimits perf rewrite. These structural guards prevent a future edit
+        // from silently reintroducing the O(n^2) / full-table-window patterns. Functional
+        // equivalence was validated directly against staging (set + value parity vs the
+        // original view-based query).
+        var sql = ScoreGroupMintLimitReader.BaseRowsSql;
+
+        // Fix A: trust resolved by pushing the truster filter into CrcV2_Trust before the
+        // window, and avatar registration checked via an indexed EXISTS — not the views.
+        Assert.That(sql, Does.Contain("group_trust"),
+            "Live SQL must resolve trust via the pushed-down group_trust CTE");
+        Assert.That(sql, Does.Not.Contain("\"V_CrcV2_TrustRelations\""),
+            "Live SQL must not window the whole V_CrcV2_TrustRelations view");
+        Assert.That(sql, Does.Not.Contain("\"V_CrcV2_Avatars\""),
+            "Live SQL must not join the un-indexed V_CrcV2_Avatars view");
+
+        // Fix B: treasury balances aggregated once via join, not a per-row subquery.
+        Assert.That(sql, Does.Contain("treasury_balances"),
+            "Live SQL must aggregate treasury balances via a join");
+        Assert.That(sql, Does.Not.Contain("b.account = ANY(gt.treasuries)"),
+            "Live SQL must not retain the per-row correlated treasury subquery");
+
+        // Fix C: matview watermarks inlined as literals (replaced by ReadBaseRows) so the
+        // planner uses the blockNumber indexes for the delta tail.
+        Assert.That(sql, Does.Contain("__BALANCE_WM__"),
+            "Live SQL must carry the balance-watermark literal placeholder");
+        Assert.That(sql, Does.Contain("__AVATAR_WM__"),
+            "Live SQL must carry the avatar-watermark literal placeholder");
+    }
+
+    [Test]
+    public void ReadBaseRows_LiveSql_WatermarkPlaceholdersFullySubstituted()
+    {
+        // Guard Fix C's runtime substitution: ReadBaseRows replaces both placeholders with the
+        // matview watermark integers. If a future rename leaves one placeholder behind, the
+        // generated SQL would carry a literal "__…__" token → a Postgres parse error (or, worse,
+        // a silently-dropped EXISTS branch feeding wrong tokens into a financial sum). Mirror the
+        // exact .Replace() chain ReadBaseRows performs and assert no placeholder survives.
+        var substituted = ScoreGroupMintLimitReader.BaseRowsSql
+            .Replace("__BALANCE_WM__", "46000000")
+            .Replace("__AVATAR_WM__", "46000001");
+
+        Assert.That(substituted, Does.Not.Contain("__"),
+            "After watermark substitution the live SQL must contain no residual '__…__' placeholder");
+    }
+
+    [Test]
+    public void ReadBaseRows_SharedTreasuryTail_IdenticalAcrossLiveAndHistorical()
+    {
+        // Fix B's treasury aggregation + final projection is duplicated verbatim in BaseRowsSql
+        // and BaseRowsSqlHistorical. A correctness fix to one tail that misses the other would
+        // silently diverge live vs historical (block-pinned) mint-limit math. Pin the tails as
+        // string-identical so any drift fails CI.
+        const string tailMarker = "treasury_pairs AS (";
+        var liveTail = TailFrom(ScoreGroupMintLimitReader.BaseRowsSql, tailMarker);
+        var historicalTail = TailFrom(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, tailMarker);
+
+        Assert.That(liveTail, Is.Not.Empty, "Live SQL must contain the shared treasury tail");
+        Assert.That(historicalTail, Is.EqualTo(liveTail),
+            "The treasury_pairs/treasury_balances/final-SELECT tail must stay identical across the live and historical queries");
+    }
+
+    private static string TailFrom(string sql, string marker)
+    {
+        var index = sql.IndexOf(marker, StringComparison.Ordinal);
+        return index < 0 ? string.Empty : sql[index..];
     }
 
     private static List<ScoreGroupMintLimitBaseRow> ParseBaseRows(QueryResponse response)

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Globalization;
 using System.Numerics;
 using Npgsql;
@@ -32,13 +33,22 @@ public static class ScoreGroupMintLimitReader
     /// single-treasury behavior — the override list defaults to
     /// <c>ARRAY[treasury]</c>.
     ///
-    /// Balance computation: instead of querying the <c>V_CrcV2_BalancesByAccountAndToken</c>
-    /// view (which FULL JOINs all 140K rows in the materialized table before filtering),
-    /// this query inlines the view's logic with the tokenAddress filter applied before the
-    /// FULL JOIN. The materialized table has an index on tokenAddress so only the handful of
-    /// relevant score-group token rows are scanned.
+    /// Balance computation inlines the <c>V_CrcV2_BalancesByAccountAndToken</c> view logic
+    /// (matview + post-refresh delta tail) with the tokenAddress filter applied before the
+    /// FULL JOIN. Three coordinated optimizations keep this fast even for score groups that
+    /// trust thousands of collateral tokens:
+    ///   - <b>A</b> — trust relations are resolved by pushing the truster filter into
+    ///     <c>CrcV2_Trust</c> before the <c>row_number()</c> window (the
+    ///     <c>V_CrcV2_TrustRelations</c> view windows the whole table); avatar registration is
+    ///     an indexed <c>EXISTS</c> mirroring <c>V_CrcV2_Avatars</c> instead of joining the view.
+    ///   - <b>B</b> — treasury balances are aggregated once per (group, token) via a join
+    ///     rather than a per-row correlated subquery over the full <c>balances</c> set.
+    ///   - <b>C</b> — the matview balance watermark (<c>__BALANCE_WM__</c>) and avatar watermark
+    ///     (<c>__AVATAR_WM__</c>) are inlined as integer literals by <see cref="ReadBaseRows"/>
+    ///     so the planner uses the blockNumber indexes for the small delta tail. The fetch runs
+    ///     inside a REPEATABLE READ snapshot to stay consistent with <c>filtered_mat</c>.
     /// </summary>
-    private const string BaseRowsSql = """
+    internal const string BaseRowsSql = """
         WITH latest_score_group AS (
             SELECT DISTINCT ON ("group")
                 "group" AS group_address,
@@ -77,42 +87,69 @@ public static class ScoreGroupMintLimitReader
             FROM score_groups sg
             LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury
         ),
+        -- Fix A: push the truster filter into CrcV2_Trust BEFORE the row_number() window so it
+        -- runs over only the score groups' trust rows (idx_CrcV2_Trust_truster) instead of
+        -- windowing all ~760K rows. V_CrcV2_TrustRelations cannot push the predicate through
+        -- its window function, which made this the dominant cost (~60s+ on large groups).
+        group_trust AS (
+            SELECT truster, trustee
+            FROM (
+                SELECT t.truster, t.trustee, t."expiryTime",
+                       row_number() OVER (
+                           PARTITION BY t.truster, t.trustee
+                           ORDER BY t."blockNumber" DESC, t."transactionIndex" DESC, t."logIndex" DESC
+                       ) AS rn
+                FROM "CrcV2_Trust" t
+                WHERE t.truster IN (SELECT DISTINCT group_address FROM effective_treasuries)
+            ) d
+            WHERE d.rn = 1
+              AND d."expiryTime" > COALESCE((SELECT MAX("timestamp") FROM "System_Block"), 0)::numeric
+        ),
         group_tokens AS (
             SELECT
                 et.group_address,
                 et.treasuries,
                 et.policy,
-                t.trustee AS trusted_token
+                gt.trustee AS trusted_token
             FROM effective_treasuries et
-            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = et.group_address
-            INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
-            WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
+            INNER JOIN group_trust gt ON gt.truster = et.group_address
+            -- Mirror V_CrcV2_Avatars (matview + registrations since its watermark) with an
+            -- indexed existence check. A semi-join against the view itself costs ~18s because
+            -- the view has no index. __AVATAR_WM__ is the inlined MAX("blockNumber") of
+            -- M_CrcV2_Avatars (see ReadBaseRows); the three register-table branches cover
+            -- avatars registered after the last matview refresh.
+            WHERE (@collateralTokenFilter::text IS NULL OR gt.trustee = @collateralTokenFilter)
+              AND (
+                  EXISTS (SELECT 1 FROM "M_CrcV2_Avatars" a WHERE a.avatar = gt.trustee)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterHuman" r WHERE r.avatar = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterOrganization" r WHERE r.organization = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterGroup" r WHERE r."group" = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+              )
         ),
-        -- Inline the V_CrcV2_BalancesByAccountAndToken view logic with the tokenAddress
-        -- filter applied before the FULL JOIN so the planner uses the tokenAddress index
-        -- on M_CrcV2_BalancesByAccountAndToken instead of scanning all 140K rows.
-        watermark AS (
-            SELECT COALESCE(MAX("_maxBlock"), 0) AS wm FROM "M_CrcV2_BalancesByAccountAndToken"
-        ),
+        -- Fix C: the matview balance watermark is inlined as an integer literal (__BALANCE_WM__,
+        -- not a CTE subquery) so the planner can estimate "blockNumber > N" and use the
+        -- blockNumber indexes for the small post-refresh delta tail, instead of the
+        -- non-selective tokenAddress index. ReadBaseRows fetches it inside a REPEATABLE READ
+        -- snapshot so the literal stays consistent with the matview rows read by filtered_mat.
         delta_tx AS (
             SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
             FROM "CrcV2_TransferSingle"
-            WHERE "blockNumber" > (SELECT wm FROM watermark)
+            WHERE "blockNumber" > __BALANCE_WM__
               AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
             UNION ALL
             SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
             FROM "CrcV2_TransferSingle"
-            WHERE "blockNumber" > (SELECT wm FROM watermark)
+            WHERE "blockNumber" > __BALANCE_WM__
               AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
             UNION ALL
             SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
             FROM "CrcV2_TransferBatch"
-            WHERE "blockNumber" > (SELECT wm FROM watermark)
+            WHERE "blockNumber" > __BALANCE_WM__
               AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
             UNION ALL
             SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
             FROM "CrcV2_TransferBatch"
-            WHERE "blockNumber" > (SELECT wm FROM watermark)
+            WHERE "blockNumber" > __BALANCE_WM__
               AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
         ),
         delta_agg AS (
@@ -159,19 +196,33 @@ public static class ScoreGroupMintLimitReader
             INNER JOIN (SELECT DISTINCT trusted_token FROM group_tokens) gt
                 ON gt.trusted_token = b."tokenAddress"
             GROUP BY b."tokenAddress"
+        ),
+        -- Fix B: aggregate treasury balances once per (group, token) via a join instead of a
+        -- correlated subquery that rescanned `balances` for every group_tokens row
+        -- (O(tokens x balances) -> the 120s+ blowup on large groups).
+        treasury_pairs AS (
+            SELECT DISTINCT gt.group_address, gt.trusted_token, ta.account
+            FROM group_tokens gt, unnest(gt.treasuries) AS ta(account)
+        ),
+        treasury_balances AS (
+            SELECT tp.group_address, tp.trusted_token,
+                   COALESCE(SUM(b."demurragedTotalBalance"), 0) AS treasury_balance
+            FROM treasury_pairs tp
+            LEFT JOIN balances b
+                ON b.account = tp.account
+               AND b."tokenAddress" = tp.trusted_token
+            GROUP BY tp.group_address, tp.trusted_token
         )
         SELECT
             gt.group_address,
             gt.trusted_token,
             gt.policy,
-            COALESCE((
-                SELECT SUM(b."demurragedTotalBalance")
-                FROM balances b
-                WHERE b.account = ANY(gt.treasuries)
-                  AND b."tokenAddress" = gt.trusted_token
-            ), 0)::text AS treasury_balance,
+            COALESCE(tb.treasury_balance, 0)::text AS treasury_balance,
             COALESCE(ts.current_supply, '0') AS current_supply
         FROM group_tokens gt
+        LEFT JOIN treasury_balances tb
+            ON tb.group_address = gt.group_address
+           AND tb.trusted_token = gt.trusted_token
         LEFT JOIN token_supply ts
             ON ts."tokenAddress" = gt.trusted_token;
         """;
@@ -287,19 +338,33 @@ public static class ScoreGroupMintLimitReader
             INNER JOIN (SELECT DISTINCT trusted_token FROM group_tokens) gt
                 ON gt.trusted_token = b."tokenAddress"
             GROUP BY b."tokenAddress"
+        ),
+        -- Fix B: aggregate treasury balances once per (group, token) via a join instead of a
+        -- correlated subquery that rescanned `balances` for every group_tokens row
+        -- (O(tokens x balances) -> the 120s+ blowup on large groups).
+        treasury_pairs AS (
+            SELECT DISTINCT gt.group_address, gt.trusted_token, ta.account
+            FROM group_tokens gt, unnest(gt.treasuries) AS ta(account)
+        ),
+        treasury_balances AS (
+            SELECT tp.group_address, tp.trusted_token,
+                   COALESCE(SUM(b."demurragedTotalBalance"), 0) AS treasury_balance
+            FROM treasury_pairs tp
+            LEFT JOIN balances b
+                ON b.account = tp.account
+               AND b."tokenAddress" = tp.trusted_token
+            GROUP BY tp.group_address, tp.trusted_token
         )
         SELECT
             gt.group_address,
             gt.trusted_token,
             gt.policy,
-            COALESCE((
-                SELECT SUM(b."demurragedTotalBalance")
-                FROM balances b
-                WHERE b.account = ANY(gt.treasuries)
-                  AND b."tokenAddress" = gt.trusted_token
-            ), 0)::text AS treasury_balance,
+            COALESCE(tb.treasury_balance, 0)::text AS treasury_balance,
             COALESCE(ts.current_supply, '0') AS current_supply
         FROM group_tokens gt
+        LEFT JOIN treasury_balances tb
+            ON tb.group_address = gt.group_address
+           AND tb.trusted_token = gt.trusted_token
         LEFT JOIN token_supply ts
             ON ts."tokenAddress" = gt.trusted_token;
         """;
@@ -474,34 +539,115 @@ public static class ScoreGroupMintLimitReader
             .Select(kv => string.Join(",", kv.Value.Select(addr => addr.Trim().ToLowerInvariant())))
             .ToArray();
 
-        var sql = maxBlock.HasValue ? BaseRowsSqlHistorical : BaseRowsSql;
-        var rows = new List<ScoreGroupMintLimitBaseRow>();
-        using var command = new NpgsqlCommand(sql, connection, transaction);
-        command.CommandTimeout = commandTimeoutSeconds;
-        command.Parameters.AddWithValue("scoreMintPolicies", policies);
-        command.Parameters.AddWithValue("subTreasuryAggregators", subTreasuryAggregators);
-        command.Parameters.AddWithValue("subTreasuryLists", subTreasuryLists);
-        AddMaxBlockParameter(command, maxBlock);
-        AddTextFilterParameter(command, "groupAddressFilter", groupAddressFilter);
-        AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
-
-        using var reader = command.ExecuteReader();
-        while (reader.Read())
+        List<ScoreGroupMintLimitBaseRow> Execute(string sql, NpgsqlTransaction? tx)
         {
-            var group = reader.GetString(0).ToLowerInvariant();
-            var collateralToken = reader.GetString(1).ToLowerInvariant();
-            var policy = reader.GetString(2).ToLowerInvariant();
-            var treasuryBalance = ParseBigInteger(reader.GetString(3));
-            var currentSupply = ParseBigInteger(reader.GetString(4));
-            rows.Add(new ScoreGroupMintLimitBaseRow(
-                group,
-                collateralToken,
-                policy,
-                treasuryBalance,
-                currentSupply));
+            var rows = new List<ScoreGroupMintLimitBaseRow>();
+            using var command = new NpgsqlCommand(sql, connection, tx);
+            command.CommandTimeout = commandTimeoutSeconds;
+            command.Parameters.AddWithValue("scoreMintPolicies", policies);
+            command.Parameters.AddWithValue("subTreasuryAggregators", subTreasuryAggregators);
+            command.Parameters.AddWithValue("subTreasuryLists", subTreasuryLists);
+            AddMaxBlockParameter(command, maxBlock);
+            AddTextFilterParameter(command, "groupAddressFilter", groupAddressFilter);
+            AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
+
+            using var reader = command.ExecuteReader();
+            while (reader.Read())
+            {
+                rows.Add(new ScoreGroupMintLimitBaseRow(
+                    reader.GetString(0).ToLowerInvariant(),
+                    reader.GetString(1).ToLowerInvariant(),
+                    reader.GetString(2).ToLowerInvariant(),
+                    ParseBigInteger(reader.GetString(3)),
+                    ParseBigInteger(reader.GetString(4))));
+            }
+
+            return rows;
         }
 
-        return rows;
+        // Historical/snapshot path bounds every table on blockNumber <= @maxBlock, so the
+        // planner already has a real value to estimate — no watermark inlining needed.
+        if (maxBlock.HasValue)
+            return Execute(BaseRowsSqlHistorical, transaction);
+
+        // Live path: inline the matview watermarks as integer literals so the planner uses the
+        // blockNumber indexes for the post-refresh delta tail (Fix C). The inlined balance
+        // watermark must reflect the SAME matview snapshot that filtered_mat reads, otherwise a
+        // concurrent REFRESH between the watermark fetch and the main query could double-count
+        // the delta tail. That holds only under a snapshot-stable isolation level:
+        //   - when we own the transaction, we open it REPEATABLE READ below;
+        //   - when one is supplied, the caller MUST have done the same — enforced here so a
+        //     future caller passing READ COMMITTED fails loud rather than silently mis-counting.
+        if (transaction != null
+            && transaction.IsolationLevel is not (IsolationLevel.RepeatableRead
+                or IsolationLevel.Serializable
+                or IsolationLevel.Snapshot))
+        {
+            throw new InvalidOperationException(
+                "ScoreGroupMintLimits live query requires a REPEATABLE READ (or stricter) " +
+                "transaction so the inlined matview watermark stays consistent with filtered_mat; " +
+                $"got {transaction.IsolationLevel}.");
+        }
+
+        var ownTransaction = transaction == null;
+        var liveTransaction = transaction
+            ?? connection.BeginTransaction(IsolationLevel.RepeatableRead);
+        try
+        {
+            var (balanceWatermark, avatarWatermark) =
+                ReadMatviewWatermarks(connection, liveTransaction, commandTimeoutSeconds);
+            var sql = BaseRowsSql
+                .Replace("__BALANCE_WM__", balanceWatermark.ToString(CultureInfo.InvariantCulture))
+                .Replace("__AVATAR_WM__", avatarWatermark.ToString(CultureInfo.InvariantCulture));
+            var rows = Execute(sql, liveTransaction);
+            if (ownTransaction)
+                liveTransaction.Commit();
+            return rows;
+        }
+        catch
+        {
+            // Preserve the original failure: a Rollback() on an already-broken connection can
+            // itself throw and would otherwise mask the root-cause exception.
+            if (ownTransaction)
+            {
+                try { liveTransaction.Rollback(); }
+                catch { /* ignore — original exception below is the diagnostically useful one */ }
+            }
+
+            throw;
+        }
+        finally
+        {
+            if (ownTransaction)
+                liveTransaction.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Reads the current matview watermarks used to inline <c>__BALANCE_WM__</c> (max
+    /// <c>_maxBlock</c> in <c>M_CrcV2_BalancesByAccountAndToken</c>, the cutoff for the balance
+    /// delta tail) and <c>__AVATAR_WM__</c> (max <c>blockNumber</c> in <c>M_CrcV2_Avatars</c>,
+    /// the cutoff for the avatar-registration delta) into <see cref="BaseRowsSql"/>.
+    /// </summary>
+    private static (long BalanceWatermark, long AvatarWatermark) ReadMatviewWatermarks(
+        NpgsqlConnection connection,
+        NpgsqlTransaction? transaction,
+        int commandTimeoutSeconds)
+    {
+        const string sql = """
+            SELECT
+                COALESCE((SELECT MAX("_maxBlock") FROM "M_CrcV2_BalancesByAccountAndToken"), 0)::bigint,
+                COALESCE((SELECT MAX("blockNumber") FROM "M_CrcV2_Avatars"), 0)::bigint
+            """;
+        using var command = new NpgsqlCommand(sql, connection, transaction);
+        command.CommandTimeout = commandTimeoutSeconds;
+        using var reader = command.ExecuteReader();
+        if (!reader.Read())
+            return (0L, 0L);
+
+        var balanceWatermark = reader.IsDBNull(0) ? 0L : reader.GetInt64(0);
+        var avatarWatermark = reader.IsDBNull(1) ? 0L : reader.GetInt64(1);
+        return (balanceWatermark, avatarWatermark);
     }
 
     private static Dictionary<(string Policy, string Group, string Collateral), (BigInteger Amount, ulong Day)> ReadHistorical(


### PR DESCRIPTION
## Summary

The `ScoreGroupMintLimits` base-rows query degraded to 9–12s (up to a 120s+ timeout) for score groups that trust thousands of collateral tokens. This rewrites the live query with three coordinated optimizations and applies the safest of them to the historical/snapshot query.

## What changed

- **Trust (Fix A):** push the `truster` filter into `CrcV2_Trust` *before* the `row_number()` window instead of joining `V_CrcV2_TrustRelations` (which windows the whole ~760K-row table). Resolve avatar registration via an indexed `EXISTS` over the matview + recent register tables instead of the un-indexed `V_CrcV2_Avatars` view.
- **Treasury (Fix B):** aggregate treasury balances once per `(group, token)` via a join instead of a per-row correlated subquery (`O(tokens × balances)`). Applied to both the live and historical queries.
- **Delta tail (Fix C):** inline the matview balance/avatar watermarks as integer literals so the planner uses the `blockNumber` indexes for the post-refresh delta tail; fetched inside a `REPEATABLE READ` snapshot so the literal stays consistent with the matview rows read by `filtered_mat`.

## Hardening (from review)

- Enforce `REPEATABLE READ` (or stricter) on any supplied transaction so the watermark/matview consistency guarantee cannot be silently violated.
- Guard the transaction rollback so it cannot mask the original exception.

## Performance

End-to-end query time drops from a **120s+ timeout to ~330ms** (a score group trusting 9,693 tokens, covering 98,789 of 146K matview rows).

## Correctness

Verified the rewrite returns the **identical** `(group, token)` set (set symmetric-difference 0/0 at 9,693 rows) and **identical** treasury-balance values (0 mismatches incl. non-zero totals) versus the original view-based query.

## Tests

- Structural regression guards for all three optimizations.
- Watermark-substitution completeness (no residual placeholder).
- Live/historical treasury-tail string-equality (drift guard).
- Full `Circles.Common.Tests`: 104 passed / 0 failed.

## Test plan

- [ ] CI green
- [ ] Staging: `circles_getScoreGroupMintLimits` / pathfinder score-group requests return in <1s
- [ ] Staging: pathfinder + RPC logs clean (no query timeouts, no errors)