### PR TITLE
feat(metrics): add circles_blacklist_members_nonzero_computed_score gauge

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/RepScoreMetrics.cs
@@ -18,7 +18,19 @@ public static class RepScoreMetrics
 
     public static readonly Gauge BlacklistMembersNonzeroScore = Prometheus.Metrics
         .CreateGauge("circles_blacklist_members_nonzero_score",
-            "Blacklisted ScoreGroup members whose last-emitted score_uint is still > 0 — alert if > 0");
+            "Blacklisted ScoreGroup members whose last-EMITTED score_uint is still > 0 — alert if > 0. "
+            + "score_uint is round() on the 0-100 scale so the smallest nonzero value (1 ≈ 1%) is already "
+            + "well above dust; this lags the computed view by up to one publish cycle (~2h).");
+
+    // Leading indicator: same condition as above but on the COMPUTED (pre-publish)
+    // rep_score_state instead of the emitted snapshot. AA forces a blacklisted avatar's
+    // score to 0 at compute time, so a blacklisted member with computed score > dust is a
+    // genuine leak visible ~2h BEFORE it would surface in the emitted metric. Float score,
+    // so a real dust threshold (score*100 > dust) applies here (unlike the integer emitted).
+    public static readonly Gauge BlacklistMembersNonzeroComputedScore = Prometheus.Metrics
+        .CreateGauge("circles_blacklist_members_nonzero_computed_score",
+            "Blacklisted ScoreGroup members whose COMPUTED (pre-publish) score is still > dust — "
+            + "leading indicator of unzeroed scores, ~2h ahead of circles_blacklist_members_nonzero_score.");
 
     public static readonly Gauge BlacklistAdditions24h = Prometheus.Metrics
         .CreateGauge("circles_blacklist_additions_24h",

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreCollectorService.cs
@@ -62,6 +62,7 @@ public class RepScoreCollectorService : BackgroundService
             RepScoreMetrics.BlacklistTotal.Set(stats.Total);
             RepScoreMetrics.BlacklistMembersTotal.Set(stats.MembersTotal);
             RepScoreMetrics.BlacklistMembersNonzeroScore.Set(stats.MembersNonzeroScore);
+            RepScoreMetrics.BlacklistMembersNonzeroComputedScore.Set(stats.MembersNonzeroComputedScore);
             RepScoreMetrics.BlacklistAdditions24h.Set(stats.Additions24h);
             RepScoreMetrics.BlacklistRemovals24h.Set(stats.Removals24h);
             RepScoreMetrics.BlacklistLastRefreshAgeSeconds.Set(stats.LastRefreshAgeSeconds);
@@ -70,6 +71,11 @@ public class RepScoreCollectorService : BackgroundService
                 _logger.LogWarning("Blacklisted ScoreGroup members with nonzero score: {Count}", stats.MembersNonzeroScore);
             else if (stats.MembersTotal > 0)
                 _logger.LogInformation("Blacklisted ScoreGroup members present but all scored 0 (grace period ok): {Count}", stats.MembersTotal);
+
+            // Leading indicator: computed-stage leak. Nonzero here means scores have not
+            // been zeroed at compute time yet — surfaces ~2h before the emitted metric.
+            if (stats.MembersNonzeroComputedScore > 0)
+                _logger.LogWarning("Blacklisted ScoreGroup members with nonzero COMPUTED (pre-publish) score: {Count} — leading leak indicator", stats.MembersNonzeroComputedScore);
 
             _logger.LogDebug("Blacklist: total={Total}, members={Members}, age={Age}s",
                 stats.Total, stats.MembersTotal, (int)stats.LastRefreshAgeSeconds);

--- a/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/RepScoreRepository.cs
@@ -17,6 +17,11 @@ public class RepScoreRepository
     public double NewZeroSignificantThreshold => _newZeroSignificantThreshold;
     private readonly ILogger<RepScoreRepository> _logger;
 
+    // Dust floor (0-100 scale) for the computed blacklist-leak count. A blacklisted
+    // avatar should compute to exactly 0 (AA forces it), so anything above dust is a
+    // genuine leak. Matches the 0.1 used by the score-distribution / new-zero logic.
+    private const double ComputedLeakDustScore100 = 0.1;
+
     public RepScoreRepository(
         string repScoreConn,
         string circlesDbConn,
@@ -43,6 +48,7 @@ public class RepScoreRepository
         long Total,
         long MembersTotal,
         long MembersNonzeroScore,
+        long MembersNonzeroComputedScore,
         long Additions24h,
         long Removals24h,
         double LastRefreshAgeSeconds);
@@ -58,6 +64,17 @@ public class RepScoreRepository
                 JOIN blacklist b ON b.address = s.avatar
                 WHERE s.group_id = @groupId
             ),
