### PR TITLE
feat(rpc): add circles_findScoreGroupRedeemPath redeem-capacity endpoint

### DIFF
--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -468,6 +468,46 @@ public static class ScoreGroupMintLimitReader
         return value.Trim().ToLowerInvariant();
     }
 
+    /// <summary>
+    /// Returns the per-(group, collateral) demurraged treasury collateral balance — i.e. the on-chain
+    /// <c>ScoreTreasury.balanceOfCollateral(c)</c> aggregated across the HIGH+LOW sub-treasuries (via the
+    /// <c>SCORE_TREASURY_SUBTREASURIES</c> override map). This is the raw treasury-side cap used by the
+    /// gCRC redeem-capacity computation: how much of each collateral the treasury can actually hand back.
+    /// Unlike <see cref="Read"/> it does NOT subtract historical/personal supply — that subtraction is the
+    /// remaining MINT headroom, the inverse of what a redeem can withdraw. The <see cref="ScoreGroupMintLimitBaseRow.TreasuryBalance"/>
+    /// field carries the demurraged balance (demurrage basis = live NOW(), matching the holder's
+    /// demurraged gCRC balance used as the redeem entitlement).
+    /// </summary>
+    public static IReadOnlyList<ScoreGroupMintLimitBaseRow> ReadTreasuryBalances(
+        NpgsqlConnection connection,
+        string[] scoreMintPolicies,
+        int commandTimeoutSeconds,
+        long? maxBlock = null,
+        NpgsqlTransaction? transaction = null,
+        string? groupAddressFilter = null,
+        string? collateralTokenFilter = null,
+        IReadOnlyDictionary<string, string[]>? subTreasuryOverrides = null)
+    {
+        var policies = scoreMintPolicies
+            .Select(x => x.Trim().ToLowerInvariant())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct()
+            .ToArray();
+
+        if (policies.Length == 0)
+            return [];
+
+        return ReadBaseRows(
+            connection,
+            policies,
+            commandTimeoutSeconds,
+            maxBlock,
+            transaction,
+            NormalizeFilter(groupAddressFilter),
+            NormalizeFilter(collateralTokenFilter),
+            subTreasuryOverrides);
+    }
+
     public static IReadOnlyList<ScoreGroupMintLimitRow> ReadFromBaseRows(
         NpgsqlConnection connection,
         string[] scoreMintPolicies,

--- a/src/Rpc/Circles.Rpc.Host.Tests/ScoreGroupRedeemPlannerTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/ScoreGroupRedeemPlannerTests.cs
@@ -1,0 +1,224 @@
+using System.Numerics;
+using Circles.Rpc.Host;
+using Cap = Circles.Rpc.Host.ScoreGroupRedeemPlanner.CollateralCap;
+
+namespace Circles.Rpc.Host.Tests;
+
+/// <summary>
+/// DB-free tests for the redeem allocation logic behind <c>circles_findScoreGroupRedeemPath</c>:
+/// the per-collateral MIN clamp, the shared-budget greedy allocation, and the findPath-shaped output
+/// (collateral legs only; <c>maxFlow</c> conveys the gCRC amount, no burn leg).
+/// </summary>
+[TestFixture]
+public class ScoreGroupRedeemPlannerTests
+{
+    private const string Holder = "0x1111111111111111111111111111111111111111";
+    private const string Treasury = "0x2222222222222222222222222222222222222222";
+    private const string ColA = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    private const string ColB = "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    private const string ColC = "0xcccccccccccccccccccccccccccccccccccccccc";
+
+    private static BigInteger Big(string s) => BigInteger.Parse(s);
+
+    [Test]
+    public void SingleCollateral_EntitlementBelowCap_RedeemsEntitlement()
+    {
+        // entitlement < cap  =>  MIN picks the entitlement
+        var r = ScoreGroupRedeemPlanner.Plan(Big("100"), new[] { new Cap(ColA, Big("1000")) }, Holder, Treasury);
+
+        Assert.That(r.MaxFlow, Is.EqualTo("100"));
+        Assert.That(r.Transfers, Has.Count.EqualTo(1)); // collateral leg only, no burn leg
+        Assert.That(r.Transfers[0].From, Is.EqualTo(Treasury));
+        Assert.That(r.Transfers[0].To, Is.EqualTo(Holder));
+        Assert.That(r.Transfers[0].TokenOwner, Is.EqualTo(ColA));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("100"));
+    }
+
+    [Test]
+    public void SingleCollateral_CapBelowEntitlement_ClampsToTreasuryHolding()
+    {
+        // cap < entitlement  =>  MIN picks the treasury cap (the "whatever is LOWER")
+        var r = ScoreGroupRedeemPlanner.Plan(Big("1000"), new[] { new Cap(ColA, Big("250")) }, Holder, Treasury);
+
+        Assert.That(r.MaxFlow, Is.EqualTo("250"));
+        Assert.That(r.Transfers, Has.Count.EqualTo(1));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("250"));
+    }
+
+    [Test]
+    public void MultiCollateral_BudgetIsShared_NotAppliedPerCollateral()
+    {
+        // The classic over-count guard: entitlement 120 with two caps of 100 each must total 120,
+        // NOT 200 (which independent MIN-per-collateral would yield). Greedy-by-largest fills the
+        // first to its cap (100) then the remainder (20) from the next.
+        var caps = new[] { new Cap(ColA, Big("100")), new Cap(ColB, Big("100")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("120"), caps, Holder, Treasury);
+
+        Assert.That(r.MaxFlow, Is.EqualTo("120"));
+        var legSum = r.Transfers.Aggregate(BigInteger.Zero, (acc, t) => acc + Big(t.Value));
+        Assert.That(legSum, Is.EqualTo(Big("120")));
+        Assert.That(r.Transfers, Has.Count.EqualTo(2));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("100")); // largest first, filled to cap
+        Assert.That(r.Transfers[1].Value, Is.EqualTo("20"));  // remainder
+    }
+
+    [Test]
+    public void MultiCollateral_GreedyFillsLargestFirst()
+    {
+        var caps = new[] { new Cap(ColA, Big("30")), new Cap(ColB, Big("500")), new Cap(ColC, Big("70")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("1000"), caps, Holder, Treasury);
+
+        // entitlement exceeds total treasury (600) => redeem all 600, ordered largest→smallest
+        Assert.That(r.MaxFlow, Is.EqualTo("600"));
+        Assert.That(r.Transfers, Has.Count.EqualTo(3));
+        Assert.That(r.Transfers[0].TokenOwner, Is.EqualTo(ColB));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("500"));
+        Assert.That(r.Transfers[1].TokenOwner, Is.EqualTo(ColC));
+        Assert.That(r.Transfers[1].Value, Is.EqualTo("70"));
+        Assert.That(r.Transfers[2].TokenOwner, Is.EqualTo(ColA));
+        Assert.That(r.Transfers[2].Value, Is.EqualTo("30"));
+    }
+
+    [Test]
+    public void MaxFlow_IsMinOfEntitlementAndTotalTreasury()
+    {
+        var caps = new[] { new Cap(ColA, Big("40")), new Cap(ColB, Big("60")) }; // total 100
+        // entitlement above total => capped at total
+        Assert.That(ScoreGroupRedeemPlanner.Plan(Big("999"), caps, Holder, Treasury).MaxFlow, Is.EqualTo("100"));
+        // entitlement below total => capped at entitlement
+        Assert.That(ScoreGroupRedeemPlanner.Plan(Big("70"), caps, Holder, Treasury).MaxFlow, Is.EqualTo("70"));
+    }
+
+    [Test]
+    public void ZeroEntitlement_ReturnsEmptyPath()
+    {
+        var r = ScoreGroupRedeemPlanner.Plan(BigInteger.Zero, new[] { new Cap(ColA, Big("100")) }, Holder, Treasury);
+        Assert.That(r.MaxFlow, Is.EqualTo("0"));
+        Assert.That(r.Transfers, Is.Empty);
+    }
+
+    [Test]
+    public void NoTreasuryCollateral_ReturnsEmptyPath()
+    {
+        // Holder has gCRC but the treasury holds nothing (e.g. all already redeemed) => nothing to give back.
+        var r = ScoreGroupRedeemPlanner.Plan(Big("100"), new[] { new Cap(ColA, BigInteger.Zero) }, Holder, Treasury);
+        Assert.That(r.MaxFlow, Is.EqualTo("0"));
+        Assert.That(r.Transfers, Is.Empty);
+    }
+
+    [Test]
+    public void NoCaps_ReturnsEmptyPath()
+    {
+        var r = ScoreGroupRedeemPlanner.Plan(Big("100"), Array.Empty<Cap>(), Holder, Treasury);
+        Assert.That(r.MaxFlow, Is.EqualTo("0"));
+        Assert.That(r.Transfers, Is.Empty);
+    }
+
+    [Test]
+    public void MaxFlow_EqualsSumOfCollateralLegs()
+    {
+        // 1:1 redemption: gCRC redeemed (maxFlow) == total collateral returned across the legs.
+        var caps = new[] { new Cap(ColA, Big("123")), new Cap(ColB, Big("456")), new Cap(ColC, Big("789")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("1000"), caps, Holder, Treasury);
+
+        var collateralOut = r.Transfers.Aggregate(BigInteger.Zero, (acc, t) => acc + Big(t.Value));
+        Assert.That(Big(r.MaxFlow), Is.EqualTo(collateralOut));
+    }
+
+    [Test]
+    public void AllLegs_AreTreasuryToHolder()
+    {
+        var caps = new[] { new Cap(ColA, Big("10")), new Cap(ColB, Big("20")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("100"), caps, Holder, Treasury);
+
+        Assert.That(r.Transfers, Is.Not.Empty);
+        Assert.That(r.Transfers, Has.All.Matches<Circles.Common.Dto.TransferPathStep>(
+            t => t.From == Treasury && t.To == Holder));
+    }
+
+    [Test]
+    public void LargeValues_NoOverflow()
+    {
+        // ~1.2e24 wei caps (well beyond Int64) exercise the BigInteger path end-to-end.
+        var caps = new[] { new Cap(ColA, Big("1200000000000000000000000")), new Cap(ColB, Big("800000000000000000000000")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("1500000000000000000000000"), caps, Holder, Treasury);
+
+        Assert.That(r.MaxFlow, Is.EqualTo("1500000000000000000000000"));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("1200000000000000000000000")); // largest cap filled
+        Assert.That(r.Transfers[1].Value, Is.EqualTo("300000000000000000000000"));  // remainder
+    }
+
+    [Test]
+    public void EqualCaps_TieBreakByAddressOrdinal_IsDeterministic()
+    {
+        // Equal balances: order must be deterministic by collateral address (ordinal), independent of
+        // input order. ColA < ColB ordinally, so ColA must come first even when passed last.
+        var caps = new[] { new Cap(ColB, Big("100")), new Cap(ColA, Big("100")) };
+        var r = ScoreGroupRedeemPlanner.Plan(Big("150"), caps, Holder, Treasury);
+
+        Assert.That(r.Transfers[0].TokenOwner, Is.EqualTo(ColA));
+        Assert.That(r.Transfers[0].Value, Is.EqualTo("100"));
+        Assert.That(r.Transfers[1].TokenOwner, Is.EqualTo(ColB));
+        Assert.That(r.Transfers[1].Value, Is.EqualTo("50"));
+    }
+
+    // ── ParseRequest (input validation, DB-free) ──────────────────────────────
+
+    [Test]
+    public void ParseRequest_ValidInputs_NormalizesAndParses()
+    {
+        var req = ScoreGroupRedeemPlanner.ParseRequest("0xABCDEF0123456789abcdef0123456789ABCDEF01", Holder, "1000");
+        Assert.That(req.Group, Is.EqualTo("0xabcdef0123456789abcdef0123456789abcdef01")); // lowercased
+        Assert.That(req.Holder, Is.EqualTo(Holder));
+        Assert.That(req.RequestedAmount, Is.EqualTo((BigInteger?)Big("1000")));
+    }
+
+    [Test]
+    public void ParseRequest_NoAmount_NullCap()
+    {
+        Assert.That(ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, null).RequestedAmount, Is.Null);
+        Assert.That(ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "  ").RequestedAmount, Is.Null);
+    }
+
+    [Test]
+    public void ParseRequest_ZeroAmount_ParsesZero()
+    {
+        Assert.That(ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "0").RequestedAmount, Is.EqualTo((BigInteger?)BigInteger.Zero));
+    }
+
+    [Test]
+    public void ParseRequest_WhitespaceAroundAmount_Trimmed()
+    {
+        Assert.That(ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, " 100 ").RequestedAmount, Is.EqualTo((BigInteger?)Big("100")));
+    }
+
+    [Test]
+    public void ParseRequest_EmptyOrMissingAddresses_Throw()
+    {
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest("", Holder, null));
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(null, Holder, null));
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, "", null));
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, null, null));
+    }
+
+    [Test]
+    public void ParseRequest_MalformedAddress_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest("0x123", Holder, null));        // too short
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest("notanaddress", Holder, null)); // no 0x / non-hex
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(
+            "0xZZZZ567890123456789012345678901234567890", Holder, null));                                          // non-hex chars
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(
+            "0x12345678901234567890123456789012345678901", Holder, null));                                         // too long (41)
+    }
+
+    [Test]
+    public void ParseRequest_NegativeOrNonDecimalAmount_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "-1"));   // negative
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "+1"));   // leading sign
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "1.5"));  // non-integer
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "0x10")); // hex
+        Assert.Throws<ArgumentException>(() => ScoreGroupRedeemPlanner.ParseRequest(ColA, Holder, "abc"));  // not a number
+    }
+}

