### PR TITLE
security(rpc): disable Debug JSON-RPC module on the gnosis node

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -43,7 +43,7 @@ services:
       --JsonRpc.Host=0.0.0.0
       --JsonRpc.Port=8545
       --JsonRpc.CorsOrigins=*
-      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Debug]
+      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles]
       --JsonRpc.JwtSecretFile=/jwt.hex
       --JsonRpc.EngineHost=0.0.0.0
       --JsonRpc.EnginePort=8551


### PR DESCRIPTION
## Summary

Removes the `Debug` namespace from the gnosis Nethermind node's `--JsonRpc.EnabledModules`, so `debug_*` methods are no longer served on the user-facing JSON-RPC port (8545) over either HTTP or WebSocket. Ports the same one-line change already merged to `staging` (#534) onto `master` (which production pins).

## Why

`debug_*` methods (e.g. `debug_traceBlock`, `debug_getSyncStage`) are expensive and were publicly reachable via the direct proxy routes, an availability/DoS exposure. Disabling the module at the node is the origin-side, bypass-proof fix (a proxy-level denylist can be evaded via JSON escaping and WS frames).

## Safety

- Nethermind serves HTTP and WS from the same port with the same module set, so this closes both transports at once.
- No internal consumer calls `debug_*`: the rpc-host classifier only proxies `eth_*`/`net_*`/`web3_*` to the node.
- `EnabledModules` governs only the user port (8545). The Engine API (8551) enables its module independently, so consensus/sync is unaffected.
- Verified end-to-end on staging: `debug_*` returns `-32600 "the namespace 'Debug' is disabled"` on both `/chain-rpc` (HTTP) and `/ws/chain` (WS); `eth`/`net`/`web3`/`circles` preserved.

## Change

`docker/docker-compose.gnosis.yml`: `EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Debug]` → `[Web3,Eth,Subscribe,Net,Circles]`