### PR TITLE
fix(rpc): parse NOTIFY payload case-insensitively (realtime push 0-0 fix)

### DIFF
--- a/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
+++ b/src/Rpc/Circles.Rpc.Host/CirclesSubscriptionService.cs
@@ -16,6 +16,13 @@ public sealed class CirclesSubscriptionService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ConcurrentDictionary<string, WebSocketSubscriber> _subscribers = new();
 
+    // The NOTIFY payload from the indexer uses camelCase property names; match them
+    // case-insensitively so the PascalCase BlockRangePayload record binds correctly.
+    private static readonly JsonSerializerOptions PayloadJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+    };
+
     public CirclesSubscriptionService(
         ILogger<CirclesSubscriptionService> logger,
         Settings settings,
@@ -103,7 +110,12 @@ public sealed class CirclesSubscriptionService : BackgroundService
         BlockRangePayload? blockRange;
         try
         {
-            blockRange = JsonSerializer.Deserialize<BlockRangePayload>(payload);
+            // The indexer serializes the payload with camelCase keys
+            // ({"fromBlock":N,"toBlock":M,"timestamp":T} — see StateMachine.NotifyViaPostgres),
+            // so deserialize case-insensitively. Without this, the PascalCase record properties
+            // never bind and every range parses as 0-0, so GetEvents finds nothing and no events
+            // are ever broadcast.
+            blockRange = JsonSerializer.Deserialize<BlockRangePayload>(payload, PayloadJsonOptions);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Follow-up to the channel fix (#513). With the listener now on the correct channel it receives notifications, but deserialized the indexer's camelCase payload (`{fromBlock,toBlock,timestamp}`) into a PascalCase record with default case-sensitive matching — so every range parsed as `0-0`, `GetEvents(0,0)` found nothing, and no events were broadcast. Verified live on staging1: rpc-host logged 143 `No events generated for range 0-0` in 15 min. Deserialize case-insensitively so the real block range binds.

- [x] `dotnet build` (Circles.Rpc.Host) — 0 errors
- [ ] Redeploy rpc to staging; confirm `circles_subscription` pushes arrive on an on-chain event