### PR TITLE
fix(docker): copy MultiAffiliateGroupRegistry csproj into Index image restore layer

### DIFF
--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -11,6 +11,7 @@ COPY src/Index/Circles.Index.CirclesV1/Circles.Index.CirclesV1.csproj ./Index/Ci
 COPY src/Index/Circles.Index.CirclesV1.NameRegistry/Circles.Index.CirclesV1.NameRegistry.csproj ./Index/Circles.Index.CirclesV1.NameRegistry/
 COPY src/Index/Circles.Index.CirclesV2/Circles.Index.CirclesV2.csproj ./Index/Circles.Index.CirclesV2/
 COPY src/Index/Circles.Index.CirclesV2.AffiliateGroupRegistry/Circles.Index.CirclesV2.AffiliateGroupRegistry.csproj ./Index/Circles.Index.CirclesV2.AffiliateGroupRegistry/
+COPY src/Index/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry.csproj ./Index/Circles.Index.CirclesV2.MultiAffiliateGroupRegistry/
 COPY src/Index/Circles.Index.CirclesV2.BaseGroupDeployer/Circles.Index.CirclesV2.BaseGroupDeployer.csproj ./Index/Circles.Index.CirclesV2.BaseGroupDeployer/
 COPY src/Index/Circles.Index.CirclesV2.CMGroupDeployer/Circles.Index.CirclesV2.CMGroupDeployer.csproj ./Index/Circles.Index.CirclesV2.CMGroupDeployer/
 COPY src/Index/Circles.Index.CirclesV2.Erc20Lift/Circles.Index.CirclesV2.Erc20Lift.csproj ./Index/Circles.Index.CirclesV2.Erc20Lift/


### PR DESCRIPTION
Adds the missing per-project `COPY` line for `Circles.Index.CirclesV2.MultiAffiliateGroupRegistry` to `docker/Index.Dockerfile` (same gap as #528 on staging, introduced by #526). Without it, `dotnet restore` skips the project and `dotnet publish --no-restore` fails with `NETSDK1004`. Verified via local `docker build --target build` on the staging twin (#528).

Only `Index.Dockerfile` uses the per-csproj pattern; rpc-host copies the whole tree, metrics/backfill are self-contained.

## Test plan
- [x] Local `docker build -f docker/Index.Dockerfile --target build .` succeeds (verified on the identical staging change).