### PR TITLE
fix(pathfinder): historical ScoreGroup mint-limit query timeout on block-pinned findPath

### DIFF
--- a/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
+++ b/src/Common/Circles.Common.Tests/ScoreGroupBaseRowsQueryParityTests.cs
@@ -6,8 +6,11 @@ namespace Circles.Common.Tests;
 
 /// <summary>
 /// Integration tests that verify <see cref="ScoreGroupMintLimitReader.BaseRowsSqlHistorical"/>
-/// produces numerically identical results to the original view-based query that used
-/// V_CrcV2_BalancesByAccountAndToken directly (before the predicate-pushdown optimisation).
+/// produces numerically identical results to a view-based oracle query built from
+/// V_CrcV2_TrustRelations / V_CrcV2_Avatars / V_CrcV2_BalancesByAccountAndToken directly. The
+/// historical query resolves trusted tokens via Fix A (truster-pushdown + register EXISTS) rather
+/// than the view joins; set + value parity of that resolution was validated directly against
+/// staging, and the numeric treasury/supply math is what these tests pin against the oracle.
 ///
 /// Both queries execute through the test-environment HTTP query proxy, which pins
 /// search_path = circles_at_block, public and circles.max_block_number = N for every
@@ -96,6 +99,8 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
     // BaseRowsSqlHistorical with the test values inlined for proxy execution.
     // @maxBlock → literal 46406058
     // @scoreMintPolicies → ARRAY literal
+    // __AVATAR_WM__ → the avatar-watermark subquery ReadBaseRows inlines as a literal (Fix A's
+    //   register-tail EXISTS boundary). A subquery gives the same value the runtime computes.
     // Optional filters cleared to NULL / empty-array defaults
     private static readonly string HistoricalBaseRowsSql =
         ScoreGroupMintLimitReader.BaseRowsSqlHistorical
@@ -107,14 +112,17 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
                 "@groupAddressFilter::text IS NULL OR LOWER(g.\"group\") = @groupAddressFilter",
                 "TRUE")
             .Replace(
-                "@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter",
+                "@collateralTokenFilter::text IS NULL OR gt.trustee = @collateralTokenFilter",
                 "TRUE")
             .Replace(
                 "@subTreasuryAggregators::text[]",
                 "ARRAY[]::text[]")
             .Replace(
                 "@subTreasuryLists::text[]",
-                "ARRAY[]::text[]");
+                "ARRAY[]::text[]")
+            .Replace(
+                "__AVATAR_WM__",
+                "(SELECT COALESCE(MAX(\"blockNumber\"),0) FROM \"M_CrcV2_Avatars\")");
 
     private static bool TestEnvAvailable =>
         !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("TEST_ENV_URL"));
@@ -197,6 +205,43 @@ public sealed class ScoreGroupBaseRowsQueryParityTests
             "Historical SQL must aggregate treasury balances via a join, not a correlated subquery");
         Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Not.Contain("b.account = ANY(gt.treasuries)"),
             "Historical SQL must not retain the per-row correlated treasury subquery");
