### PR TITLE
fix: move flag comments out of the nethermind command block scalar

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -25,6 +25,17 @@ services:
       - ../.state/jwtsecret-gnosis/jwt.hex:/jwt.hex
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
+    # NOTE: `command` below is a literal block scalar — every line is passed to the
+    # binary verbatim, so a `#` line inside it becomes an argument and Nethermind
+    # exits printing its help text. Keep comments about individual flags out here.
+    #
+    # JsonRpc.EnabledModules must include `Health`: Nethermind 1.37.x served the
+    # /health HTTP endpoint regardless of this list, but 1.39.x gates the endpoint on
+    # the module being enabled and returns 404 when it is not. The node still logs
+    # "HealthChecks by Nethermind Enabled" and reports HealthChecks.Enabled = true
+    # either way, so requesting the route is the only way to tell. Verified against a
+    # clean nethermind/nethermind:1.39.3 image with all other arguments held
+    # identical: 404 without the module, 200 with it.
     command: |
       --config=gnosis
       --datadir=/data
@@ -43,14 +54,6 @@ services:
       --JsonRpc.Host=0.0.0.0
       --JsonRpc.Port=8545
       --JsonRpc.CorsOrigins=*
-      # `Health` is required for the /health HTTP endpoint to be mapped at all.
-      # Nethermind 1.37.x served /health regardless of this list; 1.39.x gates the
-      # endpoint on the module being enabled, and simply returns 404 when it is not.
-      # The node still logs "HealthChecks by Nethermind Enabled" and reports
-      # HealthChecks.Enabled = true either way, so the only way to detect the
-      # difference is to request the route. Verified against a clean
-      # nethermind/nethermind:1.39.3 image: without `Health` /health is 404, with it
-      # 200, all other arguments held identical.
       --JsonRpc.EnabledModules=[Web3,Eth,Subscribe,Net,Circles,Health]
       --JsonRpc.JwtSecretFile=/jwt.hex
       --JsonRpc.EngineHost=0.0.0.0


### PR DESCRIPTION
## Summary

`command` in the gnosis compose service is a literal block scalar (`command: |`), so every line is passed to the binary verbatim. A comment added inside it alongside the Health module change was parsed as arguments, and the node exited printing its help text instead of starting.

## What changed

- Move the explanatory comment above `command:`, where YAML treats it as a comment.
- Record the block-scalar constraint in that comment so the next flag annotation does not repeat the mistake.

The `--JsonRpc.EnabledModules` value itself is unchanged from the previous commit.

## Verification

Parsed the compose file and asserted the rendered `command` contains zero lines starting with `#`, and that the argument list is otherwise byte-identical to before.

## Test plan

- [ ] Node starts and reaches a healthy state on a drained host
- [ ] `/health` returns 200 on the node's JSON-RPC port
- [ ] Smoke test passes before the host is returned to the pool