### PR TITLE
test(pathfinder): prove simulated overlays are load-bearing + gate mint-along-path on Anvil

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -154,3 +154,48 @@ jobs:
           name: regression-test-results
           path: TestResults/regression/
           retention-days: 30
+
+  # Anvil regression tests: execute pathfinder output on an Anvil fork of the pinned
+  # block and assert it does not revert (mint-along-path E2E). Complements the
+  # snapshot-tests differential check (ScenarioE2ETests, Category=Snapshot) by gating
+  # the previously un-gated mint-along-path suite.
+  anvil-regression:
+    runs-on: ubuntu-latest
+    # Chained after the other test-env jobs (not just build-and-test) so the three
+    # jobs never compete for the test-env's global 10-session cap.
+    needs: [build-and-test, snapshot-tests, regression-tests]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build solution
+        run: dotnet build -c Release --no-restore
+
+      - name: Run Anvil regression tests
+        env:
+          TEST_ENV_URL: https://rpc.staging.aboutcircles.com/test-env
+        run: |
+          # -m:1: see snapshot-tests — bounded by the test-env global session cap.
+          dotnet test --no-build -c Release -m:1 \
+            --filter "Category=AnvilRegression" \
+            --logger "trx;LogFileName=anvil-regression-tests.trx" \
+            --results-directory TestResults/anvil-regression
+
+      - name: Upload Anvil regression test results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: anvil-regression-test-results
+          path: TestResults/anvil-regression/
+          retention-days: 30

--- a/src/Pathfinder/Circles.Pathfinder.Tests/HistoricalGraphCacheTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/HistoricalGraphCacheTests.cs
@@ -1,7 +1,11 @@
+using Circles.Common;
+using Circles.Common.Dto;
 using Circles.Pathfinder.Graphs;
 using Circles.Pathfinder.Host;
 using Circles.Pathfinder.Host.State;
+using Circles.Pathfinder.Tests.Helpers;
 using Microsoft.Extensions.Logging.Abstractions;
+using Nethermind.Int256;
 using Npgsql;
 
 namespace Circles.Pathfinder.Tests;
@@ -133,5 +137,74 @@ public class HistoricalGraphCacheTests
         }
 
         Assert.That(cache.CachedBlockNumbers, Is.EquivalentTo(new[] { 7L, 8L }));
