### PR TITLE
ci: bound test-env session-job timeouts; docs: test-env simulation boundaries

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -72,6 +72,13 @@ jobs:
   # These tests validate database queries and business logic against real blockchain state
   snapshot-tests:
     runs-on: ubuntu-latest
+    # Bound the blast radius. These session-consuming jobs share the
+    # circles-test-env-session-pool concurrency group with cancel-in-progress:false, so a
+    # single hung run (slow near-head queries + the deliberately-generous 5m probe timeouts)
+    # would otherwise hold the group for GitHub's 6h default and queue every other run behind
+    # it fleet-wide — the "chronically red for days" cascade. A healthy run finishes well
+    # inside this budget; anything longer is a hang and should fail fast to free the group.
+    timeout-minutes: 30
     # Now runs on PRs too - test-env returns sanitized errors (no credential exposure)
     needs: build-and-test
     # Serialize the session-consuming jobs across ALL workflow runs (any branch/PR).
@@ -123,6 +130,9 @@ jobs:
   # Regression tests specifically for known bug scenarios
   regression-tests:
     runs-on: ubuntu-latest
+    # Bound the blast radius — see snapshot-tests. A hang must not hold the shared
+    # session-pool concurrency group for GitHub's 6h default.
+    timeout-minutes: 25
     # Now runs on PRs too - test-env returns sanitized errors (no credential exposure)
     # Chained after snapshot-tests (not just build-and-test) so the two jobs never
     # compete for the test-env's global 10-session cap.
@@ -174,6 +184,9 @@ jobs:
   # the previously un-gated mint-along-path suite.
   anvil-regression:
     runs-on: ubuntu-latest
+    # Bound the blast radius — see snapshot-tests. This is the lightweight single-session gate
+    # (4 tests, ~18s); a run exceeding this budget is a hang, not slow work.
+    timeout-minutes: 20
     # Chained after the other test-env jobs so the four never compete for the test-env's
     # global 10-session cap. `if` runs it regardless of whether snapshot-tests /
     # regression-tests passed — those are flaky against the shared test-env (HttpClient

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ If you're developing the plugin, building packages, or running services locally,
 - **[Metrics Exporter](src/Metrics/Circles.Metrics.Exporter/README.md)** - Prometheus metrics exporter
 - **[Configuration Reference](docs/configuration.md)** - Every environment variable across all five services
 - **[Score-group mint along path](docs/score-group-mint-along-path.md)** - Score-group routing, cache graph fields, and mint-limit capacity
+- **[Test Environment & Simulation Boundaries](docs/test-environment-simulation.md)** - Block-pinned time-travel: what's pinned, routing-on-pinned-Postgres-vs-Anvil, `simulated*` for hypotheticals, pre-deploy gate
 - **[Reindexing Guide](docs/partial-table-reindexing.md)** - Full and selected-table reindex/backfill procedures
 
 Quick commands for developers:

