### PR TITLE
ci(test-env): promote session-stability fixes (#538/#539/#540) to staging

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -181,6 +181,12 @@ jobs:
     # hostage to them. Still requires a successful build and a non-cancelled run.
     needs: [build-and-test, snapshot-tests, regression-tests]
     if: ${{ !cancelled() && needs.build-and-test.result == 'success' }}
+    # Same fleet-wide concurrency group as snapshot-tests/regression-tests: this job also
+    # consumes test-env sessions, so it must serialize with them across all runs to avoid
+    # starving the global 10-session cap.
+    concurrency:
+      group: circles-test-env-session-pool
+      cancel-in-progress: false
 
     steps:
       - name: Check out code

--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -74,6 +74,14 @@ jobs:
     runs-on: ubuntu-latest
     # Now runs on PRs too - test-env returns sanitized errors (no credential exposure)
     needs: build-and-test
+    # Serialize the session-consuming jobs across ALL workflow runs (any branch/PR).
+    # regression-tests shares this group, so at most one session-consuming job runs
+    # at a time fleet-wide — no two concurrent runs can starve the test-env's global
+    # 10-session cap (which manifests as 100s HttpClient timeouts in OneTimeSetUp).
+    # cancel-in-progress:false => queue rather than kill an in-flight run.
+    concurrency:
+      group: circles-test-env-session-pool
+      cancel-in-progress: false
 
     steps:
       - name: Check out code
@@ -119,6 +127,11 @@ jobs:
     # Chained after snapshot-tests (not just build-and-test) so the two jobs never
     # compete for the test-env's global 10-session cap.
     needs: [build-and-test, snapshot-tests]
+    # Same concurrency group as snapshot-tests: serializes session-consuming jobs
+    # across all runs (see snapshot-tests for rationale).
+    concurrency:
+      group: circles-test-env-session-pool
+      cancel-in-progress: false
 
     steps:
       - name: Check out code

--- a/src/Common/Circles.Common.TestUtils/TestEnvironmentClient.cs
+++ b/src/Common/Circles.Common.TestUtils/TestEnvironmentClient.cs
@@ -182,7 +182,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<long> GetCurrentBlockAsync(string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         var response = await GetWithTransientRetryAsync<BlockInfo>(client, "api/v1/blocks/current");
         return response?.BlockNumber ?? 0;
@@ -194,7 +199,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<bool> BlockExistsAsync(long blockNumber, string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         var response = await GetWithTransientRetryAsync<BlockExistsInfo>(
             client, $"api/v1/blocks/{blockNumber}/exists");
@@ -207,7 +217,12 @@ public class TestEnvironmentClient : IAsyncDisposable
     public static async Task<HealthResponse?> GetHealthAsync(string? testEnvUrl = null)
     {
         var baseUrl = (testEnvUrl ?? DefaultTestEnvUrl).TrimEnd('/') + "/";
-        using var client = new HttpClient { BaseAddress = new Uri(baseUrl) };
+        // 5-minute timeout (matches the instance _httpClient): under load the test-env is
+        // busy forking Anvil for other sessions, so even these lightweight health /
+        // block-exists probes can exceed HttpClient's 100s default. A 100s ceiling here
+        // surfaces as "Test environment not available: HttpClient.Timeout of 100 seconds"
+        // in scenario setup even though the env is healthy — just momentarily slow.
+        using var client = new HttpClient { BaseAddress = new Uri(baseUrl), Timeout = TimeSpan.FromMinutes(5) };
 
         return await GetWithTransientRetryAsync<HealthResponse>(client, "health");
     }

--- a/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
+++ b/src/Rpc/Circles.Rpc.Host.Tests/ScenarioTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Sockets;
 using System.Text.Json;
 using Circles.Common.TestUtils;
 using NUnit.Framework;
@@ -122,26 +123,39 @@ public class RpcScenarioTests
 
         try
         {
-            var health = await TestEnvironmentClient.GetHealthAsync();
-            if (health?.Status != "healthy")
+            // The shared, capacity-capped test environment occasionally drops a
+            // connection mid-request (transient HttpRequestException), which would
+            // otherwise hard-fail an unrelated scenario. Retry the setup probes on
+            // transient network errors only; NUnit control-flow (Assert.Ignore for
+            // un-indexed blocks, Assert.Fail for an unhealthy env) is not transient
+            // and propagates immediately without retry.
+            session = await RetryTransientAsync(async () =>
             {
-                Assert.Fail("Test environment not healthy");
-            }
+                var health = await TestEnvironmentClient.GetHealthAsync();
+                if (health?.Status != "healthy")
+                {
+                    Assert.Fail("Test environment not healthy");
+                }
 
-            var exists = await TestEnvironmentClient.BlockExistsAsync(scenario.Block);
-            if (!exists)
-            {
-                Assert.Ignore($"Block {scenario.Block} not indexed");
-            }
+                var exists = await TestEnvironmentClient.BlockExistsAsync(scenario.Block);
+                if (!exists)
+                {
+                    Assert.Ignore($"Block {scenario.Block} not indexed");
+                }
 
-            session = await TestEnvironmentClient.CreateSessionAsync(
-                scenario.Block,
-                features: ["db"],
-                ttl: "15m");
+                return await TestEnvironmentClient.CreateSessionAsync(
+                    scenario.Block,
+                    features: ["db"],
+                    ttl: "15m");
+            });
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not ResultStateException)
         {
-            Assert.Fail($"Test environment not available: {ex.Message}");
+            // Only genuine connectivity failures reach here (after retries are
+            // exhausted). NUnit's own Ignore/Fail/Inconclusive exceptions are
+            // ResultStateException subclasses and are let through unchanged so
+            // their intended result is preserved.
+            Assert.Fail($"Test environment not available after retries: {ex.Message}");
             return;
         }
 
@@ -157,6 +171,37 @@ public class RpcScenarioTests
             }
         }
     }