+    }
+
+    /// <summary>
+    /// Guards the wiring by which "what-if" overlays reach the HISTORICAL request path:
+    /// FindPathHandler.ExecuteHistorical obtains the factory from the historical cache and
+    /// then calls CreateCapacityGraph(request) (FindPathHandler.cs — GetOrLoadFactoryAsync
+    /// followed by CreateCapacityGraph). This test reproduces those two steps and asserts a
+    /// simulated overlay changes the outcome, so a refactor that dropped `request` in the
+    /// historical branch (silently ignoring overlays at a pinned block) would fail here.
+    ///
+    /// NOTE: LoadGraphOverride substitutes an in-memory factory, so this does NOT exercise
+    /// the block-pinned SQL loader (HistoricalLoadGraph / blockNumber filtering) — that is
+    /// covered by the staging-backed scenario suites. Scope here is strictly the overlay
+    /// wiring, mirroring the other tests in this fixture.
+    /// </summary>
+    [Test]
+    public async Task HistoricalFactory_ThreadsSimulatedOverlayThroughRequest()
+    {
+        const string router = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+        int Id(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+        string Addr(int i) => AddressIdPool.StringOf(Id(i));
+
+        Environment.SetEnvironmentVariable(MaxEntriesVar, "3");
+        var dataSource = NpgsqlDataSource.Create(
+            "Host=localhost;Database=never_connected;Username=never;Password=never");
+
+        // The graph the (overridden) historical factory returns: sink trusts source and the
+        // token, but source holds nothing → no path from this state alone.
+        var mock = new MockLoadGraph();
+        mock.AddTrust(Id(2), Id(1)); // sink trusts source
+        mock.AddTrust(Id(2), Id(10)); // sink trusts token
+
+        var cache = new HistoricalGraphCache(dataSource, new Host.Settings(),
+            NullLogger<HistoricalGraphCache>.Instance)
+        {
+            LoadGraphOverride = _ => new GraphFactory(router, mock)
+        };
+
+        // ExecuteHistorical step 1: factory from the historical cache.
+        var factory = await cache.GetOrLoadFactoryAsync(43_193_632);
+        var target = UInt256.Parse("1000000000000000000");
+
+        // Without overlay → no path at the pinned block.
+        var baseRequest = new FlowRequest { Source = Addr(1), Sink = Addr(2) };
+        var baseCg = factory.CreateCapacityGraph(
+            factory.V2BalanceGraph(), GraphFactory.BuildTrustLookup(factory.V2TrustGraph()), baseRequest);
+        var baseResult = new V2Pathfinder().ComputeMaxFlowWithPath(baseCg, baseRequest, target);
+        Assert.That(
+            baseResult.Transfers is null || baseResult.Transfers.Count == 0
+            || string.IsNullOrEmpty(baseResult.MaxFlow) || UInt256.Parse(baseResult.MaxFlow!) == UInt256.Zero,
+            Is.True, "Block-pinned state alone must yield no path");
+
+        // ExecuteHistorical step 2: CreateCapacityGraph(request-with-overlay) on the same
+        // historical factory → the overlay must compose with the pinned graph.
+        var overlayRequest = new FlowRequest
+        {
+            Source = Addr(1),
+            Sink = Addr(2),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new() { Holder = Addr(1), Token = Addr(10), Amount = "100000000000000000000" } // 100 CRC
+            }
+        };
+        var overlayCg = factory.CreateCapacityGraph(
+            factory.V2BalanceGraph(), GraphFactory.BuildTrustLookup(factory.V2TrustGraph()), overlayRequest);
+        var overlayResult = new V2Pathfinder().ComputeMaxFlowWithPath(overlayCg, overlayRequest, target);
+        Assert.That(overlayResult.Transfers, Is.Not.Null.And.Not.Empty,
+            "simulated overlay must compose with the block-pinned historical factory");
+        Assert.That(UInt256.Parse(overlayResult.MaxFlow!) > UInt256.Zero, Is.True);
     }
 }

--- a/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/MintAlongPathE2ETests.cs
@@ -20,12 +20,13 @@ namespace Circles.Pathfinder.Tests;
 /// - Tests create sessions with Anvil fork for contract execution
 ///
 /// The tests run by default but gracefully skip when TEST_ENV_URL is not set.
-/// Not selected by any CI job — run them explicitly (e.g.
-/// --filter "TestCategory=RequiresAnvil") with TEST_ENV_URL set.
+/// Gated in CI by the "anvil-regression" job (Category=AnvilRegression), which runs
+/// against the staging test environment on PRs and pushes to dev/staging/master.
 /// </summary>
 [TestFixture]
 [Category("RequiresTestEnv")]
 [Category("RequiresAnvil")]
+[Category("AnvilRegression")]
 public class MintAlongPathE2ETests
 {
     private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
@@ -49,7 +50,7 @@ public class MintAlongPathE2ETests
         if (string.IsNullOrEmpty(testEnvUrl))
         {
             Assert.Ignore(
-                "TEST_ENV_URL not set. Set to https://staging.circlesubi.network/test-env to run E2E tests.");
+                "TEST_ENV_URL not set. Set to https://rpc.staging.aboutcircles.com/test-env to run E2E tests.");
             return;
         }
 
@@ -103,57 +104,32 @@ public class MintAlongPathE2ETests
     }
 
     /// <summary>
-    /// Verify that the pathfinder finds a path for the bug scenario.
-    /// This test uses the Query API which works from anywhere.
+    /// The mint-along-path regression gate. At the bug-repro block it: (1) computes the
+    /// path via the block-pinned query proxy — so it runs from CI where no direct DB
+    /// connection is available, not just on a node with local Postgres; (2) verifies the
+    /// collateral-before-mint edge ordering the original bug violated; (3) executes the
+    /// resulting operateFlowMatrix on the Anvil fork and asserts it does not revert.
+    /// State mutations are isolated by an evm_snapshot/revert so the other fixture tests
+    /// are order-independent.
     /// </summary>
     [Test]
