### PR TITLE
ci: repoint TEST_ENV_URL to the rpc subdomain on the current domain

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run snapshot tests
         env:
-          TEST_ENV_URL: https://staging.circlesubi.network/test-env
+          TEST_ENV_URL: https://rpc.staging.aboutcircles.com/test-env
         run: |
           # -m:1 serializes test assemblies: the staging test-env enforces a global
           # 10-session cap, and parallel assemblies (each holding sessions for shared
@@ -139,7 +139,7 @@ jobs:
 
       - name: Run regression tests
         env:
-          TEST_ENV_URL: https://staging.circlesubi.network/test-env
+          TEST_ENV_URL: https://rpc.staging.aboutcircles.com/test-env
         run: |
           # -m:1: see snapshot-tests — bounded by the test-env global session cap.
           dotnet test --no-build -c Release -m:1 \


### PR DESCRIPTION
## Problem
`snapshot-tests` and `regression-tests` in `ci-build-test.yml` set `TEST_ENV_URL=https://staging.circlesubi.network/test-env`, which now **404s**. `build-and-test` passes, so this has silently been the only red on `master` (`snapshot-tests` fails `OneTimeSetUp` with "Test environment not available: 404"; `regression-tests` skips because it `needs: snapshot-tests`).

## Root cause
The test-env service is fine — `circles-test-environment` is Up+healthy on both staging nodes. Two problems with the URL:
1. **Wrong host** — the Caddy route for `/test-env` is on the **rpc subdomain** (matcher on `rpc.staging.*`), not the apex. `https://staging.*/test-env` 404s; `https://rpc.staging.*/test-env` serves it.
2. **Retired domain** — `staging.circlesubi.network` is being de-mirrored to `staging.aboutcircles.com`.

## Fix
Point both jobs at `https://rpc.staging.aboutcircles.com/test-env`.

Verified: `curl -L https://rpc.staging.aboutcircles.com/test-env` → **200** (after the `/test-env` → `/test-env/` 301). No change to the test-env service or the test code.

## Test plan
- [ ] CI green — `snapshot-tests` reaches the env (no more 404 in `OneTimeSetUp`) and `regression-tests` runs.