### PR TITLE
perf(pathfinder): maintain balances table incrementally instead of full REFRESH

### DIFF
--- a/src/Index/Circles.Index.CirclesViews.Tests/MaterializedViewDeltaTests.cs
+++ b/src/Index/Circles.Index.CirclesViews.Tests/MaterializedViewDeltaTests.cs
@@ -40,28 +40,42 @@ public class MaterializedViewDeltaTests
     // ================================================================
 
     [Test]
-    public void Balances_MatviewHas_MaxBlockColumn()
+    public void Balances_TableHas_MaxBlockColumn()
     {
         var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
-        var matViewSql = ExtractMatviewSql(sql);
-        Assert.That(matViewSql, Does.Contain("\"_maxBlock\""),
-            "M_CrcV2_BalancesByAccountAndToken must have _maxBlock column for watermark.");
-        Assert.That(matViewSql, Does.Contain("max(\"blockNumber\")").IgnoreCase,
-            "Matview must compute MAX(blockNumber) per group for watermark.");
+        var tableSql = ExtractMatviewSql(sql);
+        Assert.That(tableSql, Does.Contain("\"_maxBlock\""),
+            "M_CrcV2_BalancesByAccountAndToken must have _maxBlock column for the watermark.");
+        Assert.That(tableSql, Does.Contain("max(\"blockNumber\")").IgnoreCase,
+            "Bootstrap populate must compute MAX(blockNumber) per group for the watermark.");
     }
 
     [Test]
-    public void Balances_MigrationGuard_DropsMatviewWithout_MaxBlock()
+    public void Balances_IsATableNotAMatview()
+    {
+        // The balances object is maintained by incremental INSERT/ON CONFLICT/DELETE, which
+        // PostgreSQL forbids on a materialized view — so it must be a plain TABLE.
+        var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
+        var tableSql = ExtractMatviewSql(sql);
+        Assert.That(tableSql, Does.Contain("CREATE TABLE").IgnoreCase,
+            "M_CrcV2_BalancesByAccountAndToken must be a CREATE TABLE (it is written by the " +
+            "pathfinder's incremental upsert; a materialized view cannot be DML'd).");
+        Assert.That(tableSql, Does.Not.Contain("CREATE MATERIALIZED VIEW").IgnoreCase,
+            "The balances object must NOT be a materialized view.");
+    }
+
+    [Test]
+    public void Balances_MigrationGuard_DropsOldObject()
     {
         var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
-        Assert.That(sql, Does.Contain("pg_matviews"),
-            "Must check pg_matviews to detect existing matview.");
-        Assert.That(sql, Does.Contain("pg_attribute"),
-            "Must check pg_attribute for _maxBlock column existence.");
+        Assert.That(sql, Does.Contain("relkind"),
+            "Migration guard must use pg_class.relkind to detect the old object's kind.");
         Assert.That(sql, Does.Contain("DROP MATERIALIZED VIEW").IgnoreCase,
-            "Must DROP matview if _maxBlock column is missing (migration).");
+            "Must DROP the old materialized view when upgrading it to a table.");
+        Assert.That(sql, Does.Contain("DROP TABLE").IgnoreCase,
+            "Must DROP an existing table that is missing _maxBlock (schema upgrade).");
         Assert.That(sql, Does.Contain("_maxBlock").IgnoreCase,
-            "Migration guard must reference _maxBlock column.");
+            "Migration guard must reference the _maxBlock column.");
     }
 
     [Test]
@@ -605,19 +619,83 @@ public class MaterializedViewDeltaTests
     }
 
     // ================================================================
+    // Incremental upsert path — structural checks
+    // ================================================================
+
+    /// <summary>
+    /// The incremental upsert in NetworkStateUpdaterService.IncrementalRefreshBalancesMatView()
+    /// relies on the unique index (account, tokenId, tokenAddress) to support ON CONFLICT DO UPDATE.
+    /// This test ensures that index still exists after any SQL changes.
+    /// </summary>
+    [Test]
+    public void Balances_MatviewHas_UniqueIndexForOnConflict()
+    {
+        var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
+        Assert.That(sql, Does.Contain("CREATE UNIQUE INDEX").IgnoreCase,
+            "M_CrcV2_BalancesByAccountAndToken must have a UNIQUE INDEX — " +
+            "the incremental upsert path uses ON CONFLICT (account, tokenId, tokenAddress) DO UPDATE " +
+            "and requires this constraint to be present.");
+        Assert.That(sql, Does.Contain("account, \"tokenId\", \"tokenAddress\"").IgnoreCase,
+            "Unique index must cover (account, tokenId, tokenAddress) — exactly the columns " +
+            "used in the incremental ON CONFLICT clause.");
+    }
+
+    /// <summary>
+    /// The incremental delta query filters by blockNumber &gt; watermark and relies on the
+    /// primary key (blockNumber, transactionIndex, logIndex) on both transfer tables for
+    /// fast index range scans.  This test documents that assumption and verifies the
+    /// transfer tables do include blockNumber in the matview definition.
+    /// </summary>
+    [Test]
+    public void Balances_IncrementalDelta_BlockNumberIndexAssumptionHolds()
+    {
+        // The PK on CrcV2_TransferSingle / CrcV2_TransferBatch is (blockNumber, transactionIndex, logIndex).
+        // Since blockNumber is the leading column, a range scan WHERE blockNumber > @watermark is
+        // served by the PK index without a separate standalone index.
+        //
+        // This test verifies that the SQL file references blockNumber in the matview definition.
+        // If blockNumber ever disappeared from the matview, the incremental path would also be broken.
+        var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
+        Assert.That(sql, Does.Contain("\"blockNumber\"").IgnoreCase,
+            "Matview definition must reference blockNumber — the incremental upsert reads " +
+            "blockNumber > watermark from CrcV2_TransferSingle / CrcV2_TransferBatch, " +
+            "which uses the tables' PK index (blockNumber, transactionIndex, logIndex).");
+    }
+
+    /// <summary>
+    /// Verifies the incremental upsert's zero-balance handling contract: balance &gt; 0
+    /// is the matview's own inclusion criterion, and the V_ view independently re-filters.
+    /// A row with totalBalance &lt;= 0 must be excluded; otherwise stale zeros corrupt future deltas.
+    /// </summary>
+    [Test]
+    public void Balances_TableFiltersZeroBalanceAtDefinition()
+    {
+        var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
+        var tableSql = ExtractMatviewSql(sql);
+        Assert.That(tableSql, Does.Contain("balance > 0").IgnoreCase,
+            "Table bootstrap must filter balance > 0 — this is the source-of-truth criterion " +
+            "that the incremental upsert mirrors (rows > 0 upserted, rows <= 0 deleted). Stale " +
+            "zero rows would corrupt future deltas (existing balance would be added to 0).");
+    }
+
+    // ================================================================
     // Helpers
     // ================================================================
 
     /// <summary>
