### PR TITLE
chore: stop publishing a shared-framework assembly into plugins/

### DIFF
--- a/scripts/check-plugin-assembly-versions.sh
+++ b/scripts/check-plugin-assembly-versions.sh
@@ -26,6 +26,23 @@
 # builds clean, passes every unit test, and fails at runtime. This script closes
 # that gap by comparing the two directories directly.
 #
+# CHECK 2 (shared framework) exists because check 1 above is not sufficient either.
+# A shared-framework assembly such as Microsoft.Extensions.Diagnostics.HealthChecks
+# lives in /usr/share/dotnet/shared/Microsoft.AspNetCore.App/, so it appears NOWHERE
+# in the runtime root and check 1 is blind to it. A version comparison would be the
+# wrong test anyway: publishing a framework assembly into plugins/ is a hazard even
+# when the versions match, because the private copy becomes a separate assembly
+# identity inside the plugin load context, and two identities of the same type do
+# not satisfy each other's casts or DI registrations.
+#
+# Unlike check 1, this check is precautionary — it is not backed by an observed
+# outage in this repo. It was added while investigating the /health 404 on 1.39.3;
+# that turned out to have an unrelated cause (Nethermind now gates the endpoint on
+# the Health RPC module being listed in JsonRpc.EnabledModules), and a controlled
+# repro confirmed the shadowed HealthChecks assemblies did NOT break the route.
+# The check is kept because the failure mode it guards is silent by construction —
+# no crash, no log line, just a feature that quietly stops working.
+#
 # Usage:
 #   scripts/check-plugin-assembly-versions.sh [image]
 # Defaults to circles-index:local. Build the image first, e.g.
@@ -52,6 +69,9 @@ CID="$(docker create "$IMAGE")"
 trap 'docker rm -f "$CID" >/dev/null 2>&1 || true; rm -rf "$WORK"' EXIT
 docker cp "$CID:/nethermind/plugins/." "$WORK/plugins" >/dev/null
 docker cp "$CID:/nethermind/." "$WORK/runtime" >/dev/null
+# Best-effort: some images may lay the shared framework out differently. A missing
+# directory downgrades check 2 to a warning rather than failing the build.
+docker cp "$CID:/usr/share/dotnet/shared" "$WORK/shared" >/dev/null 2>&1 || true
 
 python3 - "$WORK" <<'PY'
 import os, re, subprocess, sys
@@ -59,6 +79,7 @@ import os, re, subprocess, sys
 work = sys.argv[1]
 plug_dir = os.path.join(work, "plugins")
 runt_dir = os.path.join(work, "runtime")
+shared_dir = os.path.join(work, "shared")
 
 
 def assembly_version(path):
@@ -87,16 +108,66 @@ for name in shared:
     if pv and rv and pv != rv:
         mismatches.append((name, pv, rv))
 
-print(f"Compared {len(shared)} assemblies present in both plugins/ and the runtime root.")
+print(f"Check 1: compared {len(shared)} assemblies present in both plugins/ and the runtime root.")
+
+failed = False
 
 if mismatches:
     print("\nMISMATCH — the node will fail during init with FileLoadException:\n")
     for name, pv, rv in mismatches:
-        print(f"  {name:<45} plugin={pv:<12} runtime={rv}")
+        print(f"  {name:<55} plugin={pv:<12} runtime={rv}")
     print("\nPin the offending package in Directory.Packages.props to the runtime's")
     print("version exactly. Higher is not safer here: it builds and tests clean, then")
     print("crash-loops the deployed node.")
