### PR TITLE
fix: disable the eth_getLogs range cap introduced in 1.39.2

### DIFF
--- a/docker/docker-compose.gnosis.yml
+++ b/docker/docker-compose.gnosis.yml
@@ -36,6 +36,20 @@ services:
     # either way, so requesting the route is the only way to tell. Verified against a
     # clean nethermind/nethermind:1.39.3 image with all other arguments held
     # identical: 404 without the module, 200 with it.
+    #
+    # Receipt.MaxBlockDepth=0 disables the eth_getLogs range cap that 1.39.2 introduced
+    # with a default of 10000. Despite the name it caps the RANGE WIDTH
+    # (toBlock - fromBlock + 1) of a single request, not depth from head; over-limit
+    # requests are rejected -32602. 1.37.x had no cap at all, so 0 reproduces the
+    # previous behaviour exactly and keeps the runtime bump a single-variable change.
+    # This is load-bearing: group-tms requests 100_000-block ranges in
+    # apps/community-new/multiRegistry.ts and apps/group-affiliates/realtime.ts, ten
+    # times the default cap. Those paths run only on first boot / history catch-up /
+    # WebSocket reconnect, never in steady state, so with the cap on, an upgrade looks
+    # clean and then fails on the next group-tms restart — which the infra maintenance
+    # procedure forces by stopping group-tms before gnosis work. Remove this flag only
+    # after group-tms chunks at <= 10000; its backfill path already sits exactly on the
+    # boundary at 10_000.
     command: |
       --config=gnosis
       --datadir=/data
@@ -46,6 +60,7 @@ services:
       --Sync.AncientReceiptsBarrier=12500000
       --Receipt.StoreReceipts=true
       --Receipt.TxLookupLimit=${NETHERMIND_RECEIPT_TX_LOOKUP_LIMIT:-0}
+      --Receipt.MaxBlockDepth=0
       --Pruning.Mode=Hybrid
       --Pruning.FullPruningTrigger=StateDbSize
       --Pruning.FullPruningThresholdMb=100000


### PR DESCRIPTION
## Summary

`Receipt.MaxBlockDepth` arrived in Nethermind 1.39.2 with a default of **10000**. Despite the name it caps the **range width** (`toBlock - fromBlock + 1`) of a single `eth_getLogs` request, not depth from head. Over-limit requests are rejected with `-32602`.

1.37.x had no cap at all, so setting `0` reproduces the previous behaviour exactly and keeps the runtime bump a single-variable change.

## Why this is load-bearing

group-tms requests **100_000-block ranges** in two call sites — `apps/community-new/multiRegistry.ts` and `apps/group-affiliates/realtime.ts` — ten times the default cap.

| Call site | Chunk | Against a 10000 cap |
|---|---|---|
| `community-new/multiRegistry.ts` | 100_000 | rejected |
| `group-affiliates/realtime.ts` | 100_000 | rejected |
| `group-affiliates/main.ts` (backfill) | 10_000 | passes, zero margin |
| `dublin-tms/logic.ts` | 2_000 | fine |

Those 100k paths run only on first boot, history catch-up and WebSocket reconnect — never in steady state, where requests are small and return empty. So with the cap enabled an upgrade appears completely clean and then fails on the **next restart** of that consumer. The infra maintenance procedure forces exactly that restart by stopping the consumer before gnosis work.

## Verification

Measured on a node already running 1.39.3, all other arguments identical:

| range | before this change |
|---|---|
| 10000 | accepted |
| 10001 | `-32602` rejected |
| 100000 | `-32602` rejected |

## Scope

No environment currently serving this method externally is affected: across the three production nodes, `eth_getLogs` appears in the JSON-RPC report of exactly one, and the other two (which serve the same pooled traffic) record zero calls. All usage is a single in-network consumer.

## Follow-up

Remove this flag once that consumer chunks at `<= 10000`, at which point the cap can be restored for its protective value. Its backfill path already sits exactly on the boundary.

## Test plan

- [ ] Node starts and reaches healthy state on a drained host
- [ ] A 100000-block `eth_getLogs` is accepted rather than rejected `-32602`
- [ ] Smoke test passes before the host returns to the pool