### PR TITLE
feat(metrics): stratify rep_score new_zero by prev-score tier and blacklist cause

### DIFF
--- a/Circles.sln
+++ b/Circles.sln
@@ -130,6 +130,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circles.Index.CirclesV2.Erc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circles.Index.CirclesV2.ScoreGroup", "src\Index\Circles.Index.CirclesV2.ScoreGroup\Circles.Index.CirclesV2.ScoreGroup.csproj", "{33BB3570-C5C7-4C7C-90E4-EA41F3ECFCEB}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Circles.Metrics.Exporter.Tests", "src\Metrics\Circles.Metrics.Exporter.Tests\Circles.Metrics.Exporter.Tests.csproj", "{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -619,6 +621,18 @@ Global
 		{33BB3570-C5C7-4C7C-90E4-EA41F3ECFCEB}.Release|x64.Build.0 = Release|Any CPU
 		{33BB3570-C5C7-4C7C-90E4-EA41F3ECFCEB}.Release|x86.ActiveCfg = Release|Any CPU
 		{33BB3570-C5C7-4C7C-90E4-EA41F3ECFCEB}.Release|x86.Build.0 = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|x64.Build.0 = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -670,5 +684,6 @@ Global
 		{4A1D0AFD-B98E-428D-AD9D-3A3674D1E623} = {664289F4-DCD6-D41D-7163-C693306A2F35}
 		{454E0010-6E2A-48B4-86AF-1E2FB548719D} = {664289F4-DCD6-D41D-7163-C693306A2F35}
 		{33BB3570-C5C7-4C7C-90E4-EA41F3ECFCEB} = {664289F4-DCD6-D41D-7163-C693306A2F35}
+		{B1E2A596-B0EB-4634-BDD8-2C52FCDC1AF8} = {D1E2F3A4-B5C6-7890-1234-ABCDEF123456}
 	EndGlobalSection
 EndGlobal

--- a/src/Metrics/Circles.Metrics.Exporter.Tests/AnomalyStatsSqlTests.cs
+++ b/src/Metrics/Circles.Metrics.Exporter.Tests/AnomalyStatsSqlTests.cs
@@ -1,0 +1,157 @@
+using Circles.Metrics.Exporter.Services;
+using Npgsql;
+using NUnit.Framework;
+using Testcontainers.PostgreSql;
+
+namespace Circles.Metrics.Exporter.Tests;
+
+/// <summary>
+/// Regression guard for the <c>circles_rep_score_new_zero_24h</c> tier×cause split.
+///
+/// <see cref="RepScoreRepository.AnomalyStatsSql"/> partitions the old flat
+/// "members whose score hit 0 in 24h (prev_score &gt; 0)" count into four buckets:
+/// tier ∈ {significant, fringe} × cause ∈ {blacklist, trust_collapse}, where
+/// significant means <c>prev_score*100 &gt;= @sig</c> (default @sig=0.1 i.e. prev_score
+/// &gt;= 0.001) and cause comes from a LEFT JOIN on the <c>blacklist</c> table.
+///
+/// The load-bearing invariant is CONSERVATION: the four buckets must be disjoint and
+/// exhaustive, so their sum equals the original <c>prev_score &gt; 0 AND score = 0</c>
+/// count. This fixture runs the EXACT production SQL constant (no drift) against a real
+/// Postgres and asserts the four counts, the conservation sum, the &gt;=/&lt; tier
+/// boundary, the no-fan-out LEFT JOIN, and the @sig&lt;=0 robustness guard.
+/// </summary>
+[TestFixture]
+[Category("RequiresDocker")]
+public class AnomalyStatsSqlTests
+{
+    private const string Group = "score_group";
+
+    private PostgreSqlContainer? _postgres;
+    private NpgsqlDataSource? _dataSource;
+
+    [OneTimeSetUp]
+    public async Task OneTimeSetUp()
+    {
+        try
+        {
+            _postgres = new PostgreSqlBuilder("postgres:15-alpine").Build();
+            await _postgres.StartAsync();
+        }
+        catch (Exception ex)
+        {
+            Assert.Ignore($"Docker/Postgres test container unavailable: {ex.Message}");
+            return;
+        }
+
+        _dataSource = NpgsqlDataSource.Create(_postgres.GetConnectionString());
+
+        await using var conn = await _dataSource.OpenConnectionAsync();
+        await using var cmd = conn.CreateCommand();
+        // Minimal shapes matching the columns AnomalyStatsSql touches. prev_score/score are
+        // raw [0,1] fractions (the production scale; the query multiplies by 100), blacklist
+        // keyed by a unique address. snapshot_at drives the 24h window.
+        cmd.CommandText = @"
+            CREATE TABLE rep_score_history (
+                group_id       text,
+                avatar         text,
+                snapshot_at    timestamptz,
+                prev_score     double precision,
+                score          double precision,
+                prev_is_member boolean);
+            CREATE TABLE rep_score_state (group_id text, avatar text);
+            CREATE TABLE blacklist (address text PRIMARY KEY);
+
+            INSERT INTO blacklist(address) VALUES ('0xbl_sig'), ('0xbl_fringe'), ('0xnotinhistory');
+
+            INSERT INTO rep_score_history(group_id, avatar, snapshot_at, prev_score, score, prev_is_member) VALUES
+                -- significant (prev_score*100 >= 0.1) ---------------------------------------
+                ('score_group','0xsig_trust',  now() - interval '1h', 0.00912, 0, true),  -- 0.912/100 -> sig_trust
+                ('score_group','0xboundary',   now() - interval '1h', 0.001,   0, true),  -- exactly @sig (0.1) -> sig_trust (locks >=)
+                ('score_group','0xbl_sig',     now() - interval '2h', 0.05,    0, true),  -- 5/100, blacklisted -> sig_blacklist
+                -- fringe (0 < prev_score*100 < 0.1) -----------------------------------------
+                ('score_group','0xfringe1',    now() - interval '3h', 8.4e-8,  0, true),  -- dust -> fringe_trust
+                ('score_group','0xfringe2',    now() - interval '3h', 8.6e-4,  0, true),  -- 0.086/100 -> fringe_trust
+                ('score_group','0xbl_fringe',  now() - interval '4h', 5.1e-5,  0, true),  -- dust, blacklisted -> fringe_blacklist
+                -- MUST NOT count as new_zero ------------------------------------------------
+                ('score_group','0xprev_zero',  now() - interval '1h', 0,       0, true),  -- prev_score not > 0
+                ('score_group','0xdrop_only',  now() - interval '1h', 0.50, 0.20, true),  -- dropped, not to 0
+                ('score_group','0xold',        now() - interval '30h',0.30,    0, true),  -- outside 24h window
+                ('other_group','0xothergroup', now() - interval '1h', 0.30,    0, true);  -- different group_id";
+        await cmd.ExecuteNonQueryAsync();
+    }
+
+    [OneTimeTearDown]
+    public async Task OneTimeTearDown()
+    {
+        if (_dataSource != null) await _dataSource.DisposeAsync();
+        if (_postgres != null) await _postgres.DisposeAsync();
+    }
+
+    private async Task<(long sigBl, long sigTr, long fringeBl, long fringeTr)> RunSplitAsync(double sig)
+    {
+        await using var conn = await _dataSource!.OpenConnectionAsync();
+        await using var cmd = new NpgsqlCommand(RepScoreRepository.AnomalyStatsSql, conn);
+        cmd.Parameters.AddWithValue("groupId", Group);
+        cmd.Parameters.AddWithValue("drop", 20.0);
+        cmd.Parameters.AddWithValue("sig", sig);
+        await using var reader = await cmd.ExecuteReaderAsync();
+        Assert.That(await reader.ReadAsync(), Is.True);
+        return (
+            reader.GetInt64(reader.GetOrdinal("new_zero_sig_blacklist")),
+            reader.GetInt64(reader.GetOrdinal("new_zero_sig_trust")),
+            reader.GetInt64(reader.GetOrdinal("new_zero_fringe_blacklist")),
+            reader.GetInt64(reader.GetOrdinal("new_zero_fringe_trust")));
+    }
+
+    /// <summary>
+    /// With the default @sig=0.1 the four buckets are exactly: sig_blacklist=1, sig_trust=2
+    /// (the real score AND the boundary row), fringe_blacklist=1, fringe_trust=2. Their sum
+    /// (6) equals the old flat <c>prev_score &gt; 0 AND score = 0</c> count — the rows that
+    /// must NOT count (prev_score=0, a drop-not-to-zero, an out-of-window row, and a
+    /// different group) are all excluded. The blacklist entry with no history row
+    /// (0xnotinhistory) must not inflate any bucket (no LEFT JOIN fan-out).
+    /// </summary>
+    [Test]
+    public async Task AnomalyStatsSql_PartitionsByTierAndCause_AndConserves()
+    {
+        if (_dataSource == null) Assert.Ignore("No data source (container unavailable).");
+
+        var (sigBl, sigTr, fringeBl, fringeTr) = await RunSplitAsync(0.1);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(sigBl, Is.EqualTo(1), "significant + blacklisted: 0xbl_sig");
+            Assert.That(sigTr, Is.EqualTo(2), "significant + trust: 0xsig_trust and the boundary row 0xboundary");
+            Assert.That(fringeBl, Is.EqualTo(1), "fringe + blacklisted: 0xbl_fringe");
+            Assert.That(fringeTr, Is.EqualTo(2), "fringe + trust: 0xfringe1, 0xfringe2");
+            // Conservation: the split must equal the original flat new-zero definition.
+            Assert.That(sigBl + sigTr + fringeBl + fringeTr, Is.EqualTo(6),
+                "the four buckets must be disjoint and exhaustive over prev_score>0 AND score=0");
+        });
+    }
+
+    /// <summary>
+    /// Robustness guard for the explicit <c>prev_score &gt; 0</c> predicate on the
+    /// significant filters: even a misconfigured non-positive threshold must never pull a
+    /// <c>prev_score = 0, score = 0</c> row into a bucket. With @sig=0 every positive
+    /// prev_score becomes "significant", so all six real new-zeros land in the significant
+    /// tier and fringe empties — but 0xprev_zero is still excluded everywhere, so
+    /// conservation (sum == 6) holds.
+    /// </summary>
+    [Test]
+    public async Task AnomalyStatsSql_WithNonPositiveThreshold_StillExcludesZeroPrevScore()
+    {
+        if (_dataSource == null) Assert.Ignore("No data source (container unavailable).");
+
+        var (sigBl, sigTr, fringeBl, fringeTr) = await RunSplitAsync(0.0);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fringeBl + fringeTr, Is.EqualTo(0), "@sig=0 -> no fringe tier");
+            Assert.That(sigBl, Is.EqualTo(2), "blacklisted positives: 0xbl_sig, 0xbl_fringe");
+            Assert.That(sigTr, Is.EqualTo(4), "non-blacklisted positives: sig_trust, boundary, fringe1, fringe2");
+            Assert.That(sigBl + sigTr + fringeBl + fringeTr, Is.EqualTo(6),
+                "0xprev_zero (prev_score=0) must stay excluded even at @sig<=0");
+        });
+    }
+}

