### PR TITLE
security(rpc): disable Debug JSON-RPC module on the gnosis node

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -43,7 +43,7 @@ services:
       --JsonRpc.Host=0.0.0.0
       --JsonRpc.Port=8545
       --JsonRpc.CorsOrigins=*
-      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Debug]
+      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles]
       --JsonRpc.JwtSecretFile=/jwt.hex
       --JsonRpc.EngineHost=0.0.0.0
       --JsonRpc.EnginePort=8551


### PR DESCRIPTION
Removes `Debug` from `--JsonRpc.EnabledModules` for the `nethermind-gnosis` service.

## Why
The `Debug` namespace (`debug_traceTransaction`, `debug_getRawBlock`, `debug_getSyncStage`, …) exposes expensive, unauthenticated operations. It was reachable on the public JSON-RPC port over **both HTTP and WebSocket** — Nethermind serves both transports from the same port with the same module set — making it a denial-of-service surface via the direct `chain-rpc` / `ws-chain` reverse-proxy routes.

## Why it is safe
- No internal consumer calls `debug_*`. The Circles RPC host classifier (`RpcMethodClassifier.IsProxyAllowed`) proxies only `eth_*`/`net_*`/`web3_*` to the node and rejects everything else with `-32601`; `debug_*` only ever reached the node via the direct proxy routes, never through the classifier.
- `EnabledModules` governs only the user-facing port (8545). The Engine API (consensus↔execution, 8551) enables its module independently, so consensus/sync is unaffected.
- This is the origin-side method control that the previously-reverted proxy-level denylist pointed at — enforced authoritatively at the node instead of by re-parsing request bodies in the proxy.

## Change
`--JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Debug]` → `[Web3,Eth,Subscribe,Net,Circles]`

## Test plan
- [ ] After deploy: `debug_getSyncStage` on `/chain-rpc` returns `-32601` (method not found / module disabled)
- [ ] `eth_blockNumber`, `net_version`, `web3_clientVersion` still return results
- [ ] `circles_*` methods still served
- [ ] Node stays synced to chain head; consensus (engine API) unaffected