+    failed = True
+
+# --- Check 2: no shared-framework assembly may be published into plugins/ ---
+if not os.path.isdir(shared_dir):
+    print("\nCheck 2: SKIPPED — no /usr/share/dotnet/shared in the image.")
+    print("         Framework-shadowing cannot be detected. Investigate if unexpected.")
+else:
+    framework = {}
+    for root, _dirs, files in os.walk(shared_dir):
+        for f in files:
+            if f.endswith(".dll"):
+                # Record the first framework that provides it; enough to name it.
+                framework.setdefault(f, os.path.relpath(root, shared_dir))
+
+    # Known-present before the 1.39.3 bump and not implicated in any observed
+    # failure. Both are pure interface contracts that the plugin tree pulls in
+    # transitively, and both have shipped in plugins/ across every release this
+    # repo has deployed. They are NOT proven safe — the same separate-identity
+    # hazard applies in principle — but removing them risks breaking plugin
+    # loading outright, so that is its own change with its own verification.
+    # Do not extend this list to make a new finding go away.
+    ALLOWLIST = {
+        "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
+        "Microsoft.Extensions.Logging.Abstractions.dll",
+    }
+
+    shadowed = sorted((plug & set(framework)) - ALLOWLIST)
+    allowed = sorted((plug & set(framework)) & ALLOWLIST)
+    print(f"Check 2: {len(framework)} shared-framework assemblies, "
+          f"{len(shadowed)} shadowed by plugins/ "
+          f"({len(allowed)} allowlisted).")
+    for name in allowed:
+        print(f"         allowlisted: {name}")
+
+    if shadowed:
+        print("\nFRAMEWORK SHADOWING — these are provided by the shared framework and")
+        print("should NOT be published into plugins/. A private copy becomes a separate")
+        print("assembly identity in the plugin load context: the node starts and logs")
+        print("normally, and the affected feature silently does nothing.\n")
+        for name in shadowed:
+            print(f"  {name:<55} framework={framework[name]}")
+        print("\nRemove the PackageReference from the project that publishes into")
+        print("plugins/ (src/Index/Circles.Index). If the code genuinely needs the API,")
+        print("keep the reference but add ExcludeAssets=\"runtime\" so it compiles")
+        print("against the package without copying the assembly to the output.")
+        failed = True
+
+if failed:
     sys.exit(1)
 
-print("OK: every shared assembly matches the runtime image.")
+print("\nOK: no version mismatches and no framework shadowing.")
 PY

--- a/src/Index/Circles.Index/Circles.Index.csproj
+++ b/src/Index/Circles.Index/Circles.Index.csproj
@@ -24,7 +24,16 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" />
+    <!-- Microsoft.Extensions.Diagnostics.HealthChecks was referenced here but never
+         used — no HealthCheck symbol appears anywhere in this project. Its only
+         effect was that `dotnet publish` dropped a private NuGet copy of a
+         Microsoft.AspNetCore.App shared-framework assembly into /nethermind/plugins/,
+         the directory Nethermind loads its OWN plugins from. A private copy there
+         becomes a separate assembly identity inside the plugin load context, which is
+         a latent way to break a framework feature with no crash and no log line.
+         This was NOT the cause of the /health 404 on 1.39.3 (that was Nethermind
+         gating the endpoint on the Health RPC module) — it is removed as hygiene.
+         scripts/check-plugin-assembly-versions.sh now guards the class generally. -->
   </ItemGroup>
 
 


### PR DESCRIPTION
## Summary

`Circles.Index` referenced `Microsoft.Extensions.Diagnostics.HealthChecks` but never used it — no HealthCheck symbol appears anywhere in the project. Its only effect was that `dotnet publish` dropped a private NuGet copy of a `Microsoft.AspNetCore.App` shared-framework assembly into `/nethermind/plugins/`, the directory Nethermind loads its own plugins from.

A private copy there becomes a separate assembly identity inside the plugin load context, which can break a framework feature with no crash and no log line.

**This is not the fix for the `/health` 404.** That was Nethermind gating the endpoint on the `Health` RPC module and is already fixed. A controlled repro — clean base image plus only these two assemblies added to `plugins/` — returned 200, confirming they did not affect the route. Removed as hygiene, not as a remedy.

## What changed

- Drop the unused `PackageReference`.
- Extend `scripts/check-plugin-assembly-versions.sh` with a second check: no assembly the shared framework provides may be published into `plugins/`.

The existing check compares `plugins/` against the runtime root and is structurally blind to this class, because shared-framework assemblies live in `/usr/share/dotnet/shared` and appear in neither directory.

Two pre-existing entries (`Microsoft.Extensions.DependencyInjection.Abstractions`, `Microsoft.Extensions.Logging.Abstractions`) are allowlisted with the reasoning recorded inline. They are **not** proven safe — the same hazard applies in principle — but removing them risks plugin loading outright and belongs in its own change with its own verification.

## Verification

```
Check 1: compared 19 assemblies present in both plugins/ and the runtime root.
Check 2: 313 shared-framework assemblies, 0 shadowed by plugins/ (2 allowlisted).
OK: no version mismatches and no framework shadowing.
```

Before the change the same run reported the two HealthChecks assemblies as shadowed.

## Deployment note

Taking effect requires an image rebuild, so this is not urgent and can ride the next one. Nothing currently deployed depends on it.

## Test plan

- [x] Image builds
- [x] Assembly check passes on the built image, and flags the assemblies before the fix
- [ ] Node starts normally on the next rebuild-and-deploy