### PR TITLE
fix: enable the Health RPC module so /health is served on 1.39.x

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -43,7 +43,15 @@ services:
       --JsonRpc.Host=0.0.0.0
       --JsonRpc.Port=8545
       --JsonRpc.CorsOrigins=*
-      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles]
+      # `Health` is required for the /health HTTP endpoint to be mapped at all.
+      # Nethermind 1.37.x served /health regardless of this list; 1.39.x gates the
+      # endpoint on the module being enabled, and simply returns 404 when it is not.
+      # The node still logs "HealthChecks by Nethermind Enabled" and reports
+      # HealthChecks.Enabled = true either way, so the only way to detect the
+      # difference is to request the route. Verified against a clean
+      # nethermind/nethermind:1.39.3 image: without `Health` /health is 404, with it
+      # 200, all other arguments held identical.
+      --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Health]
       --JsonRpc.JwtSecretFile=/jwt.hex
       --JsonRpc.EngineHost=0.0.0.0
       --JsonRpc.EnginePort=8551


### PR DESCRIPTION
## Summary

Nethermind 1.39 maps the HTTP health endpoint only when `Health` appears in `JsonRpc.EnabledModules`. 1.37.x mapped it unconditionally, so `/health` began returning 404 after the runtime bump.

The regression is silent by construction: the node still logs `HealthChecks by Nethermind Enabled`, reports `HealthChecks.Enabled = true`, and loads the HealthChecks plugin normally. Only requesting the route reveals it.

## What changed

- Add `Health` to `JsonRpc.EnabledModules` in `docker/docker-compose.gnosis.yml`, with a comment recording the version-dependent behaviour.

## Verification

Against a clean `nethermind/nethermind:1.39.3` image, all other arguments held identical:

| `JsonRpc.EnabledModules` | `/health` |
|---|---|
| `[Web3,Eth,Subscribe,Net]` | 404 |
| `[Web3,Eth,Subscribe,Net,Health]` | 200 |

The same image with no module list at all also returns 200, which is why this was not caught before the restricted list was applied.

## Impact

Only the internal blackbox probe of the node's own health endpoint was affected. Public health routes are served by rpc-host through the reverse proxy and returned 200 throughout, so request serving and the DNS drain prober were unaffected.

## Test plan

- [ ] Deploy to a drained node running 1.39.x and confirm `/health` returns 200 on the node's JSON-RPC port
- [ ] Confirm the external endpoint probe recovers
- [ ] Confirm JSON-RPC methods for the other enabled modules still respond