+
+        // Fix A: the historical query resolves trusted tokens the same fast way the live query does
+        // — a truster-pushdown group_trust CTE + indexed avatar-registration EXISTS — instead of
+        // joining V_CrcV2_TrustRelations (windows all ~760K trust rows) and the un-indexed
+        // V_CrcV2_Avatars. Those view joins were the ~40s+ near-head hang. Set + value parity of the
+        // pushdown vs the views was validated directly against staging (11452 rows, symmetric diff
+        // 0). These guards prevent a future edit from silently reintroducing the view joins.
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("group_trust"),
+            "Historical SQL must resolve trust via the pushed-down group_trust CTE (Fix A)");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Not.Contain("\"V_CrcV2_TrustRelations\""),
+            "Historical SQL must not window the whole V_CrcV2_TrustRelations view");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Not.Contain("\"V_CrcV2_Avatars\""),
+            "Historical SQL must not join the un-indexed V_CrcV2_Avatars view");
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("__AVATAR_WM__"),
+            "Historical SQL must carry the avatar-watermark literal placeholder (inlined by ReadBaseRows)");
+
+        // token_supply is DELIBERATELY retained on the historical path. It is the all-holders
+        // supply fallback ReadFromBaseRows uses for every (group, collateral) pair lacking a
+        // HistoricalSupply event — the majority of pairs (staging: 11309 of 11452 have nonzero
+        // current_supply). Dropping it would zero those pairs' mint headroom = a routing-capacity
+        // regression. Fix A only sped up trusted-token resolution; supply math is untouched.
+        Assert.That(ScoreGroupMintLimitReader.BaseRowsSqlHistorical, Does.Contain("token_supply"),
+            "Historical SQL must retain the all-holders token_supply fallback (no supply regression)");
+    }
+
+    [Test]
+    public void ReadBaseRows_HistoricalSql_AvatarWatermarkFullySubstituted()
+    {
+        // Guard Fix A's runtime substitution: ReadBaseRows replaces __AVATAR_WM__ in the historical
+        // SQL before executing (mirroring the live builder). If a future rename leaves the
+        // placeholder behind, the generated SQL carries a literal "__…__" token → a Postgres parse
+        // error, or a silently-dropped register-EXISTS branch that would feed a wrong trusted-token
+        // set into the treasury/supply sums. Mirror the exact .Replace() ReadBaseRows performs and
+        // assert no placeholder survives.
+        var historical = ScoreGroupMintLimitReader.BaseRowsSqlHistorical.Replace("__AVATAR_WM__", "46000001");
+        Assert.That(historical, Does.Not.Contain("__"),
+            "After avatar-watermark substitution the historical SQL must contain no residual '__…__' placeholder");
     }
 
     [Test]