+
+    /// <summary>
+    /// Retries a test-environment operation on transient network failures
+    /// (dropped connections, socket resets, client timeouts) with linear backoff.
+    /// Non-transient exceptions — including NUnit control-flow (Ignore/Fail) —
+    /// propagate immediately so intended test outcomes are preserved.
+    /// </summary>
+    private static async Task<T> RetryTransientAsync<T>(Func<Task<T>> operation, int maxAttempts = 3)
+    {
+        for (var attempt = 1; ; attempt++)
+        {
+            try
+            {
+                return await operation();
+            }
+            catch (Exception ex) when (attempt < maxAttempts && IsTransient(ex))
+            {
+                TestContext.Progress.WriteLine(
+                    $"Transient test-env error (attempt {attempt}/{maxAttempts}), retrying: {ex.Message}");
+                await Task.Delay(TimeSpan.FromSeconds(2 * attempt));
+            }
+        }
+    }
+
+    private static bool IsTransient(Exception ex) =>
+        ex is HttpRequestException
+            or TaskCanceledException
+            or TimeoutException
+            or IOException
+            or SocketException
+        || (ex.InnerException is { } inner && IsTransient(inner));
 
     private async Task ValidateAddressData(RpcScenario scenario, TestEnvironmentClient session)
     {


### PR DESCRIPTION
## Why
The `snapshot-tests` job has been failing on `staging` for days with
`Test environment not available: The request was canceled due to the configured HttpClient.Timeout of 100 seconds elapsing`.

Root cause: three test-env stability fixes were merged to **master only and never reached staging**, so staging alone still has the old, flaky behavior:
- **#539** — the static setup probes (`GetHealthAsync`/`BlockExistsAsync`/`GetCurrentBlockAsync`) used `HttpClient`'s **100s default** timeout; under load the shared test-env is busy forking Anvil and even these lightweight probes exceed 100s. Now 5 min, matching the instance client.
- **#540** — retry the setup probes on transient connection drops instead of failing fatally.
- **#538** — put the session-consuming jobs in a **fleet-wide concurrency group** so at most one runs across all branches/PRs, preventing two runs from starving the test-env's global 10-session cap.

## What
- Cherry-picks #539, #540, #538 onto staging (unchanged from master).
- Adds the `anvil-regression` job (added to staging after #538 was authored) to the **same** `circles-test-env-session-pool` concurrency group, since it also consumes sessions.

## Test plan
- [x] `dotnet build` of the affected test projects succeeds
- [ ] `snapshot-tests` on this PR / subsequent staging runs no longer times out at 100s