--- a/src/Rpc/Circles.Rpc.Host/Dispatch/RpcDispatcher.cs
+++ b/src/Rpc/Circles.Rpc.Host/Dispatch/RpcDispatcher.cs
@@ -70,6 +70,7 @@ public static class RpcDispatcher
                 "circles_getTokenHolders" => await RpcHandlers.ReflectionHandler(request, rpcModule),
                 "circlesV2_findPath" => await RpcHandlers.HandleV2FindPath(request, rpcModule),
                 "circles_getScoreGroupMintLimits" => await RpcHandlers.ReflectionHandler(request, rpcModule),
+                "circles_findScoreGroupRedeemPath" => await RpcHandlers.ReflectionHandler(request, rpcModule),
                 // System & Query Methods
                 "circles_getBlockByTimestamp" => await RpcHandlers.HandleGetBlockByTimestamp(request, rpcModule),
                 "circles_events" => await RpcHandlers.HandleEventsLegacy(request, rpcModule),

--- a/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
+++ b/src/Rpc/Circles.Rpc.Host/ICirclesRpcModule.cs
@@ -403,6 +403,25 @@ public interface ICirclesRpcModule
     Task<ScoreGroupMintLimitsResponse> GetScoreGroupMintLimits(string groupAddress, string? collateralToken = null);
 
     /// <summary>