--- a/src/Metrics/Circles.Metrics.Exporter.Tests/Circles.Metrics.Exporter.Tests.csproj
+++ b/src/Metrics/Circles.Metrics.Exporter.Tests/Circles.Metrics.Exporter.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <LangVersion>latest</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="NUnit" />
+        <PackageReference Include="NUnit.Analyzers" />
+        <PackageReference Include="NUnit3TestAdapter" />
+        <PackageReference Include="Npgsql" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="NUnit.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Circles.Metrics.Exporter\Circles.Metrics.Exporter.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/src/Metrics/Circles.Metrics.Exporter/Program.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Program.cs
@@ -61,6 +61,10 @@ if (!string.IsNullOrWhiteSpace(repScoreConnectionString))
             builder.Configuration.GetValue<string>("RepScore:GroupId", "score_group")!,
             builder.Configuration.GetValue<double>("RepScore:HighScoreThreshold", 70.0),
             builder.Configuration.GetValue<double>("RepScore:ScoreDropThreshold", 20.0),
+            // Previous-score floor (0-100 scale) below which a new-zero transition is
+            // "fringe" dust churn rather than a "significant" event. 0.1 == prev_score
+            // 0.001, matching the existing zero-rep dust line in LoadMemberAddressBuckets.
+            builder.Configuration.GetValue<double>("RepScore:NewZeroSignificantThreshold", 0.1),
             sp.GetRequiredService<ILogger<RepScoreRepository>>()));
 
     builder.Services.AddHostedService<RepScoreCollectorService>();

