### PR TITLE
fix: pin Autofac to the runtime image's exact version (9.3.1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,14 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <!-- Floor is set by Nethermind.Api: 1.39.3 binds against Autofac 9.3.1, and a
-         lower pin fails the build with CS1705 (referenced assembly older than the
-         one Nethermind.Api uses). Keep at or above the Nethermind runtime's Autofac. -->
-    <PackageVersion Include="Autofac" Version="9.3.2" />
+    <!-- Must EQUAL the Autofac the Nethermind runtime image bundles — not merely be
+         >= it. Too low fails the build with CS1705 (Nethermind.Api 1.39.3 binds against
+         9.3.1); too high starts fine, then kills the node during plugin init with
+         FileLoadException on /nethermind/plugins/Autofac.dll, because the plugin's copy
+         and the runtime's copy are different assembly identities. 9.3.2 did exactly that.
+         Same rule as Nethermind.Numerics.Int256 below. Verify against the image with
+         scripts/check-plugin-assembly-versions.sh, not against nuget's latest. -->
+    <PackageVersion Include="Autofac" Version="9.3.1" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />

--- a/scripts/check-plugin-assembly-versions.sh
+++ b/scripts/check-plugin-assembly-versions.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# check-plugin-assembly-versions.sh — fail if any assembly the plugin publishes
+# into /nethermind/plugins/ has a different version from the copy the Nethermind
+# runtime image already ships in /nethermind/.
+#
+# Why this exists: the plugin is loaded into a Nethermind process that has already
+# resolved its own copies of shared libraries. When our published copy and the
+# runtime's copy are different assembly *identities*, the CLR refuses to load ours:
+#
+#     System.IO.FileLoadException: Could not load file or assembly
+#     '/nethermind/plugins/<X>.dll'. The located assembly's manifest definition
+#     does not match the assembly reference. (0x80131040)
+#
+# The node then dies during init and restarts forever. Two real instances while
+# moving the runtime image from 1.37.2 to 1.39.3:
+#
+#   Nethermind.Numerics.Int256 1.6.0 -> aborts before any Circles code runs.
+#     Caught locally, because that assembly loads early enough that even
+#     `nethermind --version` trips it.
+#   Autofac 9.3.2 -> `--version` succeeds, the container starts, and it only
+#     dies once plugin init resolves Autofac. Reached a deployed host.
+#
+# So "the image builds and reports its version" is NOT sufficient evidence. Neither
+# is `dotnet build` — CS1705 only catches the pin being too LOW. Being too HIGH
+# builds clean, passes every unit test, and fails at runtime. This script closes
+# that gap by comparing the two directories directly.
+#
+# Usage:
+#   scripts/check-plugin-assembly-versions.sh [image]
+# Defaults to circles-index:local. Build the image first, e.g.
+#   docker build -f docker/Index.Dockerfile -t circles-index:local .
+#
+# Exit codes: 0 = every shared assembly matches, 1 = at least one mismatch.
+
+set -euo pipefail
+
+IMAGE="${1:-circles-index:local}"
+
+command -v docker >/dev/null 2>&1 || { echo "ERROR: docker not found" >&2; exit 1; }
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+    echo "ERROR: image '$IMAGE' not found locally. Build it first:" >&2
+    echo "  docker build -f docker/Index.Dockerfile -t $IMAGE ." >&2
+    exit 1
+fi
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+CID="$(docker create "$IMAGE")"
+trap 'docker rm -f "$CID" >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
+docker cp "$CID:/nethermind/plugins/." "$WORK/plugins" >/dev/null
+docker cp "$CID:/nethermind/." "$WORK/runtime" >/dev/null
+
+python3 - "$WORK" <<'PY'
+import os, re, subprocess, sys
+
+work = sys.argv[1]
+plug_dir = os.path.join(work, "plugins")
+runt_dir = os.path.join(work, "runtime")
+
+
+def assembly_version(path):
+    """First 4-part version literal in the assembly metadata."""
+    try:
+        out = subprocess.run(["strings", path], capture_output=True, text=True).stdout
+    except Exception:
+        return None
+    m = re.findall(r"^\d+\.\d+\.\d+\.\d+$", out, re.M)
+    return m[0] if m else None
+
+
+plug = {f for f in os.listdir(plug_dir) if f.endswith(".dll")}
+runt = {f for f in os.listdir(runt_dir) if f.endswith(".dll")}
+shared = sorted(plug & runt)
+
+if not shared:
+    print("ERROR: no assemblies found in both plugins/ and the runtime root.")
+    print("       The image layout probably changed — this check is now blind.")
+    sys.exit(1)
+
+mismatches = []
+for name in shared:
+    pv = assembly_version(os.path.join(plug_dir, name))
+    rv = assembly_version(os.path.join(runt_dir, name))
+    if pv and rv and pv != rv:
+        mismatches.append((name, pv, rv))
+
+print(f"Compared {len(shared)} assemblies present in both plugins/ and the runtime root.")
+
+if mismatches:
+    print("\nMISMATCH — the node will fail during init with FileLoadException:\n")
+    for name, pv, rv in mismatches:
+        print(f"  {name:<45} plugin={pv:<12} runtime={rv}")
+    print("\nPin the offending package in Directory.Packages.props to the runtime's")
+    print("version exactly. Higher is not safer here: it builds and tests clean, then")
+    print("crash-loops the deployed node.")
+    sys.exit(1)
+
+print("OK: every shared assembly matches the runtime image.")
+PY


### PR DESCRIPTION
Follow-up to #563, which pinned Autofac to 9.3.2 on the reasoning that `Nethermind.Api` binds against 9.3.1 and higher is compatible. It is not.

The plugin publishes its own `Autofac.dll` into `/nethermind/plugins/` alongside the copy the runtime image already ships. The CLR requires those to be the same assembly *identity*, not a compatible range, so the node aborted during plugin init and restarted forever:

```
System.IO.FileLoadException: Could not load file or assembly
'/nethermind/plugins/Autofac.dll'. The located assembly's manifest
definition does not match the assembly reference. (0x80131040)
  at Nethermind.Init.Steps.EthereumStepsManager.InitializeAll(...)
```

Same failure mode already documented for `Nethermind.Numerics.Int256`: the pin must **equal** the runtime's version. Too low fails the build with CS1705; too high builds clean, passes every unit test, and only fails on a running node.

## Why the checks on #563 missed it

`dotnet build` only catches the pin being too low. `Int256` is resolved early enough that `nethermind --version` trips it, which made the local verification on #563 look sufficient — but Autofac is not resolved until plugin init, which `--version` never reaches.

## New check

`scripts/check-plugin-assembly-versions.sh` diffs every assembly present in both `/nethermind/plugins/` and the runtime root, and fails on any version difference:

```
docker build -f docker/Index.Dockerfile -t circles-index:local .
scripts/check-plugin-assembly-versions.sh circles-index:local
```

Re-pinning to 9.3.2 makes it report the Autofac mismatch, so it detects the bug it exists for rather than merely passing.

## Test plan

- [x] `dotnet build -c Release`: 0 errors
- [x] Image builds
- [x] Assembly check: 19 shared assemblies, all matching
- [ ] Deploy to the drained staging node and confirm the plugin initialises
- [ ] Follow-up: wire the check into CI. There is no PR-time image build today (`docker-build-push-release.yml` runs on release only), so it needs a new job rather than a step in an existing one.