-    /// Extracts the materialized view portion of a combined SQL file.
+    /// Extracts the M_ object definition of a combined SQL file — the balances object is now a
+    /// CREATE TABLE (maintained incrementally); other M_ files are still CREATE MATERIALIZED VIEW.
+    /// Returns the span from that CREATE up to the regular V_ view creation.
     /// </summary>
     private static string ExtractMatviewSql(string sql)
     {
+        var tableStart = sql.IndexOf("CREATE TABLE", StringComparison.OrdinalIgnoreCase);
         var matViewStart = sql.IndexOf("CREATE MATERIALIZED VIEW", StringComparison.OrdinalIgnoreCase);
-        if (matViewStart < 0) return string.Empty;
-        var regularViewStart = sql.IndexOf("CREATE OR REPLACE VIEW", matViewStart + 1, StringComparison.OrdinalIgnoreCase);
-        if (regularViewStart < 0) return sql.Substring(matViewStart);
-        return sql.Substring(matViewStart, regularViewStart - matViewStart);
+        var start = new[] { tableStart, matViewStart }.Where(i => i >= 0).DefaultIfEmpty(-1).Min();
+        if (start < 0) return string.Empty;
+        var regularViewStart = sql.IndexOf("CREATE OR REPLACE VIEW", start + 1, StringComparison.OrdinalIgnoreCase);
+        if (regularViewStart < 0) return sql.Substring(start);
+        return sql.Substring(start, regularViewStart - start);
     }
 
     /// <summary>

--- a/src/Index/Circles.Index.CirclesViews.Tests/Phase3RegressionTests.cs
+++ b/src/Index/Circles.Index.CirclesViews.Tests/Phase3RegressionTests.cs
@@ -133,35 +133,37 @@ public class Phase3RegressionTests
     // ================================================================
 
     [Test]
-    public void BalancesByAccountAndToken_HasMaterializedView()
+    public void BalancesByAccountAndToken_HasPreAggregatedTable()
     {
         var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
-        Assert.That(sql, Does.Contain("CREATE MATERIALIZED VIEW").IgnoreCase,
-            "Must create a materialized view M_CrcV2_BalancesByAccountAndToken for pre-aggregated balances.");
+        Assert.That(sql, Does.Contain("CREATE TABLE").IgnoreCase,
+            "Must create the pre-aggregated table M_CrcV2_BalancesByAccountAndToken — it is " +
+            "maintained by the pathfinder's incremental upsert (a matview cannot be DML'd).");
     }
 
     [Test]
-    public void BalancesByAccountAndToken_MaterializedViewHasUniqueIndex()
+    public void BalancesByAccountAndToken_TableHasUniqueIndex()
     {
         var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
         Assert.That(sql, Does.Contain("CREATE UNIQUE INDEX").IgnoreCase,
-            "Materialized view needs a UNIQUE INDEX for REFRESH MATERIALIZED VIEW CONCURRENTLY.");
+            "The table needs a UNIQUE INDEX on (account, tokenId, tokenAddress) for the " +
+            "incremental ON CONFLICT upsert.");
     }
 
     [Test]
-    public void BalancesByAccountAndToken_MaterializedViewHasNoNow()
+    public void BalancesByAccountAndToken_PreAggregatedTableHasNoNow()
     {
         var sql = _viewSql["V_CrcV2_BalancesByAccountAndToken"];
-        // Extract only the MATERIALIZED VIEW definition (before the regular view)
-        var matViewStart = sql.IndexOf("CREATE MATERIALIZED VIEW", StringComparison.OrdinalIgnoreCase);
-        var regularViewStart = sql.IndexOf("create or replace view", matViewStart + 1, StringComparison.OrdinalIgnoreCase);
-        var matViewSql = sql.Substring(matViewStart, regularViewStart - matViewStart);
+        // Extract only the M_ table definition (before the regular V_ view)
+        var tableStart = sql.IndexOf("CREATE TABLE", StringComparison.OrdinalIgnoreCase);
+        var regularViewStart = sql.IndexOf("create or replace view", tableStart + 1, StringComparison.OrdinalIgnoreCase);
+        var tableSql = sql.Substring(tableStart, regularViewStart - tableStart);
 
-        Assert.That(matViewSql, Does.Not.Contain("NOW()").IgnoreCase,
-            "Materialized view must not use NOW() — demurrage depends on current time " +
-            "and would be stale after materialization.");
-        Assert.That(matViewSql, Does.Not.Contain("crc_demurrage").IgnoreCase,
-            "Materialized view must not call crc_demurrage — compute at read time.");
+        Assert.That(tableSql, Does.Not.Contain("NOW()").IgnoreCase,
+            "The pre-aggregated table must not use NOW() — demurrage depends on current time " +
+            "and would be stale once stored.");
+        Assert.That(tableSql, Does.Not.Contain("crc_demurrage").IgnoreCase,
+            "The pre-aggregated table must not call crc_demurrage — compute at read time in V_.");
     }
 
     [Test]

--- a/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_BalancesByAccountAndToken.sql
+++ b/src/Index/Circles.Index.CirclesViews/queries/V_CrcV2_BalancesByAccountAndToken.sql
@@ -29,21 +29,43 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql STABLE;
 
--- Migration guard: drop matview if it exists without _maxBlock column
+-- Migration guard: this object used to be a MATERIALIZED VIEW refreshed with
+-- REFRESH ... CONCURRENTLY. It is now a plain TABLE maintained incrementally by the
+-- pathfinder (INSERT ... ON CONFLICT / DELETE keyed on the _maxBlock watermark) — a
+-- materialized view cannot support that (PostgreSQL forbids DML on matviews). Drop the
+-- old object so the CREATE TABLE below can take over:
+--   * if it still exists as a materialized view -> drop it (one-time upgrade), or
+--   * if it exists as a table missing _maxBlock   -> drop it (schema upgrade).
+-- CASCADE transitively drops the dependent views: V_CrcV2_BalancesByAccountAndToken (recreated
+-- at the end of this file) -> V_CrcV2_GroupTokenHoldersBalance -> V_CrcV2_GroupTokenSupply. Those
+-- last two are recreated by the indexer's Migrate() in the SAME transaction, later in
+-- ViewDependencyOrder, so this is safe ONLY as part of the full schema apply. Do not run this
+-- file standalone, and keep GroupTokenHoldersBalance/GroupTokenSupply after Balances in
+-- ViewDependencyOrder, or those two views are left dropped.
 DO $$ BEGIN
