### PR TITLE
chore(nethermind): enable online full state pruning via StateDbSize trigger

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -35,6 +35,9 @@ services:
       --Sync.AncientReceiptsBarrier=12500000
       --Receipt.StoreReceipts=true
       --Receipt.TxLookupLimit=${NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT:-0}
+      --Pruning.Mode=Hybrid
+      --Pruning.FullPruningTrigger=StateDbSize
+      --Pruning.FullPruningThresholdMb=100000
       --log=INFO
       --JsonRpc.Enabled=true
       --JsonRpc.Host=0.0.0.0


### PR DESCRIPTION
## What

Adds three `--Pruning.*` flags to the `nethermind-gnosis` service command in `docker/docker-compose.gnosis.yml` to enable **online full state pruning** via an automatic size trigger:

```
--Pruning.Mode=Hybrid
--Pruning.FullPruningTrigger=StateDbSize
--Pruning.FullPruningThresholdMb=100000
```

## Why

The command block previously set no `--Pruning.*` flags. `Pruning.Mode` already defaults to `Hybrid` (in-memory pruning active), but `Pruning.FullPruningTrigger` defaults to `Manual`, so the on-disk full-pruning pass that compacts dead/orphaned state-trie nodes **never ran**. The state DB therefore grew without bound (~136 GB observed vs a ~66 GB pruned baseline) — the dominant component of node-disk creep.

## Scope / safety

- **State trie only.** Full pruning does not touch receipts or bodies (`Sync.Ancient*Barrier=12500000` unchanged), so re-index / from-chain re-derivation back to the Circles V1 genesis block is fully preserved.
- **Online.** The node stays up; a new pruned state DB is built alongside the old and atomically switched. Requires temporary free space ≈ the pruned state size (~66 GB); `AvailableSpaceCheckEnabled` (default `true`) refuses to start without headroom.
- **No new RPC surface.** The `StateDbSize` trigger is automatic — no `Admin` JSON-RPC module is added or exposed.
- **No thrashing.** `FullPruningMinimumDelayHours` (default `240`) caps pruning to at most one run per 10 days.
- **Trigger math.** State is ~136 GB now → a full prune fires once on restart, settles to the ~66 GB baseline, and re-fires only after ~34 GB of regrowth (months) past the 10-day gate.

Config keys verified against Nethermind 1.36.0 `IPruningConfig` / `PruningMode` / `FullPruningTrigger`.

## Deploy / test plan

- [ ] Deploy the single `nethermind-gnosis` service — recreates only the index container (no Postgres restart; RPC/pathfinder/cache keep serving from Postgres).
- [ ] Confirm the container returns healthy and `eth_blockNumber` advances (execution client + indexer resume from last block).
- [ ] Watch logs for full-pruning start and completion.
- [ ] Confirm the on-disk state DB shrinks toward the ~66 GB baseline and overall free disk increases.
- [ ] Confirm the index `/ready` endpoint returns 200 (indexer caught up) after the prune.
- [ ] Repeat on the second index node once the first is confirmed.