### PR TITLE
perf(scoregroup): materialize group_tokens into temp table for live mint-limit query

### DIFF
--- a/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
@@ -179,7 +179,7 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
     public void ReadBaseRows_HistoricalSql_HasCorrectStructure()
     {
         // Verify BaseRowsSqlHistorical bypasses the matview and uses raw tables + block timestamp.
-        // The C# dispatch (maxBlock.HasValue ? BaseRowsSqlHistorical : BaseRowsSql) is not
+        // The C# dispatch (maxBlock.HasValue ? BaseRowsSqlHistorical : live builder+tail) is not
         // exercisable without a direct DB connection; this test validates the SQL constant used
         // by that dispatch path has the expected shape.
         Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("block_ts"),
@@ -202,72 +202,115 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
     [Test]
     public void ReadBaseRows_LiveSql_HasOptimizedStructure()
     {
-        // The live (maxBlock IS NULL) query carries all three optimizations from the
-        // ScoreGroupMintLimits perf rewrite. These structural guards prevent a future edit
-        // from silently reintroducing the O(n^2) / full-table-window patterns. Functional
+        // The live (maxBlock IS NULL) query carries all optimizations from the
+        // ScoreGroupMintLimits perf rewrite, split across the group_tokens builder and the
+        // balance tail. These structural guards prevent a future edit from silently
+        // reintroducing the O(n^2) / full-table-window / inline-CTE patterns. Functional
         // equivalence was validated directly against staging (set + value parity vs the
         // original view-based query).
-        var sql = ScoreGroupMintLimitReader.BaseRowsSql;
+        var builder = ScoreGroupMintLimitReader.LiveGroupTokensSql;
+        var tail = ScoreGroupMintLimitReader.LiveBalancesTailSql;
 
         // Fix A: trust resolved by pushing the truster filter into CrcV2_Trust before the
         // window, and avatar registration checked via an indexed EXISTS — not the views.
-        Assert.That(sql, Does.Contain("group_trust"),
-            "Live SQL must resolve trust via the pushed-down group_trust CTE");
-        Assert.That(sql, Does.Not.Contain("\"V_CrcV2_TrustRelations\""),
-            "Live SQL must not window the whole V_CrcV2_TrustRelations view");
-        Assert.That(sql, Does.Not.Contain("\"V_CrcV2_Avatars\""),
-            "Live SQL must not join the un-indexed V_CrcV2_Avatars view");
+        Assert.That(builder, Does.Contain("group_trust"),
+            "Live builder must resolve trust via the pushed-down group_trust CTE");
+        Assert.That(builder, Does.Not.Contain("\"V_CrcV2_TrustRelations\""),
+            "Live builder must not window the whole V_CrcV2_TrustRelations view");
+        Assert.That(builder, Does.Not.Contain("\"V_CrcV2_Avatars\""),
+            "Live builder must not join the un-indexed V_CrcV2_Avatars view");
 
         // Fix B: treasury balances aggregated once via join, not a per-row subquery.
-        Assert.That(sql, Does.Contain("treasury_balances"),
-            "Live SQL must aggregate treasury balances via a join");
-        Assert.That(sql, Does.Not.Contain("b.account = ANY(gt.treasuries)"),
-            "Live SQL must not retain the per-row correlated treasury subquery");
+        Assert.That(tail, Does.Contain("treasury_balances"),
+            "Live tail must aggregate treasury balances via a join");
+        Assert.That(tail, Does.Not.Contain("b.account = ANY(gt.treasuries)"),
+            "Live tail must not retain the per-row correlated treasury subquery");
 
-        // Fix C: matview watermarks inlined as literals (replaced by ReadBaseRows) so the
-        // planner uses the blockNumber indexes for the delta tail.
-        Assert.That(sql, Does.Contain("__BALANCE_WM__"),
-            "Live SQL must carry the balance-watermark literal placeholder");
-        Assert.That(sql, Does.Contain("__AVATAR_WM__"),
-            "Live SQL must carry the avatar-watermark literal placeholder");
+        // Fix C: matview watermarks inlined as literals (replaced by ReadBaseRows). The avatar
+        // watermark gates the builder's registration EXISTS; the balance watermark bounds the
+        // tail's delta tail.
+        Assert.That(builder, Does.Contain("__AVATAR_WM__"),
+            "Live builder must carry the avatar-watermark literal placeholder");
+        Assert.That(tail, Does.Contain("__BALANCE_WM__"),
+            "Live tail must carry the balance-watermark literal placeholder");
+
+        // Fix D: the tail must read the ANALYZEd temp table (real cardinalities → hash joins),
+        // NOT an inline group_tokens CTE (estimated 1 row → nested-loop blowup, ~8.5s).
+        Assert.That(tail, Does.Contain(ScoreGroupMintLimitReader.LiveGroupTokensTempTable),
+            "Live tail must read the materialized group_tokens temp table");
+        Assert.That(tail, Does.Not.Contain("group_tokens AS ("),
+            "Live tail must not reintroduce an inline group_tokens CTE (defeats the temp-table plan)");
+        Assert.That(builder.TrimEnd(), Does.EndWith(";"),
+            "Live builder must be a single self-contained statement for CREATE TEMP TABLE AS");
     }
 
     [Test]
     public void ReadBaseRows_LiveSql_WatermarkPlaceholdersFullySubstituted()
     {
-        // Guard Fix C's runtime substitution: ReadBaseRows replaces both placeholders with the
-        // matview watermark integers. If a future rename leaves one placeholder behind, the
+        // Guard Fix C's runtime substitution: ReadBaseRows replaces __AVATAR_WM__ in the builder
+        // and __BALANCE_WM__ in the tail. If a future rename leaves one placeholder behind, the
         // generated SQL would carry a literal "__…__" token → a Postgres parse error (or, worse,
         // a silently-dropped EXISTS branch feeding wrong tokens into a financial sum). Mirror the
-        // exact .Replace() chain ReadBaseRows performs and assert no placeholder survives.
-        var substituted = ScoreGroupMintLimitReader.BaseRowsSql
-            .Replace("__BALANCE_WM__", "46000000")
-            .Replace("__AVATAR_WM__", "46000001");
+        // exact .Replace() calls ReadBaseRows performs and assert no placeholder survives.
+        var builder = ScoreGroupMintLimitReader.LiveGroupTokensSql.Replace("__AVATAR_WM__", "46000001");
+        var tail = ScoreGroupMintLimitReader.LiveBalancesTailSql.Replace("__BALANCE_WM__", "46000000");
 
-        Assert.That(substituted, Does.Not.Contain("__"),
-            "After watermark substitution the live SQL must contain no residual '__…__' placeholder");
+        Assert.That(builder, Does.Not.Contain("__"),
+            "After avatar-watermark substitution the live builder must contain no residual '__…__' placeholder");
+        Assert.That(tail, Does.Not.Contain("__"),
+            "After balance-watermark substitution the live tail must contain no residual '__…__' placeholder");
     }
 
     [Test]
     public void ReadBaseRows_SharedTreasuryTail_IdenticalAcrossLiveAndHistorical()
     {
-        // Fix B's treasury aggregation + final projection is duplicated verbatim in BaseRowsSql
-        // and BaseRowsSqlHistorical. A correctness fix to one tail that misses the other would
-        // silently diverge live vs historical (block-pinned) mint-limit math. Pin the tails as
-        // string-identical so any drift fails CI.
+        // Fix B's treasury aggregation + final projection is duplicated in the live tail and
+        // BaseRowsSqlHistorical. A correctness fix to one that misses the other would silently
+        // diverge live vs historical (block-pinned) mint-limit math. The only intended difference
+        // is the source relation (live reads the temp table, historical the inline group_tokens
+        // CTE), so normalize that away and pin the rest string-identical.
         const string tailMarker = "treasury_pairs AS (";
-        var liveTail = TailFrom(ScoreGroupMintLimitReader.BaseRowsSql, tailMarker);
+        var liveTail = TailFrom(ScoreGroupMintLimitReader.LiveBalancesTailSql, tailMarker)
+            .Replace(ScoreGroupMintLimitReader.LiveGroupTokensTempTable, "group_tokens");
         var historicalTail = TailFrom(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, tailMarker);
 
-        Assert.That(liveTail, Is.Not.Empty, "Live SQL must contain the shared treasury tail");
+        Assert.That(liveTail, Is.Not.Empty, "Live tail must contain the shared treasury tail");
         Assert.That(historicalTail, Is.EqualTo(liveTail),
-            "The treasury_pairs/treasury_balances/final-SELECT tail must stay identical across the live and historical queries");
+            "The treasury_pairs/treasury_balances/final-SELECT tail must stay identical (modulo source relation) across the live and historical queries");
+    }
+
+    [Test]
+    public void ReadBaseRows_SharedHeadCte_IdenticalAcrossLiveAndHistorical()
+    {
+        // The score-group resolution head (latest_score_group → score_groups → treasury_overrides
+        // → effective_treasuries) is duplicated verbatim in the live builder and the historical
+        // query; the two paths only diverge AFTER it (live: group_trust pushdown; historical:
+        // V_CrcV2_TrustRelations join). A correctness fix to score-group selection or treasury-
+        // override expansion applied to one and missed in the other would silently diverge live vs
+        // historical (block-pinned) mint-limit math on the money path. Pin the head identical.
+        const string headStart = "WITH latest_score_group AS (";
+        const string headEnd = "LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury";
+        var liveHead = Slice(ScoreGroupMintLimitReader.LiveGroupTokensSql, headStart, headEnd);
+        var historicalHead = Slice(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, headStart, headEnd);
+
+        Assert.That(liveHead, Is.Not.Empty, "Live builder must contain the shared head CTE block");
+        Assert.That(historicalHead, Is.EqualTo(liveHead),
+            "The latest_score_group/score_groups/treasury_overrides/effective_treasuries head must stay identical across the live builder and the historical query");
     }
 
     private static string TailFrom(string sql, string marker)
     {
         var index = sql.IndexOf(marker, StringComparison.Ordinal);
         return index < 0 ? string.Empty : sql[index..];
+    }
+
+    // Substring from startMarker through the end of endMarker (inclusive); empty if either absent.
+    private static string Slice(string sql, string startMarker, string endMarker)
+    {
+        var start = sql.IndexOf(startMarker, StringComparison.Ordinal);
+        if (start < 0) return string.Empty;
+        var end = sql.IndexOf(endMarker, start, StringComparison.Ordinal);
+        return end < 0 ? string.Empty : sql[start..(end + endMarker.Length)];
     }
 
     private static List<ScoreGroupMintLimitBaseRow> ParseBaseRows(QueryResponse response)

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -22,21 +22,24 @@ public static class ScoreGroupMintLimitReader
 {
     private const uint InflationDayZeroUnix = 1_602_720_000;
 
+    /// <summary>Session-local temp table holding the materialized group_tokens set on the live
+    /// path. Built + ANALYZEd by <see cref="ReadBaseRows"/> from <see cref="LiveGroupTokensSql"/>,
+    /// consumed by <see cref="LiveBalancesTailSql"/>. See Fix D on <see cref="LiveGroupTokensSql"/>.</summary>
+    internal const string LiveGroupTokensTempTable = "_sg_mint_group_tokens";
+
     /// <summary>
-    /// Base-rows SQL. Each score group's "treasury" (as recorded in
-    /// <c>CrcV2_RegisterGroup.treasury</c>) is expanded into one or more
-    /// effective treasury addresses via the <c>treasury_overrides</c> CTE.
-    /// When the on-chain treasury is a <c>ScoreTreasury</c> router/splitter
-    /// (does not custody collateral itself but forwards to score-keyed
-    /// sub-treasuries), the override list contains the sub-treasuries that
-    /// actually hold tokens. Groups not in the override map fall back to
-    /// single-treasury behavior — the override list defaults to
-    /// <c>ARRAY[treasury]</c>.
+    /// Live path, statement 1 — the base-rows builder. Each score group's "treasury" (as recorded
+    /// in <c>CrcV2_RegisterGroup.treasury</c>) is expanded into one or more effective treasury
+    /// addresses via the <c>treasury_overrides</c> CTE. When the on-chain treasury is a
+    /// <c>ScoreTreasury</c> router/splitter (does not custody collateral itself but forwards to
+    /// score-keyed sub-treasuries), the override list contains the sub-treasuries that actually
+    /// hold tokens. Groups not in the override map fall back to single-treasury behavior — the
+    /// override list defaults to <c>ARRAY[treasury]</c>.
     ///
-    /// Balance computation inlines the <c>V_CrcV2_BalancesByAccountAndToken</c> view logic
-    /// (matview + post-refresh delta tail) with the tokenAddress filter applied before the
-    /// FULL JOIN. Three coordinated optimizations keep this fast even for score groups that
-    /// trust thousands of collateral tokens:
+    /// Balance computation (in <see cref="LiveBalancesTailSql"/>) inlines the
+    /// <c>V_CrcV2_BalancesByAccountAndToken</c> view logic (matview + post-refresh delta tail)
+    /// with the tokenAddress filter applied before the FULL JOIN. Four coordinated optimizations
+    /// keep this fast even for score groups that trust thousands of collateral tokens:
     ///   - <b>A</b> — trust relations are resolved by pushing the truster filter into
     ///     <c>CrcV2_Trust</c> before the <c>row_number()</c> window (the
     ///     <c>V_CrcV2_TrustRelations</c> view windows the whole table); avatar registration is
@@ -47,8 +50,15 @@ public static class ScoreGroupMintLimitReader
     ///     (<c>__AVATAR_WM__</c>) are inlined as integer literals by <see cref="ReadBaseRows"/>
     ///     so the planner uses the blockNumber indexes for the small delta tail. The fetch runs
     ///     inside a REPEATABLE READ snapshot to stay consistent with <c>filtered_mat</c>.
+    ///   - <b>D</b> — <c>group_tokens</c> (this builder's output) is materialized into the
+    ///     <see cref="LiveGroupTokensTempTable"/> temp table and ANALYZEd before the balance tail
+    ///     runs, so the planner has real cardinalities and picks hash joins for the treasury/supply
+    ///     aggregations. As an inline CTE it estimated 1 row and collapsed those joins into a
+    ///     ~47M-row nested loop (~8.5s on a group trusting ~10k tokens).
+    /// The live query is therefore split into two statements: this builder and
+    /// <see cref="LiveBalancesTailSql"/> (which reads the temp table).
     /// </summary>
-    internal const string BaseRowsSql = """
+    internal const string LiveGroupTokensSql = """
         WITH latest_score_group AS (
             SELECT DISTINCT ON ("group")
                 "group" AS group_address,
@@ -104,53 +114,62 @@ public static class ScoreGroupMintLimitReader
             ) d
             WHERE d.rn = 1
               AND d."expiryTime" > COALESCE((SELECT MAX("timestamp") FROM "System_Block"), 0)::numeric
-        ),
-        group_tokens AS (
-            SELECT
-                et.group_address,
-                et.treasuries,
-                et.policy,
-                gt.trustee AS trusted_token
-            FROM effective_treasuries et
-            INNER JOIN group_trust gt ON gt.truster = et.group_address
-            -- Mirror V_CrcV2_Avatars (matview + registrations since its watermark) with an
-            -- indexed existence check. A semi-join against the view itself costs ~18s because
-            -- the view has no index. __AVATAR_WM__ is the inlined MAX("blockNumber") of
-            -- M_CrcV2_Avatars (see ReadBaseRows); the three register-table branches cover
-            -- avatars registered after the last matview refresh.
-            WHERE (@collateralTokenFilter::text IS NULL OR gt.trustee = @collateralTokenFilter)
-              AND (
-                  EXISTS (SELECT 1 FROM "M_CrcV2_Avatars" a WHERE a.avatar = gt.trustee)
-                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterHuman" r WHERE r.avatar = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
-                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterOrganization" r WHERE r.organization = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
-                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterGroup" r WHERE r."group" = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
-              )
-        ),
-        -- Fix C: the matview balance watermark is inlined as an integer literal (__BALANCE_WM__,
-        -- not a CTE subquery) so the planner can estimate "blockNumber > N" and use the
-        -- blockNumber indexes for the small post-refresh delta tail, instead of the
-        -- non-selective tokenAddress index. ReadBaseRows fetches it inside a REPEATABLE READ
-        -- snapshot so the literal stays consistent with the matview rows read by filtered_mat.
-        delta_tx AS (
+        )
+        -- group_tokens final projection — materialized into the temp table by ReadBaseRows.
+        -- Mirror V_CrcV2_Avatars (matview + registrations since its watermark) with an indexed
+        -- existence check. A semi-join against the view itself costs ~18s because the view has
+        -- no index. __AVATAR_WM__ is the inlined MAX("blockNumber") of M_CrcV2_Avatars (see
+        -- ReadBaseRows); the three register-table branches cover avatars registered after the
+        -- last matview refresh.
+        SELECT
+            et.group_address,
+            et.treasuries,
+            et.policy,
+            gt.trustee AS trusted_token
+        FROM effective_treasuries et
+        INNER JOIN group_trust gt ON gt.truster = et.group_address
+        WHERE (@collateralTokenFilter::text IS NULL OR gt.trustee = @collateralTokenFilter)
+          AND (
+              EXISTS (SELECT 1 FROM "M_CrcV2_Avatars" a WHERE a.avatar = gt.trustee)
+              OR EXISTS (SELECT 1 FROM "CrcV2_RegisterHuman" r WHERE r.avatar = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+              OR EXISTS (SELECT 1 FROM "CrcV2_RegisterOrganization" r WHERE r.organization = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+              OR EXISTS (SELECT 1 FROM "CrcV2_RegisterGroup" r WHERE r."group" = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+          );
+        """;
+
+    /// <summary>
+    /// Live path, statement 2: consumes the group_tokens temp table
+    /// (<see cref="LiveGroupTokensTempTable"/>) and computes per-(group, collateral) treasury
+    /// balance + current supply. Reads <c>M_CrcV2_BalancesByAccountAndToken</c> (matview) PLUS
+    /// the post-watermark delta tail and merges them, so the result reflects HEAD state even
+    /// though the matview lags. The temp table carries real ANALYZEd statistics, so the planner
+    /// picks hash joins for the treasury/supply aggregations instead of the nested-loop plan an
+    /// inline (estimated-1-row) CTE produced. Fix C: the matview balance watermark is inlined as
+    /// a literal (__BALANCE_WM__) so the planner uses the blockNumber indexes for the small delta
+    /// tail; ReadBaseRows reads it inside the same REPEATABLE READ snapshot as the matview and the
+    /// temp-table build, keeping the watermark consistent with the rows read here.
+    /// </summary>
+    internal const string LiveBalancesTailSql = """
+        WITH delta_tx AS (
             SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
             FROM "CrcV2_TransferSingle"
             WHERE "blockNumber" > __BALANCE_WM__
-              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens))
             UNION ALL
             SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
             FROM "CrcV2_TransferSingle"
             WHERE "blockNumber" > __BALANCE_WM__
-              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens))
             UNION ALL
             SELECT "timestamp", "from" AS account, "tokenAddress", id, -value AS delta
             FROM "CrcV2_TransferBatch"
             WHERE "blockNumber" > __BALANCE_WM__
