### PR TITLE
perf(metrics-exporter): run LiquidityCollector sub-collections sequentially

### DIFF
--- a/src/Metrics/Circles.Metrics.Exporter/Services/LiquidityCollectorService.cs
+++ b/src/Metrics/Circles.Metrics.Exporter/Services/LiquidityCollectorService.cs
@@ -106,16 +106,22 @@ public class LiquidityCollectorService : BackgroundService
 
     private async Task CollectAllLiquidityMetricsAsync(CancellationToken ct)
     {
-        // Run independent collections in parallel
-        await Task.WhenAll(
-            CollectBalancerVaultMetricsAsync(ct),
-            CollectGroupTreasuryMetricsAsync(ct),
-            CollectAggregateTvlMetricsAsync(ct),
-            CollectDrainDetectionMetricsAsync(ct),
-            CollectGroupTreasuryDrainDetectionAsync(ct),
-            CollectSybilDetectionMetricsAsync(ct),
-            CollectWhaleTransferMetricsAsync(ct)
-        );
+        // Run collections sequentially to cap concurrent DB load. Several of these
+        // are heavy aggregates (TVL SUM, drain/sybil/whale detection over transfer
+        // tables) that postgres parallelizes with worker backends; firing all seven
+        // at once via Task.WhenAll spiked the metrics-exporter to ~14 active backends
+        // on postgres-gnosis and tripped MetricsExporterQueryPileup. At a 300s
+        // interval, serial execution (a few seconds total) is well within budget and
+        // keeps the active-connection count to one query (+ its workers) at a time.
+        // Each sub-collection catches its own exceptions, so a failure still does not
+        // block the others (behaviour preserved from the WhenAll version).
+        await CollectBalancerVaultMetricsAsync(ct);
+        await CollectGroupTreasuryMetricsAsync(ct);
+        await CollectAggregateTvlMetricsAsync(ct);
+        await CollectDrainDetectionMetricsAsync(ct);
+        await CollectGroupTreasuryDrainDetectionAsync(ct);
+        await CollectSybilDetectionMetricsAsync(ct);
+        await CollectWhaleTransferMetricsAsync(ct);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
`LiquidityCollectorService.CollectAllLiquidityMetricsAsync` ran all seven sub-collections concurrently (`Task.WhenAll`). Several are heavy aggregates (TVL `SUM`, drain/sybil/whale detection over transfer tables) that postgres parallelizes into worker backends, so one collection cycle spiked the exporter's connection pool to ~14 active backends and tripped the query-pileup alert.

## Change
Run the sub-collections **sequentially**. At the 300s interval, serial execution (a few seconds) is well within budget and caps active connections to one query + its parallel workers. Each sub-collection already catches its own exceptions, so a single failure still does not block the others (behaviour preserved).

## Test plan
- [x] `dotnet build` — 0 errors
- [ ] After deploy: active metrics-exporter backends during a liquidity cycle drop from ~14 to a low single digit; `LiquidityLastCollectionTimestamp` keeps advancing every cycle