### PR TITLE
ci: serialize session-consuming test jobs across all workflow runs

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -74,6 +74,14 @@ jobs:
     runs-on: ubuntu-latest
     # Now runs on PRs too - test-env returns sanitized errors (no credential exposure)
     needs: build-and-test
+    # Serialize the session-consuming jobs across ALL workflow runs (any branch/PR).
+    # regression-tests shares this group, so at most one session-consuming job runs
+    # at a time fleet-wide — no two concurrent runs can starve the test-env's global
+    # 10-session cap (which manifests as 100s HttpClient timeouts in OneTimeSetUp).
+    # cancel-in-progress:false => queue rather than kill an in-flight run.
+    concurrency:
+      group: circles-test-env-session-pool
+      cancel-in-progress: false
 
     steps:
       - name: Check out code
@@ -119,6 +127,11 @@ jobs:
     # Chained after snapshot-tests (not just build-and-test) so the two jobs never
     # compete for the test-env's global 10-session cap.
     needs: [build-and-test, snapshot-tests]
+    # Same concurrency group as snapshot-tests: serializes session-consuming jobs
+    # across all runs (see snapshot-tests for rationale).
+    concurrency:
+      group: circles-test-env-session-pool
+      cancel-in-progress: false
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Problem
`snapshot-tests` and `regression-tests` each create Circles-Test-Environment sessions, and the test-env enforces a **global 10-session cap**. Within a run the two jobs are already chained (`regression` needs `snapshot`) so they never overlap. But nothing stopped two concurrent **runs** (a master push + a staging push, or several PRs) from running their session jobs simultaneously — combined demand exceeds the cap, session creation blocks past the client's 100s timeout, and `OneTimeSetUp` fails with `Test environment not available: HttpClient.Timeout of 100 seconds`.

Observed: 4 near-simultaneous runs (2 PRs + 2 merge-pushes) produced 17 such timeout failures. Verified with the test-env session logs — **0 cap errors** once runs don't overlap; a single isolated run cycles sessions cleanly (created ≈ terminated, ~0 concurrent).

## Fix
Put both session-consuming jobs in a single repo-wide `concurrency` group (`circles-test-env-session-pool`, `cancel-in-progress: false`) so at most one runs at a time across every branch/PR. `build-and-test` is unaffected (still parallel, fast feedback).

## Not changed (verified unrelated)
- The `column "balance" does not exist` log lines are **benign**: `AllSchemaTables_AreQueryable` probes every schema view with `SELECT 1 FROM …`, catches and logs failures, and only asserts on *critical* tables — non-critical view bodies (e.g. views the test-env doesn't fully materialize at the pinned block) are logged, not fatal.
- This is not caused by the `M_CrcV2_BalancesByAccountAndToken` matview→table change: every balance view returns rows live, and the public columns (`totalBalance`/`demurragedTotalBalance`) are unchanged.

## Test plan
- [x] YAML validates
- [ ] Two overlapping runs no longer time out (the later one queues behind the earlier)