### PR TITLE
style(pathfinder): fix dotnet format whitespace failure on staging

### DIFF
--- a/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/State/NetworkStateUpdaterService.cs
@@ -983,7 +983,7 @@ SELECT
                 if (reader.Read())
                 {
                     rowsUpserted = reader.GetInt64(0);
-                    rowsDeleted  = reader.GetInt64(1);
+                    rowsDeleted = reader.GetInt64(1);
                 }
             }
 


### PR DESCRIPTION
One-character whitespace fix (alignment double-space before `=`) that was failing the `Check Code Formatting` CI job (`dotnet format --verify-no-changes`) on the staging branch. Verified clean locally.