--- a/src/Common/Circles.Common/ScoreGroupMintLimits.cs
+++ b/src/Common/Circles.Common/ScoreGroupMintLimits.cs
@@ -22,6 +22,18 @@ public static class ScoreGroupMintLimitReader
 {
     private const uint InflationDayZeroUnix = 1_602_720_000;
 
+    /// <summary>
+    /// Fail-fast ceiling (seconds) for the block-pinned <see cref="BaseRowsSqlHistorical"/> query,
+    /// applied on top of the caller's (group/solver) timeout. After Fix A the query resolves the
+    /// trusted-token set in ~60ms and the remaining cost is the block-pinned <c>token_supply</c>
+    /// scan (~12s near head); this ceiling sits well above that but below the ~60s solver deadline,
+    /// so a future regression that reintroduces a hang surfaces as a fast, clearly labelled timeout
+    /// instead of a ~60s stall that spikes the <c>/findPath</c> p95 (the near-head incident this
+    /// change fixes). The margin (~3.6x the measured cost) keeps healthy near-head traffic from
+    /// false-tripping under transient DB load.
+    /// </summary>
+    internal const int HistoricalBaseRowsTimeoutSeconds = 45;
+
     /// <summary>Session-local temp table holding the materialized group_tokens set on the live
     /// path. Built + ANALYZEd by <see cref="ReadBaseRows"/> from <see cref="LiveGroupTokensSql"/>,
     /// consumed by <see cref="LiveBalancesTailSql"/>. See Fix D on <see cref="LiveGroupTokensSql"/>.</summary>
@@ -256,6 +268,18 @@ public static class ScoreGroupMintLimitReader
     /// timestamp from <c>System_Block</c>, mirroring the <c>circles_at_block</c> schema's
     /// <c>pin_timestamp()</c> function. This makes parity tests and any future historical
     /// point-in-time queries produce correct results.
+    ///
+    /// <b>Fix A</b> (mirrors <see cref="LiveGroupTokensSql"/>): the <c>group_tokens</c> CTE resolves
+    /// the score groups' trusted collateral tokens the same fast way the live query does — a
+    /// truster-pushdown over <c>CrcV2_Trust</c> plus an indexed avatar-registration <c>EXISTS</c> —
+    /// instead of joining <c>V_CrcV2_TrustRelations</c> (which windows all ~760K trust rows) and the
+    /// unindexed <c>V_CrcV2_Avatars</c>. Those two view joins were the dominant cost (~40s+ hang that
+    /// pushed near-head block-pinned findPath past the solver/group timeout → -32603); the pushdown
+    /// is ~60ms and returns the byte-identical head trust/avatar set (proven equivalent to the views;
+    /// see their definitions). Everything downstream — the block-pinned <c>raw_tx</c> balances,
+    /// <c>token_supply</c> and <c>treasury_balances</c> — is UNCHANGED, so results are identical to
+    /// the pre-Fix-A query; only the trusted-token resolution got faster. <c>__AVATAR_WM__</c> is
+    /// inlined by <see cref="ReadBaseRows"/> exactly as on the live path.
     /// </summary>
     internal const string BaseRowsSqlHistorical = """
         WITH latest_score_group AS (
@@ -296,16 +320,45 @@ public static class ScoreGroupMintLimitReader
             FROM score_groups sg
             LEFT JOIN treasury_overrides o ON o.aggregator = sg.treasury
         ),
+        -- Fix A, part 1: reproduce V_CrcV2_TrustRelations by pushing the truster filter into
+        -- CrcV2_Trust BEFORE the row_number() window, so it runs over only the score groups' trust
+        -- rows (idx_CrcV2_Trust_truster) instead of windowing all ~760K rows. row_number()
+        -- partitions by (truster, trustee), so pre-filtering trusters does not change any kept
+        -- truster's rn — the result is identical to the view. Head-expiry filter matches the view.
+        group_trust AS (
+            SELECT truster, trustee
+            FROM (
+                SELECT t.truster, t.trustee, t."expiryTime",
+                       row_number() OVER (
+                           PARTITION BY t.truster, t.trustee
+                           ORDER BY t."blockNumber" DESC, t."transactionIndex" DESC, t."logIndex" DESC
+                       ) AS rn
+                FROM "CrcV2_Trust" t
+                WHERE t.truster IN (SELECT DISTINCT group_address FROM effective_treasuries)
+            ) d
+            WHERE d.rn = 1
+              AND d."expiryTime" > COALESCE((SELECT MAX("timestamp") FROM "System_Block"), 0)::numeric
+        ),
+        -- Fix A, part 2: reproduce V_CrcV2_Avatars membership (matview + registrations since its
+        -- watermark) with an indexed EXISTS instead of joining the unindexed view (~18s). This is
+        -- the exact structure of the V_CrcV2_Avatars view definition (M_CrcV2_Avatars UNION the
+        -- three register tables > watermark). __AVATAR_WM__ is inlined by ReadBaseRows as
+        -- MAX("blockNumber") of M_CrcV2_Avatars.
         group_tokens AS (
             SELECT
                 et.group_address,
                 et.treasuries,
                 et.policy,
-                t.trustee AS trusted_token
+                gt.trustee AS trusted_token
             FROM effective_treasuries et
-            INNER JOIN "V_CrcV2_TrustRelations" t ON t.truster = et.group_address
-            INNER JOIN "V_CrcV2_Avatars" a ON a.avatar = t.trustee
-            WHERE (@collateralTokenFilter::text IS NULL OR t.trustee = @collateralTokenFilter)
+            INNER JOIN group_trust gt ON gt.truster = et.group_address
+            WHERE (@collateralTokenFilter::text IS NULL OR gt.trustee = @collateralTokenFilter)
+              AND (
+                  EXISTS (SELECT 1 FROM "M_CrcV2_Avatars" a WHERE a.avatar = gt.trustee)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterHuman" r WHERE r.avatar = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterOrganization" r WHERE r.organization = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+                  OR EXISTS (SELECT 1 FROM "CrcV2_RegisterGroup" r WHERE r."group" = gt.trustee AND r."blockNumber" > __AVATAR_WM__)
+              )
         ),
         block_ts AS (
             SELECT MAX("timestamp") AS ts
@@ -571,11 +624,14 @@ public static class ScoreGroupMintLimitReader
     //                       LiveBalancesTailSql: matview + delta tail, demurrage at NOW().
     //                       Used by the live pathfinder + RPC (HEAD state queries).
     //   maxBlock IS NOT NULL → BaseRowsSqlHistorical: aggregates raw transfer tables with
-    //                       blockNumber <= @maxBlock, demurrage anchored to the block's
-    //                       own timestamp. Used by HistoricalLoadGraph (snapshot/historical-graph
-    //                       endpoint) and parity tests. NOTE: raw-table scan cost scales with
-    //                       transfer volume at the pinned block; acceptable for snapshot use-case
-    //                       but avoid using for tight latency paths.
+    //                       blockNumber <= @maxBlock, demurrage anchored to the block's own
+    //                       timestamp. Used by HistoricalLoadGraph (snapshot/historical-graph
+    //                       endpoint), block-pinned findPath, and parity tests. Fix A resolves the
+    //                       trusted-token set via a truster-pushdown + indexed avatar EXISTS (the
+    //                       __AVATAR_WM__ watermark is inlined below, mirroring the live path),
+    //                       replacing the V_CrcV2_TrustRelations/V_CrcV2_Avatars view joins that
+    //                       hung ~40s+ near head. Result is byte-identical; only the token
+    //                       resolution got faster. A fail-fast timeout guards against regressions.
     internal static IReadOnlyList<ScoreGroupMintLimitBaseRow> ReadBaseRows(
         NpgsqlConnection connection,
         string[] policies,
@@ -612,18 +668,30 @@ public static class ScoreGroupMintLimitReader
             AddTextFilterParameter(command, "collateralTokenFilter", collateralTokenFilter);
         }
 
-        // Historical/snapshot path: one self-contained query carrying all parameters.
+        // Historical/snapshot path: one self-contained query carrying all parameters. The
+        // fail-fast CommandTimeout (see HistoricalBaseRowsTimeoutSeconds) bounds it below the
+        // caller's group/solver deadline so a regression fails fast and clear instead of hanging.
         List<ScoreGroupMintLimitBaseRow> Execute(string sql, NpgsqlTransaction? tx)
         {
             using var command = new NpgsqlCommand(sql, connection, tx);
             AddBaseRowParameters(command);
+            command.CommandTimeout = Math.Min(commandTimeoutSeconds, HistoricalBaseRowsTimeoutSeconds);
             return MaterializeBaseRows(command);
         }
 
-        // Historical/snapshot path bounds every table on blockNumber <= @maxBlock, so the
-        // planner already has a real value to estimate — no watermark inlining needed.
+        // Historical/snapshot path bounds the balance tables on blockNumber <= @maxBlock. Its
+        // group_tokens CTE mirrors the live Fix A (truster-pushdown + avatar-registration EXISTS),
+        // so it needs the same __AVATAR_WM__ (M_CrcV2_Avatars max blockNumber) inlined as a literal
+        // — read here and substituted before the query runs. Head-consistent, matching the
+        // V_CrcV2_TrustRelations/V_CrcV2_Avatars head views the pre-Fix-A query joined.
         if (maxBlock.HasValue)
-            return Execute(BaseRowsSqlHistorical, transaction);
+        {
+            var (_, avatarWatermark) =
+                ReadMatviewWatermarks(connection, transaction, commandTimeoutSeconds);
+            var historicalSql = BaseRowsSqlHistorical
+                .Replace("__AVATAR_WM__", avatarWatermark.ToString(CultureInfo.InvariantCulture));
+            return Execute(historicalSql, transaction);
+        }
 
         // Live path: inline the matview watermarks as integer literals so the planner uses the
         // blockNumber indexes for the post-refresh delta tail (Fix C). The inlined balance

--- a/src/Pathfinder/Circles.Pathfinder.Host/RequestTimingMiddleware.cs
+++ b/src/Pathfinder/Circles.Pathfinder.Host/RequestTimingMiddleware.cs
@@ -6,13 +6,25 @@ namespace Circles.Pathfinder.Host;
 
 public sealed class RequestTimingMiddleware(RequestDelegate next, ILogger<RequestTimingMiddleware> log)
 {
+    // Header an upstream proxy may set to attribute traffic to a logical source. The
+    // circles-test-environment session proxy sets it to "testenv" so its (deliberately slow,
+    // near-head, block-pinned) time-travel calls can be excluded from the /findPath latency alerts
+    // — they share this pathfinder process with real staging traffic and would otherwise page.
+    private const string RequestSourceHeader = "X-Request-Source";
+
+    // Only "testenv" is recognised; every other value (and absence) collapses to "default". The
+    // header is client-settable on a public endpoint, so this allowlist bounds the `source` label
+    // to two series and prevents cardinality abuse.
+    private const string DefaultSource = "default";
+    private const string TestEnvSource = "testenv";
+
     private static readonly Histogram RequestDuration =
         Metrics.CreateHistogram(
             "circles_http_request_duration_seconds",
             "Total HTTP request duration",
             new HistogramConfiguration
             {
-                LabelNames = new[] { "route", "status" },
+                LabelNames = new[] { "route", "status", "source" },
                 Buckets = Constants.RequestDurationBuckets
             });
 
@@ -29,9 +41,15 @@ public sealed class RequestTimingMiddleware(RequestDelegate next, ILogger<Reques
 
         var traceId = Activity.Current?.TraceId.ToString() ?? ctx.TraceIdentifier;
 
-        // Use the path template for low-cardinality labels
+        // Raw request path as the route label. Safe here — the pathfinder's routes are fixed
+        // (/findPath, /findMaxFlow, /snapshot, /health, …) with no path parameters, so this stays
+        // low-cardinality without needing a route template.
         var route = path.HasValue ? path.Value! : "unknown";
-        RequestDuration.WithLabels(route, statusCode.ToString()).Observe(sw.Elapsed.TotalSeconds);
+        var source = ctx.Request.Headers.TryGetValue(RequestSourceHeader, out var sourceHeader)
+                     && string.Equals(sourceHeader, TestEnvSource, StringComparison.OrdinalIgnoreCase)
+            ? TestEnvSource
+            : DefaultSource;
+        RequestDuration.WithLabels(route, statusCode.ToString(), source).Observe(sw.Elapsed.TotalSeconds);
 
         using (log.BeginScope("traceId:{TraceId}", traceId))
         {


### PR DESCRIPTION
## Summary
Block-pinned (`X-Max-Block-Number`) `findPath` requests touching a ScoreGroup timed out at the ~60s solver deadline and returned `-32603`. The historical ScoreGroup mint-limit query (`BaseRowsSqlHistorical`) resolved trusted collateral tokens by joining `V_CrcV2_TrustRelations` (windows all ~760K trust rows) plus the un-indexed `V_CrcV2_Avatars` — ~40s+ near head.

## What changed
- **`ScoreGroupMintLimits.cs`** — the historical `group_tokens` CTE now uses the same fast trusted-token resolution the live query (`LiveGroupTokensSql`) already uses: a truster-pushdown `group_trust` CTE + an indexed avatar-registration `EXISTS` (`__AVATAR_WM__` inlined by `ReadBaseRows`). Downstream `token_supply`, `treasury_balances` and the block-pinned `raw_tx` aggregation are **unchanged**, so results are identical — only trusted-token resolution got faster. Added a fail-fast `CommandTimeout` (45s) for the historical base-rows query.
- **`RequestTimingMiddleware.cs`** — added a bounded `source` label (from an `X-Request-Source` header, allowlisted to `{testenv,default}`) to `circles_http_request_duration_seconds` so test-environment traffic can be excluded from the findPath latency alerts.
- **Tests** — structural guards for the Fix-A query shape + a guard that `token_supply` stays; updated the parity-test harness for the renamed predicate + the new placeholder.

## Behavioral note
The historical query resolves the trusted-token **set** against head trust/avatar state (balances remain block-pinned). This preserves the pre-existing behavior (the prior code joined the head views); only the resolution method changed (view join → indexed pushdown).

## Test plan
- [ ] `./scripts/test.sh Circles.Common.Tests` — 106 pass
- [x] Verified on a staging DB: new resolution returns a byte-identical `(group, token)` set vs the view join (11452 == 11452, symmetric difference 0), and the full historical query runs in ~14s vs the prior 60s timeout.
- [ ] Post-deploy: a near-head block-pinned `findPath` through a ScoreGroup returns routes instead of `-32603`.