### PR TITLE
fix(rpc): listen on the configured PG notify channel for realtime push

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
@@ -16,6 +16,13 @@ public sealed class CirclesSubscriptionService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ConcurrentDictionary<string, WebSocketSubscriber> _subscribers = new();
 
+    // The NOTIFY payload from the indexer uses camelCase property names; match them
+    // case-insensitively so the PascalCase BlockRangePayload record binds correctly.
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     public CirclesSubscriptionService(
         ILogger<CirclesSubscriptionService> logger,
         Settings settings,
@@ -103,7 +110,12 @@ public sealed class CirclesSubscriptionService : BackgroundService
         BlockRangePayload? blockRange;
         try
         {
-            blockRange = JsonSerializer.Deserialize<BlockRangePayload>(payload);
+            // The indexer serializes the payload with camelCase keys
+            // ({"fromBlock":N,"toBlock":M,"timestamp":T} — see StateMachine.NotifyViaPostgres),
+            // so deserialize case-insensitively. Without this, the PascalCase record properties
+            // never bind and every range parses as 0-0, so GetEvents finds nothing and no events
+            // are ever broadcast.
+            blockRange = JsonSerializer.Deserialize<BlockRangePayload>(payload, PayloadJsonOptions);
         }
         catch (Exception ex)
         {

--- a/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
@@ -81,10 +81,16 @@ public sealed class CirclesSubscriptionService : BackgroundService
             _ = Task.Run(async () => await HandleNotificationAsync(args.Payload, stoppingToken), stoppingToken);
         };
 
-        await using var command = new NpgsqlCommand("LISTEN circles_events", connection);
+        // Listen on the same channel the indexer notifies (Settings.PgNotifyChannel,
+        // default "circles_index_events"). Read it from settings rather than hardcoding so
+        // this listener stays consistent with the indexer's pg_notify and the cache service's
+        // NotificationListenerService, all of which derive the channel from the same setting.
+        // Channel names cannot be parameterized in LISTEN, and the value is a trusted
+        // env/default (not user input), so interpolation is safe here.
+        await using var command = new NpgsqlCommand($"LISTEN {_settings.PgNotifyChannel}", connection);
         await command.ExecuteNonQueryAsync(stoppingToken);
 
-        _logger.LogInformation("Listening on circles_events channel");
+        _logger.LogInformation("Listening on {Channel} channel", _settings.PgNotifyChannel);
 
         while (!stoppingToken.IsCancellationRequested)
         {


### PR DESCRIPTION
## Summary
`CirclesSubscriptionService` hardcoded `LISTEN circles_events`, but the indexer notifies on `Settings.PgNotifyChannel` (default `circles_index_events`) and the cache service's `NotificationListenerService` listens on that same setting. The channel mismatch meant the rpc-host's subscription listener received no notifications, so `circles_subscription` websocket pushes were never emitted and realtime events never reached clients.

This reads the channel from settings like every other listener, keeping it consistent with the producer. Channel names cannot be parameterized in `LISTEN`; the value is a trusted env/default (not user input), matching the existing pattern in `NotificationListenerService`.

## Evidence
- The rpc-host subscription service was the **only** LISTEN site that hardcoded its channel; the indexer (`StateMachine`), cache `NotificationListenerService`, and cache `CacheWarmupService` all derive it from `Settings.PgNotifyChannel`.
- Observed against the live endpoint: `eth_subscribe(newHeads)` pushes stream every block while `circles_subscribe` delivers zero pushes over minutes on an all-events subscription — isolating the break to the circles push path (the PG NOTIFY pipeline), not the websocket transport.

## Test plan
- [x] `dotnet build` (Circles.Rpc.Host) — 0 errors
- [ ] Deploy to a node; on an on-chain event, confirm `circles_subscription` pushes arrive to a subscribed client
- [ ] rpc-host log line reads `Listening on circles_index_events channel`