### PR TITLE
test(env-client): give health/block probes the same 5m timeout as the session client

### DIFF
--- a/src/Common/Circles.Common.TestUtils/TestEnvironmentClient.cs
+++ b/src/Common/Circles.Common.TestUtils/TestEnvironmentClient.cs
@@ -182,7 +182,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<long> GetCurrentBlockAsync(string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         var response = await GetWithTransientRetryAsync<BlockInfo>(client, "api/v1/blocks/current");
         return response?.BlockNumber ?? 0;
@@ -194,7 +199,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<bool> BlockExistsAsync(long blockNumber, string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         var response = await GetWithTransientRetryAsync<BlockExistsInfo>(
             client, $"api/v1/blocks/{blockNumber}/exists");
@@ -207,7 +217,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<HealthResponse?> GetHealthAsync(string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         return await GetWithTransientRetryAsync<HealthResponse>(client, "health");
     }


### PR DESCRIPTION
## Problem
Once the `TEST_ENV_URL` 404 was fixed (#535) and the session-based tests started actually running, the RPC scenario tests (`RPC/flag-interaction`, `RPC/consented-flow`, `RPC/invitation/invitation-stress-001`, `RPC/quantized-mode/…`) failed with **`Test environment not available: HttpClient.Timeout of 100 seconds`** — each failure taking exactly 1m40s.

## Root cause
`TestEnvironmentClient`'s instance `HttpClient` already uses a **5-minute** timeout (session creation forks Anvil and is slow), but the three static probe helpers — `GetHealthAsync`, `BlockExistsAsync`, `GetCurrentBlockAsync` — used a bare `new HttpClient`, which defaults to **exactly 100 seconds**. `ScenarioTests` calls `GetHealthAsync` + `BlockExistsAsync` in its setup; under load (the shared test-env busy forking Anvil for other sessions) even these lightweight probes exceed 100s, and the setup `catch` reports the env "not available" though it's healthy — just momentarily slow.

## Fix
Give the three probe helpers the same 5-minute timeout as the instance client. Combined with the cross-run session-job `concurrency` guard (#538), the session-consuming tests stop spuriously failing when the shared test-env is briefly busy.

## Test plan
- [ ] Scenario tests no longer fail with the 100s timeout in setup