-              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens))
             UNION ALL
             SELECT "timestamp", "to" AS account, "tokenAddress", id, value AS delta
             FROM "CrcV2_TransferBatch"
             WHERE "blockNumber" > __BALANCE_WM__
-              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+              AND "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens))
         ),
         delta_agg AS (
             SELECT account, id::text AS "tokenId", "tokenAddress",
@@ -161,7 +180,7 @@ public static class ScoreGroupMintLimitReader
         filtered_mat AS (
             SELECT account, "tokenId", "tokenAddress", "lastActivity", "totalBalance"
             FROM "M_CrcV2_BalancesByAccountAndToken"
-            WHERE "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM group_tokens))
+            WHERE "tokenAddress" = ANY(ARRAY(SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens))
               AND account <> '0x0000000000000000000000000000000000000000'
         ),
         merged AS (
@@ -193,7 +212,7 @@ public static class ScoreGroupMintLimitReader
                 b."tokenAddress",
                 SUM(b."demurragedTotalBalance")::text AS current_supply
             FROM balances b
-            INNER JOIN (SELECT DISTINCT trusted_token FROM group_tokens) gt
+            INNER JOIN (SELECT DISTINCT trusted_token FROM _sg_mint_group_tokens) gt
                 ON gt.trusted_token = b."tokenAddress"
             GROUP BY b."tokenAddress"
         ),
@@ -202,7 +221,7 @@ public static class ScoreGroupMintLimitReader
         -- (O(tokens x balances) -> the 120s+ blowup on large groups).
         treasury_pairs AS (
             SELECT DISTINCT gt.group_address, gt.trusted_token, ta.account
-            FROM group_tokens gt, unnest(gt.treasuries) AS ta(account)
+            FROM _sg_mint_group_tokens gt, unnest(gt.treasuries) AS ta(account)
         ),
         treasury_balances AS (
             SELECT tp.group_address, tp.trusted_token,
@@ -219,7 +238,7 @@ public static class ScoreGroupMintLimitReader
             gt.policy,
             COALESCE(tb.treasury_balance, 0)::text AS treasury_balance,
             COALESCE(ts.current_supply, '0') AS current_supply
-        FROM group_tokens gt
+        FROM _sg_mint_group_tokens gt
         LEFT JOIN treasury_balances tb
             ON tb.group_address = gt.group_address
            AND tb.trusted_token = gt.trusted_token
@@ -228,7 +247,8 @@ public static class ScoreGroupMintLimitReader
         """;
 
     /// <summary>
-    /// Historical variant of <see cref="BaseRowsSql"/> used when <c>maxBlock</c> is non-null.
+    /// Historical variant of the live <see cref="LiveGroupTokensSql"/> + <see cref="LiveBalancesTailSql"/>
+    /// pair, used when <c>maxBlock</c> is non-null.
     /// Bypasses <c>M_CrcV2_BalancesByAccountAndToken</c> (the matview, which only holds HEAD
     /// state and has no block-pinned twin in the test environment) and instead aggregates
     /// directly from raw <c>CrcV2_TransferSingle/Batch</c> tables with
@@ -507,8 +527,9 @@ public static class ScoreGroupMintLimitReader
     }
 
     // Two SQL paths selected at runtime:
-    //   maxBlock IS NULL  → BaseRowsSql: fast matview + delta tail, demurrage at NOW().
-    //                       Used by the live pathfinder (HEAD state queries).
+    //   maxBlock IS NULL  → LiveGroupTokensSql (materialized into an ANALYZEd temp table) +
+    //                       LiveBalancesTailSql: matview + delta tail, demurrage at NOW().
+    //                       Used by the live pathfinder + RPC (HEAD state queries).
     //   maxBlock IS NOT NULL → BaseRowsSqlHistorical: aggregates raw transfer tables with
     //                       blockNumber <= @maxBlock, demurrage anchored to the block's
     //                       own timestamp. Used by HistoricalLoadGraph (snapshot/historical-graph
@@ -539,10 +560,9 @@ public static class ScoreGroupMintLimitReader
             .Select(kv => string.Join(",", kv.Value.Select(addr => addr.Trim().ToLowerInvariant())))
             .ToArray();
 
-        List<ScoreGroupMintLimitBaseRow> Execute(string sql, NpgsqlTransaction? tx)
+        // Binds the parameters shared by the historical query and the live temp-table builder.
+        void AddBaseRowParameters(NpgsqlCommand command)
         {
-            var rows = new List<ScoreGroupMintLimitBaseRow>();
-            using var command = new NpgsqlCommand(sql, connection, tx);
             command.CommandTimeout = commandTimeoutSeconds;
             command.Parameters.AddWithValue("scoreMintPolicies", policies);
             command.Parameters.AddWithValue("subTreasuryAggregators", subTreasuryAggregators);
@@ -550,19 +570,14 @@ public static class ScoreGroupMintLimitReader
             AddMaxBlockParameter(command, maxBlock);
             AddTextFilterParameter(command, "groupAddressFilter", groupAddressFilter);
             AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
+        }
 
-            using var reader = command.ExecuteReader();
-            while (reader.Read())
-            {
-                rows.Add(new ScoreGroupMintLimitBaseRow(
-                    reader.GetString(0).ToLowerInvariant(),
-                    reader.GetString(1).ToLowerInvariant(),
-                    reader.GetString(2).ToLowerInvariant(),
-                    ParseBigInteger(reader.GetString(3)),
-                    ParseBigInteger(reader.GetString(4))));
-            }
-
-            return rows;
+        // Historical/snapshot path: one self-contained query carrying all parameters.
+        List<ScoreGroupMintLimitBaseRow> Execute(string sql, NpgsqlTransaction? tx)
+        {
+            using var command = new NpgsqlCommand(sql, connection, tx);
+            AddBaseRowParameters(command);
+            return MaterializeBaseRows(command);
         }
 
         // Historical/snapshot path bounds every table on blockNumber <= @maxBlock, so the
@@ -596,10 +611,41 @@ public static class ScoreGroupMintLimitReader
         {
             var (balanceWatermark, avatarWatermark) =
                 ReadMatviewWatermarks(connection, liveTransaction, commandTimeoutSeconds);
-            var sql = BaseRowsSql
-                .Replace("__BALANCE_WM__", balanceWatermark.ToString(CultureInfo.InvariantCulture))
+
+            // Fix D: materialize group_tokens into an ANALYZEd temp table so the planner has the
+            // real row count (~10k for a large score group) for the balance/treasury joins in the
+            // tail. As an inline CTE it estimated 1 row and the treasury_balances/token_supply
+            // joins collapsed into a nested loop (a ~47M-row filter, ~8.5s); with real stats they
+            // become hash joins (~0.6s). The temp table is ON COMMIT DROP and lives in the same
+            // REPEATABLE READ snapshot as the watermark read above — consistent and self-cleaning.
+            var builderSql = LiveGroupTokensSql
                 .Replace("__AVATAR_WM__", avatarWatermark.ToString(CultureInfo.InvariantCulture));
-            var rows = Execute(sql, liveTransaction);
+            using (var dropCommand = new NpgsqlCommand(
+                       $"DROP TABLE IF EXISTS {LiveGroupTokensTempTable}", connection, liveTransaction))
+            {
+                dropCommand.CommandTimeout = commandTimeoutSeconds;
+                dropCommand.ExecuteNonQuery();
+            }
+            using (var buildCommand = new NpgsqlCommand(
+                       $"CREATE TEMP TABLE {LiveGroupTokensTempTable} ON COMMIT DROP AS\n{builderSql}",
+                       connection, liveTransaction))
+            {
+                AddBaseRowParameters(buildCommand);
+                buildCommand.ExecuteNonQuery();
+            }
+            using (var analyzeCommand = new NpgsqlCommand(
+                       $"ANALYZE {LiveGroupTokensTempTable}", connection, liveTransaction))
+            {
+                analyzeCommand.CommandTimeout = commandTimeoutSeconds;
+                analyzeCommand.ExecuteNonQuery();
+            }
+
+            var tailSql = LiveBalancesTailSql
+                .Replace("__BALANCE_WM__", balanceWatermark.ToString(CultureInfo.InvariantCulture));
+            using var tailCommand = new NpgsqlCommand(tailSql, connection, liveTransaction);
+            tailCommand.CommandTimeout = commandTimeoutSeconds;
+            var rows = MaterializeBaseRows(tailCommand);
+
             if (ownTransaction)
                 liveTransaction.Commit();
             return rows;
@@ -624,10 +670,32 @@ public static class ScoreGroupMintLimitReader
     }
 
     /// <summary>
+    /// Reads the 5-column base-row shape (group, collateral, policy, treasury balance, supply)
+    /// produced by both the historical query and the live balance tail.
+    /// </summary>
+    private static List<ScoreGroupMintLimitBaseRow> MaterializeBaseRows(NpgsqlCommand command)
+    {
+        var rows = new List<ScoreGroupMintLimitBaseRow>();
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+        {
+            rows.Add(new ScoreGroupMintLimitBaseRow(
+                reader.GetString(0).ToLowerInvariant(),
+                reader.GetString(1).ToLowerInvariant(),
+                reader.GetString(2).ToLowerInvariant(),
+                ParseBigInteger(reader.GetString(3)),
+                ParseBigInteger(reader.GetString(4))));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
     /// Reads the current matview watermarks used to inline <c>__BALANCE_WM__</c> (max
     /// <c>_maxBlock</c> in <c>M_CrcV2_BalancesByAccountAndToken</c>, the cutoff for the balance
     /// delta tail) and <c>__AVATAR_WM__</c> (max <c>blockNumber</c> in <c>M_CrcV2_Avatars</c>,
-    /// the cutoff for the avatar-registration delta) into <see cref="BaseRowsSql"/>.
+    /// the cutoff for the avatar-registration delta) into <see cref="LiveGroupTokensSql"/>
+    /// (avatar) and <see cref="LiveBalancesTailSql"/> (balance).
     /// </summary>
     private static (long BalanceWatermark, long AvatarWatermark) ReadMatviewWatermarks(
         NpgsqlConnection connection,

--- a/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
+++ b/src/Pathfinder/Circles.Pathfinder/Validation/HubContractValidator.cs
@@ -671,8 +671,8 @@ public static class HubContractValidator
     // Collateral keying: matches GraphFactory.cs:999 + GraphFactory.cs:1032
     // exactly — raw TokenOwner address, no wrapper resolution. The
     // ScoreGroupMintLimits cache is keyed on avatar addresses (per
-    // ScoreGroupMintLimits.cs BaseRowsSql joining V_CrcV2_TrustRelations
-    // → V_CrcV2_Avatars), so groups only trust avatars, not wrapper
+    // ScoreGroupMintLimits.cs, whose trust resolution only admits registered
+    // avatars as trustees), so groups only trust avatars, not wrapper
     // contracts — wrappers cannot appear as TokenOwner on a
     // score-router→group hop. Resolving wrappers here would create
     // a key mismatch with the cache and spuriously fail-close.


### PR DESCRIPTION
## Summary
The live (HEAD-state) score-group mint-limit query estimated its `group_tokens` CTE at one row, so the planner chose nested-loop joins for the treasury-balance and supply aggregations — ~8.5s on a score group trusting ~9.7k collateral tokens (a ~47M-row nested-loop join filter). This splits the monolithic query into a builder and a tail; the builder is materialized into an `ON COMMIT DROP` temp table that is `ANALYZE`d before the tail runs, so the planner has real cardinalities and picks hash joins (~0.4s end-to-end).

## What changed
- Split the live `BaseRowsSql` into `LiveGroupTokensSql` (builder) + `LiveBalancesTailSql` (tail).
- `ReadBaseRows` live path now: `DROP TABLE IF EXISTS` → `CREATE TEMP TABLE … ON COMMIT DROP AS <builder>` → `ANALYZE` → run `<tail>`, all inside the existing REPEATABLE READ transaction. Watermark-inlining consistency and the RR isolation guard are preserved.
- Historical/snapshot path (`maxBlock` set) is unchanged.
- Shared helpers extracted (`AddBaseRowParameters`, `MaterializeBaseRows`).
- Parity tests updated for the split; added a head-CTE parity guard pinning score-group resolution identical across the live and historical paths.
- Corrected a stale comment referencing the removed `BaseRowsSql` constant.

## Why temp table (not a planner hint)
A `MATERIALIZED` CTE fences the CTE but still gives downstream joins a 1-row estimate; only an `ANALYZE`d relation fixes the cardinality misestimate. The temp table is session-local, `ON COMMIT DROP`, and runs on a per-node read-write indexer DB.

## Test plan
- [x] `dotnet build Circles.sln -c Release` — 0 errors
- [x] `Circles.Common.Tests` — 105 pass / 0 fail
- [x] Result parity vs the prior query verified byte-identical (single-group and all-groups) against real data
- [x] Query timing reduced from ~8.5s to ~0.4s on real data
- [ ] Post-deploy: re-verify live `circles_getScoreGroupMintLimits` < 1s on the heavy group; soak 24–48h (span timing, no query timeouts, no InvalidOperationException, canary clean)

## Follow-ups (deferred)
- Execution-level test of the live temp-table path + RR isolation-guard test (needs a Testcontainers harness in `Circles.Common.Tests`).
- Fail-closed (vs `long.MaxValue`) when a mint-limit is absent in `GraphFactory` (pre-existing).