--- a/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
@@ -82,9 +82,15 @@ public static class RepScoreMetrics
         .CreateGauge("circles_rep_score_drops_24h",
             "Members with a score drop >= threshold in the last 24 hours (organised attack signal)");
 
+    // Stratified by previous-score tier and cause so the alert can target genuine
+    // events instead of dust churn:
+    //   tier  = significant (prev_score*100 >= NewZeroSignificantThreshold) | fringe
+    //   cause = blacklist (avatar in TrustGard blacklist) | trust_collapse (not blacklisted)
+    // Alert on sum without(cause)(...{tier="significant"}) > 5.
     public static readonly Gauge NewZeroScore24h = Prometheus.Metrics
         .CreateGauge("circles_rep_score_new_zero_24h",
-            "Members whose score hit 0 in the last 24 hours (new blacklisting or gate failures) — alert if > 5");
+            "Members whose score hit 0 in the last 24 hours, by previous-score tier and cause — alert if sum without(cause)(...{tier=\"significant\"}) > 5",
+            new GaugeConfiguration { LabelNames = ["tier", "cause"] });
 
     public static readonly Gauge NewMembers24h = Prometheus.Metrics
         .CreateGauge("circles_rep_score_new_members_24h",

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
@@ -133,12 +133,20 @@ public class RepScoreCollectorService : BackgroundService
             var anomaly = await _repository.GetAnomalyStatsAsync(ct);
 
             RepScoreMetrics.ScoreDrops24h.Set(anomaly.Drops24h);
-            RepScoreMetrics.NewZeroScore24h.Set(anomaly.NewZero24h);
+            // Set all four tier×cause children every cycle (even at 0) so the
+            // {tier="significant"} series the alert queries always exists.
+            RepScoreMetrics.NewZeroScore24h.WithLabels("significant", "blacklist").Set(anomaly.NewZeroSignificantBlacklist24h);
+            RepScoreMetrics.NewZeroScore24h.WithLabels("significant", "trust_collapse").Set(anomaly.NewZeroSignificantTrust24h);
+            RepScoreMetrics.NewZeroScore24h.WithLabels("fringe", "blacklist").Set(anomaly.NewZeroFringeBlacklist24h);
+            RepScoreMetrics.NewZeroScore24h.WithLabels("fringe", "trust_collapse").Set(anomaly.NewZeroFringeTrust24h);
             RepScoreMetrics.NewMembers24h.Set(anomaly.NewMembers24h);
             RepScoreMetrics.LostMembers24h.Set(anomaly.LostMembers24h);
 
-            if (anomaly.NewZero24h > 0)
-                _logger.LogWarning("{Count} member(s) dropped to rep_score=0 in the last 24h", anomaly.NewZero24h);
+            var newZeroSignificant = anomaly.NewZeroSignificantBlacklist24h + anomaly.NewZeroSignificantTrust24h;
+            if (newZeroSignificant > 0)
+                _logger.LogWarning(
+                    "{Count} member(s) hit a significant rep_score=0 in 24h (blacklist={Blacklist}, trust_collapse={Trust}; prev_score >= {Threshold}/100)",
+                    newZeroSignificant, anomaly.NewZeroSignificantBlacklist24h, anomaly.NewZeroSignificantTrust24h, _repository.NewZeroSignificantThreshold);
 
             if (anomaly.Drops24h > 0)
                 _logger.LogInformation("Rep score drops (>={Threshold}pts) in 24h: {Count}", _repository.ScoreDropThreshold, anomaly.Drops24h);

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
@@ -10,7 +10,11 @@ public class RepScoreRepository
     private readonly string _groupId;
     private readonly double _highScoreThreshold;
     private readonly double _scoreDropThreshold;
+    // Previous-score floor (0-100 scale) separating "significant" new-zero
+    // transitions from fringe dust churn. Mirrors the _scoreDropThreshold pattern.
+    private readonly double _newZeroSignificantThreshold;
     public double ScoreDropThreshold => _scoreDropThreshold;
+    public double NewZeroSignificantThreshold => _newZeroSignificantThreshold;
     private readonly ILogger<RepScoreRepository> _logger;
 
     public RepScoreRepository(
@@ -19,6 +23,7 @@ public class RepScoreRepository
         string groupId,
         double highScoreThreshold,
         double scoreDropThreshold,
+        double newZeroSignificantThreshold,
         ILogger<RepScoreRepository> logger)
     {
         _repScoreConn = repScoreConn;
@@ -26,6 +31,7 @@ public class RepScoreRepository
         _groupId = groupId;
         _highScoreThreshold = highScoreThreshold;
         _scoreDropThreshold = scoreDropThreshold;
+        _newZeroSignificantThreshold = newZeroSignificantThreshold;
         _logger = logger;
     }
 
@@ -185,53 +191,86 @@ public class RepScoreRepository
 
     public record AnomalyStats(
         long Drops24h,
-        long NewZero24h,
+        long NewZeroSignificantBlacklist24h,
+        long NewZeroSignificantTrust24h,
+        long NewZeroFringeBlacklist24h,
+        long NewZeroFringeTrust24h,
         long NewMembers24h,
         long LostMembers24h);
 
+    // new_zero is split by previous-score tier (significant vs fringe dust) and by
+    // cause (blacklisted vs not). The LEFT JOIN blacklist mirrors the direct
+    // address match in GetBlacklistStatsAsync (no case normalisation — AA writes
+    // blacklist.address and rep_score_history.avatar in the same representation).
+    // blacklist.address is unique, so the join cannot fan out history rows.
+    //
+    // NOTE: is_blacklisted reflects CURRENT blacklist membership at scrape time, not
+    // membership at the instant the score hit zero — so the `cause` split is a triage
+    // hint, not an exact transition cause. It never changes the new-zero TOTAL (the
+    // sum over cause that the alert fires on), only its attribution. If the blacklist
+    // table is empty/unpopulated, every new-zero is attributed to trust_collapse.
+    //
+    // The `prev_score > 0` guard is on ALL FOUR new_zero filters (not just fringe) so
+    // the significant+fringe partition stays disjoint AND exhaustive over the original
+    // `prev_score > 0 AND score = 0` domain for ANY @sig — including a misconfigured
+    // @sig <= 0, which would otherwise pull `prev_score = 0` rows into significant.
+    //
+    // Exposed as a const so Circles.Metrics.Exporter.Tests can run the EXACT production
+    // SQL (no drift). Bind @groupId, @drop, @sig before executing.
+    public const string AnomalyStatsSql = """
+        WITH window_24h AS (
+            SELECT h.avatar, h.prev_score, h.score, h.prev_is_member,
+                   (b.address IS NOT NULL) AS is_blacklisted
+            FROM rep_score_history h
+            LEFT JOIN blacklist b ON b.address = h.avatar
+            WHERE h.group_id = @groupId
+              AND h.snapshot_at > NOW() - INTERVAL '24 hours'
+        ),
+        lost AS (
+            SELECT COUNT(DISTINCT h.avatar) AS cnt
+            FROM rep_score_history h
+            LEFT JOIN rep_score_state s ON s.group_id = @groupId AND s.avatar = h.avatar
+            WHERE h.group_id = @groupId
+              AND h.snapshot_at > NOW() - INTERVAL '24 hours'
+              AND h.prev_is_member = true
+              AND s.avatar IS NULL
+        )
+        SELECT
+            COUNT(*) FILTER (WHERE (prev_score - score) * 100 >= @drop AND prev_score > score)                                 AS drops_24h,
+            COUNT(*) FILTER (WHERE prev_score > 0 AND prev_score * 100 >= @sig AND score = 0 AND is_blacklisted)               AS new_zero_sig_blacklist,
+            COUNT(*) FILTER (WHERE prev_score > 0 AND prev_score * 100 >= @sig AND score = 0 AND NOT is_blacklisted)           AS new_zero_sig_trust,
+            COUNT(*) FILTER (WHERE prev_score > 0 AND prev_score * 100 < @sig AND score = 0 AND is_blacklisted)                AS new_zero_fringe_blacklist,
+            COUNT(*) FILTER (WHERE prev_score > 0 AND prev_score * 100 < @sig AND score = 0 AND NOT is_blacklisted)            AS new_zero_fringe_trust,
+            COUNT(*) FILTER (WHERE prev_is_member = false OR prev_is_member IS NULL)                                           AS new_members_24h,
+            (SELECT cnt FROM lost)                                                                                             AS lost_members_24h
+        FROM window_24h
+        """;
+
     public async Task<AnomalyStats> GetAnomalyStatsAsync(CancellationToken ct = default)
     {
-        const string sql = """
-            WITH window_24h AS (
-                SELECT avatar, prev_score, score, prev_is_member
-                FROM rep_score_history
-                WHERE group_id = @groupId
-                  AND snapshot_at > NOW() - INTERVAL '24 hours'
-            ),
-            lost AS (
-                SELECT COUNT(DISTINCT h.avatar) AS cnt
-                FROM rep_score_history h
-                LEFT JOIN rep_score_state s ON s.group_id = @groupId AND s.avatar = h.avatar
-                WHERE h.group_id = @groupId
-                  AND h.snapshot_at > NOW() - INTERVAL '24 hours'
-                  AND h.prev_is_member = true
-                  AND s.avatar IS NULL
-            )
-            SELECT
-                COUNT(*) FILTER (WHERE (prev_score - score) * 100 >= @drop AND prev_score > score) AS drops_24h,
-                COUNT(*) FILTER (WHERE prev_score > 0 AND score = 0)                       AS new_zero_24h,
-                COUNT(*) FILTER (WHERE prev_is_member = false OR prev_is_member IS NULL)   AS new_members_24h,
-                (SELECT cnt FROM lost)                                                     AS lost_members_24h
-            FROM window_24h
-            """;
-
         await using var conn = new NpgsqlConnection(_repScoreConn);
         await conn.OpenAsync(ct);
-        await using var cmd = new NpgsqlCommand(sql, conn);
+        await using var cmd = new NpgsqlCommand(AnomalyStatsSql, conn);
         cmd.Parameters.AddWithValue("groupId", _groupId);
         cmd.Parameters.AddWithValue("drop", _scoreDropThreshold);
+        cmd.Parameters.AddWithValue("sig", _newZeroSignificantThreshold);
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
         if (await reader.ReadAsync(ct))
         {
+            // Named arguments: the four same-typed `long` NewZero* fields map positionally
+            // to the SQL column order, so name them to make a transposition a compile error.
             return new AnomalyStats(
-                reader.GetInt64(0),
-                reader.GetInt64(1),
-                reader.GetInt64(2),
-                reader.IsDBNull(3) ? 0 : reader.GetInt64(3));
+                Drops24h: reader.GetInt64(0),
+                NewZeroSignificantBlacklist24h: reader.GetInt64(1),
+                NewZeroSignificantTrust24h: reader.GetInt64(2),
+                NewZeroFringeBlacklist24h: reader.GetInt64(3),
+                NewZeroFringeTrust24h: reader.GetInt64(4),
+                NewMembers24h: reader.GetInt64(5),
+                LostMembers24h: reader.IsDBNull(6) ? 0 : reader.GetInt64(6));
         }
 
-        return new AnomalyStats(0, 0, 0, 0);
+        return new AnomalyStats(0, 0, 0, 0, 0, 0, 0);
     }
 
     // ===========================================