-    public async Task ComputePath_BugScenario_FindsPath()
+    public async Task MintAlongPath_ComputeOrderAndExecuteOnFork_NoRevert()
     {
         Assert.That(_session, Is.Not.Null, "Session should be created in setup");
+        Assert.That(_anvil, Is.Not.Null, "Anvil should be available");
 
-        // Use ExecuteQueryAsync for external access (proxied through test-env)
-        var countResult = await _session!.ExecuteScalarAsync(
-            "SELECT COUNT(*) FROM \"CrcV2_Trust\" WHERE \"blockNumber\" <= @block",
-            new Dictionary<string, object?> { { "block", BugReproBlock } });
-
-        TestContext.Out.WriteLine($"Trust relationships at block {BugReproBlock}: {countResult}");
-
-        // For pathfinding, we need direct database access or to use the Pathfinder service
-        // Since direct access may not be available externally, we test what we can
-        if (!_session.IsDirectConnectionAvailable)
-        {
-            // Verify we can query trust data through the proxy
-            var trustResult = await _session.ExecuteQueryAsync(
-                @"SELECT truster, trustee FROM ""CrcV2_Trust""
-                  WHERE truster = @source OR trustee = @source
-                  LIMIT 10",
-                new Dictionary<string, object?>
-                {
-                    { "source", BugSource }
-                });
-
-            Assert.That(trustResult.RowCount, Is.GreaterThan(0),
-                "Source address should have trust relationships");
-
-            TestContext.Out.WriteLine($"Found {trustResult.RowCount} trust relationships for source");
-            Assert.Pass("Query API working - full path computation requires direct DB access");
-            return;
-        }
-
-        // Direct connection available - run full pathfinding test
-        var loadGraph = new LoadGraph(_session.PostgresConnectionString!, _settings!);
+        // Works from anywhere: direct DB when available, else the block-pinned query proxy
+        // (mirrors ScenarioTests' loader selection so the path is computed even in CI).
+        ILoadGraph loadGraph = _session!.IsDirectConnectionAvailable
+            ? new LoadGraph(_session.PostgresConnectionString!, _settings!)
+            : new ProxyLoadGraph(_session, _settings!);
         var factory = new GraphFactory(RouterAddress, loadGraph);
 
         var trustGraph = factory.V2TrustGraph();
         var balanceGraph = factory.V2BalanceGraph();
         var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
 
-        var request = new FlowRequest
-        {
-            Source = BugSource,
-            Sink = BugSink
-        };
-
+        var request = new FlowRequest { Source = BugSource, Sink = BugSink };
         var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
         var pathfinder = new V2Pathfinder();
 
@@ -161,77 +137,39 @@ public class MintAlongPathE2ETests
         var response = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, targetFlow);
 
         Assert.That(response.Transfers, Is.Not.Null.And.Not.Empty,
-            "Should find a path for the bug scenario");
+            "Should find a path for the mint-along-path bug scenario");
+        TestContext.Out.WriteLine($"Found path with {response.Transfers!.Count} steps, maxFlow {response.MaxFlow}");
 
