### PR TITLE
chore(nethermind): enable online full state pruning via StateDbSize trigger

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -35,6 +35,9 @@ services:
       --Sync.AncientReceiptsBarrier=12500000
       --Receipt.StoreReceipts=true
       --Receipt.TxLookupLimit=${NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT:-0}
+      --Pruning.Mode=Hybrid
+      --Pruning.FullPruningTrigger=StateDbSize
+      --Pruning.FullPruningThresholdMb=100000
       --log=INFO
       --JsonRpc.Enabled=true
       --JsonRpc.Host=0.0.0.0


### PR DESCRIPTION
Promotes the state-pruning configuration (already on `staging`) to `dev`.

## What changed
Adds three flags to the `nethermind-gnosis` service command:

```
--Pruning.Mode=Hybrid
--Pruning.FullPruningTrigger=StateDbSize
--Pruning.FullPruningThresholdMb=100000
```

## Why
Without any `--Pruning.*` flags the node never runs online full state pruning, so the state-trie DB grows unbounded. This bounds it:

- Online full pruning mirrors the live state trie into a fresh DB and atomically switches — the node stays up and serving throughout.
- Receipts/bodies DBs are untouched, so re-index / full resync capability is preserved.
- Threshold 100000 MB (~93 GiB) fires once above current state size, then re-fires only after regrowth past the threshold plus the 10-day `FullPruningMinimumDelayHours` gate (bounded sawtooth, not a monotonic climb).

Cherry-pick of the same commit already live on `staging`; compose-only, +3 lines.

## Test plan
- [ ] Deploy gnosis to each production node one at a time
- [ ] Confirm `Full Pruning Finished … nodes mirrored` in node logs
- [ ] Confirm `circles_health=Healthy`, `pathfinder /ready=200`, `test-env /health=200` during and after the prune
- [ ] Confirm state dir settles and disk reclaim holds