--- a/src/Metrics/Circles.Metrics.Exporter/appsettings.json
+++ b/src/Metrics/Circles.Metrics.Exporter/appsettings.json
@@ -14,7 +14,8 @@
     "GroupId": "score_group",
     "CollectionIntervalSeconds": 120,
     "HighScoreThreshold": 70.0,
-    "ScoreDropThreshold": 20.0
+    "ScoreDropThreshold": 20.0,
+    "NewZeroSignificantThreshold": 0.1
   },
   "Deployment": {
     "Environments": {


### PR DESCRIPTION
## Summary
Splits the `circles_rep_score_new_zero_24h` gauge into `tier`{significant,fringe} × `cause`{blacklist,trust_collapse} so the alerting layer can target genuine score collapses instead of dust-tier churn.

The flat metric counted every `prev_score > 0 → score = 0` transition, so members whose normalized reputation score was already near-zero (`prev_score < 0.001`) inflated the count and tripped the `> 5` alert on background noise rather than real blacklistings.

## What changed
- `RepScoreMetrics.cs` — `NewZeroScore24h` gauge gains `tier` + `cause` labels
- `RepScoreRepository.cs` — `GetAnomalyStatsAsync` splits the single new-zero count into four `tier×cause` counts; `LEFT JOIN blacklist` derives cause; `prev_score > 0` guard on all four filters keeps the partition disjoint + exhaustive for any threshold; SQL promoted to an `AnomalyStatsSql` const; named-argument record construction
- `Program.cs` + `appsettings.json` — new configurable `RepScore:NewZeroSignificantThreshold` (default `0.1` on the 0–100 scale = `prev_score 0.001`), wired like `ScoreDropThreshold`
- `RepScoreCollectorService.cs` — emits all four children every cycle (so `{tier="significant"}` always exists); logs the significant count
- `Circles.Metrics.Exporter.Tests` (new) — Testcontainers fixture running the production `AnomalyStatsSql`, asserting the four counts, the conservation invariant (split total == old flat count), the tier boundary, and the non-positive-threshold guard

## Coupling
The alert + dashboard that consume this metric are updated in `aboutcircles-infrastructure`. That change is forward-compatible and should be deployed **before or with** this image: the old bare `circles_rep_score_new_zero_24h > 5` rule evaluated against the new labeled series would false-fire on the fringe tier.

## Test plan
- [x] `dotnet build` exporter — 0 errors
- [x] `dotnet test Circles.Metrics.Exporter.Tests` (Testcontainers Postgres) — 2/2 pass
- [ ] post-deploy: scrape `/metrics` on a node with RepScoreDb → confirm `circles_rep_score_new_zero_24h{tier="significant"}` and `{tier="fringe"}` series present