### PR TITLE
deps: bump Nethermind runtime to 1.39.3 and Lighthouse to v8.2.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Autofac" Version="9.1.0" />
+    <!-- Floor is set by Nethermind.Api: 1.39.3 binds against Autofac 9.3.1, and a
+         lower pin fails the build with CS1705 (referenced assembly older than the
+         one Nethermind.Api uses). Keep at or above the Nethermind runtime's Autofac. -->
+    <PackageVersion Include="Autofac" Version="9.3.2" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
@@ -21,12 +24,20 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Nethereum.Util" Version="5.8.0" />
     <PackageVersion Include="Nethereum.Web3" Version="6.1.0" />
+    <!-- Do NOT bump independently of the runtime image. The Nethermind image bundles
+         its own /nethermind/Nethermind.Int256.dll, and the plugin publishes a copy into
+         /nethermind/plugins/. If the two assembly versions differ the node does not
+         start: it aborts with a FileLoadException ("manifest definition does not match
+         the assembly reference") before any Circles code runs. nethermind:1.39.3 ships
+         assembly version 1.5.0.0, so this stays 1.5.0. Verify against the image, not
+         against nuget's latest, whenever the runtime image moves. -->
     <PackageVersion Include="Nethermind.Numerics.Int256" Version="1.5.0" />
     <!-- Must stay compatible with the Nethermind runtime image in docker/Index.Dockerfile
-         (currently nethermind/nethermind:1.37.2). The ref-assemblies package may trail the
-         runtime image by a patch release (currently 1.37.1 vs image 1.37.2); keep both within
-         the same minor and bump together once the matching ref-assemblies release exists. -->
-    <PackageVersion Include="Nethermind.ReferenceAssemblies" Version="1.37.1" />
+         (currently nethermind/nethermind:1.39.3). Both are on 1.39.3 exactly — the
+         ref-assemblies package has historically trailed the runtime image by a patch
+         (it was 1.37.1 against image 1.37.2), but a matching 1.39.3 release exists, so
+         there is no skew to carry. Keep them equal, and bump them in the same commit. -->
+    <PackageVersion Include="Nethermind.ReferenceAssemblies" Version="1.39.3" />
     <PackageVersion Include="Npgsql" Version="10.0.1" />
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.1" />
     <PackageVersion Include="NUnit" Version="4.6.0" />

--- a/docker/Index.Dockerfile
+++ b/docker/Index.Dockerfile
@@ -46,7 +46,7 @@ RUN dotnet publish \
     -o /circles-nethermind-plugin \
     --no-restore
 
-FROM nethermind/nethermind:1.37.2 AS base
+FROM nethermind/nethermind:1.39.3 AS base
 
 # Install psql for manual DB operations (runs as root, compose sets runtime user)
 RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*

--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -77,7 +77,7 @@ services:
 
   consensus-gnosis:
     container_name: consensus-gnosis
-    image: sigp/lighthouse:v8.1.3
+    image: sigp/lighthouse:v8.2.1
     restart: always
     depends_on:
       nethermind-gnosis:

--- a/src/Index/Circles.Index/Plugin.cs
+++ b/src/Index/Circles.Index/Plugin.cs
@@ -42,7 +42,9 @@ public class Plugin : INethermindPlugin
 
     public Task Init(INethermindApi nethermindApi)
     {
-        ILogger baseLogger = nethermindApi.LogManager.GetClassLogger();
+        // Nethermind 1.39 dropped the parameterless GetClassLogger() overload that
+        // inferred the calling type; only GetClassLogger<T>() remains.
+        ILogger baseLogger = nethermindApi.LogManager.GetClassLogger<Plugin>();
         InterfaceLogger pluginLogger = new LoggerWithPrefix($"{Name}: ", baseLogger);
 
         if (!Enabled)


### PR DESCRIPTION
The Nethermind base image was two minors behind. 1.39.2 moved Nethermind onto Microsoft's July 2026 .NET servicing release (10.0.10), which carries 17 security fixes; the node containers were still running .NET 10.0.5. Every other .NET service in this repo builds from the floating `aspnet:10.0` tag and so already picks up servicing updates on rebuild — the node is the only one pinned to a third-party image, which is why it alone was left behind.

## What changed

- `docker/Index.Dockerfile`: `nethermind/nethermind` 1.37.2 -> 1.39.3
- `Nethermind.ReferenceAssemblies` 1.37.1 -> 1.39.3. Compile-time refs and the runtime image are now on the same version; the patch-level skew the surrounding comment described no longer applies.
- `Autofac` 9.1.0 -> 9.3.2. Required, not cosmetic: `Nethermind.Api` 1.39.3 binds against Autofac 9.3.1, so the old pin failed the build with CS1705.
- `Plugin.cs`: `GetClassLogger()` -> `GetClassLogger<Plugin>()`. 1.39 dropped the parameterless overload that inferred the calling type (CS0411).
- `docker/docker-compose.gnosis.yml`: `sigp/lighthouse` v8.1.3 -> v8.2.1
- `Nethermind.Numerics.Int256` stays at 1.5.0, now documented.

## Why Int256 must not be bumped on its own

Bumping it to 1.6.0 compiles and passes the full test suite, then crash-loops the node at startup. The runtime image bundles its own `Nethermind.Int256.dll` and the plugin publishes a copy into `plugins/`; when the assembly versions differ the process aborts with a `FileLoadException` ("manifest definition does not match the assembly reference") before any Circles code runs. 1.39.3 ships assembly version 1.5.0.0. This is only observable by starting the built image, so the constraint is now a comment in `Directory.Packages.props`.

## Relationship to the Dependabot PR

Supersedes the Docker-only bump on the equivalent Dependabot branch, which targets the production branch rather than this one and does not move `Nethermind.ReferenceAssemblies`, leaving compile-time refs two minors behind the runtime.

## Behavioural change that needs attention before the production rollout

1.39.2 makes the `eth_getLogs` block-range limit explicit and consistently applied: `Receipt.MaxBlockDepth`, default 10,000 blocks, rejecting wider requests with `-32602`. It is ignored when the log index is enabled — this deployment does not enable it, so the limit applies. `eth_getLogs` is in active use against the production RPC and is not exercised on staging, so a staging soak cannot validate this path. Set `--Receipt.MaxBlockDepth=0` to preserve the previous behaviour if any consumer needs wider ranges.

## Test plan

- [x] `dotnet build -c Release`: 0 errors
- [x] `dotnet test`: 1855 passed, 0 failed across all 8 unit test assemblies
- [x] `docker build` of `Index.Dockerfile` succeeds
- [x] Built image starts and reports Nethermind 1.39.3 on .NET 10.0.10
- [x] Runtime and plugin `Nethermind.Int256` assemblies both report 1.5.0.0
- [ ] Deploy to staging; confirm the node syncs and the Circles plugin loads
- [ ] Confirm the indexer keeps up and pathfinder serves paths
- [ ] Decide on `Receipt.MaxBlockDepth` before promoting to the production branch