-    IF EXISTS (SELECT 1 FROM pg_matviews WHERE matviewname = 'M_CrcV2_BalancesByAccountAndToken')
-       AND NOT EXISTS (
-           SELECT 1 FROM pg_attribute a
-           JOIN pg_class c ON c.oid = a.attrelid
-           WHERE c.relname = 'M_CrcV2_BalancesByAccountAndToken'
-             AND a.attname = '_maxBlock'
-       ) THEN
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+        WHERE c.relname = 'M_CrcV2_BalancesByAccountAndToken' AND c.relkind = 'm'
+    ) THEN
         DROP MATERIALIZED VIEW "M_CrcV2_BalancesByAccountAndToken" CASCADE;
+    ELSIF EXISTS (
+        SELECT 1 FROM pg_class c
+        WHERE c.relname = 'M_CrcV2_BalancesByAccountAndToken' AND c.relkind = 'r'
+    ) AND NOT EXISTS (
+        SELECT 1 FROM pg_attribute a
+        JOIN pg_class c ON c.oid = a.attrelid
+        WHERE c.relname = 'M_CrcV2_BalancesByAccountAndToken' AND a.attname = '_maxBlock'
+    ) THEN
+        DROP TABLE "M_CrcV2_BalancesByAccountAndToken" CASCADE;
     END IF;
 END $$;
 
--- Materialized view: pre-aggregated balances without demurrage (refreshed periodically)
-CREATE MATERIALIZED VIEW IF NOT EXISTS "M_CrcV2_BalancesByAccountAndToken"
+-- Pre-aggregated balances without demurrage. Maintained incrementally by the pathfinder
+-- (Circles.Pathfinder.Host NetworkStateUpdaterService.IncrementalRefreshBalancesMatView):
+-- each cycle folds in only transfers with blockNumber > MAX("_maxBlock"). On first creation
+-- the table is fully populated (WITH DATA) so the watermark starts at the current chain tip;
+-- if it already exists this statement is a no-op (the SELECT is not re-run).
+CREATE TABLE IF NOT EXISTS "M_CrcV2_BalancesByAccountAndToken"
     (account, "tokenId", "tokenAddress", "lastActivity", "totalBalance", "_maxBlock") AS
 with
     tx as (
@@ -81,7 +103,7 @@ from agg
 where account <> '0x0000000000000000000000000000000000000000'
   and balance > 0::numeric;
 
--- Unique index required for REFRESH MATERIALIZED VIEW CONCURRENTLY
+-- Unique index required for the incremental ON CONFLICT (account, tokenId, tokenAddress) upsert
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_M_CrcV2_BalancesByAccountAndToken_pk"
     ON "M_CrcV2_BalancesByAccountAndToken" (account, "tokenId", "tokenAddress");
 

--- a/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/GraphUpdateMetrics.cs
@@ -225,4 +225,29 @@ internal static class GraphUpdateMetrics
         "circles_matview_last_refresh_block",
         "Block number of last materialized view refresh",
         new GaugeConfiguration { LabelNames = new[] { "tier" } });
+
+    // ─── Incremental balance matview refresh metrics ─────────────────────
+
+    /// <summary>
+    /// Rows upserted or deleted during an incremental balance matview refresh.
+    /// Label "op": "upsert" or "delete".
+    /// </summary>
+    public static readonly Counter BalanceMatViewIncrementalRows = Metrics.CreateCounter(
+        "circles_matview_balance_incremental_rows_total",
+        "Rows upserted or deleted during incremental M_CrcV2_BalancesByAccountAndToken refresh",
+        new CounterConfiguration { LabelNames = new[] { "op" } });
+
+    /// <summary>
+    /// How many blocks the incremental refresh covered (watermark advance).
+    /// </summary>
+    public static readonly Gauge BalanceMatViewWatermarkAdvance = Metrics.CreateGauge(
+        "circles_matview_balance_watermark_advance_blocks",
+        "Blocks advanced by last incremental balance matview refresh");
+
+    /// <summary>
+    /// Current watermark (_maxBlock) of M_CrcV2_BalancesByAccountAndToken.
+    /// </summary>
+    public static readonly Gauge BalanceMatViewWatermark = Metrics.CreateGauge(
+        "circles_matview_balance_watermark_block",
+        "Current _maxBlock watermark of M_CrcV2_BalancesByAccountAndToken");
 }