-        TestContext.Out.WriteLine($"Found path with {response.Transfers!.Count} steps");
-        TestContext.Out.WriteLine($"Max flow: {response.MaxFlow}");
-    }
-
-    /// <summary>
-    /// Integration test: Verify that sorted paths have correct edge ordering.
-    /// Requires direct database connection for full path computation.
-    /// </summary>
-    [Test]
-    public void SortedPath_HasCorrectEdgeOrdering()
-    {
-        Assert.That(_session, Is.Not.Null);
-
-        if (!_session!.IsDirectConnectionAvailable)
-        {
-            Assert.Ignore("Test requires direct database connection. Run on staging CI.");
-            return;
-        }
-
-        var loadGraph = new LoadGraph(_session.PostgresConnectionString!, _settings!);
-        var factory = new GraphFactory(RouterAddress, loadGraph);
-
-        var trustGraph = factory.V2TrustGraph();
-        var balanceGraph = factory.V2BalanceGraph();
-        var trustLookup = GraphFactory.BuildTrustLookup(trustGraph);
-
-        var request = new FlowRequest
-        {
-            Source = BugSource,
-            Sink = BugSink
-        };
-
-        var capacityGraph = factory.CreateCapacityGraph(balanceGraph, trustLookup, request);
-        var pathfinder = new V2Pathfinder();
-
-        var targetFlow = UInt256.Parse("1000000000000000000000"); // 1000 CRC
-        var response = pathfinder.ComputeMaxFlowWithPath(capacityGraph, request, targetFlow);
-
-        if (response.Transfers == null || response.Transfers.Count == 0)
-        {
-            Assert.Ignore("No path found at this block state");
-            return;
-        }
-
-        // Verify edge ordering: for each group, collateral edges must come before mint edges
+        // Collateral-before-mint ordering: every Group→Avatar mint must be preceded by a
+        // Router→Group collateral deposit for that group (the invariant the bug broke).
         var groupsWithCollateral = new HashSet<string>();
         var routerAddr = RouterAddress.ToLowerInvariant();
-
         foreach (var step in response.Transfers)
         {
             var from = step.From?.ToLowerInvariant() ?? "";
             var to = step.To?.ToLowerInvariant() ?? "";
-
-            // Check if this is a Router → Group edge (collateral deposit)
             if (from == routerAddr && capacityGraph.IsGroup(AddressIdPool.IdOf(to)))
-            {
                 groupsWithCollateral.Add(to);
-            }
 
-            // Check if this is a Group → Avatar edge (minting)
             var fromId = AddressIdPool.IdOf(from);
             if (capacityGraph.IsGroup(fromId) && !capacityGraph.IsGroup(AddressIdPool.IdOf(to)) && to != routerAddr)
-            {
                 Assert.That(groupsWithCollateral.Contains(from), Is.True,
                     $"Group {from} minted before receiving collateral");
-            }
         }
 
-        TestContext.Out.WriteLine("Edge ordering verified successfully");
+        // Execute the computed flow matrix on the fork — must not revert.
+        var snapshotId = await _anvil!.SnapshotAsync();
+        try
+        {
+            var result = await _anvil.ExecuteTransferPathAsync(BugSource, BugSink, response.Transfers);
+            Assert.That(result.Success, Is.True,
+                $"operateFlowMatrix reverted on the fork: {result.Error}");
+            TestContext.Out.WriteLine($"Executed on fork without revert: gas {result.GasUsed}, tx {result.TxHash}");
+        }
+        finally
+        {
+            await _anvil.RevertAsync(snapshotId);
+        }
     }
 
     /// <summary>