--- a/docs/test-environment-simulation.md
+++ b/docs/test-environment-simulation.md
@@ -1,0 +1,128 @@
+# Test Environment & Simulation Boundaries
+
+How to validate pathfinder / RPC output against real historical on-chain state **before**
+deploying, and the boundaries of what that validation does — and does not — cover.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [What gets pinned to a block](#what-gets-pinned-to-a-block)
+- [The core boundary: routing is on pinned Postgres, not Anvil overlay](#the-core-boundary-routing-is-on-pinned-postgres-not-anvil-overlay)
+- [Hypothetical state: use `simulated*`, not fork mutation](#hypothetical-state-use-simulated-not-fork-mutation)
+- [Known partial pins and approximations](#known-partial-pins-and-approximations)
+- [Using the test environment](#using-the-test-environment)
+- [Pre-deploy regression gate](#pre-deploy-regression-gate)
+
+---
+
+## Overview
+
+The **circles-test-environment** is a non-production tool that pins the data planes to a past
+block so you can ask *"does the path the pathfinder computes for real block-N state actually
+execute on-chain?"* — instead of choosing between testing with tiny amounts on head and a
+blind deploy.
+
+It exposes a session API: create a session for a block number and a set of features
+(`db`, `rpc`, `pathfinder`, `anvil`), then drive the returned per-session proxy URLs. The
+proxies inject the pinning header server-side, so clients (including the SDK and the
+flow-visualization time-travel UI) need no header hacks.
+
+> The test environment is **staging-only**. There is no production test-env, and the pinning
+> planes below are the plugin's own capability — they exist on `staging`, `dev`, and `master`
+> regardless of whether a test-env container is deployed.
+
+---
+
+## What gets pinned to a block
+
+| Plane | Pinned? | Mechanism |
+| --- | --- | --- |
+| **Postgres (DB)** | ✅ | `circles_at_block` twin views; header-gated `SET search_path` |
+| **RPC** | ✅ | `X-Max-Block-Number` → `search_path` switch + cache-bypass |
+| **Pathfinder** | ✅ | `X-Max-Block-Number` → `ExecuteHistorical` → `HistoricalGraphCache` → `HistoricalLoadGraph` |
+| **Anvil (fork)** | ✅ | real fork at `--fork-block-number N` |
+| **Cache Service** | ⚠️ head-only | **bypassed** when the header is present (reads go to the pinned DB path) |
+
+A request without `X-Max-Block-Number` behaves exactly as production: live state, served
+through the cache. The header is what activates every pinned path above.
+
+---
+
+## The core boundary: routing is on pinned Postgres, not Anvil overlay
+
+The pathfinder computes routes from **pinned Postgres state** (trust, balances, group mint
+limits as of block N). It does **not** route against the Anvil fork's overlay.
+
+Practically:
+
+- ✅ You **can** test *"the path pathfinder computed for real block-N state executes on-chain
+  without reverting"* — the Anvil fork is block-N state, and `execute-on-fork` /
+  `AnvilExecutionHelper` run the resulting `operateFlowMatrix` via `eth_call` as ground truth.
+- ❌ You **cannot** mutate the Anvil fork (`setBalance`, mint, impersonate) and have the
+  pathfinder *re-route* against that mutated state. Fork mutation changes the chain, not the
+  Postgres the solver reads.
+
+`execute-on-fork` is therefore a *validator* of a computed path against real block-N state —
+not a what-if routing engine.
+
+---
+
+## Hypothetical state: use `simulated*`, not fork mutation
+
+For "what if this avatar had this balance / trust / consent?" scenarios, use the pathfinder's
+`simulated*` request fields — they overlay onto the solver's input:
+
+- `simulatedBalances`
+- `simulatedTrusts`
+- `simulatedConsentedAvatars`
+
+These compose with block pinning: a `simulated*` overlay on top of a pinned block N answers
+*"what path would exist at block N if this hypothetical held?"*.
+
+**Caveat:** `simulated*` overlays are validated on **solver output** (max-flow, transfers, the
+solver-integrity validator), **not** via `eth_call`. Hypothetical state is not on-chain, so it
+cannot be checked against the fork. Reserve the Anvil differential check for non-simulated
+scenarios.
+
+---
+
+## Known partial pins and approximations
+
+- **Cache Service is head-only.** It is bypassed when `X-Max-Block-Number` is set, so pinned
+  reads go straight to the DB path. Do not expect the cache to serve pinned state.
+- **ScoreGroup treasury supply is approximate.** The treasury-supply component reads the
+  current (unpinned) balance view; the token mapping is exact but the magnitude is
+  head-state, not block-N. Group mint-limit *routing capacity* is otherwise pinned.
+
+---
+
+## Using the test environment
+
+1. `POST /api/v1/session` with `{ "blockNumber": N, "features": ["db","rpc","pathfinder","anvil"] }`.
+2. Drive the returned session-proxy URLs:
+   - `…/session/{id}/query` — pinned Postgres
+   - `…/session/{id}/rpc` — pinned RPC (`X-Max-Block-Number` injected)
+   - `…/session/{id}/pathfinder/findPath` — pinned pathfinding
+   - `…/session/{id}/anvil` — the block-N fork
+3. Sessions are held for their TTL under a **global `MaxConcurrentSessions` cap** (default 10).
+   Over the cap, session creation returns HTTP 503. Session-pool saturation, pinning
+   degradation, and Anvil spawn failures are exported as `testenv_*` Prometheus metrics.
+
+The **flow-visualization** time-travel feature is the interactive front end for this: pick a
+past block, see the graph, run `simulated*` overlays as of that block, and optionally execute
+the path on the session's Anvil fork. It is opt-in (`VITE_TEST_ENV_URL` must be set) and
+staging-only.
+
+---
+
+## Pre-deploy regression gate
+
+`Category=AnvilRegression` (CI job `anvil-regression`) is the pre-deploy gate: it forks the
+pinned block, builds the pathfinder's `operateFlowMatrix`, and asserts it does not revert —
+covering the mint-along-path path that was previously un-gated. It runs even when the broader
+`snapshot-tests` differential job is red, because those flake against the shared test-env
+under load.
+
+All test-env-session-consuming CI jobs share one fleet-wide concurrency group so they never
+compete for the global session cap, and each carries a `timeout-minutes` bound so a hung run
+fails fast instead of holding the group.


### PR DESCRIPTION
## Summary
The three test-env-session-consuming CI jobs (`snapshot-tests`, `regression-tests`, `anvil-regression`) share one `circles-test-env-session-pool` concurrency group with `cancel-in-progress: false` and had **no `timeout-minutes`**, so GitHub's 6-hour default applied. A single hung run (slow near-head queries + the deliberately-generous 5-minute probe timeouts) holds the shared group and queues every other session-consuming run behind it fleet-wide — the mechanism behind the chronic, cascading `snapshot-tests` redness.

Diagnosed from a live run whose `snapshot-tests` step sat `in_progress` for ~50 min while the test-env session pool was **not** saturated (1 active session) — i.e. head-of-line blocking, not raw capacity.

## Changes
- `timeout-minutes` on each session-consuming job (snapshot 30 / regression 25 / anvil-regression 20). A healthy run finishes well within budget; a hang now fails fast and frees the shared group. (`build-and-test` is left on the default — it consumes no test-env sessions.)
- New `docs/test-environment-simulation.md`: block-pinning planes, the routing-on-pinned-Postgres-not-Anvil-overlay boundary, when to use `simulated*` overlays, head-only cache + approximate ScoreGroup treasury supply, and the pre-deploy gate. Linked from the README docs index.

## Notes
- No runtime/binary change — CI config + docs only.
- Complements the already-deployed historical-ScoreGroup query speedup (#546), which cuts the slowest near-head snapshot scenarios ~60s→~15s, improving the chance a run fits the budget.

## Test plan
- [x] Workflow YAML parses; timeouts present on the three jobs (30/25/20)
- [ ] Next CI run: `snapshot-tests` completes or fails within 30 min (no multi-hour hang); the shared group is not held open