### PR TITLE
fix(docker): copy MultiAffiliateGroupRegistry csproj into Index image restore layer

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -11,6 +11,7 @@ COPY src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj ./Index/Ci
 COPY src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj ./Index/Circles.Index.CirclesV1.NameRegistry/
 COPY src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj ./Index/Circles.Index.CirclesV2/
 COPY src/Index/Circles.Index.CirclesV2.AffiliateGroupRegistry/Circles.Index.CirclesV2.AffiliateGroupRegistry.csproj ./Index/Circles.Index.CirclesV2.AffiliateGroupRegistry/
+COPY src/Index/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry.csproj ./Index/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry/
 COPY src/Index/Circles.Index.CirclesV2.BaseGroupDeployer/Circles.Index.CirclesV2.BaseGroupDeployer.csproj ./Index/Circles.Index.CirclesV2.BaseGroupDeployer/
 COPY src/Index/Circles.Index.CirclesV2.CMGroupDeployer/Circles.Index.CirclesV2.CMGroupDeployer.csproj ./Index/Circles.Index.CirclesV2.CMGroupDeployer/
 COPY src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj ./Index/Circles.Index.CirclesV2.Erc20Lift/


### PR DESCRIPTION
## What

Adds the missing per-project `COPY` line for `Circles.Index.CirclesV2.MultiAffiliateGroupRegistry` to `docker/Index.Dockerfile`.

## Why

The Index image restores `Circles.Index` via per-project `.csproj` COPY lines for Docker layer caching, then publishes with `--no-restore`. The new `Circles.Index.CirclesV2.MultiAffiliateGroupRegistry` project was added to the solution and to `Circles.Index`'s project references but not to this COPY list, so `dotnet restore` skipped it ("project not found") and `dotnet publish --no-restore` failed with `NETSDK1004` (missing `project.assets.json`). Local `dotnet build` and CI build the full source tree, so they did not exercise the per-csproj restore layer.

Only `Index.Dockerfile` uses this per-csproj pattern. `rpc-host.Dockerfile` copies the whole `src/Index` tree before restore, and `metrics-exporter`/`backfill` are self-contained — none need changes.

## Test plan

- [x] `docker build -f docker/Index.Dockerfile --target build .` succeeds (restore + publish); `MultiAffiliateGroupRegistry.dll` is produced.