--- a/src/Pathfinder/Circles.Pathfinder.Tests/SimulatedOverlayCausalityTests.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Tests/SimulatedOverlayCausalityTests.cs
@@ -1,0 +1,185 @@
+using Circles.Common;
+using Circles.Common.Dto;
+using Circles.Pathfinder.Graphs;
+using Circles.Pathfinder.Tests.Helpers;
+using Nethermind.Int256;
+using NUnit.Framework;
+
+namespace Circles.Pathfinder.Tests;
+
+/// <summary>
+/// Causality tests for the pathfinder "what-if" overlay inputs (simulatedBalances /
+/// simulatedTrusts). Existing coverage (<see cref="SimulatedBalanceTests"/>,
+/// GraphFactoryTests) proves the overlay produces a path, but never asserts the
+/// counterfactual — that the SAME graph yields NO path once the overlay is removed.
+/// Without that negative control a "path found" result cannot distinguish
+/// "the overlay created the path" from "the path existed anyway".
+///
+/// Each test runs the identical base graph twice: once without the overlay (expect no
+/// path) and once with it (expect a path with positive flow), making the overlay
+/// verifiably load-bearing. In every base graph BOTH endpoints already exist as real
+/// nodes (via unrelated balance/trust) so the no-path result is caused specifically by
+/// the missing liquidity/trust the overlay supplies — not by an absent source/sink node.
+/// All offline (MockLoadGraph) → runs in CI without TEST_ENV_URL.
+/// </summary>
+[TestFixture, Parallelizable]
+[Category("Unit")]
+public class SimulatedOverlayCausalityTests
+{
+    private const string RouterAddress = "0xdc287474114cc0551a81ddc2eb51783fbf34802f";
+
+    private static int Node(int i) => AddressIdPool.IdOf($"0x{i:X40}");
+    private static string Addr(int i) => AddressIdPool.StringOf(Node(i));
+
+    // 1 CRC in wei — a modest target every positive case comfortably satisfies.
+    private static readonly UInt256 OneCrc = UInt256.Parse("1000000000000000000");
+
+    [Test]
+    public void SimulatedBalance_IsLoadBearing_NoBalanceNoPath_WithOverlayPath()
+    {
+        // sink trusts the token, so the ONLY thing missing for a path is source-side
+        // liquidity. Supplying it via simulatedBalances must create the path.
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+
+        MockLoadGraph BaseGraph()
+        {
+            var mock = new MockLoadGraph();
+            mock.AddTrust(sink, source); // source present as a node; still holds nothing
+            mock.AddTrust(sink, token); // sink present and trusts the token
+            return mock;
+        }
+
+        var baseRequest = new FlowRequest { Source = Addr(1), Sink = Addr(2) };
+        AssertNoPath(BaseGraph(), baseRequest,
+            "Source has no balance and no overlay — a path must not exist");
+
+        var overlayRequest = new FlowRequest
+        {
+            Source = Addr(1),
+            Sink = Addr(2),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new() { Holder = Addr(1), Token = Addr(10), Amount = "100000000000000000000" } // 100 CRC
+            }
+        };
+        AssertHasPath(BaseGraph(), overlayRequest,
+            "simulatedBalances must create a path that did not exist without it");
+    }
+
+    [Test]
+    public void SimulatedTrust_IsLoadBearing_NoTrustNoPath_WithOverlayPath()
+    {
+        // source holds a real balance; the ONLY thing missing is the sink trusting that
+        // token. Supplying it via simulatedTrusts must create the path.
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+        var unrelated = Node(99);
+
+        MockLoadGraph BaseGraph()
+        {
+            var mock = new MockLoadGraph();
+            mock.AddBalance(source, token, 100_000_000); // 100 CRC of token(10)
+            mock.AddTrust(sink, unrelated); // sink is a node, but does NOT trust token(10)
+            return mock;
+        }
+
+        var baseRequest = new FlowRequest { Source = Addr(1), Sink = Addr(2) };
+        AssertNoPath(BaseGraph(), baseRequest,
+            "Sink does not trust the source token and there is no overlay — a path must not exist");
+
+        var overlayRequest = new FlowRequest
+        {
+            Source = Addr(1),
+            Sink = Addr(2),
+            SimulatedTrusts = new List<SimulatedTrust>
+            {
+                new() { Truster = Addr(2), Trustee = Addr(10) }
+            }
+        };
+        AssertHasPath(BaseGraph(), overlayRequest,
+            "simulatedTrusts must create a path that did not exist without it");
+    }
+
+    [Test]
+    public void SimulatedBalanceAndTrust_Combined_IsLoadBearing()
+    {
+        // Both endpoints exist on-chain via unrelated filler balance/trust, so the
+        // negative control isolates the missing liquidity+trust for `token` rather than
+        // missing graph nodes. Only both overlays together can create a path.
+        var source = Node(1);
+        var sink = Node(2);
+        var token = Node(10);
+        var fillerHeld = Node(98); // source holds this, but sink does not trust it
+        var fillerTrusted = Node(99); // sink trusts this, but nobody holds it
+
+        MockLoadGraph BaseGraph()
+        {
+            var mock = new MockLoadGraph();
+            mock.AddBalance(source, fillerHeld, 100_000_000); // source present, no usable route
+            mock.AddTrust(sink, fillerTrusted); // sink present, trusts nothing that is held
+            return mock;
+        }
+
+        var baseRequest = new FlowRequest { Source = Addr(1), Sink = Addr(2) };
+        AssertNoPath(BaseGraph(), baseRequest,
+            "Endpoints exist but neither liquidity nor trust for the token — no path without overlay");
+
+        var overlayRequest = new FlowRequest
+        {
+            Source = Addr(1),
+            Sink = Addr(2),
+            SimulatedBalances = new List<SimulatedBalance>
+            {
+                new() { Holder = Addr(1), Token = Addr(10), Amount = "100000000000000000000" }
+            },
+            SimulatedTrusts = new List<SimulatedTrust>
+            {
+                new() { Truster = Addr(2), Trustee = Addr(10) }
+            }
+        };
+        AssertHasPath(BaseGraph(), overlayRequest,
+            "Combined simulatedBalances + simulatedTrusts must create a path");
+    }
+
+    // ---- helpers -----------------------------------------------------------
+
+    private static (BalanceGraph bg, Dictionary<int, HashSet<int>> lookup) Build(MockLoadGraph mock)
+    {
+        var factory = new GraphFactory(RouterAddress, mock);
+        var balanceGraph = factory.V2BalanceGraph();
+        var trustLookup = GraphFactory.BuildTrustLookup(factory.V2TrustGraph());
+        return (balanceGraph, trustLookup);
+    }
+
+    private static void AssertHasPath(MockLoadGraph mock, FlowRequest request, string because)
+    {
+        var factory = new GraphFactory(RouterAddress, mock);
+        var (bg, lookup) = Build(mock);
+        var capacityGraph = factory.CreateCapacityGraph(bg, lookup, request);
+        var result = new V2Pathfinder().ComputeMaxFlowWithPath(capacityGraph, request, OneCrc);
+
+        Assert.That(result.Transfers, Is.Not.Null.And.Not.Empty, because);
+        Assert.That(result.MaxFlow, Is.Not.Null.And.Not.Empty, "MaxFlow must be populated");
+        Assert.That(UInt256.Parse(result.MaxFlow!) > UInt256.Zero, Is.True, because);
+    }
+
+    private static void AssertNoPath(MockLoadGraph mock, FlowRequest request, string because)
+    {
+        // Both endpoints exist in every base graph, so no-path manifests as a zero-flow
+        // response from the solver (V2Pathfinder.ResolveAndGuard / MaxFlowSolver), NOT as
+        // an exception. Any exception here is a genuine failure and must surface, so this
+        // deliberately does not swallow one.
+        var factory = new GraphFactory(RouterAddress, mock);
+        var (bg, lookup) = Build(mock);
+        var capacityGraph = factory.CreateCapacityGraph(bg, lookup, request);
+        var result = new V2Pathfinder().ComputeMaxFlowWithPath(capacityGraph, request, OneCrc);
+
+        var noTransfers = result.Transfers is null || result.Transfers.Count == 0;
+        var zeroFlow = string.IsNullOrEmpty(result.MaxFlow) || UInt256.Parse(result.MaxFlow!) == UInt256.Zero;
+        Assert.That(noTransfers, Is.True, because);
+        Assert.That(zeroFlow, Is.True, because);
+    }
+}