+    /// Computes the redeem capacity for a holder converting a score group's gCRC back into its
+    /// backing collateral (source==sink==holder, fromToken=gCRC). Output mirrors
+    /// <see cref="FindPathV2"/> (a <c>MaxFlowResponse</c>) so SDK clients consume it unchanged.
+    ///
+    /// Redeemable per collateral = MIN(holder entitlement budget, ScoreTreasury.balanceOfCollateral(c)),
+    /// where the budget is the holder's demurraged gCRC balance (capped by <paramref name="amount"/>)
+    /// allocated greedily (largest treasury holding first) across collaterals. <c>transfers</c> is one
+    /// collateral leg (treasury → holder) per allocated collateral; <c>maxFlow</c> = total gCRC
+    /// redeemable (== Σ collateral, 1:1). No gCRC "burn leg" is emitted — its on-chain destination
+    /// depends on the not-yet-deployed redeem contract and <c>maxFlow</c> already states the amount.
+    /// The collateral-selection order is a greedy placeholder, finalized once the redeem contract ships;
+    /// the amounts/clamping are final.
+    /// </summary>
+    /// <param name="group">Score group address whose gCRC is being redeemed.</param>
+    /// <param name="holder">Holder/redeemer address (== source == sink).</param>
+    /// <param name="amount">Optional uint256 decimal cap on gCRC to redeem; null/empty redeems up to the full balance.</param>
+    Task<MaxFlowResponse> FindScoreGroupRedeemPath(string group, string holder, string? amount = null);
+
+    /// <summary>
     /// Gets a snapshot of the entire Circles trust network.
     /// This method proxies the request to an external Pathfinder service.
     /// Returns the raw pathfinder response to match production behavior.