--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -802,9 +802,11 @@ public class NetworkStateUpdaterService : BackgroundService
 
         if (fastDue)
         {
+            // Balances use an incremental upsert path — avoids full table scan (10-24s → <1s).
+            IncrementalRefreshBalancesMatView(conn);
+
             var fastViews = new[]
             {
-                "M_CrcV2_BalancesByAccountAndToken",
                 "M_CrcV2_Avatars",
                 "M_CrcV2_ReceiveCount",
                 "M_CrcV2_Groups"
@@ -822,6 +824,204 @@ public class NetworkStateUpdaterService : BackgroundService
             RefreshSingleMatView(conn, "V_TrustScores_Current");
             _lastSlowMatViewRefreshBlock = currentBlock;
             GraphUpdateMetrics.LastMatViewRefreshBlock.WithLabels("slow").Set(currentBlock);
+        }
+    }
+
+    /// <summary>
+    /// Incrementally maintains the <c>M_CrcV2_BalancesByAccountAndToken</c> table without a full
+    /// table scan. (This object is a plain table — created + bootstrap-populated in
+    /// <c>V_CrcV2_BalancesByAccountAndToken.sql</c> — precisely so it can be written incrementally;
+    /// a materialized view cannot be, since PostgreSQL forbids DML on matviews.)
+    ///
+    /// Strategy:
+    ///   1. Read the <c>_maxBlock</c> watermark (global MAX; COALESCE 0 when empty). This is the
+    ///      same cutoff the <c>V_</c> live view and ScoreGroupMintLimits use for their delta tails.
+    ///   2. Aggregate balance deltas only for transfers with <c>blockNumber &gt; watermark</c>
+    ///      (PK index <c>(blockNumber, transactionIndex, logIndex)</c> serves the range scan).
+    ///   3. In a single transaction, driving from the delta (so only (account, token) pairs that
+    ///      actually changed are touched — no full-table rewrite):
+    ///      a. UPSERT rows whose new running total is &gt; 0 (update existing or insert new).
+    ///      b. DELETE rows whose running total dropped to ≤ 0 (zero/negative balance, burn).
+    ///   Both mutations and the watermark advance commit together, so a crash mid-refresh leaves
+    ///   the watermark behind (safe: the additive delta is re-applied next cycle) never ahead.
+    ///
+    /// First-boot path: when the table is empty (_maxBlock = 0) the delta covers all rows, i.e. a
+    /// full build. In practice the table is bootstrap-populated at creation, so the first cycle
+    /// starts at the chain tip. Either way no blocking REFRESH fallback is needed.
+    /// </summary>
+    internal void IncrementalRefreshBalancesMatView(NpgsqlConnection conn)
+    {
+        const string viewName = "M_CrcV2_BalancesByAccountAndToken";
+        var sw = Stopwatch.StartNew();
+
+        try
+        {
+            using var txn = conn.BeginTransaction();
+
+            // ── Step 1: read current watermark ──────────────────────────────
+            long watermark;
+            using (var wmCmd = conn.CreateCommand())
+            {
+                wmCmd.Transaction = txn;
+                wmCmd.CommandText = @"SELECT COALESCE(MAX(""_maxBlock""), 0) FROM ""M_CrcV2_BalancesByAccountAndToken""";
+                wmCmd.CommandTimeout = 60;
+                watermark = wmCmd.ExecuteScalar() is long wm ? wm : 0L;
+            }
+
+            // ── Step 2 + 3: delta upsert + delete in one statement ───────────
+            // Uses CTEs to avoid re-reading the delta twice.
+            //
+            // delta_tx:  flatten (from/to) legs for blockNumber > watermark from both tables.
+            //            The PK (blockNumber, transactionIndex, logIndex) index makes this a
+            //            fast index range scan even on tens of millions of rows.
+            //
+            // delta_agg: sum deltas per (account, tokenId::text, tokenAddress) + per-pair max block.
+            //
+            // merged:    delta_agg LEFT JOIN the existing table — driven by the delta, so ONLY
+            //            (account, token) pairs with activity since the watermark are produced
+            //            (existing balance folded in additively). No full-table rewrite.
+            //
+            // upserted:  INSERT ... ON CONFLICT DO UPDATE for rows with new total > 0.
+            //
+            // deleted:   DELETE table rows whose new running total ≤ 0 (burn / full spend).
+            //
+            // Note: account <> zero-address filter mirrors the table definition.
+
+            using var upsertCmd = conn.CreateCommand();
+            upsertCmd.Transaction = txn;
+            upsertCmd.CommandTimeout = 300;
+            upsertCmd.Parameters.AddWithValue("watermark", watermark);
+
+            // language=sql
+            upsertCmd.CommandText = @"
+WITH delta_tx AS (
+    SELECT ""blockNumber"", ""timestamp"", ""from"" AS account, ""tokenAddress"", id, -value AS delta
+    FROM ""CrcV2_TransferSingle""
+    WHERE ""blockNumber"" > @watermark
+      AND ""from"" <> '0x0000000000000000000000000000000000000000'
+    UNION ALL
+    SELECT ""blockNumber"", ""timestamp"", ""to""   AS account, ""tokenAddress"", id,  value AS delta
+    FROM ""CrcV2_TransferSingle""
+    WHERE ""blockNumber"" > @watermark
+      AND ""to""   <> '0x0000000000000000000000000000000000000000'
+    UNION ALL
+    SELECT ""blockNumber"", ""timestamp"", ""from"" AS account, ""tokenAddress"", id, -value AS delta
+    FROM ""CrcV2_TransferBatch""
+    WHERE ""blockNumber"" > @watermark
+      AND ""from"" <> '0x0000000000000000000000000000000000000000'
+    UNION ALL
+    SELECT ""blockNumber"", ""timestamp"", ""to""   AS account, ""tokenAddress"", id,  value AS delta
+    FROM ""CrcV2_TransferBatch""
+    WHERE ""blockNumber"" > @watermark
+      AND ""to""   <> '0x0000000000000000000000000000000000000000'
+),
+delta_agg AS (
+    SELECT
+        account,
+        id::text                AS ""tokenId"",
+        ""tokenAddress"",
+        SUM(delta)              AS delta_balance,
+        MAX(""timestamp"")      AS delta_last_ts,
+        MAX(""blockNumber"")    AS delta_max_block
+    FROM delta_tx
+    GROUP BY account, id, ""tokenAddress""
+),
+merged AS (
+    -- Driven by delta_agg (LEFT JOIN), so every row here is an (account, token) pair that
+    -- changed since the watermark. Unchanged rows are never selected → never rewritten.
+    SELECT
+        d.account                                        AS account,
+        d.""tokenId""                                    AS ""tokenId"",
+        d.""tokenAddress""                               AS ""tokenAddress"",
+        GREATEST(COALESCE(m.""lastActivity"", 0), d.delta_last_ts)
+                                                         AS ""lastActivity"",
+        COALESCE(m.""totalBalance"", 0) + d.delta_balance AS ""totalBalance"",
+        -- Advance watermark for this (account, token) pair to the highest block seen.
+        GREATEST(COALESCE(m.""_maxBlock"", 0), d.delta_max_block)
+                                                         AS ""_maxBlock""
+    FROM delta_agg d
+    LEFT JOIN ""M_CrcV2_BalancesByAccountAndToken"" m
+        ON m.account          = d.account
+       AND m.""tokenId""      = d.""tokenId""
+       AND m.""tokenAddress"" = d.""tokenAddress""
+),
+-- UPSERT rows with positive balance
+upserted AS (
+    INSERT INTO ""M_CrcV2_BalancesByAccountAndToken""
+        (account, ""tokenId"", ""tokenAddress"", ""lastActivity"", ""totalBalance"", ""_maxBlock"")
+    SELECT account, ""tokenId"", ""tokenAddress"", ""lastActivity"", ""totalBalance"", ""_maxBlock""
+    FROM merged
+    WHERE ""totalBalance"" > 0
+    ON CONFLICT (account, ""tokenId"", ""tokenAddress"")
+    DO UPDATE SET
+        ""lastActivity"" = EXCLUDED.""lastActivity"",
+        ""totalBalance"" = EXCLUDED.""totalBalance"",
+        ""_maxBlock""    = EXCLUDED.""_maxBlock""
+    RETURNING 1
+),
+-- DELETE rows that now have zero / negative balance
+deleted AS (
+    DELETE FROM ""M_CrcV2_BalancesByAccountAndToken"" m
+    USING merged merged_alias
+    WHERE m.account          = merged_alias.account
+      AND m.""tokenId""      = merged_alias.""tokenId""
+      AND m.""tokenAddress"" = merged_alias.""tokenAddress""
+      AND merged_alias.""totalBalance"" <= 0
+    RETURNING 1
+)
+SELECT
+    (SELECT COUNT(*) FROM upserted) AS rows_upserted,
+    (SELECT COUNT(*) FROM deleted)  AS rows_deleted;
+";
+
+            long rowsUpserted = 0;
+            long rowsDeleted = 0;
+            long newWatermark = watermark;
+
+            using (var reader = upsertCmd.ExecuteReader())
+            {
+                if (reader.Read())
+                {
+                    rowsUpserted = reader.GetInt64(0);
+                    rowsDeleted  = reader.GetInt64(1);
+                }
+            }
+
+            // ── Step 4: read back the new watermark after upsert ────────────
+            // The upsert already wrote the per-row delta_max_block into _maxBlock.
+            // Read the global max to report the watermark advance in metrics/logs.
+            // Only query if rows were actually touched to avoid an extra round-trip on idle cycles.
+            if (rowsUpserted > 0 || rowsDeleted > 0)
+            {
+                using var wmReadCmd = conn.CreateCommand();
+                wmReadCmd.Transaction = txn;
+                wmReadCmd.CommandTimeout = 60;
+                wmReadCmd.CommandText = @"SELECT COALESCE(MAX(""_maxBlock""), 0) FROM ""M_CrcV2_BalancesByAccountAndToken""";
+                newWatermark = wmReadCmd.ExecuteScalar() is long nw ? nw : watermark;
+            }
+
+            txn.Commit();
+
+            sw.Stop();
+            GraphUpdateMetrics.MatViewRefreshDuration.WithLabels(viewName).Observe(sw.Elapsed.TotalSeconds);
+            GraphUpdateMetrics.MatViewRefreshTotal.WithLabels(viewName).Inc();
+            GraphUpdateMetrics.BalanceMatViewIncrementalRows.WithLabels("upsert").Inc(rowsUpserted);
+            GraphUpdateMetrics.BalanceMatViewIncrementalRows.WithLabels("delete").Inc(rowsDeleted);
+            GraphUpdateMetrics.BalanceMatViewWatermarkAdvance.Set(newWatermark - watermark);
+            GraphUpdateMetrics.BalanceMatViewWatermark.Set(newWatermark);
+
+            _log.LogInformation(
+                "Incremental refresh of {View} in {Ms} ms — watermark {Old} → {New}, " +
+                "upserted {Ups} rows, deleted {Del} rows",
+                viewName, sw.ElapsedMilliseconds, watermark, newWatermark, rowsUpserted, rowsDeleted);
+        }
+        catch (Exception ex)
+        {
+            sw.Stop();
+            GraphUpdateMetrics.MatViewRefreshErrors.WithLabels(viewName).Inc();
+            _log.LogWarning(ex,
+                "Incremental refresh of {View} failed in {Ms} ms — stale data until next refresh",
+                viewName, sw.ElapsedMilliseconds);
         }
     }
 