### PR DESCRIPTION
## Summary
Closes coverage gaps in the pathfinder testing pipeline and turns the previously un-gated mint-along-path Anvil E2E into a real pre-deploy CI gate. Test + CI only — no runtime binary change.

## What changed
- **SimulatedOverlayCausalityTests** (new, offline/CI-always): positive **+ negative** controls proving `simulatedBalances`/`simulatedTrusts` (and their combination) create a source→sink path that does **not** exist without them. Existing `SimulatedBalanceTests`/`GraphFactoryTests` only asserted the positive half, so a "path found" could not be attributed to the overlay. Base graphs seed both endpoints as real nodes so the counterfactual isolates missing liquidity/trust, not missing nodes.
- **HistoricalGraphCacheTests** (+1 test): guards that the historical request path threads the `request` (and its overlays) through `GetOrLoadFactoryAsync → CreateCapacityGraph` — the exact two steps `ExecuteHistorical` performs — so a refactor dropping the request in the historical branch is caught. Scoped to the wiring (the pinned SQL loader is covered by the staging suites).
- **MintAlongPathE2ETests**: the two path tests loaded via a direct DB connection and short-circuited (`Assert.Pass`/`Ignore`) in CI, where no direct connection exists — so the fixture gated nothing. Merged into `MintAlongPath_ComputeOrderAndExecuteOnFork_NoRevert`, which computes the bug-repro path via the block-pinned **query proxy** (runs in CI), verifies collateral-before-mint edge ordering, and **executes the `operateFlowMatrix` on the Anvil fork asserting no revert** (snapshot/revert-isolated).
- **CI**: new `anvil-regression` job (`Category=AnvilRegression`) chained after the other test-env jobs so the jobs never contend for the test environment's global session cap.

## Test plan
- [x] `dotnet test --filter "FullyQualifiedName~SimulatedOverlayCausalityTests|FullyQualifiedName~HistoricalGraphCacheTests"` → 8/8 pass, build clean
- [x] `dotnet test --filter "Category=AnvilRegression"` discovers the gate (skips without `TEST_ENV_URL`)
- [ ] CI `anvil-regression` job green against the staging test environment (runs on this PR)