--- a/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
+++ b/src/Rpc/Circles.Rpc.Host/OpenRpc/OpenRpcGenerator.cs
@@ -121,6 +121,10 @@ public static class OpenRpcGenerator
             "Get per-collateral mint limits for a score-weighted group",
             "Returns the available mint limit for each (group, collateral) pair governed by an on-chain score-weighted group mint policy. Server applies the on-chain demurrage policy at query time; clients may subtract their own safety margin before minting.\n\n**Common use case**: Pre-flight check before invoking a score-group mint — discover how much of the group token can be minted from each collateral the caller holds.\n\n**Params**:\n- `groupAddress` (required): The group token address.\n- `collateralToken` (optional): Restrict to a single collateral token; omit to return all collaterals."),
 
+        ("circles_findScoreGroupRedeemPath", "FindScoreGroupRedeemPath", "Groups",
+            "Compute redeem capacity for a score group's gCRC into its collateral",
+            "Computes how much of a score group's gCRC a holder can redeem back into the backing collateral (source==sink==holder, fromToken=gCRC), decomposed per collateral. Output matches `circlesV2_findPath` (a `MaxFlowResponse` with `maxFlow` + `transfers`) so SDKs consume it unchanged.\n\nPer collateral the redeemable amount is `MIN(holder entitlement, ScoreTreasury.balanceOfCollateral(c))`, where the entitlement is the holder's demurraged gCRC balance (capped by `amount`) allocated greedily — largest treasury holding first — across collaterals. `transfers` is one collateral leg (treasury → holder) per allocated collateral; `maxFlow` is the total redeemable gCRC (== sum of the collateral legs, 1:1). No gCRC burn leg is emitted — `maxFlow` already states how much gCRC to redeem.\n\n**Note**: no on-chain redeem path is deployed yet, so the collateral-selection order is a greedy placeholder, finalized once the redeem contract ships. The amounts/clamping are final.\n\n**Params**:\n- `group` (required): Score group address whose gCRC is being redeemed.\n- `holder` (required): Holder/redeemer address.\n- `amount` (optional): uint256 decimal cap on gCRC to redeem; omit to redeem up to the full balance."),
+
         // ── Transaction Methods ──────────────────────────────────────────────
         ("circles_getTransactionHistory", "GetTransactionHistory", "Transactions",
             "Get transaction history for an avatar",
@@ -434,6 +438,17 @@ public static class OpenRpcGenerator
             Param("collateralToken", false, "string",
                 "Optional collateral-token filter. When provided, restricts the response to the single (group, collateral) row matching this token. When omitted, returns all collaterals governed by the group's on-chain mint policy.",
                 pattern: AddrPattern)
+        ],
+        ["circles_findScoreGroupRedeemPath"] =
+        [
+            Param("group", true, "string",
+                "Score group address whose gCRC is being redeemed back into collateral.",
+                pattern: AddrPattern),
+            Param("holder", true, "string",
+                "Holder/redeemer address (acts as both source and sink of the redeem).",
+                pattern: AddrPattern),
+            Param("amount", false, "string",
+                "Optional uint256 decimal cap (CRC wei) on the gCRC to redeem. Omit to redeem up to the holder's full balance.")
         ],
         ["circles_getTransactionHistory"] =
         [
@@ -1148,6 +1163,30 @@ public static class OpenRpcGenerator
                 [
                     new() { Name = "groupAddress", Value = ExampleGroup },
                     new() { Name = "collateralToken", Value = ExampleToken },
+                ],
+            }
+        ],
+        ["circles_findScoreGroupRedeemPath"] =
+        [
+            new()
+            {
+                Name = "Redeem up to the full gCRC balance",
+                Description = "Decompose a holder's entire gCRC balance into redeemable collateral, clamped by treasury holdings",
+                Params =
+                [
+                    new() { Name = "group", Value = ExampleGroup },
+                    new() { Name = "holder", Value = ExampleAddr1 },
+                ],
+            },
+            new()
+            {
+                Name = "Redeem a capped amount",
+                Description = "Redeem at most the given gCRC amount (CRC wei)",
+                Params =
+                [
+                    new() { Name = "group", Value = ExampleGroup },
+                    new() { Name = "holder", Value = ExampleAddr1 },
+                    new() { Name = "amount", Value = "1000000000000000000" },
                 ],
             }
         ],