+            member_blacklist_computed AS (
+                -- Leading indicator: blacklisted members whose COMPUTED (pre-publish)
+                -- score is still above dust. AA forces a blacklisted avatar to 0 at
+                -- compute time, so any row here is a genuine leak ~2h ahead of the
+                -- emitted view. score is the [0,1] float, hence the *100 dust compare.
+                SELECT COUNT(DISTINCT st.avatar) AS members_nonzero_computed
+                FROM rep_score_state st
+                JOIN blacklist b ON b.address = st.avatar
+                WHERE st.group_id = @groupId
+                  AND st.score * 100 > @dust
+            ),
             refresh_stats AS (
                 SELECT
                     COALESCE(EXTRACT(EPOCH FROM (NOW() - MAX(completed_at) FILTER (WHERE error IS NULL))), 999999) AS last_refresh_age,
@@ -69,16 +86,18 @@ public class RepScoreRepository
                 (SELECT COUNT(*) FROM blacklist) AS total,
                 mb.members_total,
                 mb.members_nonzero_score,
+                mbc.members_nonzero_computed,
                 rs.additions_24h,
                 rs.removals_24h,
                 rs.last_refresh_age
-            FROM member_blacklist mb, refresh_stats rs
+            FROM member_blacklist mb, member_blacklist_computed mbc, refresh_stats rs
             """;
 
         await using var conn = new NpgsqlConnection(_repScoreConn);
         await conn.OpenAsync(ct);
         await using var cmd = new NpgsqlCommand(sql, conn);
         cmd.Parameters.AddWithValue("groupId", _groupId);
+        cmd.Parameters.AddWithValue("dust", ComputedLeakDustScore100);
         await using var reader = await cmd.ExecuteReaderAsync(ct);
 
         if (await reader.ReadAsync(ct))
@@ -89,10 +108,11 @@ public class RepScoreRepository
                 reader.GetInt64(2),
                 reader.GetInt64(3),
                 reader.GetInt64(4),
-                reader.GetDouble(5));
+                reader.GetInt64(5),
+                reader.GetDouble(6));
         }
 
-        return new BlacklistStats(0, 0, 0, 0, 0, 999999);
+        return new BlacklistStats(0, 0, 0, 0, 0, 0, 999999);
     }
 
     // ===========================================


### PR DESCRIPTION
## What
Adds a new Prometheus gauge **`circles_blacklist_members_nonzero_computed_score`** to the rep-score metrics exporter: the count of blacklisted ScoreGroup members whose **computed** (pre-publish) `rep_score_state.score * 100` is still above the dust floor (0.1 on the 0–100 scale).

## Why
Blacklisted avatars are forced to a 0 score at *compute* time, so a blacklisted member with a nonzero computed score is a genuine leak. The existing `circles_blacklist_members_nonzero_score` reads the *emitted* snapshot, which lags compute by up to one publish cycle (~2h) — this new gauge is the **leading indicator**, surfacing the same condition ~2h earlier.

It also clarifies that the emitted metric is already dust-immune: `score_uint = round()` on the 0–100 scale, so its smallest nonzero value (1 ≈ 1%) is well above dust and no fractional threshold applies there.

## How
- Folded the computed-leak count into the existing `GetBlacklistStatsAsync` query (one extra CTE on `rep_score_state`, single round-trip) — added `MembersNonzeroComputedScore` to the result record.
- Dust floor is a named const (`ComputedLeakDustScore100 = 0.1`), matching the existing score-distribution / new-zero logic.
- Collector sets the gauge and logs a warning when nonzero.

## Test plan
- [x] `dotnet build src/Metrics/Circles.Metrics.Exporter` — 0 errors.
- [x] New CTE uses the same table/columns (`rep_score_state`, `score`, `group_id`, `avatar`) as the existing distribution query.
- [ ] After deploy: confirm `circles_blacklist_members_nonzero_computed_score` appears and reads 0 in steady state.