### PR TITLE
fix(rpc): listen on the configured PG notify channel for realtime push

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
@@ -81,10 +81,16 @@ public sealed class CirclesSubscriptionService : BackgroundService
             _ = Task.Run(async () => await HandleNotificationAsync(args.Payload, stoppingToken), stoppingToken);
         };
 
-        await using var command = new NpgsqlCommand("LISTEN circles_events", connection);
+        // Listen on the same channel the indexer notifies (Settings.PgNotifyChannel,
+        // default "circles_index_events"). Read it from settings rather than hardcoding so
+        // this listener stays consistent with the indexer's pg_notify and the cache service's
+        // NotificationListenerService, all of which derive the channel from the same setting.
+        // Channel names cannot be parameterized in LISTEN, and the value is a trusted
+        // env/default (not user input), so interpolation is safe here.
+        await using var command = new NpgsqlCommand($"LISTEN {_settings.PgNotifyChannel}", connection);
         await command.ExecuteNonQueryAsync(stoppingToken);
 
-        _logger.LogInformation("Listening on circles_events channel");
+        _logger.LogInformation("Listening on {Channel} channel", _settings.PgNotifyChannel);
 
         while (!stoppingToken.IsCancellationRequested)
         {


### PR DESCRIPTION
Cherry-pick of the realtime-push channel fix onto `staging` for a rolling staging deploy.

`CirclesSubscriptionService` hardcoded `LISTEN circles_events`, but the indexer notifies on `Settings.PgNotifyChannel` (default `circles_index_events`) and the cache service's `NotificationListenerService` listens on that same setting. The mismatch meant the rpc-host's subscription listener received no notifications, so `circles_subscription` websocket pushes were never emitted. Reads the channel from settings like every other listener.

- [x] `dotnet build` (Circles.Rpc.Host) — 0 errors
- [ ] Rolling deploy to staging (SERVICE=rpc); confirm rpc-host log reads `Listening on circles_index_events channel`
- [ ] Subscribe from a client; on an on-chain event, `circles_subscription` pushes arrive