### PR TITLE
ci: repoint TEST_ENV_URL to the rpc subdomain (staging branch)

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Run snapshot tests
         env:
-          TEST_ENV_URL: https://staging.circlesubi.network/test-env
+          TEST_ENV_URL: https://rpc.staging.aboutcircles.com/test-env
         run: |
           # -m:1 serializes test assemblies: the staging test-env enforces a global
           # 10-session cap, and parallel assemblies (each holding sessions for shared
@@ -139,7 +139,7 @@ jobs:
 
       - name: Run regression tests
         env:
-          TEST_ENV_URL: https://staging.circlesubi.network/test-env
+          TEST_ENV_URL: https://rpc.staging.aboutcircles.com/test-env
         run: |
           # -m:1: see snapshot-tests — bounded by the test-env global session cap.
           dotnet test --no-build -c Release -m:1 \


### PR DESCRIPTION
Same repoint as the master PR, applied to the `staging` branch's `ci-build-test.yml`. `TEST_ENV_URL` moves from the 404ing `https://staging.circlesubi.network/test-env` (apex + retired domain) to `https://rpc.staging.aboutcircles.com/test-env` (the rpc-subdomain route where the healthy `circles-test-environment` container is actually served; verified 200). Unblocks snapshot-tests / regression-tests on staging-branch runs.