--- a/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcMethodClassifier.cs
@@ -51,6 +51,7 @@ public static class RpcMethodClassifier
         "circles_getGroupMembers", "circles_getGroupMemberships",
         "circles_getTransactionHistory", "circles_getTransferData", "circles_getTokenHolders",
         "circlesV2_findPath",
+        "circles_getScoreGroupMintLimits", "circles_findScoreGroupRedeemPath",
         "circles_getBlockByTimestamp",
         "circles_events", "circles_events_paginated",
         "circles_health", "circles_tables", "circles_query", "circles_paginated_query",

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/CirclesRpcModule.ScoreGroup.cs
@@ -1,4 +1,8 @@
+using System.Globalization;
+using System.Numerics;
 using Circles.Common;
+using Circles.Common.Dto;
+using Npgsql;
 
 namespace Circles.Rpc.Host;
 
@@ -46,5 +50,107 @@ public partial class CirclesRpcModule : ICirclesRpcModule
             .ToArray();
 
         return new ScoreGroupMintLimitsResponse(group, rpcRows);
+    }
+
+    /// <inheritdoc />
+    public async Task<MaxFlowResponse> FindScoreGroupRedeemPath(
+        string group,
+        string holder,
+        string? amount = null)
+    {
+        // Validate + normalize (throws ArgumentException on malformed input → -32602, never a silent 0).
+        var (groupAddress, holderAddress, requestedAmount) =
+            ScoreGroupRedeemPlanner.ParseRequest(group, holder, amount);
+
+        var empty = new MaxFlowResponse("0", new List<TransferPathStep>());
+
+        var policies = _settings.ScoreGroupMintPolicies;
+        if (policies == null || policies.Length == 0)
+        {
+            // Server misconfiguration, not a legitimately-empty result — make it visible rather than
+            // returning a "0" that looks like a valid answer.
+            _logger?.LogWarning(
+                "FindScoreGroupRedeemPath: ScoreGroupMintPolicies (V2_SCORE_GROUP_MINT_POLICIES) is not configured; returning empty");
+            return empty;
+        }
+
+        await using var connection = await CreateConnectionAsync();
+
+        // Entitlement: the holder's demurraged gCRC balance (live NOW() basis), capped by `amount`.
+        // Query first so a holder with nothing to redeem short-circuits before the heavier caps query.
+        var holderBalance = await GetDemurragedBalanceAsync(connection, holderAddress, groupAddress);
+        var entitlement = requestedAmount.HasValue
+            ? BigInteger.Min(holderBalance, requestedAmount.Value)
+            : holderBalance;
+        if (entitlement <= BigInteger.Zero)
+            return empty;
+
+        // Per-collateral caps: demurraged ScoreTreasury.balanceOfCollateral(c) = HIGH+LOW sub-treasury
+        // holdings (same NOW() demurrage basis as the entitlement, so the MIN compares like with like).
+        var caps = ScoreGroupMintLimitReader.ReadTreasuryBalances(
+                connection,
+                policies,
+                commandTimeoutSeconds: _settings.DatabaseQueryTimeoutSeconds,
+                groupAddressFilter: groupAddress,
+                subTreasuryOverrides: _settings.ScoreTreasurySubTreasuries)
+            .Select(r => new ScoreGroupRedeemPlanner.CollateralCap(r.CollateralToken, r.TreasuryBalance))
+            .ToList();
+
+        // The treasury that returns collateral on redeem (the group's on-chain ScoreTreasury aggregator).
+        // A non-empty `caps` means the group is a registered score group, so its treasury must exist;
+        // if it somehow doesn't, return empty rather than fabricating a wrong `from` on the legs.
+        var treasury = await GetGroupTreasuryAsync(connection, groupAddress);
+        if (string.IsNullOrEmpty(treasury))
+            return empty;
+
+        return ScoreGroupRedeemPlanner.Plan(entitlement, caps, holderAddress, treasury);
+    }
+
+    /// <summary>
+    /// Demurraged ERC-1155 balance of <paramref name="tokenAddress"/> held by <paramref name="account"/>
+    /// (live NOW() demurrage basis via <c>V_CrcV2_BalancesByAccountAndToken</c>). Both inputs are
+    /// expected pre-lowercased; the view stores lowercase addresses so the filter stays index-friendly.
+    /// The view is schema-qualified as <c>public.</c> so that an <c>X-Max-Block-Number</c> header (which
+    /// pins this connection's <c>search_path</c> to the <c>circles_at_block</c> twin schema) cannot
+    /// silently resolve this read to a block-pinned twin while the treasury caps read live HEAD — that
+    /// would make the MIN compare two different blocks. This method is intentionally HEAD-only.
+    /// </summary>
+    private async Task<BigInteger> GetDemurragedBalanceAsync(
+        NpgsqlConnection connection,
+        string account,
+        string tokenAddress)
+    {
+        const string sql = """
+            SELECT COALESCE(SUM("demurragedTotalBalance"), 0)::text
+            FROM public."V_CrcV2_BalancesByAccountAndToken"
+            WHERE account = @account AND "tokenAddress" = @token
+            """;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.CommandTimeout = _settings.DatabaseQueryTimeoutSeconds;
+        command.Parameters.AddWithValue("account", account);
+        command.Parameters.AddWithValue("token", tokenAddress);
+        var result = (string?)await command.ExecuteScalarAsync();
+        return string.IsNullOrEmpty(result)
+            ? BigInteger.Zero
+            : BigInteger.Parse(result, CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Latest-recorded treasury address (<c>CrcV2_RegisterGroup.treasury</c>) for a score group —
+    /// the deployed <c>ScoreTreasury</c> aggregator. Returns null if the group is unknown.
+    /// </summary>
+    private async Task<string?> GetGroupTreasuryAsync(NpgsqlConnection connection, string group)
+    {
+        const string sql = """
+            SELECT LOWER("treasury")
+            FROM "CrcV2_RegisterGroup"
+            WHERE LOWER("group") = @group
+            ORDER BY "blockNumber" DESC, "transactionIndex" DESC, "logIndex" DESC
+            LIMIT 1
+            """;
+        await using var command = new NpgsqlCommand(sql, connection);
+        command.CommandTimeout = _settings.DatabaseQueryTimeoutSeconds;
+        command.Parameters.AddWithValue("group", group);
+        return (string?)await command.ExecuteScalarAsync();
     }
 }

--- a/src/Rpc/Circles.Rpc.Host/RpcModule/ScoreGroupRedeemPlanner.cs
+++ b/src/Rpc/Circles.Rpc.Host/RpcModule/ScoreGroupRedeemPlanner.cs
@@ -1,0 +1,129 @@
+using System.Globalization;
+using System.Numerics;
+using Circles.Common.Dto;
+
+namespace Circles.Rpc.Host;
+
+/// <summary>
+/// Pure (DB-free) allocation logic for <c>circles_findScoreGroupRedeemPath</c>. Kept separate from the
+/// RPC module so the MIN/greedy clamping can be unit-tested without a database.
+///
+/// A redeem converts a score group's gCRC back into its backing collateral. The holder's demurraged
+/// gCRC balance (capped by the requested amount) is a single shared budget; each collateral the
+/// treasury holds caps how much of that collateral can be returned. Per collateral:
+/// <c>redeemable(c) = MIN(remaining budget, treasuryBalance(c))</c>. Collaterals are filled greedily,
+/// largest treasury holding first (a deterministic placeholder until the redeem contract defines the
+/// real collateral-selection order). Output mirrors <c>circlesV2_findPath</c> so SDKs consume it as-is.
+/// </summary>
+public static class ScoreGroupRedeemPlanner
+{
+    /// <summary>A collateral the group's treasury holds, with its demurraged balance (the per-leg cap).</summary>
+    public readonly record struct CollateralCap(string Collateral, BigInteger Balance);
+
+    /// <summary>Validated, normalized redeem request inputs.</summary>
+    public readonly record struct RedeemRequest(string Group, string Holder, BigInteger? RequestedAmount);
+
+    /// <summary>
+    /// Validates and normalizes the raw RPC inputs (DB-free, so it is unit-tested directly).
+    /// Lowercases and format-checks <paramref name="group"/>/<paramref name="holder"/> as 0x-prefixed
+    /// 40-hex addresses; parses <paramref name="amount"/> as a non-negative uint256 decimal cap
+    /// (null/empty ⇒ no cap, i.e. redeem up to the full balance). Throws <see cref="ArgumentException"/>
+    /// on any malformed input rather than silently returning a zero result.
+    /// </summary>
+    public static RedeemRequest ParseRequest(string? group, string? holder, string? amount)
+    {
+        var groupAddress = NormalizeAddress(group, nameof(group));
+        var holderAddress = NormalizeAddress(holder, nameof(holder));
+
+        BigInteger? requestedAmount = null;
+        if (!string.IsNullOrWhiteSpace(amount))
+        {
+            // NumberStyles.None rejects signs, whitespace, and non-decimal forms, so "-1"/"+1"/"1.5"/
+            // "0x10" all throw rather than being silently coerced. "0" is valid (a no-op redeem).
+            if (!BigInteger.TryParse(amount.Trim(), NumberStyles.None, CultureInfo.InvariantCulture, out var parsed))
+                throw new ArgumentException("amount must be a non-negative uint256 decimal string", nameof(amount));
+            requestedAmount = parsed;
+        }
+
+        return new RedeemRequest(groupAddress, holderAddress, requestedAmount);
+    }
+
+    private static string NormalizeAddress(string? value, string paramName)
+    {
+        var addr = (value ?? string.Empty).Trim().ToLowerInvariant();
+        if (string.IsNullOrEmpty(addr))
+            throw new ArgumentException($"{paramName} is required", paramName);
+        if (!IsHexAddress(addr))
+            throw new ArgumentException($"{paramName} must be a 0x-prefixed 40-hex-char address", paramName);
+        return addr;
+    }
+
+    private static bool IsHexAddress(string lower)
+    {
+        if (lower.Length != 42 || lower[0] != '0' || lower[1] != 'x')
+            return false;
+        for (var i = 2; i < 42; i++)
+        {
+            var c = lower[i];
+            if (c is not ((>= '0' and <= '9') or (>= 'a' and <= 'f')))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Allocates <paramref name="entitlement"/> across <paramref name="caps"/> and returns a
+    /// findPath-shaped response whose <c>transfers</c> are one collateral leg
+    /// (<paramref name="treasury"/> → <paramref name="holder"/>) per allocated collateral, and whose
+    /// <c>maxFlow</c> is the total redeemable gCRC (== Σ collateral, since redemption is 1:1 in value;
+    /// the holder burns that much gCRC to receive the collateral). No gCRC "burn leg" is emitted: its
+    /// on-chain destination depends on the not-yet-deployed redeem contract, and <c>maxFlow</c> already
+    /// states the amount. Returns an empty <c>maxFlow:"0"</c> response when nothing can be redeemed.
+    /// </summary>
+    public static MaxFlowResponse Plan(
+        BigInteger entitlement,
+        IReadOnlyList<CollateralCap> caps,
+        string holder,
+        string treasury)
+    {
+        var empty = new MaxFlowResponse("0", new List<TransferPathStep>());
+        if (entitlement <= BigInteger.Zero || caps.Count == 0)
+            return empty;
+
+        // Greedy-by-largest, tie-broken by address for deterministic output.
+        var ordered = caps
+            .Where(c => c.Balance > BigInteger.Zero)
+            .OrderByDescending(c => c.Balance)
+            .ThenBy(c => c.Collateral, StringComparer.Ordinal)
+            .ToList();
+
+        var legs = new List<TransferPathStep>();
+        var remaining = entitlement;
+        var total = BigInteger.Zero;
+        foreach (var cap in ordered)
+        {
+            if (remaining <= BigInteger.Zero)
+                break;
+
+            var alloc = BigInteger.Min(remaining, cap.Balance); // the MIN clamp
+            if (alloc <= BigInteger.Zero)
+                continue;
+
+            // Collateral leg: the treasury returns this collateral to the holder on redeem.
+            legs.Add(new TransferPathStep
+            {
+                From = treasury,
+                To = holder,
+                TokenOwner = cap.Collateral,
+                Value = alloc.ToString(CultureInfo.InvariantCulture)
+            });
+            remaining -= alloc;
+            total += alloc;
+        }
+
+        if (total <= BigInteger.Zero)
+            return empty;
+
+        return new MaxFlowResponse(total.ToString(CultureInfo.InvariantCulture), legs);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a read-only JSON-RPC method `circles_findScoreGroupRedeemPath(group, holder, amount?)` that computes how much of a score group's gCRC a holder can redeem back into the backing collateral, decomposed per collateral. Output reuses `MaxFlowResponse` (same shape as `circlesV2_findPath`) so SDK clients consume it unchanged.

## What it computes
- entitlement = holder's demurraged gCRC balance (capped by `amount`)
- per-collateral cap = demurraged `ScoreTreasury.balanceOfCollateral(c)` (HIGH+LOW sub-treasury sum, via the existing treasury-balance machinery)
- `redeemable(c) = MIN(remaining shared budget, cap(c))`, greedy by largest holding; `maxFlow` = Σ allocated
- `transfers` = collateral legs only (treasury → holder); no burn leg (maxFlow conveys the gCRC amount)

## What changed
- `Common`: new public `ScoreGroupMintLimitReader.ReadTreasuryBalances` (raw demurraged treasury holdings, reusing `ReadBaseRows`)
- `Rpc`: `FindScoreGroupRedeemPath` + pure `ScoreGroupRedeemPlanner` (allocation + `ParseRequest` validation); dispatch/classifier/interface/OpenRPC wiring; registers the previously-missing `circles_getScoreGroupMintLimits` metric label
- Balance view schema-qualified as `public.` so an `X-Max-Block-Number` header cannot half-pin the entitlement read against live treasury caps (method is HEAD-only)
- Returns empty instead of fabricating a counterparty when a group's treasury is absent; warns when score mint policies are unconfigured

## Notes
No on-chain redeem mechanism is deployed yet, so the collateral-selection order is a documented placeholder; the per-collateral amounts and clamping are final. Per-collateral caps verified byte-exact against on-chain `ScoreTreasury.balanceOfCollateral`.

## Test plan
- [x] Full solution build: 0 errors
- [x] 20 DB-free unit tests: MIN clamp, shared-budget allocation, tie-break, BigInteger overflow, input validation
- [x] OpenRPC discovery / snapshot tests pass
- [x] Per-collateral cap byte-exact vs on-chain `balanceOfCollateral` (staging group)
- [ ] Live RPC smoke on staging after deploy