--- a/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/Circles.Pathfinder.Tests.csproj
@@ -36,6 +36,7 @@
         </PackageReference>
         <PackageReference Include="NUnit3TestAdapter" />
         <PackageReference Include="BenchmarkDotNet" />
+        <PackageReference Include="Testcontainers.PostgreSql" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalBalanceRefreshIntegrationTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/IncrementalBalanceRefreshIntegrationTests.cs
@@ -1,0 +1,378 @@
+using Circles.Pathfinder.Data;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Host;
+using Circles.Pathfinder.Host.State;
+using Circles.Pathfinder.Tests.Helpers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Npgsql;
+using Testcontainers.PostgreSql;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Execution-level tests for <see cref="NetworkStateUpdaterService.IncrementalRefreshBalancesMatView"/>
+/// against a real PostgreSQL (Testcontainers). These are the tests that actually run the incremental
+/// SQL — the structural string-match tests cannot catch a query that is syntactically fine but wrong
+/// against a live database (e.g. the earlier attempt that DML'd a materialized view).
+///
+/// Every scenario asserts the maintained table is byte-for-byte identical to a full recompute of the
+/// balances aggregation, so any divergence in the incremental delta logic fails the test.
+///
+/// Docker-gated: skipped when no Docker endpoint is detectable (set RUN_PATHFINDER_INTEGRATION_TESTS
+/// to force on/off). Not parallelizable — reads a process-wide metric counter around the refresh call.
+/// </summary>
+[TestFixture]
+public class IncrementalBalanceRefreshIntegrationTests
+{
+    private const string RouterAddr = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+    private const string Zero = "0x0000000000000000000000000000000000000000";
+    private const string Alice = "0xaa00000000000000000000000000000000000001";
+    private const string Bob = "0xbb00000000000000000000000000000000000002";
+    private const string Carol = "0xcc00000000000000000000000000000000000003";
+    private const string TokenA = "0x1100000000000000000000000000000000000001";
+    private const string TokenB = "0x2200000000000000000000000000000000000002";
+
+    private static readonly bool DockerEnabled = ComputeDockerEnabled();
+    private static readonly string BalancesSql = LoadBalancesSql();
+
+    private PostgreSqlContainer? _pg;
+    private string _connStr = null!;
+
+    private static bool ComputeDockerEnabled()
+    {
+        var env = Environment.GetEnvironmentVariable("RUN_PATHFINDER_INTEGRATION_TESTS");
+        if (string.Equals(env, "true", StringComparison.OrdinalIgnoreCase)) return true;
+        if (string.Equals(env, "false", StringComparison.OrdinalIgnoreCase)) return false;
+        return File.Exists("/var/run/docker.sock")
+               || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("DOCKER_HOST"))
+               || File.Exists(Path.Combine(
+                   Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".docker", "run", "docker.sock"));
+    }
+
+    /// <summary>Locates the production balances SQL by walking up from the test output dir to the repo.</summary>
+    private static string LoadBalancesSql()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir.FullName,
+                "src", "Index", "Circles.Index.CirclesViews", "queries", "V_CrcV2_BalancesByAccountAndToken.sql");
+            if (File.Exists(candidate)) return File.ReadAllText(candidate);
+            dir = dir.Parent;
+        }
+        throw new FileNotFoundException(
+            $"Could not locate V_CrcV2_BalancesByAccountAndToken.sql walking up from {AppContext.BaseDirectory}");
+    }
+
+    [OneTimeSetUp]
+    public async Task StartContainer()
+    {
+        // Host.Settings/Common.Settings constructors require these; harmless dummies for the test.
+        Environment.SetEnvironmentVariable("POSTGRES_CONNECTION_STRING",
+            Environment.GetEnvironmentVariable("POSTGRES_CONNECTION_STRING") ?? "Host=localhost;Database=test;Username=test;Password=test");
+        Environment.SetEnvironmentVariable("NETHERMIND_RPC_URL",
+            Environment.GetEnvironmentVariable("NETHERMIND_RPC_URL") ?? "http://localhost:8545");
+
+        if (!DockerEnabled) return;
+        _pg = new PostgreSqlBuilder("postgres:15-alpine")
+            .WithDatabase("circles_test").WithUsername("test").WithPassword("test").Build();
+        await _pg.StartAsync();
+        _connStr = _pg.GetConnectionString();
+    }
+
+    [OneTimeTearDown]
+    public async Task StopContainer()
+    {
+        if (_pg != null) await _pg.DisposeAsync();
+    }
+
+    [SetUp]
+    public void ResetSchema()
+    {
+        if (!DockerEnabled) Assert.Ignore("Docker not available — skipping Postgres integration test.");
+        using var conn = Open();
+        Exec(conn, """
+            DROP VIEW  IF EXISTS public."V_CrcV2_BalancesByAccountAndToken";
+            DROP TABLE IF EXISTS "M_CrcV2_BalancesByAccountAndToken" CASCADE;
+            DROP TABLE IF EXISTS "CrcV2_TransferSingle";
+            DROP TABLE IF EXISTS "CrcV2_TransferBatch";
+            CREATE TABLE "CrcV2_TransferSingle" (
+                "blockNumber" bigint NOT NULL, "transactionIndex" bigint NOT NULL, "logIndex" bigint NOT NULL,
+                "timestamp" bigint NOT NULL, "from" text NOT NULL, "to" text NOT NULL,
+                "id" numeric NOT NULL, "value" numeric NOT NULL, "tokenAddress" text NOT NULL,
+                PRIMARY KEY ("blockNumber","transactionIndex","logIndex"));
+            CREATE TABLE "CrcV2_TransferBatch" (
+                "blockNumber" bigint NOT NULL, "transactionIndex" bigint NOT NULL, "logIndex" bigint NOT NULL,
+                "batchIndex" bigint NOT NULL, "timestamp" bigint NOT NULL, "from" text NOT NULL, "to" text NOT NULL,
+                "id" numeric NOT NULL, "value" numeric NOT NULL, "tokenAddress" text NOT NULL,
+                PRIMARY KEY ("blockNumber","transactionIndex","logIndex","batchIndex"));
+            """);
+    }
+
+    // ── Scenarios ────────────────────────────────────────────────────────────
+
+    [Test]
+    public void Refresh_AppliesDelta_AndMatchesFullRecompute()
+    {
+        using var conn = Open();
+        // Bootstrap: block 1 mints 100 tokenA to Alice.
+        Single(conn, block: 1, from: Zero, to: Alice, token: TokenA, value: "100");
+        ApplyBalancesSchema(conn);
+        Assert.That(Watermark(conn), Is.EqualTo(1), "watermark should start at the bootstrap tip");
+
+        // Delta: Alice sends 30 to Bob (block 2); a fresh mint of 50 tokenB to Carol (block 3).
+        Single(conn, block: 2, from: Alice, to: Bob, token: TokenA, value: "30");
+        Single(conn, block: 3, from: Zero, to: Carol, token: TokenB, value: "50");
+
+        Refresh(conn);
+
+        Assert.That(Mismatches(conn), Is.Zero, "table must equal a full recompute after the incremental delta");
+        Assert.That(Balance(conn, Alice, TokenA), Is.EqualTo(70m));
+        Assert.That(Balance(conn, Bob, TokenA), Is.EqualTo(30m));
+        Assert.That(Balance(conn, Carol, TokenB), Is.EqualTo(50m));
+        Assert.That(Watermark(conn), Is.EqualTo(3), "watermark must advance to the newest processed block");
+    }
+
+    [Test]
+    public void Refresh_ZeroBalance_DeletesRow()
+    {
+        using var conn = Open();
+        Single(conn, block: 1, from: Zero, to: Alice, token: TokenA, value: "100");
+        ApplyBalancesSchema(conn);
+
+        // Alice spends her entire balance to Bob → Alice hits 0 and must be removed.
+        Single(conn, block: 2, from: Alice, to: Bob, token: TokenA, value: "100");
+        Refresh(conn);
+
+        Assert.That(Mismatches(conn), Is.Zero);
+        Assert.That(RowCount(conn, Alice, TokenA), Is.Zero, "zeroed account/token must be deleted, not kept at 0");
+        Assert.That(Balance(conn, Bob, TokenA), Is.EqualTo(100m));
+    }
+
+    [Test]
+    public void Refresh_FirstBoot_EmptyTable_BuildsEverything()
+    {
+        using var conn = Open();
+        // No transfers at bootstrap → empty table, watermark 0.
+        ApplyBalancesSchema(conn);
+        Assert.That(Watermark(conn), Is.Zero);
+        Assert.That(TotalRows(conn), Is.Zero);
+
+        // All history arrives after bootstrap; the watermark-0 delta must cover it all.
+        Single(conn, block: 5, from: Zero, to: Alice, token: TokenA, value: "100");
+        Single(conn, block: 6, from: Alice, to: Bob, token: TokenA, value: "40");
+        Refresh(conn);
+
+        Assert.That(Mismatches(conn), Is.Zero, "first-boot delta (watermark 0) must equal a full recompute");
+        Assert.That(Balance(conn, Alice, TokenA), Is.EqualTo(60m));
+        Assert.That(Balance(conn, Bob, TokenA), Is.EqualTo(40m));
+    }
+
+    [Test]
+    public void Refresh_NoNewTransfers_IsNoOp()
+    {
+        using var conn = Open();
+        Single(conn, block: 1, from: Zero, to: Alice, token: TokenA, value: "100");
+        ApplyBalancesSchema(conn);
+        Refresh(conn); // fold in whatever exists (nothing past watermark)
+
+        var upsertsBefore = UpsertCount();
+        var deletesBefore = DeleteCount();
+        var wmBefore = Watermark(conn);
+
+        Refresh(conn); // second cycle, no new transfers
+
+        Assert.That(Mismatches(conn), Is.Zero);
+        Assert.That(Watermark(conn), Is.EqualTo(wmBefore), "watermark must not move without new data");
+        Assert.That(UpsertCount() - upsertsBefore, Is.Zero, "idle cycle must upsert nothing");
+        Assert.That(DeleteCount() - deletesBefore, Is.Zero, "idle cycle must delete nothing");
+    }
+
+    [Test]
+    public void Refresh_TouchesOnlyChangedRows_NoWriteAmplification()
+    {
+        using var conn = Open();
+        // Bootstrap 50 independent accounts (mints in early blocks) → 50 rows.
+        for (var i = 0; i < 50; i++)
+        {
+            var acct = $"0xac00000000000000000000000000000000{i:x6}";
+            Single(conn, block: 1, tx: i, from: Zero, to: acct, token: TokenA, value: "100");
+        }
+        ApplyBalancesSchema(conn);
+        Assert.That(TotalRows(conn), Is.EqualTo(50));
+
+        // Later transfers touch exactly two (account, token) pairs: Alice/TokenB and Bob/TokenB.
+        Single(conn, block: 3, from: Zero, to: Alice, token: TokenB, value: "70"); // Alice/TokenB = 70
+        Single(conn, block: 4, from: Alice, to: Bob, token: TokenB, value: "20");  // Alice → 50, Bob → 20
+
+        var upsertsBefore = UpsertCount();
+        Refresh(conn);
+        var upserted = UpsertCount() - upsertsBefore;
+
+        Assert.That(Mismatches(conn), Is.Zero);
+        // Only Alice/TokenB and Bob/TokenB changed. With the old FULL OUTER JOIN this would rewrite
+        // all ~52 rows; the delta-driven LEFT JOIN must touch just the changed pairs.
+        Assert.That(upserted, Is.EqualTo(2),
+            "incremental refresh must upsert only the (account, token) pairs that changed, not the whole table");
+    }
+
+    [Test]
+    public void Refresh_IncludesBatchTransfers()
+    {
+        using var conn = Open();
+        Single(conn, block: 1, from: Zero, to: Alice, token: TokenA, value: "100");
+        ApplyBalancesSchema(conn);
+
+        // A batch transfer (block 2) moving two tokens from Alice to Bob.
+        Batch(conn, block: 2, batchIndex: 0, from: Alice, to: Bob, token: TokenA, value: "25");
+        Batch(conn, block: 2, batchIndex: 1, from: Zero, to: Bob, token: TokenB, value: "10");
+        Refresh(conn);
+
+        Assert.That(Mismatches(conn), Is.Zero, "batch legs must be folded in identically to single legs");
+        Assert.That(Balance(conn, Alice, TokenA), Is.EqualTo(75m));
+        Assert.That(Balance(conn, Bob, TokenA), Is.EqualTo(25m));
+        Assert.That(Balance(conn, Bob, TokenB), Is.EqualTo(10m));
+    }
+
+    [Test]
+    public void Refresh_MultipleCycles_StayCorrect()
+    {
+        using var conn = Open();
+        Single(conn, block: 1, from: Zero, to: Alice, token: TokenA, value: "100");
+        ApplyBalancesSchema(conn);
+
+        // Cycle 1
+        Single(conn, block: 2, from: Alice, to: Bob, token: TokenA, value: "30");
+        Refresh(conn);
+        Assert.That(Mismatches(conn), Is.Zero);
+        Assert.That(Watermark(conn), Is.EqualTo(2));
+
+        // Cycle 2 — builds on the state left by cycle 1
+        Single(conn, block: 3, from: Bob, to: Carol, token: TokenA, value: "30"); // Bob → 0 (deleted), Carol → 30
+        Single(conn, block: 4, from: Zero, to: Alice, token: TokenA, value: "5");  // Alice 70 → 75
+        Refresh(conn);
+
+        Assert.That(Mismatches(conn), Is.Zero, "accumulated state across cycles must equal a full recompute");
+        Assert.That(Balance(conn, Alice, TokenA), Is.EqualTo(75m));
+        Assert.That(RowCount(conn, Bob, TokenA), Is.Zero);
+        Assert.That(Balance(conn, Carol, TokenA), Is.EqualTo(30m));
+        Assert.That(Watermark(conn), Is.EqualTo(4));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private NpgsqlConnection Open()
+    {
+        var conn = new NpgsqlConnection(_connStr);
+        conn.Open();
+        return conn;
+    }
+
+    private static void Exec(NpgsqlConnection conn, string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    private void ApplyBalancesSchema(NpgsqlConnection conn) => Exec(conn, BalancesSql);
+
+    private static void Single(NpgsqlConnection conn, long block, string from, string to, string token, string value,
+        long tx = 0, long log = 0)
+        => Exec(conn, $"""
+            INSERT INTO "CrcV2_TransferSingle" ("blockNumber","transactionIndex","logIndex","timestamp","from","to","id","value","tokenAddress")
+            VALUES ({block},{tx},{log},{block * 10},'{from}','{to}',{TokenId(token)},{value},'{token}');
+            """);
+
+    private static void Batch(NpgsqlConnection conn, long block, long batchIndex, string from, string to, string token,
+        string value, long tx = 0, long log = 0)
+        => Exec(conn, $"""
+            INSERT INTO "CrcV2_TransferBatch" ("blockNumber","transactionIndex","logIndex","batchIndex","timestamp","from","to","id","value","tokenAddress")
+            VALUES ({block},{tx},{log},{batchIndex},{block * 10},'{from}','{to}',{TokenId(token)},{value},'{token}');
+            """);
+
+    // Deterministic token id per token address (both the refresh and the recompute read the same
+    // (id, tokenAddress) from the transfer rows, so any stable mapping keeps them in agreement).
+    private static string TokenId(string token) => token switch
+    {
+        TokenA => "1",
+        TokenB => "2",
+        _ => "3"
+    };
+
+    private long Watermark(NpgsqlConnection conn)
+        => Scalar<long>(conn, "SELECT COALESCE(MAX(\"_maxBlock\"), 0) FROM \"M_CrcV2_BalancesByAccountAndToken\"");
+
+    private long TotalRows(NpgsqlConnection conn)
+        => Scalar<long>(conn, "SELECT COUNT(*) FROM \"M_CrcV2_BalancesByAccountAndToken\"");
+
+    private long RowCount(NpgsqlConnection conn, string account, string token)
+        => Scalar<long>(conn,
+            $"SELECT COUNT(*) FROM \"M_CrcV2_BalancesByAccountAndToken\" WHERE account='{account}' AND \"tokenAddress\"='{token}'");
+
+    private decimal Balance(NpgsqlConnection conn, string account, string token)
+        => Scalar<decimal>(conn,
+            $"SELECT \"totalBalance\" FROM \"M_CrcV2_BalancesByAccountAndToken\" WHERE account='{account}' AND \"tokenAddress\"='{token}'");
+
+    private static T Scalar<T>(NpgsqlConnection conn, string sql)
+    {
+        using var cmd = conn.CreateCommand();
+        cmd.CommandText = sql;
+        var o = cmd.ExecuteScalar();
+        return o is T t ? t : (T)Convert.ChangeType(o!, typeof(T));
+    }
+
+    /// <summary>
+    /// Symmetric difference between the maintained table and a from-scratch recompute of the balances
+    /// aggregation. Zero rows ⇒ the incremental table is exactly correct (keys, totals, lastActivity, _maxBlock).
+    /// </summary>
+    private int Mismatches(NpgsqlConnection conn)
+    {
+        const string sql = """
+            WITH tx AS (
+                SELECT "blockNumber","timestamp","from" AS account,"tokenAddress",id,-value AS delta FROM "CrcV2_TransferSingle"
+                UNION ALL SELECT "blockNumber","timestamp","to","tokenAddress",id, value FROM "CrcV2_TransferSingle"
+                UNION ALL SELECT "blockNumber","timestamp","from","tokenAddress",id,-value FROM "CrcV2_TransferBatch"
+                UNION ALL SELECT "blockNumber","timestamp","to","tokenAddress",id, value FROM "CrcV2_TransferBatch"
+            ), agg AS (
+                SELECT account, id, "tokenAddress", sum(delta) AS balance, max("timestamp") AS last_ts, max("blockNumber") AS max_block
+                FROM tx GROUP BY account, id, "tokenAddress"
+            ), recompute AS (
+                SELECT account, id::text AS "tokenId", "tokenAddress", last_ts AS "lastActivity",
+                       balance AS "totalBalance", max_block AS "_maxBlock"
+                FROM agg
+                WHERE account <> '0x0000000000000000000000000000000000000000' AND balance > 0
+            ), diff AS (
+                (SELECT account,"tokenId","tokenAddress","lastActivity","totalBalance","_maxBlock" FROM recompute
+                 EXCEPT
+                 SELECT account,"tokenId","tokenAddress","lastActivity","totalBalance","_maxBlock" FROM "M_CrcV2_BalancesByAccountAndToken")
+                UNION ALL
+                (SELECT account,"tokenId","tokenAddress","lastActivity","totalBalance","_maxBlock" FROM "M_CrcV2_BalancesByAccountAndToken"
+                 EXCEPT
+                 SELECT account,"tokenId","tokenAddress","lastActivity","totalBalance","_maxBlock" FROM recompute)
+            )
+            SELECT COUNT(*) FROM diff;
+            """;
+        return (int)Scalar<long>(conn, sql);
+    }
+
+    private void Refresh(NpgsqlConnection conn)
+    {
+        // A dedicated connection: the method opens its own transaction on the connection it is given.
+        using var svcConn = Open();
+        CreateService().IncrementalRefreshBalancesMatView(svcConn);
+    }
+
+    private static NetworkStateUpdaterService CreateService()
+    {
+        var settings = new Circles.Pathfinder.Host.Settings { FullRefreshIntervalBlocks = 200, IncrementalEnabled = true };
+        var mockLoadGraph = new MockLoadGraph();
+        var pool = new CapacityGraphPool(RouterAddr, mockLoadGraph);
+        var loadGraph = new LoadGraph("Host=localhost;Database=dummy;Username=x;Password=x", new Circles.Pathfinder.Settings());
+        return new NetworkStateUpdaterService(new NetworkState(), settings,
+            NullLogger<NetworkStateUpdaterService>.Instance, pool, loadGraph);
+    }
+
+    private static double UpsertCount() => GraphUpdateMetrics.BalanceMatViewIncrementalRows.WithLabels("upsert").Value;
+    private static double DeleteCount() => GraphUpdateMetrics.BalanceMatViewIncrementalRows.WithLabels("delete").Value;
+}


### PR DESCRIPTION
## Summary
`REFRESH MATERIALIZED VIEW CONCURRENTLY "M_CrcV2_BalancesByAccountAndToken"` re-scans **all** `CrcV2_TransferSingle`/`CrcV2_TransferBatch` history on every fast-tier cycle (10–24s, verified via traces) and scales with chain length, not activity.

This converts `M_CrcV2_BalancesByAccountAndToken` from a **materialized view** to a plain **table** maintained incrementally. A materialized view cannot be the target of INSERT/UPDATE/DELETE, so the object must be a table for the incremental path to run at all.

## What changed
- **`V_CrcV2_BalancesByAccountAndToken.sql`** — `CREATE TABLE` (bootstrap-populated `WITH DATA` on first creation, so the watermark starts at the chain tip) + a `relkind`-based migration guard that drops the old matview (or a pre-`_maxBlock` table). `CASCADE` transitively drops `V_CrcV2_GroupTokenHoldersBalance` → `V_CrcV2_GroupTokenSupply`, which the indexer's `Migrate()` recreates in the **same transaction** in `ViewDependencyOrder` (documented inline). The `V_` live view and its readers only `SELECT` from the object, so they are unchanged.
- **`NetworkStateUpdaterService.IncrementalRefreshBalancesMatView`** — aggregate only transfers with `blockNumber > MAX("_maxBlock")` and apply them in one transaction: `INSERT … ON CONFLICT DO UPDATE` for balance > 0, `DELETE` for balance ≤ 0. The merge is **delta-driven** (`delta_agg LEFT JOIN table`), so only changed (account, token) pairs are written — unchanged rows are never rewritten. Watermark advance and row mutations commit together, so a crash re-applies the same additive delta rather than skipping blocks.
- **Metrics** — `circles_matview_balance_incremental_rows_total{op}`, `_watermark_advance_blocks`, `_watermark_block`.
- **Tests** — new Testcontainers Postgres suite executes the real incremental SQL and asserts the table equals a full recompute across accumulation, zero-balance deletion, first-boot, multi-cycle and batch transfers, plus a no-write-amplification guard. Structural tests updated for the table (vs matview) contract.

## Why not just keep the matview
PostgreSQL forbids DML on materialized views (`ERROR: cannot change materialized view`). An earlier attempt that issued INSERT/DELETE against the matview compiled and passed string-match tests but would have thrown on the first cycle and silently frozen the object. The new integration tests execute the SQL against a real database to prevent that class of regression.

## Test plan
- [x] `dotnet build` full solution — 0 errors
- [x] Structural tests (CirclesViews.Tests) — 83 passed
- [x] Integration tests (Testcontainers Postgres) — 7 passed, incl. no-write-amplification + zero-balance delete + first-boot
- [x] Full Pathfinder.Tests suite — 1201 passed, 0 failed
- [ ] Deploy to staging (drained, per-node); confirm refresh traces drop to ms and `V_` balances match a full recompute for sampled accounts
- [ ] Confirm `circles_matview_balance_watermark_block` advances each cycle

## Deploy note
On the upgrade deploy the indexer's `Migrate()` converts matview→table. Until that runs, the pathfinder's incremental cycle may briefly fail against the still-matview (caught + logged as `MatViewRefreshErrors`, self-heals next cycle). Expected and transient on the first upgrade; fresh nodes create it as a table directly. Run as a drained per-node deploy.